### PR TITLE
Make the provider facing libibverbs interface private

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set(PACKAGE_NAME "RDMA")
 
 # See Documentation/versioning.md
-set(PACKAGE_VERSION "12")
+set(PACKAGE_VERSION "13")
 
 #-------------------------
 # Basic standard paths

--- a/Documentation/versioning.md
+++ b/Documentation/versioning.md
@@ -138,3 +138,25 @@ $ readelf -s build/lib/libibumad.so.3.1.11
 ```
 
 Finally update the `debian/libibumad3.symbols` file.
+
+## Private symbols in libibverbs
+
+Many symbols in libibverbs are private to rdma-core, they are being marked in
+the map file using the IBVERBS_PRIVATE_ prefix.
+
+For simplicity, there is only one version of the private symbol version
+stanza, and it is bumped whenever any change (add/remove/modify) to any of the
+private ABI is done. This makes it very clear if an incompatible provider is
+being used with libibverbs.
+
+Due to this there is no reason to provide compat symbol versions for the
+private ABI.
+
+### Use of private symbols between component packages
+
+A distribution packaging system still must have the correct dependencies
+between libraries within rdma-core that may use these private symbols.
+
+For this reason the private symbols can only be used by provider libraries and
+the distribution must ensure that a matched set of provider libraries and
+libibverbs are installed.

--- a/Documentation/versioning.md
+++ b/Documentation/versioning.md
@@ -17,37 +17,49 @@ When the PACKAGE_VERSION is changed, the packaging files should be updated:
 
 ```diff
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 389feee1e0f9..63854fe8f07f 100644
+index 8f7a47580f7b95..45cbc4e018b296 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -26,7 +26,7 @@ project(RDMA C)
+@@ -44,7 +44,7 @@ endif()
  set(PACKAGE_NAME "RDMA")
  
  # See Documentation/versioning.md
--set(PACKAGE_VERSION "11")
-+set(PACKAGE_VERSION "12")
+-set(PACKAGE_VERSION "12")
++set(PACKAGE_VERSION "13")
  
  #-------------------------
  # Basic standard paths
+diff --git a/debian/changelog b/debian/changelog
+index 6cabcc483ca85e..3defc050c5e457 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,4 +1,4 @@
+-rdma-core (12-1) unstable; urgency=low
++rdma-core (13-1) unstable; urgency=low
+ 
+   * New version.
+   * Adding debian/copyright.
 diff --git a/rdma-core.spec b/rdma-core.spec
-index d1407ee9e24b..fca79ccf57e5 100644
+index 41eedb2813c52d..6519bc370a230a 100644
 --- a/rdma-core.spec
 +++ b/rdma-core.spec
 @@ -1,5 +1,5 @@
  Name: rdma-core
--Version: 11
-+Version: 12
+-Version: 12
++Version: 13
  Release: 1%{?dist}
- Summary: Userspace components for the Linux Kernel\'s drivers/infiniband stack
-diff --git a/debian/changelog b/debian/changelog
-index 0e6cba0be464..a12ac6b60028 100644
---- a/debian/changelog
-+++ b/debian/changelog
-@@ -1,4 +1,4 @@
--rdma-core (11-1) unstable; urgency=low
-+rdma-core (12-1) unstable; urgency=low
+ Summary: RDMA core userspace libraries and daemons
  
