### PR TITLE
Updates for versioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 set(PACKAGE_NAME "RDMA")
 
 # See Documentation/versioning.md
-set(PACKAGE_VERSION "12")
+set(PACKAGE_VERSION "13")
 
 #-------------------------
 # Basic standard paths

--- a/Documentation/versioning.md
+++ b/Documentation/versioning.md
@@ -17,37 +17,49 @@ When the PACKAGE_VERSION is changed, the packaging files should be updated:
 
 ```diff
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index 389feee1e0f9..63854fe8f07f 100644
+index 8f7a47580f7b95..45cbc4e018b296 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -26,7 +26,7 @@ project(RDMA C)
+@@ -44,7 +44,7 @@ endif()
  set(PACKAGE_NAME "RDMA")
  
  # See Documentation/versioning.md
--set(PACKAGE_VERSION "11")
-+set(PACKAGE_VERSION "12")
+-set(PACKAGE_VERSION "12")
++set(PACKAGE_VERSION "13")
  
  #-------------------------
  # Basic standard paths
+diff --git a/debian/changelog b/debian/changelog
+index 6cabcc483ca85e..3defc050c5e457 100644
+--- a/debian/changelog
++++ b/debian/changelog
+@@ -1,4 +1,4 @@
+-rdma-core (12-1) unstable; urgency=low
++rdma-core (13-1) unstable; urgency=low
+ 
+   * New version.
+   * Adding debian/copyright.
 diff --git a/rdma-core.spec b/rdma-core.spec
-index d1407ee9e24b..fca79ccf57e5 100644
+index 41eedb2813c52d..6519bc370a230a 100644
 --- a/rdma-core.spec
 +++ b/rdma-core.spec
 @@ -1,5 +1,5 @@
  Name: rdma-core
--Version: 11
-+Version: 12
+-Version: 12
++Version: 13
  Release: 1%{?dist}
- Summary: Userspace components for the Linux Kernel\'s drivers/infiniband stack
-diff --git a/debian/changelog b/debian/changelog
-index 0e6cba0be464..a12ac6b60028 100644
---- a/debian/changelog
-+++ b/debian/changelog
-@@ -1,4 +1,4 @@
--rdma-core (11-1) unstable; urgency=low
-+rdma-core (12-1) unstable; urgency=low
+ Summary: RDMA core userspace libraries and daemons
  
-   * New version
+diff --git a/redhat/rdma-core.spec b/redhat/rdma-core.spec
+index 4271e7c9817e67..f2198ee3cd9410 100644
+--- a/redhat/rdma-core.spec
++++ b/redhat/rdma-core.spec
+@@ -1,5 +1,5 @@
+ Name: rdma-core
+-Version: 12
++Version: 13
+ Release: 1%{?dist}
+ Summary: RDMA core userspace libraries and daemons
  
 ```
 

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# Copyright 2017 Obsidian Research Corp. See COPYING.
+"""check-build - Run static checks on a build"""
+import argparse
+import inspect
+import os
+import re
+import subprocess
+from contextlib import contextmanager;
+
+def get_src_dir():
+    """Get the source directory using git"""
+    git_top = subprocess.check_output(["git","rev-parse","--git-dir"]).strip();
+    if git_top == ".git":
+        return ".";
+    return os.path.dirname(git_top);
+
+def get_package_version(args):
+    """Return PACKAGE_VERSION from CMake"""
+    with open(os.path.join(args.SRC,"CMakeLists.txt")) as F:
+        for ln in F:
+            g = re.match(r'^set\(PACKAGE_VERSION "(.+)"\)',ln)
+            if g is None:
+                continue;
+            return g.group(1);
+    raise RuntimeError("Could not find version");
+
+@contextmanager
+def inDirectory(dir):
+    cdir = os.getcwd();
+    try:
+        os.chdir(dir);
+        yield True;
+    finally:
+        os.chdir(cdir);
+
+# -------------------------------------------------------------------------
+
+def get_symbol_vers(fn):
+    """Return the symbol version suffixes from the ELF file, eg IB_VERBS_1.0, etc"""
+    syms = subprocess.check_output(["readelf","--wide","-s",fn]);
+    go = False;
+    res = set();
+    for I in syms.splitlines():
+        if I.startswith("Symbol table '.dynsym'"):
+            go = True;
+            continue;
+
+        if I.startswith(" ") and go:
+            itms = I.split();
+            if (len(itms) == 8 and itms[3] == "OBJECT" and
+                itms[4] == "GLOBAL" and itms[6] == "ABS"):
+                res.add(itms[7]);
+        else:
+            go = False;
+    if not res:
+        raise ValueError("Faild to read ELF symbol versions from %r"%(fn));
+    return res;
+
+def check_lib_symver(args,fn):
+    g = re.match(r"lib([^.]+)\.so\.(\d+)\.(\d+)\.(.*)",fn);
+    if g.group(4) != args.PACKAGE_VERSION:
+        raise ValueError("Shared Library filename %r does not have the package version %r (%r)%"(
+            fn,args.PACKAGE_VERSION,g.groups()));
+
+    # umad used the wrong symbol version name when they moved to soname 3.0
+    if g.group(1) == "ibumad":
+        newest_symver = "%s_%s.%s"%(g.group(1).upper(),'1',g.group(3));
+    else:
+        newest_symver = "%s_%s.%s"%(g.group(1).upper(),g.group(2),g.group(3));
+
+    syms = get_symbol_vers(fn);
+    if newest_symver not in syms:
+        raise ValueError("Symbol version %r implied by filename %r not in ELF (%r)"%(
+            newest_symver,fn,syms));
+
+    syms = list(syms);
+    syms.sort(key=lambda x:re.split('[._]',x));
+    if newest_symver != syms[-1]:
+        raise ValueError("Symbol version %r implied by filename %r not the newest in ELF (%r)"%(
+            newest_symver,fn,syms));
+
+def test_lib_names(args):
+    """Check that the library filename matches the symbol versions"""
+    libd = os.path.join(args.BUILD,"lib");
+
+    # List of shlibs that follow the ABI guidelines
+    libs = {};
+    with inDirectory(libd):
+        for fn in os.listdir("."):
+            if os.path.islink(fn):
+                lfn = os.readlink(fn);
+                if not os.path.islink(lfn):
+                    check_lib_symver(args,lfn);
+
+# -------------------------------------------------------------------------
+
+parser = argparse.ArgumentParser(description='Run build time tests')
+parser.add_argument("--build",default=os.getcwd(),dest="BUILD",
+                    help="Build directory to inpsect");
+parser.add_argument("--src",default=None,dest="SRC",
+                    help="Top of the source tree");
+args = parser.parse_args();
+
+if args.SRC is None:
+    args.SRC = get_src_dir();
+args.PACKAGE_VERSION = get_package_version(args);
+
+funcs = globals();
+for k,v in funcs.items():
+    if k.startswith("test_") and inspect.isfunction(v):
+        v(args);

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -10,6 +10,7 @@ cd build
 # The goal is warning free compile on latest gcc.
 CC=gcc-6 CFLAGS=-Werror cmake -GNinja ..
 ninja
