### PR TITLE
Debian fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,5 +1,7 @@
 rdma-core (12-1) unstable; urgency=low
 
-  * New version
+  * New version.
+  * Adding debian/copyright.
+  * Close ITP (Closes: #848971).
 
  -- Jason Gunthorpe <jgg@obsidianresearch.com>  Mon, 12 Sep 2016 13:44:24 -0600

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,0 +1,565 @@
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: rdma-core
+Upstream-Contact: Doug Ledford <dledford@redhat.com>,
+                  Leon Romanovsky <Leon@kernel.org>
+Source: https://github.com/linux-rdma/rdma-core
+
+Files: *
+Copyright: disclaimed
+License: GPL-2 or BSD
+
+Files: debian/*
+Copyright: 2015-2016, Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
+           2016-2017, Talat Batheesh <talatb@mellanox.com>
+License: GPL-2
+
+Files: buildlib/cbuild
+Copyright: 2015-2016, Obsidian Research Corp.
+License: GPL-2 or BSD
+
+Files: buildlib/fixup-include/*
+Copyright: 2016, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: ccan/*
+Copyright: unspecified
+License: CC0 and BSD-MIT
+
+Files: ibacm/*
+Copyright: 2013-2015, Mellanox Technologies LTD.
+           2009-2014, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: ibacm/src/acm_util.c
+  ibacm/src/acm_util.h
+  ibacm/src/parse.c
+Copyright: 2004-2016, Intel Corporation.
+License: BSD
+
+Files: ibacm/man/*
+  ibacm/ibacm.init.in
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: iwpmd/*
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibcm/*
+Copyright: 2005, Topspin Communications.
+           2005-2006, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibcm/cm.h
+Copyright: 2004-2006, Intel Corporation.
+           2004, Voltaire Corporation.
+           2004, Topspin Corporation.
+License: GPL-2 or BSD
+
+Files: libibcm/examples/*
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/*
+Copyright: 2004-2008, Voltaire Inc.
+License: GPL-2 or BSD
+
+Files: libibumad/tests/*
+Copyright: 2014, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/umad.c
+  libibumad/umad.h
+Copyright: 2005-2014, Intel Corporation.
+           2004-2009, Voltaire Inc.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_cm.h
+Copyright: 2013-2015, Mellanox Technologies LTD.
+           2009-2014, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_sa.h
+Copyright: 2014, Mellanox Technologies LTD.
+           2006, 2010, Intel Corporation.
+           2005, Voltaire, Inc.
+           2004, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_sm.h
+Copyright: 2013, Oracle and/or its affiliates.
+           2004-2014, Mellanox Technologies Ltd.
+           2004, Voltaire Corporation.
+           2004, Topspin Corporation.
+           2004, Intel Corporation.
+           2004, Infinicon Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_str.c
+Copyright: 2014, Mellanox Technologies LTD.
+        2013, Lawrence Livermore National Security.
+        2004-2005, 2010, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_str.h
+Copyright: 2013, Lawrence Livermore National Security.
+           2004-2005, 2010, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/umad_types.h
+Copyright: 2004-2006, Voltaire Corporation.
+           2004, Topspin Corporation.
+           2004, Mellanox Technologies Ltd.
+           2004, Infinicon Corporation.
+           2004, 2010, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibumad/man/*
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: libibverbs/*
+Copyright: 2006, 2007, Cisco Systems, Inc.
+           2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/arch.h
+  libibverbs/opcode.h
+Copyright: 2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/cmd.c
+Copyright: 2006, Cisco Systems, Inc.
+           2005, Topspin Communications.
+           2005, PathScale, Inc.
+License: GPL-2 or BSD
+
+Files: libibverbs/compat-1_0.c
+  libibverbs/sysfs.c
+Copyright: 2006, 2007, Cisco Systems, Inc.
+License: GPL-2 or BSD
+
+Files: libibverbs/driver.h
+Copyright: 2005, PathScale, Inc.
+           2005-2006, Cisco Systems, Inc.
+           2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/enum_strs.c
+Copyright: 2008, Lawrence Livermore National Laboratory.
+License: GPL-2 or BSD
+
+Files: libibverbs/examples/*
+Copyright: 2004- 2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/examples/devinfo.c
+Copyright: 2005, Mellanox Technologies Ltd.
+           2005, Cisco Systems.
+License: GPL-2 or BSD
+
+Files: libibverbs/examples/pingpong.c
+  libibverbs/examples/pingpong.h
+Copyright: 2005, 2006, Cisco Systems.
+License: GPL-2 or BSD
+
+Files: libibverbs/examples/xsrq_pingpong.c
+Copyright: 2011, Intel Corporation, Inc.
+           2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/kern-abi.h
+Copyright: 2005, Topspin Communications.
+           2005, PathScale, Inc.
+           2005-2006, Cisco Systems.
+License: GPL-2 or BSD
+
+Files: libibverbs/marshall.c
+  libibverbs/marshall.h
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: libibverbs/sa.h
+Copyright: 2005, Voltaire, Inc.
+           2004, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/verbs.h
+Copyright: 2005-2007, Cisco Systems, Inc.
+           2005, PathScale, Inc.
+           2004, 2011-2012, Intel Corporation.
+           2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: libibverbs/man/*
+  libibverbs/neigh.h
+  libibverbs/nl1_compat.h
+  libibverbs/neigh.c
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: librdmacm/*
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: librdmacm/examples/riostream.c
+  librdmacm/examples/rstream.c
+Copyright: 2013-2015, Mellanox Technologies LTD.
+           2009-2014, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: librdmacm/examples/rping.c
+Copyright: 2006, Open Grid Computing, Inc.
+           2005, Ammasso, Inc.
+License: GPL-2 or BSD
+
+Files: librdmacm/rdma_cma.h
+Copyright: 2005-2014, Intel Corporation.
+           2004-2009, Voltaire Inc.
+License: GPL-2 or BSD
+
+Files: librdmacm/docs/rsocket
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: librdmacm/man/*
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: providers/*
+Copyright: 2004-2016, Chelsio, Inc.
+License: GPL-2 or BSD
+
+Files: providers/cxgb4/t4_chip_type.h
+  providers/cxgb4/t4_pci_id_tbl.h
+  providers/cxgb4/t4_regs.h
+  providers/cxgb4/t4fw_api.h
+Copyright: 2003-2015, Chelsio Communications, Inc.
+License: GPL-2 or BSD
+
+Files: providers/hfi1verbs/*
+Copyright: no-info-found
+License: BSD-3-clause or GPL-2
+
+Files: providers/hns/*
+Copyright: 2016, Hisilicon Limited.
+License: GPL-2 or BSD
+
+Files: providers/i40iw/*
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: providers/ipathverbs/*
+Copyright: 2006-2009, QLogic Corp.
+           2005, PathScale, Inc.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/*
+Copyright: 2006-2007, Cisco, Inc.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/cq.c
+Copyright: 2006-2007, Cisco Systems.
+           2005, Topspin Communications.
+           2005, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/dbrec.c
+Copyright: 2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/mlx4.h
+Copyright: 2005-2007, Cisco Systems.
+           2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/qp.c
+Copyright: 2007, Cisco, Inc.
+           2005, Topspin Communications.
+           2005, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: providers/mlx4/mmio.h
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: providers/mlx5/*
+Copyright: 2012, Mellanox Technologies, Inc.
+License: GPL-2 or BSD
+
+Files: providers/mlx5/bitmap.h
+Copyright: 2000, 2011, Mellanox Technology Inc.
+License: GPL-2 or BSD
+
+Files: providers/mthca/*
+Copyright: 2005-2007, Cisco Systems.
+           2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: providers/mthca/ah.c
+  providers/mthca/doorbell.h
+  providers/mthca/memfree.c
+Copyright: 2004-2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: providers/mthca/buf.c
+Copyright: 2006-2007, Cisco Systems, Inc.
+License: GPL-2 or BSD
+
+Files: providers/mthca/cq.c
+Copyright: 2006-2007, Cisco Systems.
+           2005, Topspin Communications.
+           2005, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: providers/mthca/qp.c
+Copyright: 2005, Topspin Communications.
+           2005, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: providers/mthca/srq.c
+Copyright: 2005-2006, Cisco Systems.
+License: GPL-2 or BSD
+
+Files: providers/mthca/verbs.c
+Copyright: 2005, Topspin Communications.
+           2005-2006, Cisco Systems.
+License: GPL-2 or BSD
+
+Files: providers/nes/*
+Copyright: 2006-2010, Intel Corporation.
+           2006, Open Grid Computing, Inc.
+License: GPL-2 or BSD
+
+Files: providers/nes/nes_uverbs.c
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: providers/ocrdma/*
+Copyright: 2008-2013, Emulex.
+License: GPL-2 or BSD-2-clause
+
+Files: providers/qedr/*
+Copyright: 2015-2016, QLogic Corporation.
+License: GPL-2 or BSD
+
+Files: providers/rxe/*
+Copyright: 2009-2011, System Fabric Works, Inc.
+           2009-2011, Mellanox Technologies Ltd.
+License: GPL-2 or BSD
+
+Files: providers/rxe/rxe.*
+Copyright: 2009, System Fabric Works, Inc.
+           2009, Mellanox Technologies Ltd.
+           2006-2007, QLogic Corporation.
+           2005, PathScale, Inc.
+License: GPL-2 or BSD
+
+Files: rdma-ndd/*
+Copyright: 2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: rdma-ndd/rdma-ndd.c
+Copyright: 2004-2016, Intel Corporation.
+License: GPL-2 or BSD
+
+Files: redhat/*
+Copyright: 1996-2013, Red Hat, Inc.
+License: GPL-2
+
+Files: srp_daemon/*
+Copyright: 2006, Mellanox Technologies Ltd.
+           2006, Cisco Systems, Inc.
+           2005, Topspin Communications.
+License: GPL-2 or BSD
+
+Files: srp_daemon/srp_daemon.1.in
+  srp_daemon/srpd.in
+  srp_daemon/ibsrpdm.1
+Copyright: disclaimed
+License: BSD-2-clause
+
+Files: srp_daemon/srp_daemon.sh.in
+  srp_daemon/srp_handle_traps.c
+Copyright: 2006, Mellanox Technologies.
+License: GPL-2 or BSD
+
+License: BSD
+ OpenIB.org BSD license (MIT variant)
+ Redistribution and use in source and binary forms, with or
+ without modification, are permitted provided that the following
+ conditions are met:
+  * Redistributions of source code must retain the above
+    copyright notice, this list of conditions and the following
+    disclaimer.
+  * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following
+    disclaimer in the documentation and/or other materials
+    provided with the distribution.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+
+License: BSD-2-clause
+ OpenIB.org BSD license (FreeBSD Variant)
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are met:
+  * Redistributions of source code must retain the above copyright notice,
+    this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation
+    and/or other materials provided with the distribution.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+ FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: BSD-3-clause
+ The BSD License
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   * Neither the name of foo nor the names of its
+     contributors may be used to endorse or promote products derived from
+     this software without specific prior written permission.
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+License: GPL-2
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; version 2 dated June, 1991.
+ On Debian systems, the complete text of version 2 of the GNU General
+ Public License can be found in '/usr/share/common-licenses/GPL-2'.
+
+License: CC0
+ Statement of Purpose.
+ The laws of most jurisdictions throughout the world automatically confer
+ exclusive Copyright and Related Rights (defined below) upon the creator and
+ subsequent owner(s) (each and all, an "owner") of an original work of
+ authorship and/or a database (each, a "Work").
+ Certain owners wish to permanently relinquish those rights to a Work for the
+ purpose of contributing to a commons of creative, cultural and scientific works
+ ("Commons") that the public can reliably and without fear of later claims of
+ infringement build upon, modify, incorporate in other works, reuse and
+ redistribute as freely as possible in any form whatsoever and for any purposes,
+ including without limitation commercial purposes. These owners may contribute
+ to the Commons to promote the ideal of a free culture and the further
+ production of creative, cultural and scientific works, or to gain reputation or
+ greater distribution for their Work in part through the use and efforts of
+ others.
+ For these and/or other purposes and motivations, and without any expectation of
+ additional consideration or compensation, the person associating CC0 with a
+ Work (the "Affirmer"), to the extent that he or she is an owner of Copyright
+ and Related Rights in the Work, voluntarily elects to apply CC0 to the Work and
+ publicly distribute the Work under its terms, with knowledge of his or her
+ Copyright and Related Rights in the Work and the meaning and intended legal
+ effect of CC0 on those rights.
+ 1. Copyright and Related Rights. A Work made available under CC0 may be
+ protected by copyright and related or neighboring rights ("Copyright and
+ Related Rights"). Copyright and Related Rights include, but are not limited to,
+ the following:
+     the right to reproduce, adapt, distribute, perform, display, communicate,
+ and translate a Work; moral rights retained by the original author(s) and/or
+ performer(s); publicity and privacy rights pertaining to a person's image or
+ likeness depicted in a Work; rights protecting against unfair competition in
+ regards to a Work, subject to the limitations in paragraph 4(a), below; rights
+ protecting the extraction, dissemination, use and reuse of data in a Work;
+ database rights (such as those arising under Directive 96/9/EC of the European
+ Parliament and of the Council of 11 March 1996 on the legal protection of
+ databases, and under any national implementation thereof, including any amended
+ or successor version of such directive); and other similar, equivalent or
+ corresponding rights throughout the world based on applicable law or treaty,
+ and any national implementations thereof.
+ 2. Waiver. To the greatest extent permitted by, but not in contravention of,
+ applicable law, Affirmer hereby overtly, fully, permanently, irrevocably and
+ unconditionally waives, abandons, and surrenders all of Affirmer's Copyright
+ and Related Rights and associated claims and causes of action, whether now
+ known or unknown (including existing as well as future claims and causes of
+ action), in the Work (i) in all territories worldwide, (ii) for the maximum
+ duration provided by applicable law or treaty (including future time
+ extensions), (iii) in any current or future medium and for any number of
+ copies, and (iv) for any purpose whatsoever, including without limitation
+ commercial, advertising or promotional purposes (the "Waiver"). Affirmer makes
+ the Waiver for the benefit of each member of the public at large and to the
+ detriment of Affirmer's heirs and successors, fully intending that such Waiver
+ shall not be subject to revocation, rescission, cancellation, termination, or
+ any other legal or equitable action to disrupt the quiet enjoyment of the Work
+ by the public as contemplated by Affirmer's express Statement of Purpose.
+ 3. Public License Fallback. Should any part of the Waiver for any reason be
+ judged legally invalid or ineffective under applicable law, then the Waiver
+ shall be preserved to the maximum extent permitted taking into account
+ Affirmer's express Statement of Purpose. In addition, to the extent the Waiver
+ is so judged Affirmer hereby grants to each affected person a royalty-free, non
+ transferable, non sublicensable, non exclusive, irrevocable and unconditional
+ license to exercise Affirmer's Copyright and Related Rights in the Work (i) in
+ all territories worldwide, (ii) for the maximum duration provided by applicable
+ law or treaty (including future time extensions), (iii) in any current or
+ future medium and for any number of copies, and (iv) for any purpose
+ whatsoever, including without limitation commercial, advertising or promotional
+ purposes (the "License"). The License shall be deemed effective as of the date
+ CC0 was applied by Affirmer to the Work. Should any part of the License for any
+ reason be judged legally invalid or ineffective under applicable law, such
+ partial invalidity or ineffectiveness shall not invalidate the remainder of the
+ License, and in such case Affirmer hereby affirms that he or she will not (i)
+ exercise any of his or her remaining Copyright and Related Rights in the Work
+ or (ii) assert any associated claims and causes of action with respect to the
+ Work, in either case contrary to Affirmer's express Statement of Purpose.
+ 4. Limitations and Disclaimers.
+     No trademark or patent rights held by Affirmer are waived, abandoned,
+ surrendered, licensed or otherwise affected by this document.  Affirmer offers
+ the Work as-is and makes no representations or warranties of any kind
+ concerning the Work, express, implied, statutory or otherwise, including
+ without limitation warranties of title, merchantability, fitness for a
+ particular purpose, non infringement, or the absence of latent or other
+ defects, accuracy, or the present or absence of errors, whether or not
+ discoverable, all to the greatest extent permissible under applicable law.
+ Affirmer disclaims responsibility for clearing rights of other persons that may
+ apply to the Work or any use thereof, including without limitation any person's
+ Copyright and Related Rights in the Work. Further, Affirmer disclaims
+ responsibility for obtaining any necessary consents, permissions or other
+ rights required for any use of the Work.  Affirmer understands and acknowledges
+ that Creative Commons is not a party to this document and has no duty or
+ obligation with respect to this CC0 or use of the Work.
+
+License: BSD-MIT
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.


### PR DESCRIPTION
This is a set of patches to fix up errors and warnings in the debian
files that reported by lintian [1]. It includes debian/copyright file
according to debian's format [2].

[1]
E: rdma-core changes: bad-distribution-in-changes-file unstable
W: rdma-core source: native-package-with-dash-version
E: rdma-core source: build-depends-on-build-essential build-depends
W: rdma-core source: no-debian-copyright
W: ibverbs-providers: new-package-should-close-itp-bug
E: ibverbs-providers: no-copyright-file
W: libibcm1-dbg: new-package-should-close-itp-bug
E: libibcm1-dbg: no-copyright-file
W: librdmacm1: new-package-should-close-itp-bug
E: librdmacm1: no-copyright-file
W: libibumad3-dbg: new-package-should-close-itp-bug
E: libibumad3-dbg: no-copyright-file
W: rdma-core: new-package-should-close-itp-bug
E: rdma-core: no-copyright-file
W: ibacm: new-package-should-close-itp-bug
E: ibacm: no-copyright-file
W: libibverbs1-dbg: new-package-should-close-itp-bug
E: libibverbs1-dbg: no-copyright-file
W: librdmacm-dev: new-package-should-close-itp-bug
E: librdmacm-dev: no-copyright-file
W: srptools: new-package-should-close-itp-bug
E: srptools: no-copyright-file
W: libibverbs1: new-package-should-close-itp-bug
E: libibverbs1: no-copyright-file
W: rdmacm-utils: new-package-should-close-itp-bug
E: rdmacm-utils: no-copyright-file
W: libibverbs-dev: new-package-should-close-itp-bug
E: libibverbs-dev: no-copyright-file
W: libibcm-dev: new-package-should-close-itp-bug
E: libibcm-dev: no-copyright-file
W: iwpmd: new-package-should-close-itp-bug
E: iwpmd: no-copyright-file
W: libibumad3: new-package-should-close-itp-bug
E: libibumad3: no-copyright-file
W: libibcm1: new-package-should-close-itp-bug
E: libibcm1: no-copyright-file
W: ibverbs-utils: new-package-should-close-itp-bug
E: ibverbs-utils: no-copyright-file
W: libibumad-dev: new-package-should-close-itp-bug
E: libibumad-dev: no-copyright-file
W: librdmacm1-dbg: new-package-should-close-itp-bug
E: librdmacm1-dbg: no-copyright-file

[2]
https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/