### PR TITLE
Debian packaging changes from libibverbs 1.2.1-2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Build-Depends: cmake (>= 2.8.11),
 Standards-Version: 3.9.8
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
+Homepage: https://github.com/linux-rdma/rdma-core
 
 Package: ibacm
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -29,7 +29,6 @@ Description: InfiniBand Communication Manager Assistant (ACM)
  A primary user of the ibacm service is the librdmacm library.
 
 Package: ibverbs-utils
-Section: net
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Examples for the libibverbs library
@@ -46,7 +45,6 @@ Description: Examples for the libibverbs library
  ibv_devinfo, which displays information about InfiniBand devices.
 
 Package: ibverbs-providers
-Section: net
 Architecture: linux-any
 Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
 Provides: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
@@ -262,7 +260,6 @@ Description: Development files for the librdmacm library
  needed for compiling.
 
 Package: rdma-core
-Section: net
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: RDMA core userspace infrastructure and documentation.
@@ -270,7 +267,6 @@ Description: RDMA core userspace infrastructure and documentation.
  for systems that use the Linux kernel's RDMA subystem.
 
 Package: rdmacm-utils
-Section: net
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Examples for the librdmacm library

--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #!/usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+
 %:
 	dh $@ --with systemd --builddirectory=build-deb
 

--- a/debian/watch
+++ b/debian/watch
@@ -1,0 +1,2 @@
+version=3
+https://github.com/linux-rdma/rdma-core/releases (?:.*?/)?(?:rdma-core-|v)?(\d[\d.]*)\.tar\.gz

--- a/ibacm/man/ib_acme.1
+++ b/ibacm/man/ib_acme.1
@@ -49,7 +49,7 @@ Displays one (N = 1, 2, ...) or all endpoints (N = 0 or not present).
 \-P [opt]
 Queries performance data from the destination service.  Valid options are:
 "col" for outputting combined data in column format,  "N" (N = 1, 2, ...) for
-outputing data for a specific endpoint N,  "all" for outputting data for all
+outputting data for a specific endpoint N,  "all" for outputting data for all
 endpoints,  and "s" for outputting data for a specific endpoint with the address
 given by the -s option.
 .TP

--- a/ibacm/src/acme.c
+++ b/ibacm/src/acme.c
@@ -91,7 +91,7 @@ static void show_usage(char *program)
 	printf("   [-c]             - read ACM cached data only\n");
 	printf("   [-P [opt]]       - query performance data from destination service:\n");
 	printf("                        No option: output combined data in row format.\n");
-	printf("                        col: output combined data in colum format.\n");
+	printf("                        col: output combined data in column format.\n");
 	printf("                        N: output data for endpoint N (N = 1, 2,...)\n");
 	printf("                        all: output data for all endpoints\n");
 	printf("                        s: output data for the endpoint with the\n");

--- a/libibverbs/man/ibv_rereg_mr.3
+++ b/libibverbs/man/ibv_rereg_mr.3
@@ -57,7 +57,7 @@ represents the error as of below.
 .br
 IBV_REREG_MR_ERR_INPUT - Old MR is valid, an input error was detected by libibverbs.
 .br