-   * New version
+diff --git a/redhat/rdma-core.spec b/redhat/rdma-core.spec
+index 4271e7c9817e67..f2198ee3cd9410 100644
+--- a/redhat/rdma-core.spec
++++ b/redhat/rdma-core.spec
+@@ -1,5 +1,5 @@
+ Name: rdma-core
+-Version: 12
++Version: 13
+ Release: 1%{?dist}
+ Summary: RDMA core userspace libraries and daemons
  
 ```
 

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -74,7 +74,18 @@ def check_lib_symver(args,fn):
         raise ValueError("Symbol version %r implied by filename %r not in ELF (%r)"%(
             newest_symver,fn,syms));
 
-    syms = list(syms);
+    # The private symbol tag should also be older than the package version
+    private = set(I for I in syms if "PRIVATE" in I)
+    if len(private) > 1:
+        raise ValueError("Too many private symbol versions in ELF %r (%r)"%(fn,private));
+    if private:
+        private_rel = list(private)[0].split('_')[-1];
+        print repr(private_rel)
+        if private_rel > args.PACKAGE_VERSION:
+            raise ValueError("Private Symbol Version %r is newer than the package version %r"%(
+                private,args.PACKAGE_VERSION));
+
+    syms = list(syms - private);
     syms.sort(key=lambda x:re.split('[._]',x));
     if newest_symver != syms[-1]:
         raise ValueError("Symbol version %r implied by filename %r not the newest in ELF (%r)"%(

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Copyright 2017 Obsidian Research Corp. See COPYING.
+"""check-build - Run static checks on a build"""
+import argparse
+import inspect
+import os
+import re
+import subprocess
+from contextlib import contextmanager;
+
+def get_src_dir():
+    """Get the source directory using git"""
+    git_top = subprocess.check_output(["git","rev-parse","--git-dir"]).strip();
+    if git_top == ".git":
+        return ".";
+    return os.path.dirname(git_top);
+
+def get_package_version(args):
+    """Return PACKAGE_VERSION from CMake"""
+    with open(os.path.join(args.SRC,"CMakeLists.txt")) as F:
+        for ln in F:
+            g = re.match(r'^set\(PACKAGE_VERSION "(.+)"\)',ln)
+            if g is None:
+                continue;
+            return g.group(1);
+    raise RuntimeError("Could not find version");
+
+@contextmanager
+def inDirectory(dir):
+    cdir = os.getcwd();
+    try:
+        os.chdir(dir);
+        yield True;
+    finally:
+        os.chdir(cdir);
+
+# -------------------------------------------------------------------------
+
+def get_symbol_vers(fn):
+    """Return the symbol version suffixes from the ELF file, eg IB_VERBS_1.0, etc"""
+    syms = subprocess.check_output(["readelf","--wide","-s",fn]);
+    go = False;
+    res = set();
+    for I in syms.splitlines():
+        if I.startswith("Symbol table '.dynsym'"):
+            go = True;
+            continue;
+
+        if I.startswith(" ") and go:
+            itms = I.split();
+            if (len(itms) == 8 and itms[3] == "OBJECT" and
+                itms[4] == "GLOBAL" and itms[6] == "ABS"):
+                res.add(itms[7]);
+        else:
+            go = False;
+    if not res:
+        raise ValueError("Faild to read ELF symbol versions from %r"%(fn));
+    return res;
+
+def check_lib_symver(args,fn):
+    g = re.match(r"lib([^.]+)\.so\.(\d+)\.(\d+)\.(.*)",fn);
+    if g.group(4) != args.PACKAGE_VERSION:
+        raise ValueError("Shared Library filename %r does not have the package version %r (%r)%"(
+            fn,args.PACKAGE_VERSION,g.groups()));
+
+    # umad used the wrong symbol version name when they moved to soname 3.0
+    if g.group(1) == "ibumad":
+        newest_symver = "%s_%s.%s"%(g.group(1).upper(),'1',g.group(3));
+    else:
+        newest_symver = "%s_%s.%s"%(g.group(1).upper(),g.group(2),g.group(3));
+
+    syms = get_symbol_vers(fn);
+    if newest_symver not in syms:
+        raise ValueError("Symbol version %r implied by filename %r not in ELF (%r)"%(
+            newest_symver,fn,syms));
+
+    syms = list(syms);
+    syms.sort(key=lambda x:re.split('[._]',x));
+    if newest_symver != syms[-1]:
+        raise ValueError("Symbol version %r implied by filename %r not the newest in ELF (%r)"%(
+            newest_symver,fn,syms));
+
+def test_lib_names(args):
+    """Check that the library filename matches the symbol versions"""
+    libd = os.path.join(args.BUILD,"lib");
+
+    # List of shlibs that follow the ABI guidelines
+    libs = {};
+    with inDirectory(libd):
+        for fn in os.listdir("."):
+            if os.path.islink(fn):
+                lfn = os.readlink(fn);
+                if not os.path.islink(lfn):
+                    check_lib_symver(args,lfn);
+
+# -------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser(description='Run build time tests')
+parser.add_argument("--build",default=os.getcwd(),dest="BUILD",
+                    help="Build directory to inpsect");
+parser.add_argument("--src",default=None,dest="SRC",
+                    help="Top of the source tree");
+args = parser.parse_args();
+
+if args.SRC is None:
+    args.SRC = get_src_dir();
+args.PACKAGE_VERSION = get_package_version(args);
+
+funcs = globals();
+for k,v in funcs.items():
+    if k.startswith("test_") and inspect.isfunction(v):
+        v(args);

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -10,6 +10,7 @@ cd build
 # The goal is warning free compile on latest gcc.
 CC=gcc-6 CFLAGS=-Werror cmake -GNinja ..
 ninja
+../buildlib/check-build --src ..
 
 # .. and latest clang
 cd ../build-clang

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rdma-core (12-1) unstable; urgency=low
+rdma-core (13-1) unstable; urgency=low
 
   * New version.
   * Adding debian/copyright.

--- a/debian/control
+++ b/debian/control
@@ -47,7 +47,7 @@ Description: Examples for the libibverbs library
 Package: ibverbs-providers
 Section: net
 Architecture: linux-any
-Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
+Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
 Provides: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
 Replaces: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
 Breaks: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1

--- a/debian/libibverbs-dev.install
+++ b/debian/libibverbs-dev.install
@@ -1,7 +1,4 @@
-usr/include/infiniband/arch.h
-usr/include/infiniband/driver.h
 usr/include/infiniband/kern-abi.h
-usr/include/infiniband/marshall.h
 usr/include/infiniband/opcode.h
 usr/include/infiniband/sa-kern-abi.h
 usr/include/infiniband/sa.h

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -85,6 +85,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_read_sysfs_file@IBVERBS_1.0 1.1.6
  ibv_reg_mr@IBVERBS_1.0 1.1.6
  ibv_reg_mr@IBVERBS_1.1 1.1.6
+ ibv_register_driver@IBVERBS_1.1 1.1.6
  ibv_rereg_mr@IBVERBS_1.1 1.2.1
  ibv_resize_cq@IBVERBS_1.0 1.1.6
  ibv_resize_cq@IBVERBS_1.1 1.1.6

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -1,6 +1,8 @@
 libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
+# This version should always reflect the current package version.
+ (regex|optional)"@IBVERBS_PRIVATE_" 12-1
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6
@@ -11,46 +13,6 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_attach_mcast@IBVERBS_1.1 1.1.6
  ibv_close_device@IBVERBS_1.0 1.1.6
  ibv_close_device@IBVERBS_1.1 1.1.6
- ibv_cmd_alloc_mw@IBVERBS_1.1 1.2.1
- ibv_cmd_alloc_pd@IBVERBS_1.0 1.1.6
- ibv_cmd_attach_mcast@IBVERBS_1.0 1.1.6
- ibv_cmd_close_xrcd@IBVERBS_1.1 1.1.8
- ibv_cmd_create_ah@IBVERBS_1.0 1.1.6
- ibv_cmd_create_cq@IBVERBS_1.0 1.1.6
- ibv_cmd_create_cq_ex@IBVERBS_1.0 1.2.1
- ibv_cmd_create_flow@IBVERBS_1.0 1.1.8
- ibv_cmd_create_qp@IBVERBS_1.0 1.1.6
- ibv_cmd_create_qp_ex2@IBVERBS_1.1 1.2.1
- ibv_cmd_create_qp_ex@IBVERBS_1.1 1.1.8
- ibv_cmd_create_srq@IBVERBS_1.0 1.1.6
- ibv_cmd_create_srq_ex@IBVERBS_1.1 1.1.8
- ibv_cmd_dealloc_mw@IBVERBS_1.1 1.2.1
- ibv_cmd_dealloc_pd@IBVERBS_1.0 1.1.6
- ibv_cmd_dereg_mr@IBVERBS_1.0 1.1.6
- ibv_cmd_destroy_ah@IBVERBS_1.0 1.1.6
- ibv_cmd_destroy_cq@IBVERBS_1.0 1.1.6
- ibv_cmd_destroy_flow@IBVERBS_1.0 1.1.8
- ibv_cmd_destroy_qp@IBVERBS_1.0 1.1.6
- ibv_cmd_destroy_srq@IBVERBS_1.0 1.1.6
- ibv_cmd_detach_mcast@IBVERBS_1.0 1.1.6
- ibv_cmd_get_context@IBVERBS_1.0 1.1.6
- ibv_cmd_modify_qp@IBVERBS_1.0 1.1.6
- ibv_cmd_modify_srq@IBVERBS_1.0 1.1.6
- ibv_cmd_open_qp@IBVERBS_1.1 1.1.8
- ibv_cmd_open_xrcd@IBVERBS_1.1 1.1.8
- ibv_cmd_poll_cq@IBVERBS_1.0 1.1.6
- ibv_cmd_post_recv@IBVERBS_1.0 1.1.6
- ibv_cmd_post_send@IBVERBS_1.0 1.1.6
- ibv_cmd_post_srq_recv@IBVERBS_1.0 1.1.6
- ibv_cmd_query_device@IBVERBS_1.0 1.1.6
- ibv_cmd_query_device_ex@IBVERBS_1.0 1.2.0
- ibv_cmd_query_port@IBVERBS_1.0 1.1.6
- ibv_cmd_query_qp@IBVERBS_1.0 1.1.6
- ibv_cmd_query_srq@IBVERBS_1.0 1.1.6
- ibv_cmd_reg_mr@IBVERBS_1.0 1.1.6
- ibv_cmd_req_notify_cq@IBVERBS_1.0 1.1.6
- ibv_cmd_rereg_mr@IBVERBS_1.1 1.2.1
- ibv_cmd_resize_cq@IBVERBS_1.0 1.1.6
  ibv_copy_ah_attr_from_kern@IBVERBS_1.1 1.1.6
  ibv_copy_path_rec_from_kern@IBVERBS_1.0 1.1.6
  ibv_copy_path_rec_to_kern@IBVERBS_1.0 1.1.6
@@ -123,7 +85,6 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_read_sysfs_file@IBVERBS_1.0 1.1.6
  ibv_reg_mr@IBVERBS_1.0 1.1.6
  ibv_reg_mr@IBVERBS_1.1 1.1.6
- ibv_register_driver@IBVERBS_1.1 1.1.6
  ibv_rereg_mr@IBVERBS_1.1 1.2.1
  ibv_resize_cq@IBVERBS_1.0 1.1.6
  ibv_resize_cq@IBVERBS_1.1 1.1.6
@@ -131,4 +92,3 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_wc_status_str@IBVERBS_1.1 1.1.6
  mbps_to_ibv_rate@IBVERBS_1.1 1.1.8
  mult_to_ibv_rate@IBVERBS_1.0 1.1.6
- verbs_register_driver@IBVERBS_1.1 1.1.8

--- a/libibumad/CMakeLists.txt
+++ b/libibumad/CMakeLists.txt
@@ -9,7 +9,7 @@ publish_headers(infiniband
 
 rdma_library(ibumad libibumad.map
   # See Documentation/versioning.md
-  3 3.1.${PACKAGE_VERSION}
+  3 3.0.${PACKAGE_VERSION}
   sysfs.c
   umad.c
   umad_str.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 rdma_library(ibverbs libibverbs.map
   # See Documentation/versioning.md
-  1 1.3.${PACKAGE_VERSION}
+  1 1.4.${PACKAGE_VERSION}
   cmd.c
   compat-1_0.c
   device.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -1,12 +1,15 @@
 publish_headers(infiniband
-  arch.h
-  driver.h
   kern-abi.h
-  marshall.h
   opcode.h
   sa-kern-abi.h
   sa.h
   verbs.h
+  )
+
+publish_internal_headers(infiniband
+  arch.h
+  driver.h
+  marshall.h
   )
 
 if (NOT NL_KIND EQUAL 0)
@@ -17,7 +20,7 @@ endif()
 
 rdma_library(ibverbs libibverbs.map
   # See Documentation/versioning.md
-  1 1.4.${PACKAGE_VERSION}
+  1 1.1.${PACKAGE_VERSION}
   cmd.c
   compat-1_0.c
   device.c

--- a/libibverbs/compat-1_0.c
+++ b/libibverbs/compat-1_0.c
@@ -937,3 +937,14 @@ int __ibv_detach_mcast_1_0(struct ibv_qp_1_0 *qp, union ibv_gid *gid, uint16_t l
 	return ibv_detach_mcast(qp->real_qp, gid, lid);
 }
 symver(__ibv_detach_mcast_1_0, ibv_detach_mcast, IBVERBS_1.0);
+
+typedef struct ibv_device *(*ibv_driver_init_func_1_1)(const char *uverbs_sys_path,
+						       int abi_version);
+void __ibv_register_driver_1_1(const char *name, ibv_driver_init_func init_func_1_1)
+{
+	/* The driver interface is private as of rdma-core 13. This stub is
+	 * left to preserve dynamic-link compatability with old libfabrics
+	 * usnic providers which use this function only to suppress a fprintf
+	 * in old versions of libibverbs. */
+}
+symver(__ibv_register_driver_1_1, ibv_register_driver, IBVERBS_1.1);

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -47,6 +47,8 @@
 #define symver(name, api, ver) asm(".symver " #name "," #api "@" #ver)
 #define default_symver(name, api)                                              \
 	asm(".symver " #name "," #api "@@" DEFAULT_ABI)
+#define private_symver(name, api)                                              \
+	asm(".symver " #name "," #api "@@IBVERBS_PRIVATE_13")
 
 #define PFX		"libibverbs: "
 

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -48,6 +48,8 @@
 
 #include "ibverbs.h"
 
+#pragma GCC diagnostic ignored "-Wmissing-prototypes"
+
 int abi_ver;
 
 struct ibv_sysfs_dev {
@@ -175,10 +177,11 @@ static void register_driver(const char *name, ibv_driver_init_func init_func,
 	tail_driver = driver;
 }
 
-void ibv_register_driver(const char *name, ibv_driver_init_func init_func)
+void __ibv_register_driver(const char *name, ibv_driver_init_func init_func)
 {
 	register_driver(name, init_func, NULL);
 }
+private_symver(__ibv_register_driver, ibv_register_driver);
 
 /* New registration symbol with same functionality - used by providers to
   * validate that library supports verbs extension.

--- a/libibverbs/libibverbs.map
+++ b/libibverbs/libibverbs.map
@@ -65,6 +65,7 @@ IBVERBS_1.1 {
 		ibv_fork_init;
 		ibv_dontfork_range;
 		ibv_dofork_range;
+		ibv_register_driver;
 
 		ibv_node_type_str;
 		ibv_port_state_str;
@@ -84,7 +85,7 @@ IBVERBS_1.1 {
 /* NOTE: The next stanza for public symbols should be IBVERBS_1.4 due to release 12 */
 
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
-   version. */
+   version. Also see the private_symver() macro */
 IBVERBS_PRIVATE_13 {
 	global:
 		/* These historical symbols are now private to libibverbs */

--- a/libibverbs/libibverbs.map
+++ b/libibverbs/libibverbs.map
@@ -37,43 +37,14 @@ IBVERBS_1.0 {
 		ibv_destroy_ah;
 		ibv_attach_mcast;
 		ibv_detach_mcast;
-		ibv_cmd_get_context;
-		ibv_cmd_query_device;
-		ibv_cmd_query_device_ex;
-		ibv_cmd_query_port;
-		ibv_cmd_query_gid;
-		ibv_cmd_query_pkey;
-		ibv_cmd_alloc_pd;
-		ibv_cmd_dealloc_pd;
-		ibv_cmd_reg_mr;
-		ibv_cmd_dereg_mr;
-		ibv_cmd_create_cq;
-		ibv_cmd_create_cq_ex;
-		ibv_cmd_poll_cq;
-		ibv_cmd_req_notify_cq;
-		ibv_cmd_resize_cq;
-		ibv_cmd_destroy_cq;
-		ibv_cmd_create_srq;
-		ibv_cmd_modify_srq;
-		ibv_cmd_query_srq;
-		ibv_cmd_destroy_srq;
-		ibv_cmd_create_qp;
-		ibv_cmd_query_qp;
-		ibv_cmd_modify_qp;
-		ibv_cmd_destroy_qp;
-		ibv_cmd_post_send;
-		ibv_cmd_post_recv;
-		ibv_cmd_post_srq_recv;
-		ibv_cmd_destroy_ah;
-		ibv_cmd_attach_mcast;
-		ibv_cmd_detach_mcast;
-		ibv_cmd_create_flow;
-		ibv_cmd_destroy_flow;
-		ibv_copy_qp_attr_from_kern;
-		ibv_copy_path_rec_from_kern;
-		ibv_copy_path_rec_to_kern;
 		ibv_rate_to_mult;
 		mult_to_ibv_rate;
+
+		/* These historical symbols are now private to libibverbs, but used by
+		   other rdma-core libraries. Do not change them. */
+		ibv_copy_path_rec_from_kern;
+		ibv_copy_path_rec_to_kern;
+		ibv_copy_qp_attr_from_kern;
 		ibv_get_sysfs_path;
 		ibv_read_sysfs_file;
 
@@ -91,48 +62,81 @@ IBVERBS_1.1 {
 
 		ibv_init_ah_from_wc;
 		ibv_create_ah_from_wc;
-		ibv_copy_ah_attr_from_kern;
 		ibv_fork_init;
 		ibv_dontfork_range;
 		ibv_dofork_range;
-		ibv_register_driver;
-		verbs_register_driver;
 
 		ibv_node_type_str;
 		ibv_port_state_str;
 		ibv_event_type_str;
 		ibv_wc_status_str;
 
-		ibv_cmd_alloc_mw;
-		ibv_cmd_dealloc_mw;
-
 		ibv_rate_to_mbps;
 		mbps_to_ibv_rate;
 
 		ibv_resolve_eth_l2_from_gid;
 
-		ibv_cmd_open_xrcd;
-		ibv_cmd_close_xrcd;
-		ibv_cmd_create_srq_ex;
-		ibv_cmd_create_qp_ex;
-		ibv_cmd_create_qp_ex2;
-		ibv_cmd_open_qp;
-		ibv_cmd_rereg_mr;
-
+		/* These historical symbols are now private to libibverbs, but used by
+		   other rdma-core libraries. Do not change them. */
+		ibv_copy_ah_attr_from_kern;
 } IBVERBS_1.0;
 
-IBVERBS_1.3 {
-	global:
-		ibv_cmd_create_wq;
-		ibv_cmd_modify_wq;
-		ibv_cmd_destroy_wq;
-		ibv_cmd_create_rwq_ind_table;
-		ibv_cmd_destroy_rwq_ind_table;
-		ibv_query_gid_type;
-} IBVERBS_1.1;
+/* NOTE: The next stanza for public symbols should be IBVERBS_1.4 due to release 12 */
 
-IBVERBS_1.4 {
+/* If any symbols in this stanza change ABI then the entire staza gets a new symbol
+   version. */
+IBVERBS_PRIVATE_13 {
 	global:
-		ibv_cmd_modify_qp_ex;
+		/* These historical symbols are now private to libibverbs */
+		ibv_cmd_alloc_mw;
+		ibv_cmd_alloc_pd;
+		ibv_cmd_attach_mcast;
+		ibv_cmd_close_xrcd;
 		ibv_cmd_create_ah;
-} IBVERBS_1.3;
+		ibv_cmd_create_cq;
+		ibv_cmd_create_cq_ex;
+		ibv_cmd_create_flow;
+		ibv_cmd_create_qp;
+		ibv_cmd_create_qp_ex2;
+		ibv_cmd_create_qp_ex;
+		ibv_cmd_create_rwq_ind_table;
+		ibv_cmd_create_srq;
+		ibv_cmd_create_srq_ex;
+		ibv_cmd_create_wq;
+		ibv_cmd_dealloc_mw;
+		ibv_cmd_dealloc_pd;
+		ibv_cmd_dereg_mr;
+		ibv_cmd_destroy_ah;
+		ibv_cmd_destroy_cq;
+		ibv_cmd_destroy_flow;
+		ibv_cmd_destroy_qp;
+		ibv_cmd_destroy_rwq_ind_table;
+		ibv_cmd_destroy_srq;
+		ibv_cmd_destroy_wq;
+		ibv_cmd_detach_mcast;
+		ibv_cmd_get_context;
+		ibv_cmd_modify_qp;
+		ibv_cmd_modify_qp_ex;
+		ibv_cmd_modify_srq;
+		ibv_cmd_modify_wq;
+		ibv_cmd_open_qp;
+		ibv_cmd_open_xrcd;
+		ibv_cmd_poll_cq;
+		ibv_cmd_post_recv;
+		ibv_cmd_post_send;
+		ibv_cmd_post_srq_recv;
+		ibv_cmd_query_device;
+		ibv_cmd_query_device_ex;
+		ibv_cmd_query_gid;
+		ibv_cmd_query_pkey;
+		ibv_cmd_query_port;
+		ibv_cmd_query_qp;
+		ibv_cmd_query_srq;
+		ibv_cmd_reg_mr;
+		ibv_cmd_req_notify_cq;
+		ibv_cmd_rereg_mr;
+		ibv_cmd_resize_cq;
+		ibv_query_gid_type;
+		ibv_register_driver;
+		verbs_register_driver;
+};

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -10,7 +10,7 @@ publish_headers(infiniband
 
 rdma_library(rdmacm librdmacm.map
   # See Documentation/versioning.md
-  1 1.1.${PACKAGE_VERSION}
+  1 1.0.${PACKAGE_VERSION}
   acm.c
   addrinfo.c
   cma.c

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 12
+Version: 13
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 12
+Version: 13
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 


### PR DESCRIPTION
The first part is to remove the header files that define the
prototypes for these symbols from the set of packaged headers.
This ensures that nothing can compile and use these symbols.

Next we move the symbols into a new symbol version stanza only
for the private ABI. This breaks every existing out of-tree provider,
but the earlier change to ibv_cmd_create_ah already did that.

There are a few symbols that are still private by virtue of not being
in public headers, but these are used internally by the other libraries.
For distribution sanity continue to treat them as public ABI.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>