### PR TITLE
Fix build failures on arm32

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
       - lib32gcc-6-dev
 
 script:
-  - mkdir build build-clang build32
+  - mkdir build build-clang build32 build-no-dma
   - cd build
   # The goal is warning free compile on latest gcc.
   - CC=gcc-6 CFLAGS=-Werror cmake -GNinja ..
@@ -52,4 +52,11 @@ script:
   # travis's trusty is not configured in a way that enables all 32 bit
   # packages. We could fix this with some sudo stuff.. For now turn off libnl
   - CC=gcc-6 CFLAGS="-Werror -m32" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0
+  - ninja
+
+  # Test with coherent DMA mode disabled (ie as would be on ARM32, etc)
+  - cd ../build-clang
+  - echo "#error Fail" >> ../libibverbs/arch.h
+  - rm CMakeCache.txt
+  - CC=clang-3.9 CFLAGS=-Werror cmake -GNinja ..
   - ninja

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,13 +381,13 @@ add_subdirectory(providers/mthca)
 add_subdirectory(providers/nes)
 add_subdirectory(providers/ocrdma)
 add_subdirectory(providers/qedr)
+add_subdirectory(providers/vmw_pvrdma)
 endif()
 
 add_subdirectory(providers/hfi1verbs)
 add_subdirectory(providers/ipathverbs)
 add_subdirectory(providers/rxe)
 add_subdirectory(providers/rxe/man)
-add_subdirectory(providers/vmw_pvrdma)
 
 # Binaries
 add_subdirectory(ibacm)


### PR DESCRIPTION
The vmw driver was done before the ARM32 support, and the merge didn't quite work out.

@aditr 