+../buildlib/check-build --src ..
 
 # .. and latest clang
 cd ../build-clang

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rdma-core (12-1) unstable; urgency=low
+rdma-core (13-1) unstable; urgency=low
 
   * New version.
   * Adding debian/copyright.

--- a/libibumad/CMakeLists.txt
+++ b/libibumad/CMakeLists.txt
@@ -9,7 +9,7 @@ publish_headers(infiniband
 
 rdma_library(ibumad libibumad.map
   # See Documentation/versioning.md
-  3 3.1.${PACKAGE_VERSION}
+  3 3.0.${PACKAGE_VERSION}
   sysfs.c
   umad.c
   umad_str.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 
 rdma_library(ibverbs libibverbs.map
   # See Documentation/versioning.md
-  1 1.3.${PACKAGE_VERSION}
+  1 1.4.${PACKAGE_VERSION}
   cmd.c
   compat-1_0.c
   device.c

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -10,7 +10,7 @@ publish_headers(infiniband
 
 rdma_library(rdmacm librdmacm.map
   # See Documentation/versioning.md
-  1 1.1.${PACKAGE_VERSION}
+  1 1.0.${PACKAGE_VERSION}
   acm.c
   addrinfo.c
   cma.c

--- a/rdma-core.spec
+++ b/rdma-core.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 12
+Version: 13
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 12
+Version: 13
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 


### PR DESCRIPTION
Teach travis to check that the shared library versions and their internal symvers match our internal scheme.

This is to prevent recent mistakes in missing the cmakefile update when changing the map file.

Also update the package version to 13.

