### PR TITLE
Fix common rdma-core.spec for systemd systems

### DIFF
--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -46,6 +46,13 @@ BuildRequires: make
 %endif
 %endif
 
+# Detect if systemd is supported on this system
+%if 0%{?_unitdir:1}
+Requires(post): systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
+%endif
+
 %description
 Temporary packaging
 
@@ -59,9 +66,6 @@ This is a simple example without the split sub packages to get things started.
 # Detect if systemd is supported on this system
 %if 0%{?_unitdir:1}
 %define my_unitdir %{_unitdir}
-Requires(post): systemd-units
-Requires(preun): systemd-units
-Requires(postun): systemd-units
 %else
 %define my_unitdir /tmp/
 %endif

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -170,6 +170,7 @@ librdmacm provides a userspace RDMA Communication Managment API.
 
 %package -n librdmacm-utils
 Summary: Examples for the librdmacm library
+Requires: librdmacm%{?_isa} = %{version}-%{release}
 
 %description -n librdmacm-utils
 Example test programs for the librdmacm library.


### PR DESCRIPTION
RPM needs the Requires lines for systemd to be earlier.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>