### PR TITLE
libibverbs Debian packaging improvements

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Description: Examples for the libibverbs library
 
 Package: ibverbs-providers
 Architecture: linux-any
-Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
+Depends: ${misc:Depends}, ${perl:Depends}, ${shlibs:Depends}
 Provides: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
 Replaces: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
 Breaks: libcxgb3-1, libipathverbs1, libmlx4-1, libmlx5-1, libmthca1, libnes1
@@ -143,6 +143,7 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ibverbs-providers
+Breaks: ibverbs-providers (<< 13)
 Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and

--- a/debian/control
+++ b/debian/control
@@ -139,6 +139,7 @@ Description: Development files for libibumad
 
 Package: libibverbs1
 Architecture: linux-any
+Multi-Arch: same
 Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
@@ -162,6 +163,7 @@ Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
 Package: libibverbs1-dbg
 Section: debug
 Architecture: linux-any
+Multi-Arch: same
 Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}
 Description: Debugging symbols for the libibverbs library
  libibverbs is a library that allows userspace processes to use RDMA
@@ -180,6 +182,7 @@ Description: Debugging symbols for the libibverbs library
 Package: libibverbs-dev
 Section: libdevel
 Architecture: linux-any
+Multi-Arch: same
 Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}
 Description: Development files for the libibverbs library
  libibverbs is a library that allows userspace processes to use RDMA

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -1,8 +1,7 @@
 libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
-# This version should always reflect the current package version.
- (regex|optional)"@IBVERBS_PRIVATE_" 12-1
+ (symver)IBVERBS_PRIVATE_13 13
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6


### PR DESCRIPTION
This merge proposal contains two different packaging changes: The handling of private symbols of libibverbs and multi-arch settings. Please see the individual git commit messages for details.