### PR TITLE
Fix the travis header check to use -Werror

### DIFF
--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -146,7 +146,7 @@ def test_public_headers(args):
     with private_tmp() as tmpd:
         with open(os.path.join(tmpd,"build.ninja"),"wt") as F:
             print >> F,"rule comp";
-            print >> F," command = cc -c -I %s $in -o $out"%(incdir);
+            print >> F," command = cc -Werror -c -I %s $in -o $out"%(incdir);
             print >> F," description=Header check for $in";
             count = 0;
             for I in sorted(includes):

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -44,6 +44,8 @@
 #include <tmmintrin.h>
 #endif /* defined(__SSE3__) */
 
+#include <infiniband/verbs.h>
+
 /* Always inline the functions */
 #ifdef __GNUC__
 #define MLX5DV_ALWAYS_INLINE inline __attribute__((always_inline))


### PR DESCRIPTION
The mlx5dv push included some warnings from travis:

build/include/infiniband/mlx5dv.h:83:11: warning: 'struct ibv_context' declared inside parameter list [enabled by default]
    struct mlx5dv_context *attrs_out);

Which should have caused travis to fail.

Add the missing include to fix them..

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>