### PR TITLE
libibverbs: ibv_*_pingpong manpage and usage consistency

### DIFF
--- a/libibverbs/examples/ud_pingpong.c
+++ b/libibverbs/examples/ud_pingpong.c
@@ -544,6 +544,7 @@ static void usage(const char *argv0)
 	printf("  -s, --size=<size>      size of message to exchange (default 2048)\n");
 	printf("  -r, --rx-depth=<dep>   number of receives to post at a time (default 500)\n");
 	printf("  -n, --iters=<iters>    number of exchanges (default 1000)\n");
+        printf("  -l, --sl=<SL>          send messages with service level <SL> (default 0)\n");
 	printf("  -e, --events           sleep on CQ events (default poll)\n");
 	printf("  -g, --gid-idx=<gid index> local port gid index\n");
 }

--- a/libibverbs/man/ibv_rc_pingpong.1
+++ b/libibverbs/man/ibv_rc_pingpong.1
@@ -6,12 +6,14 @@ ibv_rc_pingpong \- simple InfiniBand RC transport test
 
 .SH SYNOPSIS
 .B ibv_rc_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e] \fBHOSTNAME\fR
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
+[\-o] [\-t] \fBHOSTNAME\fR
 
 .B ibv_rc_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e]
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
+[\-o] [\-t]
 
 .SH DESCRIPTION
 .PP
@@ -34,6 +36,9 @@ use IB port \fIPORT\fR (default port 1)
 \fB\-s\fR, \fB\-\-size\fR=\fISIZE\fR
 ping-pong messages of size \fISIZE\fR (default 4096)
 .TP
+\fB\-m\fR, \fB\-\-mtu\fR=\fISIZE\fR
+path MTU \fISIZE\fR (default 1024)
+.TP
 \fB\-r\fR, \fB\-\-rx\-depth\fR=\fIDEPTH\fR
 post \fIDEPTH\fR receives at a time (default 1000)
 .TP
@@ -46,11 +51,21 @@ use \fISL\fR as the service level value of the QP (default 0)
 \fB\-e\fR, \fB\-\-events\fR
 sleep while waiting for work completion events (default is to poll for
 completions)
+.TP
+\fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
+local port \fIGIDINDEX\fR
+.TP
+\fB\-o\fR, \fB\-\-odp\fR
+use on demand paging
+.TP
+\fB\-t\fR, \fB\-\-ts\fR
+get CQE with timestamp
 
 .SH SEE ALSO
 .BR ibv_uc_pingpong (1),
 .BR ibv_ud_pingpong (1),
-.BR ibv_srq_pingpong (1)
+.BR ibv_srq_pingpong (1),
+.BR ibv_xsrq_pingpong (1)
 
 .SH AUTHORS
 .TP

--- a/libibverbs/man/ibv_srq_pingpong.1
+++ b/libibverbs/man/ibv_srq_pingpong.1
@@ -6,12 +6,14 @@ ibv_srq_pingpong \- simple InfiniBand shared receive queue test
 
 .SH SYNOPSIS
 .B ibv_srq_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-q num QPs] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e] \fBHOSTNAME\fR
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-q num QPs] [\-r rx depth] [\-n iters] [\-l sl] [\-e]
+[\-g gid index] \fBHOSTNAME\fR
 
 .B ibv_srq_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-q num QPs] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e]
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-q num QPs] [\-r rx depth] [\-n iters] [\-l sl] [\-e]
+[\-g gid index]
 
 .SH DESCRIPTION
 .PP
@@ -35,6 +37,9 @@ use IB port \fIPORT\fR (default port 1)
 \fB\-s\fR, \fB\-\-size\fR=\fISIZE\fR
 ping-pong messages of size \fISIZE\fR (default 4096)
 .TP
+\fB\-m\fR, \fB\-\-mtu\fR=\fISIZE\fR
+path MTU \fISIZE\fR (default 1024)
+.TP
 \fB\-q\fR, \fB\-\-num\-qp\fR=\fINUM\fR
 use \fINUM\fR queue pairs for test (default 16)
 .TP
@@ -50,11 +55,15 @@ use \fISL\fR as the service level value of the QPs (default 0)
 \fB\-e\fR, \fB\-\-events\fR
 sleep while waiting for work completion events (default is to poll for
 completions)
+.TP
+\fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
+local port \fIGIDINDEX\fR
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),
 .BR ibv_uc_pingpong (1),
