### PR TITLE
rxe: Remove patent clause leftovers

### DIFF
--- a/providers/rxe/rxe-abi.h
+++ b/providers/rxe/rxe-abi.h
@@ -30,9 +30,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Patent licenses, if any, provided herein do not apply to
- * combinations of this program with other software, or any other
- * product whatsoever.
  */
 
 #ifndef RXE_ABI_H

--- a/providers/rxe/rxe_queue.h
+++ b/providers/rxe/rxe_queue.h
@@ -30,9 +30,6 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  *
- * Patent licenses, if any, provided herein do not apply to
- * combinations of this program with other software, or any other
- * product whatsoever.
  */
 
 /* implements a simple circular buffer with sizes a power of 2 */


### PR DESCRIPTION
RXE is using default dual-license instead of PathScale,
but commit 275684bf8cb1 didn't remove everything.

Fixes: 275684bf8cb1 ("rxe: Use default dual-license instead of PathScale")
Signed-off-by: Leon Romanovsky <leon@kernel.org>