### PR TITLE
rxe: Use default dual-license instead of PathScale

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -45,11 +45,6 @@ ipathverbs
 ocrdma
 : Dual License: GPLv2 or OpenIB.org BSD (FreeBSD variant), See COPYING.BSD_FB
 
-rxe
-: A combination of the
-    - Default Dual License
-    - GPLv2 or PathScale BSD Patent license
-
 ## Libraries
 
 All library compilable source code (.c and .h files) are available under the

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -31,10 +31,6 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
- * Patent licenses, if any, provided herein do not apply to
- * combinations of this program with other software, or any other
- * product whatsoever.
  */
 
 #include <config.h>

--- a/providers/rxe/rxe.h
+++ b/providers/rxe/rxe.h
@@ -31,10 +31,6 @@
  * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- *
- * Patent licenses, if any, provided herein do not apply to
- * combinations of this program with other software, or any other
- * product whatsoever.
  */
 
 #ifndef RXE_H


### PR DESCRIPTION
Remove the patent clauses from RXE copyright notice.

Signed-off-by: Leon Romanovsky <leon@kernel.org>
Reviewed-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>