### PR TITLE
ibacm: Fix possible buffer overrun

### DIFF
--- a/ibacm/prov/acmp/src/acmp.c
+++ b/ibacm/prov/acmp/src/acmp.c
@@ -2877,7 +2877,7 @@ static void acmp_set_options(void)
 		if (s[0] == '#')
 			continue;
 
-		if (sscanf(s, "%32s%256s", opt, value) != 2)
+		if (sscanf(s, "%31s%255s", opt, value) != 2)
 			continue;
 
 		if (!stricmp("addr_prot", opt))


### PR DESCRIPTION
Fixes bugzilla bug 2605.

prov/acmp/src/acmp.c:2869]: (error) Width 32 given in format string (no. 1) is
larger than destination buffer 'opt[32]', use %31s to prevent overflowing it.

prov/acmp/src/acmp.c:2869]: (error) Width 256 given in format string (no. 2) is
larger than destination buffer 'value[256]', use %255s to prevent overflowing
it.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>

This is a trivial fix, but it is untested.