### PR TITLE
Add a build.sh helper to allow for a one-stop build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,7 @@ Additional service daemons are provided for:
 This project uses a cmake based build system. Quick start:
 
 ```sh
-$ mkdir build
-$ cd build
-$ cmake -GNinja ..
-$ ninja
+$ bash build.sh
 ```
 
 *build/bin* will contain the sample programs and *build/lib* will contain the
@@ -76,16 +73,6 @@ Install required packages:
 $ yum install cmake gcc libnl3-devel make pkgconfig valgrind-devel
 ```
 
-For end users, the package can be built using GNU Make and the old cmake
-included with the distro:
-
-```sh
-$ mkdir build
-$ cd build
-$ cmake  ..
-$ make
-```
-
 Developers are suggested to install more modern tooling for the best experience.
 
 ```sh
@@ -95,8 +82,6 @@ $ curl -OL https://github.com/ninja-build/ninja/releases/download/v1.7.1/ninja-l
 $ unzip ninja-linux.zip
 $ install -m755 ninja /usr/local/bin/ninja
 ```
-
-Use the 'cmake3' program in place of `cmake` in the above instructions.
 
 # Reporting bugs
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+SRCDIR=`dirname $0`
+BUILDDIR="$SRCDIR/build"
+
+mkdir -p "$BUILDDIR"
+
+if hash cmake3 2>/dev/null; then
+    # CentOS users are encouraged to install cmake3 from EPEL
+    CMAKE=cmake3
+else
+    CMAKE=cmake
+fi
+
+if hash ninja-build 2>/dev/null; then
+    # Fedora uses this name
+    NINJA=ninja-build
+elif hash ninja 2>/dev/null; then
+    NINJA=ninja
+fi
+
+cd "$BUILDDIR"
+
+if [ "x$NINJA" == "x" ]; then
+    cmake ..
+    make
+else
+    cmake -GNinja ..
+    $NINJA
+fi


### PR DESCRIPTION
This allows for a quick build instead of typing the whole mkdir, cd,
cmake and ninja sequence.

Signed-off-by: Christoph Hellwig <hch@lst.de>
Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>