### PR TITLE
rxe: Fix dropped padding in rxe_queue

### DIFF
--- a/providers/rxe/rxe_queue.h
+++ b/providers/rxe/rxe_queue.h
@@ -47,6 +47,7 @@ struct rxe_queue {
 	_Atomic(uint32_t)	producer_index;
 	uint32_t		pad_2[31];
 	_Atomic(uint32_t)	consumer_index;
+	uint32_t		pad_3[31];
 	uint8_t			data[0];
 };
 


### PR DESCRIPTION
Dropping it was a typo.

Reported-by: Josh Beavers <josh.beavers@gmail.com>
Fixes: 6b26a9e24739 ("Use C11 atomics instead of wmb/rmb macros for CPU-only atomics")
Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>