### PR TITLE
ibverbs: increase value[] len to read all node_type values

### DIFF
--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -372,7 +372,7 @@ static struct ibv_device *try_driver(struct ibv_driver *driver,
 {
 	struct verbs_device *vdev;
 	struct ibv_device *dev;
-	char value[8];
+	char value[16];
 
 	if (driver->init_func) {
 		dev = driver->init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);


### PR DESCRIPTION
This commit increases the length of the value[] array to 16 because 8 bytes is not long enough to read all valid /sys/class/infiniband/*/node_type files.  For example:

```
$ cat /sys/class/infiniband/usnic_0/node_type
6: usNIC UDP
```

Including \n, this is 13 characters.

More speicifcally, in the kernel IB core, drivers/inifiniband/core/sysfs.c returns "%d: usNIC UDP\n" as the value from catenating the node_type file.

Signed-off-by: Jeff Squyres jsquyres@cisco.com