-.BR ibv_ud_pingpong (1)
+.BR ibv_ud_pingpong (1),
+.BR ibv_xsrq_pingpong (1)
 
 .SH AUTHORS
 .TP

--- a/libibverbs/man/ibv_uc_pingpong.1
+++ b/libibverbs/man/ibv_uc_pingpong.1
@@ -6,12 +6,13 @@ ibv_uc_pingpong \- simple InfiniBand UC transport test
 
 .SH SYNOPSIS
 .B ibv_uc_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e] \fBHOSTNAME\fR
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
+\fBHOSTNAME\fR
 
 .B ibv_uc_pingpong
-[\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e]
+[\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
+[\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
 
 .SH DESCRIPTION
 .PP
@@ -34,6 +35,9 @@ use IB port \fIPORT\fR (default port 1)
 \fB\-s\fR, \fB\-\-size\fR=\fISIZE\fR
 ping-pong messages of size \fISIZE\fR (default 4096)
 .TP
+\fB\-m\fR, \fB\-\-mtu\fR=\fISIZE\fR
+path MTU \fISIZE\fR (default 1024)
+.TP
 \fB\-r\fR, \fB\-\-rx\-depth\fR=\fIDEPTH\fR
 post \fIDEPTH\fR receives at a time (default 1000)
 .TP
@@ -46,11 +50,15 @@ use \fISL\fR as the service level value of the QP (default 0)
 \fB\-e\fR, \fB\-\-events\fR
 sleep while waiting for work completion events (default is to poll for
 completions)
+.TP
+\fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
+local port \fIGIDINDEX\fR
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),
 .BR ibv_ud_pingpong (1),
-.BR ibv_srq_pingpong (1)
+.BR ibv_srq_pingpong (1),
+.BR ibv_xsrq_pingpong (1)
 
 .SH AUTHORS
 .TP

--- a/libibverbs/man/ibv_ud_pingpong.1
+++ b/libibverbs/man/ibv_ud_pingpong.1
@@ -7,11 +7,11 @@ ibv_ud_pingpong \- simple InfiniBand UD transport test
 .SH SYNOPSIS
 .B ibv_ud_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e] \fBHOSTNAME\fR
+[\-n iters] [\-l sl] [\-e] [\-g gid index] \fBHOSTNAME\fR
 
 .B ibv_ud_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-r rx depth]
-[\-n iters] [\-l sl] [\-e]
+[\-n iters] [\-l sl] [\-e] [\-g gid index]
 
 .SH DESCRIPTION
 .PP
@@ -46,11 +46,15 @@ send messages with service level \fISL\fR (default 0)
 \fB\-e\fR, \fB\-\-events\fR
 sleep while waiting for work completion events (default is to poll for
 completions)
+.TP
+\fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
+local port \fIGIDINDEX\fR
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),
 .BR ibv_uc_pingpong (1),
-.BR ibv_srq_pingpong (1)
+.BR ibv_srq_pingpong (1),
+.BR ibv_xsrq_pingpong (1)
 
 .SH AUTHORS
 .TP

--- a/libibverbs/man/ibv_xsrq_pingpong.1
+++ b/libibverbs/man/ibv_xsrq_pingpong.1
@@ -7,11 +7,11 @@ ibv_xsrq_pingpong \- simple InfiniBand shared receive queue test
 .SH SYNOPSIS
 .B ibv_xsrq_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m mtu] [\-c clients]
-[\-n num_tests] [\-l sl] [\-e] \fBHOSTNAME\fR
+[\-n num_tests] [\-l sl] [\-e] [\-g gid index] \fBHOSTNAME\fR
 
 .B ibv_xsrq_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m mtu] [\-c clients]
-[\-n num_tests] [\-l sl] [\-e]
+[\-n num_tests] [\-l sl] [\-e] [\-g gid index]
 
 .SH DESCRIPTION
 .PP
@@ -49,6 +49,9 @@ use \fISL\fR as the service level value (default 0)
 \fB\-e\fR, \fB\-\-events\fR
 sleep while waiting for work completion events (default is to poll for
 completions)
+.TP
+\fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
+local port \fIGIDINDEX\fR
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),


### PR DESCRIPTION
Several of the ibv pingpong utilities had inconsistent options listed in their usage and manpages.  This pull request aims to make them consistent by adding in the options where they were missing.  Additionally, ibv_{ud|uc|rc|srq}_pingpong manpages all have a pointer back to ibv_xsrq_pingpong's manpage, since ibv_xsrq_pingpong's manpage points out to all of them.