### PR TITLE
ibacm: Modify comment related to default pkey in ibacm_addr.cfg

### DIFF
--- a/ibacm/src/acme.c
+++ b/ibacm/src/acme.c
@@ -354,7 +354,7 @@ static void gen_addr_temp(FILE *f)
 	fprintf(f, "#\n");
 	fprintf(f, "# device name - struct ibv_device name\n");
 	fprintf(f, "# port number - valid port number on device (numbering starts at 1)\n");
-	fprintf(f, "# pkey - partition key in hex (can specify 'default' for pkey 0xFFFF)\n");
+	fprintf(f, "# pkey - partition key in hex (can specify 'default' for first entry in pkey table)\n");
 	fprintf(f, "#\n");
 	fprintf(f, "# Up to 4 addresses can be associated with a given <device, port, pkey> tuple\n");
 	fprintf(f, "#\n");


### PR DESCRIPTION
Comment in ibacm_addr.cfg mentions that default pkey is 0xffff while
the default pkey is the first entry in pkey table which may be
different from 0xffff. Hence, comment specifying default key as 0xffff
is misleading.

Signed-off-by: Jay Patel <jay.p.patel@intel.com>
Signed-off-by: Sean Hefty <sean.hefty@intel.com>