-IBV_REREG_MR_ERR_DONT_FORK_NEW - Old MR is valid, failed via dont fork on new address range.
+IBV_REREG_MR_ERR_DONT_FORK_NEW - Old MR is valid, failed via don't fork on new address range.
 .br
 IBV_REREG_MR_ERR_DO_FORK_OLD - New MR is valid, failed via do fork on old address range.
 .br

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1687,7 +1687,7 @@ struct ibv_mr *ibv_reg_mr(struct ibv_pd *pd, void *addr,
 enum ibv_rereg_mr_err_code {
 	/* Old MR is valid, invalid input */
 	IBV_REREG_MR_ERR_INPUT = -1,
-	/* Old MR is valid, failed via dont fork on new address range */
+	/* Old MR is valid, failed via don't fork on new address range */
 	IBV_REREG_MR_ERR_DONT_FORK_NEW = -2,
 	/* New MR is valid, failed via do fork on old address range */
 	IBV_REREG_MR_ERR_DO_FORK_OLD = -3,

--- a/providers/i40iw/i40iw_uverbs.c
+++ b/providers/i40iw/i40iw_uverbs.c
@@ -286,7 +286,7 @@ struct ibv_cq *i40iw_ucreate_cq(struct ibv_context *context, int cqe,
 	if (!ret)
 		return &iwucq->ibv_cq;
 	else
-		fprintf(stderr, PFX "%s: failed to initialze CQ, status %d\n", __func__, ret);
+		fprintf(stderr, PFX "%s: failed to initialize CQ, status %d\n", __func__, ret);
 err:
 	if (info.cq_base)
 		free(info.cq_base);

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -1200,7 +1200,7 @@ static inline int ocrdma_build_inline_sges(struct ocrdma_qp *qp,
 		hdr->total_len = ocrdma_sglist_len(wr->sg_list, wr->num_sge);
 		if (hdr->total_len > qp->max_inline_data) {
 			ocrdma_err
-			("%s() supported_len=0x%x, unspported len req=0x%x\n",
+			("%s() supported_len=0x%x, unsupported len req=0x%x\n",
 			__func__, qp->max_inline_data, hdr->total_len);
 			return EINVAL;
 		}

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -1083,7 +1083,7 @@ int ocrdma_destroy_qp(struct ibv_qp *ibqp)
 		munmap(qp->sq.va, qp->sq.len);
 
 	/* ensure that CQEs for newly created QP (whose id may be same with
-	 * one which just getting destroyed are same), dont get
+	 * one which just getting destroyed are same), don't get
 	 * discarded until the old CQEs are discarded.
 	 */
 	pthread_mutex_lock(&dev->dev_lock);

--- a/providers/qedr/qelr_hsi_rdma.h
+++ b/providers/qedr/qelr_hsi_rdma.h
@@ -272,7 +272,7 @@ struct rdma_sq_atomic_wqe
 #define RDMA_SQ_ATOMIC_WQE_RD_FENCE_FLG_SHIFT    1
 #define RDMA_SQ_ATOMIC_WQE_INV_FENCE_FLG_MASK    0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_ATOMIC_WQE_INV_FENCE_FLG_SHIFT   2
-#define RDMA_SQ_ATOMIC_WQE_SE_FLG_MASK           0x1 /* Dont care for atomic wqe */
+#define RDMA_SQ_ATOMIC_WQE_SE_FLG_MASK           0x1 /* Don't care for atomic wqe */
 #define RDMA_SQ_ATOMIC_WQE_SE_FLG_SHIFT          3
 #define RDMA_SQ_ATOMIC_WQE_INLINE_FLG_MASK       0x1 /* Should be 0 for atomic wqe */
 #define RDMA_SQ_ATOMIC_WQE_INLINE_FLG_SHIFT      4
@@ -306,7 +306,7 @@ struct rdma_sq_atomic_wqe_1st
 #define RDMA_SQ_ATOMIC_WQE_1ST_RD_FENCE_FLG_SHIFT  1
 #define RDMA_SQ_ATOMIC_WQE_1ST_INV_FENCE_FLG_MASK  0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_ATOMIC_WQE_1ST_INV_FENCE_FLG_SHIFT 2
-#define RDMA_SQ_ATOMIC_WQE_1ST_SE_FLG_MASK         0x1 /* Dont care for atomic wqe */
+#define RDMA_SQ_ATOMIC_WQE_1ST_SE_FLG_MASK         0x1 /* Don't care for atomic wqe */
 #define RDMA_SQ_ATOMIC_WQE_1ST_SE_FLG_SHIFT        3
 #define RDMA_SQ_ATOMIC_WQE_1ST_INLINE_FLG_MASK     0x1 /* Should be 0 for atomic wqe */
 #define RDMA_SQ_ATOMIC_WQE_1ST_INLINE_FLG_SHIFT    4
@@ -350,7 +350,7 @@ struct rdma_sq_bind_wqe
 #define RDMA_SQ_BIND_WQE_RD_FENCE_FLG_SHIFT  1
 #define RDMA_SQ_BIND_WQE_INV_FENCE_FLG_MASK  0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_BIND_WQE_INV_FENCE_FLG_SHIFT 2
-#define RDMA_SQ_BIND_WQE_SE_FLG_MASK         0x1 /* Dont care for bind wqe */
+#define RDMA_SQ_BIND_WQE_SE_FLG_MASK         0x1 /* Don't care for bind wqe */
 #define RDMA_SQ_BIND_WQE_SE_FLG_SHIFT        3
 #define RDMA_SQ_BIND_WQE_INLINE_FLG_MASK     0x1 /* Should be 0 for bind wqe */
 #define RDMA_SQ_BIND_WQE_INLINE_FLG_SHIFT    4
@@ -401,7 +401,7 @@ struct rdma_sq_bind_wqe_1st
 #define RDMA_SQ_BIND_WQE_1ST_RD_FENCE_FLG_SHIFT  1
 #define RDMA_SQ_BIND_WQE_1ST_INV_FENCE_FLG_MASK  0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_BIND_WQE_1ST_INV_FENCE_FLG_SHIFT 2
-#define RDMA_SQ_BIND_WQE_1ST_SE_FLG_MASK         0x1 /* Dont care for bind wqe */
+#define RDMA_SQ_BIND_WQE_1ST_SE_FLG_MASK         0x1 /* Don't care for bind wqe */
 #define RDMA_SQ_BIND_WQE_1ST_SE_FLG_SHIFT        3
 #define RDMA_SQ_BIND_WQE_1ST_INLINE_FLG_MASK     0x1 /* Should be 0 for bind wqe */
 #define RDMA_SQ_BIND_WQE_1ST_INLINE_FLG_SHIFT    4
@@ -482,7 +482,7 @@ struct rdma_sq_fmr_wqe
 #define RDMA_SQ_FMR_WQE_RD_FENCE_FLG_SHIFT           1
 #define RDMA_SQ_FMR_WQE_INV_FENCE_FLG_MASK           0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_FMR_WQE_INV_FENCE_FLG_SHIFT          2
-#define RDMA_SQ_FMR_WQE_SE_FLG_MASK                  0x1 /* Dont care for FMR wqe */
+#define RDMA_SQ_FMR_WQE_SE_FLG_MASK                  0x1 /* Don't care for FMR wqe */
 #define RDMA_SQ_FMR_WQE_SE_FLG_SHIFT                 3
 #define RDMA_SQ_FMR_WQE_INLINE_FLG_MASK              0x1 /* Should be 0 for FMR wqe */
 #define RDMA_SQ_FMR_WQE_INLINE_FLG_SHIFT             4
@@ -558,7 +558,7 @@ struct rdma_sq_fmr_wqe_1st
 #define RDMA_SQ_FMR_WQE_1ST_RD_FENCE_FLG_SHIFT    1
 #define RDMA_SQ_FMR_WQE_1ST_INV_FENCE_FLG_MASK    0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_FMR_WQE_1ST_INV_FENCE_FLG_SHIFT   2
-#define RDMA_SQ_FMR_WQE_1ST_SE_FLG_MASK           0x1 /* Dont care for FMR wqe */
+#define RDMA_SQ_FMR_WQE_1ST_SE_FLG_MASK           0x1 /* Don't care for FMR wqe */
 #define RDMA_SQ_FMR_WQE_1ST_SE_FLG_SHIFT          3
 #define RDMA_SQ_FMR_WQE_1ST_INLINE_FLG_MASK       0x1 /* Should be 0 for FMR wqe */
 #define RDMA_SQ_FMR_WQE_1ST_INLINE_FLG_SHIFT      4
@@ -647,7 +647,7 @@ struct rdma_sq_local_inv_wqe
 #define RDMA_SQ_LOCAL_INV_WQE_RD_FENCE_FLG_SHIFT    1
 #define RDMA_SQ_LOCAL_INV_WQE_INV_FENCE_FLG_MASK    0x1 /* If set, all pending operations will be completed before start processing this WQE */
 #define RDMA_SQ_LOCAL_INV_WQE_INV_FENCE_FLG_SHIFT   2
-#define RDMA_SQ_LOCAL_INV_WQE_SE_FLG_MASK           0x1 /* Dont care for local invalidate wqe */
+#define RDMA_SQ_LOCAL_INV_WQE_SE_FLG_MASK           0x1 /* Don't care for local invalidate wqe */
 #define RDMA_SQ_LOCAL_INV_WQE_SE_FLG_SHIFT          3
 #define RDMA_SQ_LOCAL_INV_WQE_INLINE_FLG_MASK       0x1 /* Should be 0 for local invalidate wqe */
 #define RDMA_SQ_LOCAL_INV_WQE_INLINE_FLG_SHIFT      4

--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -173,7 +173,7 @@ struct ibv_mr *qelr_reg_mr(struct ibv_pd *ibpd, void *addr,
 	}
 
 	DP_VERBOSE(cxt->dbg_fp, QELR_MSG_MR,
-		   "MR Register %p completed succesfully pd_id=%d addr=%p len=%zu access=%d lkey=%x rkey=%x\n",
+		   "MR Register %p completed successfully pd_id=%d addr=%p len=%zu access=%d lkey=%x rkey=%x\n",
 		   mr, pd->pd_id, addr, len, access, mr->ibv_mr.lkey,
 		   mr->ibv_mr.rkey);
 
@@ -192,7 +192,7 @@ int qelr_dereg_mr(struct ibv_mr *mr)
 	free(mr);
 
 	DP_VERBOSE(cxt->dbg_fp, QELR_MSG_MR,
-		   "MR DERegister %p completed succesfully\n", mr);
+		   "MR DERegister %p completed successfully\n", mr);
 	return 0;
 }
 
@@ -804,7 +804,7 @@ int qelr_destroy_qp(struct ibv_qp *ibqp)
 	free(qp);
 
 	DP_VERBOSE(cxt->dbg_fp, QELR_MSG_QP,
-		   "destroy cq: succesfully destroyed %p\n", qp);
+		   "destroy cq: successfully destroyed %p\n", qp);
 
 	return 0;
 }

--- a/redhat/rdma.mlx4-setup.sh
+++ b/redhat/rdma.mlx4-setup.sh
@@ -55,7 +55,7 @@ function set_dual_port() {
 	fi
 
 	# our mode is not eth <anything> as that is covered above
-	# so we should be able to succesfully set the ports in
+	# so we should be able to successfully set the ports in
 	# port1 then port2 order
 	if [ "$cur_p1" != "$port1" -o "$cur_p2" != "$port2" ]; then
 		# Try setting the ports in order first


### PR DESCRIPTION
A full review of the packaging differences between libibverbs 1.2.1-2 from Debian and the combined rdma-core package revealed some changes. These commits contain the changes that should be carried over to rdma-core.