### PR TITLE
remove unused declarations; add providers to redhat's spec

### DIFF
--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -123,10 +123,6 @@ int ibv_cmd_query_device_ex(struct ibv_context *context,
 int ibv_cmd_query_port(struct ibv_context *context, uint8_t port_num,
 		       struct ibv_port_attr *port_attr,
 		       struct ibv_query_port *cmd, size_t cmd_size);
-int ibv_cmd_query_gid(struct ibv_context *context, uint8_t port_num,
-		      int index, union ibv_gid *gid);
-int ibv_cmd_query_pkey(struct ibv_context *context, uint8_t port_num,
-		       int index, uint16_t *pkey);
 int ibv_cmd_alloc_pd(struct ibv_context *context, struct ibv_pd *pd,
 		     struct ibv_alloc_pd *cmd, size_t cmd_size,
 		     struct ibv_alloc_pd_resp *resp, size_t resp_size);

--- a/libibverbs/libibverbs.map
+++ b/libibverbs/libibverbs.map
@@ -128,8 +128,6 @@ IBVERBS_PRIVATE_13 {
 		ibv_cmd_post_srq_recv;
 		ibv_cmd_query_device;
 		ibv_cmd_query_device_ex;
-		ibv_cmd_query_gid;
-		ibv_cmd_query_pkey;
 		ibv_cmd_query_port;
 		ibv_cmd_query_qp;
 		ibv_cmd_query_srq;

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -110,6 +110,7 @@ Device-specific plug-in ibverbs userspace drivers are included:
 - libcxgb3: Chelsio T3 iWARP HCA
 - libcxgb4: Chelsio T4 iWARP HCA
 - libhfi1: Intel Omni-Path HFI
+- libhns: HiSilicon Hip06 SoC
 - libi40iw: Intel Ethernet Connection X722 RDMA
 - libipathverbs: QLogic InfiniPath HCA
 - libmlx4: Mellanox ConnectX-3 InfiniBand HCA
@@ -117,7 +118,9 @@ Device-specific plug-in ibverbs userspace drivers are included:
 - libmthca: Mellanox InfiniBand HCA
 - libnes: NetEffect RNIC
 - libocrdma: Emulex OneConnect RDMA/RoCE Device
+- libqedr: QLogic QL4xxx RoCE HCA
 - librxe: A software implementation of the RoCE protocol
+- libvmw_pvrdma: VMware paravirtual RDMA device
 
 %package -n libibverbs-utils
 Summary: Examples for the libibverbs library


### PR DESCRIPTION
Please pull the following commits:
1. Remove unused declarations
2. Add providers to redhat's rdma-core.spec - libqedr, libhns and libvmw_pvrdma

Thanks,
Ram
