### PR TITLE
libqedr: Three queue related fixes

### DIFF
--- a/providers/qedr/qelr_chain.c
+++ b/providers/qedr/qelr_chain.c
@@ -87,7 +87,6 @@ int qelr_chain_alloc(struct qelr_chain *chain, int chain_size, int page_size,
 
 	/* init chain */
 	memset(chain, 0, sizeof(*chain));
-	memset(chain->first_addr, 0, chain->size);
 	chain->first_addr = addr;
 	chain->size = a_chain_size;
 	chain->p_cons_elem = chain->first_addr;
@@ -96,6 +95,8 @@ int qelr_chain_alloc(struct qelr_chain *chain, int chain_size, int page_size,
 	chain->n_elems = chain->size / elem_size;
 	chain->last_addr = (void *)
 			((uint8_t *)addr + (elem_size * (chain->n_elems -1)));
+
+	/* Note: since we are using MAP_ANONYMOUS the chain is zeroed for us */
 
 	return 0;
 }

--- a/providers/qedr/qelr_chain.c
+++ b/providers/qedr/qelr_chain.c
@@ -76,7 +76,7 @@ int qelr_chain_alloc(struct qelr_chain *chain, int chain_size, int page_size,
 	addr = mmap(NULL, a_chain_size, PROT_READ | PROT_WRITE,
 			 MAP_PRIVATE | MAP_ANONYMOUS, QELR_ANON_FD,
 			 QELR_ANON_OFFSET);
-	if (chain->first_addr == MAP_FAILED)
+	if (addr == MAP_FAILED)
 		return errno;
 
 	ret = ibv_dontfork_range(addr, a_chain_size);

--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -366,8 +366,6 @@ static inline int qelr_create_qp_buffers_rq(struct qelr_devctx *cxt,
 	max_recv_wr = min_t(uint32_t, max_recv_wr, cxt->max_recv_wr);
 	max_recv_sges = max_recv_wr * cxt->sges_per_recv_wr;
 	max_recv_buf = max_recv_sges * QELR_RQE_ELEMENT_SIZE;
-	qp->rq.max_wr = max_recv_wr;
-	qp->rq.max_sges = RDMA_MAX_SGE_PER_RQ_WQE;
 
 	chain_size = max_recv_buf;
 	rc = qelr_chain_alloc(&qp->rq.chain, chain_size, cxt->kernel_page_size,


### PR DESCRIPTION
Ram Amrani (3):
libqedr: Check queue mapping return value correctly
libqedr: Remove redundant memset
libqedr: Remove redundant RQ configuration