### PR TITLE
librdmacm: Avoid possible hang on device removal

### DIFF
--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -224,6 +224,8 @@ static int rping_cma_event_handler(struct rdma_cm_id *cma_id,
 
 	case RDMA_CM_EVENT_DEVICE_REMOVAL:
 		fprintf(stderr, "cma detected device removal!!!!\n");
+		cb->state = ERROR;
+		sem_post(&cb->sem);
 		ret = -1;
 		break;
 


### PR DESCRIPTION
When we get an RDMA_CM_EVENT_DEVICE_REMOVAL the cm_thread will
exit and because flush errors are ignored the cb->sem may not get signaled.
So just signal on device removal event.

Fixes: 612eae1f6fe3 ("rping: ignore flushed completions")
Signed-off-by: Mustafa Ismail <mustafa.ismail@intel.com>
Reviewed-by: Steve Wise <swise@opengridcomputing.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>