### PR TITLE
mlx5: Update PCI supported list

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -74,7 +74,10 @@ static struct {
 	HCA(MELLANOX, 4118),	/* ConnectX-4LX Virtual Function */
 	HCA(MELLANOX, 4119),	/* ConnectX-5, PCIe 3.0 */
 	HCA(MELLANOX, 4120),	/* ConnectX-5 Virtual Function */
-	HCA(MELLANOX, 4121),    /* ConnectX-5, PCIe 4.0 */
+	HCA(MELLANOX, 4121),    /* ConnectX-5 Ex */
+	HCA(MELLANOX, 4122),	/* ConnectX-5 Ex VF */
+	HCA(MELLANOX, 4123),    /* ConnectX-6 */
+	HCA(MELLANOX, 4124),	/* ConnectX-6 VF */
 };
 
 uint32_t mlx5_debug_mask = 0;


### PR DESCRIPTION
-Rename the ConnectX-5 PCIe 4.0 to be ConnectX-5 Ex.
-Add the VF ID of the ConnectX-5 Ex.
-Add the upcoming ConnectX-6 ID and its VF.

Signed-off-by: Majd Dibbiny <majd@mellanox.com>
Reviewed-by: Yishai Hadas <yishaih@mellanox.com>