### PR TITLE
mlx5: Add support for efficient UAR allocation

### DIFF
--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -48,10 +48,16 @@ enum {
 };
 
 enum {
-	MLX5_NUM_UUARS_PER_PAGE = 2,
-	MLX5_MAX_UAR_PAGES	= 1 << 8,
-	MLX5_MAX_UUARS		= MLX5_MAX_UAR_PAGES * MLX5_NUM_UUARS_PER_PAGE,
-	MLX5_DEF_TOT_UUARS	= 8 * MLX5_NUM_UUARS_PER_PAGE,
+	MLX5_NUM_NON_FP_BFREGS_PER_UAR	= 2,
+	NUM_BFREGS_PER_UAR		= 4,
+	MLX5_MAX_UARS			= 1 << 8,
+	MLX5_MAX_BFREGS			= MLX5_MAX_UARS * MLX5_NUM_NON_FP_BFREGS_PER_UAR,
+	MLX5_DEF_TOT_UUARS		= 8 * MLX5_NUM_NON_FP_BFREGS_PER_UAR,
+	MLX5_MED_BFREGS_TSHOLD		= 12,
+};
+
+enum mlx5_lib_caps {
+	MLX5_LIB_CAP_4K_UAR		= 1 << 0,
 };
 
 struct mlx5_alloc_ucontext {
@@ -64,6 +70,7 @@ struct mlx5_alloc_ucontext {
 	__u8				reserved0;
 	__u16				reserved1;
 	__u32				reserved2;
+	__u64				lib_caps;
 };
 
 enum mlx5_ib_alloc_ucontext_resp_mask {
@@ -89,6 +96,8 @@ struct mlx5_alloc_ucontext_resp {
 	__u8				cmds_supp_uhw;
 	__u16				reserved2;
 	__u64				hca_core_clock_offset;
+	__u32				log_uar_size;
+	__u32				num_uars_per_page;
 };
 
 struct mlx5_create_ah_resp {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -66,6 +66,10 @@ enum {
 	MLX5_CQE_VERSION_V1	= 1,
 };
 
+enum {
+	MLX5_ADAPTER_PAGE_SIZE		= 4096,
+};
+
 #define MLX5_CQ_PREFIX "MLX_CQ"
 #define MLX5_QP_PREFIX "MLX_QP"
 #define MLX5_MR_PREFIX "MLX_MR"
@@ -199,6 +203,7 @@ struct mlx5_context {
 	int				bf_reg_size;
 	int				tot_uuars;
 	int				low_lat_uuars;
+	int				num_uars_per_page;
 	int				bf_regs_per_page;
 	int				num_bf_regs;
 	int				prefer_bf;
@@ -221,7 +226,7 @@ struct mlx5_context {
 	}				uidx_table[MLX5_UIDX_TABLE_SIZE];
 	pthread_mutex_t                 uidx_table_mutex;
 
-	void			       *uar[MLX5_MAX_UAR_PAGES];
+	void			       *uar[MLX5_MAX_UARS];
 	struct mlx5_spinlock		lock32;
 	struct mlx5_db_page	       *db_list;
 	pthread_mutex_t			db_list_mutex;
@@ -251,6 +256,7 @@ struct mlx5_context {
 	void			       *hca_core_clock;
 	struct ibv_tso_caps		cached_tso_caps;
 	int				cmds_supp_uhw;
+	uint32_t			uar_size;
 };
 
 struct mlx5_bitmap {


### PR DESCRIPTION
The hardware allows now to use UARs with a fixed size of 4KB. To enable
this feature we need both firmware and driver to support this feature in
order to make benefit of this. Benefit is obtained when the system page
size is larger than 4KB, like power pc.

In order to support compatbility between any version of
library/driver/firmware we add a flags field to struct
mlx5_alloc_ucontext to notify the kernel driver whether this is a new
library that supports 4KB UARs. In response, the kernel driver will
return log_uar_size and number of UARs in a page.

We also make order in the terms used. So a "page" now refers to a system
page, "uar" refers to the 4KB UAR area and "uuar" or micro uar refers to
the section in the device registers that is used for posting doorbells.

In case of larger page sizes, we will try to assign more lockless uuars
and preserve the number of medium latency uuars.

Signed-off-by: Eli Cohen <eli@mellanox.com>
Reviewed-by: Yishai Hadas <yishaih@mellanox.com>