### PR TITLE
Cleanup ibv_register_driver

### DIFF
--- a/libibverbs/compat-1_0.c
+++ b/libibverbs/compat-1_0.c
@@ -940,7 +940,7 @@ symver(__ibv_detach_mcast_1_0, ibv_detach_mcast, IBVERBS_1.0);
 
 typedef struct ibv_device *(*ibv_driver_init_func_1_1)(const char *uverbs_sys_path,
 						       int abi_version);
-void __ibv_register_driver_1_1(const char *name, ibv_driver_init_func init_func_1_1)
+void __ibv_register_driver_1_1(const char *name, ibv_driver_init_func_1_1 init_func)
 {
 	/* The driver interface is private as of rdma-core 13. This stub is
 	 * left to preserve dynamic-link compatability with old libfabrics

--- a/libibverbs/compat-1_0.c
+++ b/libibverbs/compat-1_0.c
@@ -161,7 +161,7 @@ struct ibv_device_1_0 {
 	void		       *obsolete_sysfs_dev;
 	void		       *obsolete_sysfs_ibdev;
 	struct ibv_device      *real_device; /* was obsolete driver member */
-	struct ibv_device_ops	ops;
+	struct _ibv_device_ops	_ops;
 };
 
 struct ibv_context_ops_1_0 {

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -115,8 +115,8 @@ static inline struct verbs_device *verbs_get_device(
 		NULL : container_of(dev, struct verbs_device, device);
 }
 
-typedef struct ibv_device *(*ibv_driver_init_func)(const char *uverbs_sys_path,
-						   int abi_version);
+typedef struct verbs_device *(*ibv_driver_init_func)(const char *uverbs_sys_path,
+						     int abi_version);
 typedef struct verbs_device *(*verbs_driver_init_func)(const char *uverbs_sys_path,
 						       int abi_version);
 

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -96,6 +96,25 @@ struct verbs_qp {
 	uint32_t		comp_mask;
 	struct verbs_xrcd       *xrcd;
 };
+
+/* Must change the PRIVATE IBVERBS_PRIVATE_ symbol if this is changed */
+struct verbs_device {
+	struct ibv_device device; /* Must be first */
+	size_t	sz;
+	size_t	size_of_context;
+	int	(*init_context)(struct verbs_device *device,
+				struct ibv_context *ctx, int cmd_fd);
+	void	(*uninit_context)(struct verbs_device *device,
+				struct ibv_context *ctx);
+};
+
+static inline struct verbs_device *verbs_get_device(
+					const struct ibv_device *dev)
+{
+	return (dev->ops.alloc_context) ?
+		NULL : container_of(dev, struct verbs_device, device);
+}
+
 typedef struct ibv_device *(*ibv_driver_init_func)(const char *uverbs_sys_path,
 						   int abi_version);
 typedef struct verbs_device *(*verbs_driver_init_func)(const char *uverbs_sys_path,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -127,13 +127,10 @@ verbs_get_device(const struct ibv_device *dev)
 	return container_of(dev, struct verbs_device, device);
 }
 
-typedef struct verbs_device *(*ibv_driver_init_func)(const char *uverbs_sys_path,
-						     int abi_version);
 typedef struct verbs_device *(*verbs_driver_init_func)(const char *uverbs_sys_path,
 						       int abi_version);
-
-void ibv_register_driver(const char *name, ibv_driver_init_func init_func);
 void verbs_register_driver(const char *name, verbs_driver_init_func init_func);
+
 int ibv_cmd_get_context(struct ibv_context *context, struct ibv_get_context *cmd,
 			size_t cmd_size, struct ibv_get_context_resp *resp,
 			size_t resp_size);

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -45,6 +45,7 @@
 #include <sys/resource.h>
 #include <dirent.h>
 #include <errno.h>
+#include <assert.h>
 
 #include <util/util.h>
 #include "ibverbs.h"
@@ -394,8 +395,8 @@ static struct ibv_device *try_driver(struct ibv_driver *driver,
 			return NULL;
 
 		dev = &vdev->device;
-		dev->ops.alloc_context = NULL;
-		dev->ops.free_context = NULL;
+		assert(dev->_ops._dummy1 == NULL);
+		assert(dev->_ops._dummy2 == NULL);
 	}
 
 	if (ibv_read_sysfs_file(sysfs_dev->ibdev_path, "node_type", value, sizeof value) < 0) {

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -384,9 +384,10 @@ static struct ibv_device *try_driver(struct ibv_driver *driver,
 	char value[16];
 
 	if (driver->init_func) {
-		dev = driver->init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
-		if (!dev)
+		vdev = driver->init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
+		if (!vdev)
 			return NULL;
+		dev = &vdev->device;
 	} else {
 		vdev = driver->verbs_init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
 		if (!vdev)

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -71,7 +71,6 @@ struct ibv_driver_name {
 
 struct ibv_driver {
 	const char	       *name;
-	ibv_driver_init_func	init_func;
 	verbs_driver_init_func	verbs_init_func;
 	struct ibv_driver      *next;
 };
@@ -161,8 +160,8 @@ static int find_sysfs_devs(void)
 	return ret;
 }
 
-static void register_driver(const char *name, ibv_driver_init_func init_func,
-			    verbs_driver_init_func verbs_init_func)
+void verbs_register_driver(const char *name,
+			   verbs_driver_init_func verbs_init_func)
 {
 	struct ibv_driver *driver;
 
@@ -173,7 +172,6 @@ static void register_driver(const char *name, ibv_driver_init_func init_func,
 	}
 
 	driver->name            = name;
-	driver->init_func	= init_func;
 	driver->verbs_init_func = verbs_init_func;
 	driver->next            = NULL;
 
@@ -182,20 +180,6 @@ static void register_driver(const char *name, ibv_driver_init_func init_func,
 	else
 		head_driver = driver;
 	tail_driver = driver;
-}
-
-void __ibv_register_driver(const char *name, ibv_driver_init_func init_func)
-{
-	register_driver(name, init_func, NULL);
-}
-private_symver(__ibv_register_driver, ibv_register_driver);
-
-/* New registration symbol with same functionality - used by providers to
-  * validate that library supports verbs extension.
-  */
-void verbs_register_driver(const char *name, verbs_driver_init_func init_func)
-{
-	register_driver(name, NULL, init_func);
 }
 
 #define __IBV_QUOTE(x)	#x
@@ -384,20 +368,13 @@ static struct ibv_device *try_driver(struct ibv_driver *driver,
 	struct ibv_device *dev;
 	char value[16];
 
-	if (driver->init_func) {
-		vdev = driver->init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
-		if (!vdev)
-			return NULL;
-		dev = &vdev->device;
-	} else {
-		vdev = driver->verbs_init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
-		if (!vdev)
-			return NULL;
+	vdev = driver->verbs_init_func(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
+	if (!vdev)
+		return NULL;
 
-		dev = &vdev->device;
-		assert(dev->_ops._dummy1 == NULL);
-		assert(dev->_ops._dummy2 == NULL);
-	}
+	dev = &vdev->device;
+	assert(dev->_ops._dummy1 == NULL);
+	assert(dev->_ops._dummy2 == NULL);
 
 	if (ibv_read_sysfs_file(sysfs_dev->ibdev_path, "node_type", value, sizeof value) < 0) {
 		fprintf(stderr, PFX "Warning: no node_type attr under %s.\n",

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1304,9 +1304,10 @@ struct ibv_flow {
 struct ibv_device;
 struct ibv_context;
 
-struct ibv_device_ops {
-	struct ibv_context *	(*alloc_context)(struct ibv_device *device, int cmd_fd);
-	void			(*free_context)(struct ibv_context *context);
+/* Obsolete, never used, do not touch */
+struct _ibv_device_ops {
+	struct ibv_context *	(*_dummy1)(struct ibv_device *device, int cmd_fd);
+	void			(*_dummy2)(struct ibv_context *context);
 };
 
 enum {
@@ -1315,7 +1316,7 @@ enum {
 };
 
 struct ibv_device {
-	struct ibv_device_ops	ops;
+	struct _ibv_device_ops	_ops;
 	enum ibv_node_type	node_type;
 	enum ibv_transport_type	transport_type;
 	/* Name of underlying kernel IB device, eg "mthca0" */

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1328,17 +1328,6 @@ struct ibv_device {
 	char			ibdev_path[IBV_SYSFS_PATH_MAX];
 };
 
-struct verbs_device {
-	struct ibv_device device; /* Must be first */
-	size_t	sz;
-	size_t	size_of_context;
-	int	(*init_context)(struct verbs_device *device,
-				struct ibv_context *ctx, int cmd_fd);
-	void	(*uninit_context)(struct verbs_device *device,
-				struct ibv_context *ctx);
-	/* future fields added here */
-};
-
 struct ibv_context_ops {
 	int			(*query_device)(struct ibv_context *context,
 					      struct ibv_device_attr *device_attr);
@@ -1514,13 +1503,6 @@ static inline struct verbs_context *verbs_get_ctx(struct ibv_context *ctx)
 	struct verbs_context *vctx = _vctx; \
 	if (vctx && (vctx->sz >= sizeof(*vctx) - offsetof(struct verbs_context, op))) \
 		vctx->op = ptr; })
-
-static inline struct verbs_device *verbs_get_device(
-					const struct ibv_device *dev)
-{
-	return (dev->ops.alloc_context) ?
-		NULL : container_of(dev, struct verbs_device, device);
-}
 
 /**
  * ibv_get_device_list - Get list of IB devices currently available

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -171,8 +171,8 @@ static struct ibv_device_ops iwch_dev_ops = {
 	.free_context = iwch_free_context
 };
 
-static struct ibv_device *cxgb3_driver_init(const char *uverbs_sys_path,
-					    int abi_version)
+static struct verbs_device *cxgb3_driver_init(const char *uverbs_sys_path,
+					      int abi_version)
 {
 	char devstr[IBV_SYSFS_PATH_MAX], ibdev[16], value[32], *cp;
 	struct iwch_device *dev;
@@ -245,13 +245,13 @@ found:
 	PDBG("%s found vendor %d device %d type %d\n", 
 	     __FUNCTION__, vendor, device, hca_table[i].type);
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		return NULL;
 	}
 
 	pthread_spin_init(&dev->lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.ops = iwch_dev_ops;
+	dev->ibv_dev.device.ops = iwch_dev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->abi_version = abi_version;
 

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -284,5 +284,5 @@ err1:
 
 static __attribute__((constructor)) void cxgb3_register_driver(void)
 {
-	ibv_register_driver("cxgb3", cxgb3_driver_init);
+	verbs_register_driver("cxgb3", cxgb3_driver_init);
 }

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -166,7 +166,7 @@ static void iwch_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops iwch_dev_ops = {
+static struct verbs_device_ops iwch_dev_ops = {
 	.alloc_context = iwch_alloc_context,
 	.free_context = iwch_free_context
 };
@@ -251,7 +251,7 @@ found:
 	}
 
 	pthread_spin_init(&dev->lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.device.ops = iwch_dev_ops;
+	dev->ibv_dev.ops = &iwch_dev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->abi_version = abi_version;
 

--- a/providers/cxgb3/iwch.h
+++ b/providers/cxgb3/iwch.h
@@ -51,7 +51,7 @@ struct iwch_mr;
 #define ABI_VERS 1
 
 struct iwch_device {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 	enum iwch_hca_type hca_type;
 	struct iwch_mr **mmid2ptr;
 	struct iwch_qp **qpid2ptr;

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -397,8 +397,8 @@ void dump_state(void)
  */
 int c4iw_abi_version = 1;
 
-static struct ibv_device *cxgb4_driver_init(const char *uverbs_sys_path,
-					    int abi_version)
+static struct verbs_device *cxgb4_driver_init(const char *uverbs_sys_path,
+					      int abi_version)
 {
 	char devstr[IBV_SYSFS_PATH_MAX], ibdev[16], value[32], *cp;
 	struct c4iw_dev *dev;
@@ -470,7 +470,7 @@ found:
 	}
 
 	pthread_spin_init(&dev->lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.ops = c4iw_dev_ops;
+	dev->ibv_dev.device.ops = c4iw_dev_ops;
 	dev->chip_version = CHELSIO_CHIP_VERSION(hca_table[i].device >> 8);
 	dev->abi_version = abi_version;
 	list_node_init(&dev->list);

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -512,7 +512,7 @@ static __attribute__((constructor)) void cxgb4_register_driver(void)
 	c4iw_page_size = sysconf(_SC_PAGESIZE);
 	c4iw_page_shift = long_log2(c4iw_page_size);
 	c4iw_page_mask = ~(c4iw_page_size - 1);
-	ibv_register_driver("cxgb4", cxgb4_driver_init);
+	verbs_register_driver("cxgb4", cxgb4_driver_init);
 }
 
 #ifdef STATS

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -220,7 +220,7 @@ static void c4iw_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops c4iw_dev_ops = {
+static struct verbs_device_ops c4iw_dev_ops = {
 	.alloc_context = c4iw_alloc_context,
 	.free_context = c4iw_free_context
 };
@@ -470,7 +470,7 @@ found:
 	}
 
 	pthread_spin_init(&dev->lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.device.ops = c4iw_dev_ops;
+	dev->ibv_dev.ops = &c4iw_dev_ops;
 	dev->chip_version = CHELSIO_CHIP_VERSION(hca_table[i].device >> 8);
 	dev->abi_version = abi_version;
 	list_node_init(&dev->list);

--- a/providers/cxgb4/libcxgb4.h
+++ b/providers/cxgb4/libcxgb4.h
@@ -51,7 +51,7 @@ extern unsigned long c4iw_page_mask;
 struct c4iw_mr;
 
 struct c4iw_dev {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 	unsigned chip_version;
 	int max_mr;
 	struct c4iw_mr **mmid2ptr;

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -178,8 +178,8 @@ static struct ibv_device_ops hfi1_dev_ops = {
 	.free_context	= hfi1_free_context
 };
 
-static struct ibv_device *hfi1_driver_init(const char *uverbs_sys_path,
-					    int abi_version)
+static struct verbs_device *hfi1_driver_init(const char *uverbs_sys_path,
+					     int abi_version)
 {
 	char			value[8];
 	struct hfi1_device    *dev;
@@ -204,14 +204,14 @@ static struct ibv_device *hfi1_driver_init(const char *uverbs_sys_path,
 	return NULL;
 
 found:
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
 			uverbs_sys_path);
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = hfi1_dev_ops;
+	dev->ibv_dev.device.ops = hfi1_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -173,7 +173,7 @@ static void hfi1_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops hfi1_dev_ops = {
+static struct verbs_device_ops hfi1_dev_ops = {
 	.alloc_context	= hfi1_alloc_context,
 	.free_context	= hfi1_free_context
 };
@@ -211,7 +211,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = hfi1_dev_ops;
+	dev->ibv_dev.ops = &hfi1_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -219,5 +219,5 @@ found:
 
 static __attribute__((constructor)) void hfi1_register_driver(void)
 {
-	ibv_register_driver("hfi1verbs", hfi1_driver_init);
+	verbs_register_driver("hfi1verbs", hfi1_driver_init);
 }

--- a/providers/hfi1verbs/hfiverbs.h
+++ b/providers/hfi1verbs/hfiverbs.h
@@ -69,7 +69,7 @@
 #define PFX		"hfi1: "
 
 struct hfi1_device {
-	struct ibv_device	ibv_dev;
+	struct verbs_device	ibv_dev;
 	int			abi_version;
 };
 

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -178,8 +178,8 @@ static struct ibv_device_ops hns_roce_dev_ops = {
 	.free_context	= hns_roce_free_context
 };
 
-static struct ibv_device *hns_roce_driver_init(const char *uverbs_sys_path,
-					       int abi_version)
+static struct verbs_device *hns_roce_driver_init(const char *uverbs_sys_path,
+						 int abi_version)
 {
 	struct hns_roce_device  *dev;
 	char			 value[128];
@@ -208,14 +208,14 @@ static struct ibv_device *hns_roce_driver_init(const char *uverbs_sys_path,
 	return NULL;
 
 found:
-	dev = malloc(sizeof(struct hns_roce_device));
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
 			uverbs_sys_path);
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = hns_roce_dev_ops;
+	dev->ibv_dev.device.ops = hns_roce_dev_ops;
 	dev->u_hw = (struct hns_roce_u_hw *)u_hw;
 	dev->hw_version = hw_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -224,5 +224,5 @@ found:
 
 static __attribute__((constructor)) void hns_roce_register_driver(void)
 {
-	ibv_register_driver("hns", hns_roce_driver_init);
+	verbs_register_driver("hns", hns_roce_driver_init);
 }

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -173,7 +173,7 @@ static void hns_roce_free_context(struct ibv_context *ibctx)
 	context = NULL;
 }
 
-static struct ibv_device_ops hns_roce_dev_ops = {
+static struct verbs_device_ops hns_roce_dev_ops = {
 	.alloc_context = hns_roce_alloc_context,
 	.free_context	= hns_roce_free_context
 };
@@ -215,7 +215,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = hns_roce_dev_ops;
+	dev->ibv_dev.ops = &hns_roce_dev_ops;
 	dev->u_hw = (struct hns_roce_u_hw *)u_hw;
 	dev->hw_version = hw_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -80,7 +80,7 @@ enum {
 };
 
 struct hns_roce_device {
-	struct ibv_device		ibv_dev;
+	struct verbs_device		ibv_dev;
 	int				page_size;
 	struct hns_roce_u_hw		*u_hw;
 	int				hw_version;

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -256,5 +256,5 @@ found:
 
 static __attribute__ ((constructor)) void i40iw_register_driver(void)
 {
-	ibv_register_driver("i40iw", i40iw_driver_init);
+	verbs_register_driver("i40iw", i40iw_driver_init);
 }

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -208,7 +208,7 @@ static void i40iw_ufree_context(struct ibv_context *ibctx)
 	free(iwvctx);
 }
 
-static struct ibv_device_ops i40iw_udev_ops = {
+static struct verbs_device_ops i40iw_udev_ops = {
 	.alloc_context	= i40iw_ualloc_context,
 	.free_context	= i40iw_ufree_context
 };
@@ -248,7 +248,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = i40iw_udev_ops;
+	dev->ibv_dev.ops = &i40iw_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = I40IW_HW_PAGE_SIZE;
 	return &dev->ibv_dev;

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -218,7 +218,8 @@ static struct ibv_device_ops i40iw_udev_ops = {
  * @uverbs_sys_path: sys path
  * @abi_version: not used
  */
-struct ibv_device *i40iw_driver_init(const char *uverbs_sys_path, int abi_version)
+static struct verbs_device *i40iw_driver_init(const char *uverbs_sys_path,
+					      int abi_version)
 {
 	char value[16];
 	struct i40iw_udevice *dev;
@@ -241,13 +242,13 @@ struct ibv_device *i40iw_driver_init(const char *uverbs_sys_path, int abi_versio
 
 	return NULL;
 found:
-	dev = malloc(sizeof(*dev));
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "%s: failed to allocate memory for device object\n", __func__);
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = i40iw_udev_ops;
+	dev->ibv_dev.device.ops = i40iw_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = I40IW_HW_PAGE_SIZE;
 	return &dev->ibv_dev;

--- a/providers/i40iw/i40iw_umain.h
+++ b/providers/i40iw/i40iw_umain.h
@@ -69,7 +69,7 @@ enum i40iw_uhca_type {
 };
 
 struct i40iw_udevice {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 	enum i40iw_uhca_type hca_type;
 	int page_size;
 };
@@ -155,9 +155,6 @@ static inline struct i40iw_uqp *to_i40iw_uqp(struct ibv_qp *ibqp)
 {
 	return to_i40iw_uxxx(qp, qp);
 }
-
-/* i40iw_umain.c */
-struct ibv_device *i40iw_driver_init(const char *, int);
 
 /* i40iw_uverbs.c */
 int i40iw_uquery_device(struct ibv_context *, struct ibv_device_attr *);

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -172,7 +172,7 @@ static void ipath_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops ipath_dev_ops = {
+static struct verbs_device_ops ipath_dev_ops = {
 	.alloc_context	= ipath_alloc_context,
 	.free_context	= ipath_free_context
 };
@@ -210,7 +210,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = ipath_dev_ops;
+	dev->ibv_dev.ops = &ipath_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -177,8 +177,8 @@ static struct ibv_device_ops ipath_dev_ops = {
 	.free_context	= ipath_free_context
 };
 
-static struct ibv_device *ipath_driver_init(const char *uverbs_sys_path,
-					    int abi_version)
+static struct verbs_device *ipath_driver_init(const char *uverbs_sys_path,
+					      int abi_version)
 {
 	char			value[8];
 	struct ipath_device    *dev;
@@ -203,14 +203,14 @@ static struct ibv_device *ipath_driver_init(const char *uverbs_sys_path,
 	return NULL;
 
 found:
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
 			uverbs_sys_path);
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = ipath_dev_ops;
+	dev->ibv_dev.device.ops = ipath_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -218,5 +218,5 @@ found:
 
 static __attribute__((constructor)) void ipath_register_driver(void)
 {
-	ibv_register_driver("ipathverbs", ipath_driver_init);
+	verbs_register_driver("ipathverbs", ipath_driver_init);
 }

--- a/providers/ipathverbs/ipathverbs.h
+++ b/providers/ipathverbs/ipathverbs.h
@@ -49,7 +49,7 @@
 #define PFX		"ipath: "
 
 struct ipath_device {
-	struct ibv_device	ibv_dev;
+	struct verbs_device	ibv_dev;
 	int			abi_version;
 };
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -263,6 +263,11 @@ static void mlx4_uninit_context(struct verbs_device *v_device,
 		       to_mdev(&v_device->device)->page_size);
 }
 
+static struct verbs_device_ops mlx4_dev_ops = {
+	.init_context = mlx4_init_context,
+	.uninit_context = mlx4_uninit_context,
+};
+
 static struct verbs_device *mlx4_driver_init(const char *uverbs_sys_path, int abi_version)
 {
 	char			value[8];
@@ -308,12 +313,10 @@ found:
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->abi_version = abi_version;
 
+	dev->verbs_dev.ops = &mlx4_dev_ops;
 	dev->verbs_dev.sz = sizeof(*dev);
 	dev->verbs_dev.size_of_context =
 		sizeof(struct mlx4_context) - sizeof(struct ibv_context);
-	/* mlx4_init_context will initialize provider calls */
-	dev->verbs_dev.init_context = mlx4_init_context;
-	dev->verbs_dev.uninit_context = mlx4_uninit_context;
 
 	return &dev->verbs_dev;
 }

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -900,6 +900,11 @@ static void mlx5_cleanup_context(struct verbs_device *device,
 	close_debug_file(context);
 }
 
+static struct verbs_device_ops mlx5_dev_ops = {
+	.init_context = mlx5_init_context,
+	.uninit_context = mlx5_cleanup_context,
+};
+
 static struct verbs_device *mlx5_driver_init(const char *uverbs_sys_path,
 					     int abi_version)
 {
@@ -945,11 +950,11 @@ found:
 
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->driver_abi_ver = abi_version;
+
+	dev->verbs_dev.ops = &mlx5_dev_ops;
 	dev->verbs_dev.sz = sizeof(*dev);
 	dev->verbs_dev.size_of_context = sizeof(struct mlx5_context) -
 		sizeof(struct ibv_context);
-	dev->verbs_dev.init_context = mlx5_init_context;
-	dev->verbs_dev.uninit_context = mlx5_cleanup_context;
 
 	return &dev->verbs_dev;
 }

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -214,7 +214,7 @@ static struct ibv_device_ops mthca_dev_ops = {
 	.free_context  = mthca_free_context
 };
 
-static struct ibv_device *mthca_driver_init(const char *uverbs_sys_path,
+static struct verbs_device *mthca_driver_init(const char *uverbs_sys_path,
 					    int abi_version)
 {
 	char			value[8];
@@ -246,14 +246,14 @@ found:
 		return NULL;
 	}
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
 			uverbs_sys_path);
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = mthca_dev_ops;
+	dev->ibv_dev.device.ops = mthca_dev_ops;
 	dev->hca_type    = hca_table[i].type;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -209,7 +209,7 @@ static void mthca_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops mthca_dev_ops = {
+static struct verbs_device_ops mthca_dev_ops = {
 	.alloc_context = mthca_alloc_context,
 	.free_context  = mthca_free_context
 };
@@ -253,7 +253,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = mthca_dev_ops;
+	dev->ibv_dev.ops = &mthca_dev_ops;
 	dev->hca_type    = hca_table[i].type;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -262,5 +262,5 @@ found:
 
 static __attribute__((constructor)) void mthca_register_driver(void)
 {
-	ibv_register_driver("mthca", mthca_driver_init);
+	verbs_register_driver("mthca", mthca_driver_init);
 }

--- a/providers/mthca/mthca.h
+++ b/providers/mthca/mthca.h
@@ -89,7 +89,7 @@ enum {
 struct mthca_ah_page;
 
 struct mthca_device {
-	struct ibv_device   ibv_dev;
+	struct verbs_device ibv_dev;
 	enum mthca_hca_type hca_type;
 	int                 page_size;
 };

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -194,7 +194,8 @@ static struct ibv_device_ops nes_udev_ops = {
 /**
  * nes_driver_init
  */
-struct ibv_device *nes_driver_init(const char *uverbs_sys_path, int abi_version)
+static struct verbs_device *nes_driver_init(const char *uverbs_sys_path,
+					    int abi_version)
 {
 	char value[16];
 	struct nes_udevice *dev;
@@ -229,13 +230,13 @@ found:
 			sscanf(value, "%u", &nes_debug_level);
 	}
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		nes_debug(NES_DBG_INIT, "Fatal: couldn't allocate device for libnes\n");
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = nes_udev_ops;
+	dev->ibv_dev.device.ops = nes_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = sysconf(_SC_PAGESIZE);
 

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -185,7 +185,7 @@ static void nes_ufree_context(struct ibv_context *ibctx)
 }
 
 
-static struct ibv_device_ops nes_udev_ops = {
+static struct verbs_device_ops nes_udev_ops = {
 	.alloc_context = nes_ualloc_context,
 	.free_context = nes_ufree_context
 };
@@ -236,7 +236,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = nes_udev_ops;
+	dev->ibv_dev.ops = &nes_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = sysconf(_SC_PAGESIZE);
 

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -253,5 +253,5 @@ static __attribute__((constructor)) void nes_register_driver(void)
 {
 	/* fprintf(stderr, PFX "nes_register_driver: call ibv_register_driver()\n"); */
 
-	ibv_register_driver("nes", nes_driver_init);
+	verbs_register_driver("nes", nes_driver_init);
 }

--- a/providers/nes/nes_umain.h
+++ b/providers/nes/nes_umain.h
@@ -248,7 +248,7 @@ struct nes_user_doorbell {
 };
 
 struct nes_udevice {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 	enum nes_uhca_type hca_type;
 	int page_size;
 };
@@ -350,9 +350,6 @@ static inline struct nes_uqp *to_nes_uqp(struct ibv_qp *ibqp)
 	return to_nes_uxxx(qp, qp);
 }
 
-
-/* nes_umain.c */
-struct ibv_device *nes_driver_init(const char *, int);
 
 /* nes_uverbs.c */
 int nes_uquery_device(struct ibv_context *, struct ibv_device_attr *);

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -237,5 +237,5 @@ qp_err:
 static __attribute__ ((constructor))
 void ocrdma_register_driver(void)
 {
-	ibv_register_driver("ocrdma", ocrdma_driver_init);
+	verbs_register_driver("ocrdma", ocrdma_driver_init);
 }

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -103,7 +103,7 @@ static struct ibv_context_ops ocrdma_ctx_ops = {
 	.detach_mcast = ocrdma_detach_mcast
 };
 
-static struct ibv_device_ops ocrdma_dev_ops = {
+static struct verbs_device_ops ocrdma_dev_ops = {
 	.alloc_context = ocrdma_alloc_context,
 	.free_context = ocrdma_free_context
 };
@@ -220,7 +220,7 @@ found:
 	bzero(dev->qp_tbl, OCRDMA_MAX_QP * sizeof(struct ocrdma_qp *));
 	pthread_mutex_init(&dev->dev_lock, NULL);
 	pthread_spin_init(&dev->flush_q_lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.device.ops = ocrdma_dev_ops;
+	dev->ibv_dev.ops = &ocrdma_dev_ops;
 	list_node_init(&dev->entry);
 	pthread_mutex_lock(&ocrdma_dev_list_lock);
 	list_add_tail(&ocrdma_dev_list, &dev->entry);

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -172,8 +172,8 @@ static void ocrdma_free_context(struct ibv_context *ibctx)
 /**
  * ocrdma_driver_init
  */
-struct ibv_device *ocrdma_driver_init(const char *uverbs_sys_path,
-				      int abi_version)
+static struct verbs_device *ocrdma_driver_init(const char *uverbs_sys_path,
+					       int abi_version)
 {
 
 	char value[16];
@@ -207,20 +207,20 @@ found:
 		return NULL;
 	}
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		ocrdma_err("%s() Fatal: fail allocate device for libocrdma\n",
 			   __func__);
 		return NULL;
 	}
-	bzero(dev, sizeof *dev);
+
 	dev->qp_tbl = malloc(OCRDMA_MAX_QP * sizeof(struct ocrdma_qp *));
 	if (!dev->qp_tbl)
 		goto qp_err;
 	bzero(dev->qp_tbl, OCRDMA_MAX_QP * sizeof(struct ocrdma_qp *));
 	pthread_mutex_init(&dev->dev_lock, NULL);
 	pthread_spin_init(&dev->flush_q_lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.ops = ocrdma_dev_ops;
+	dev->ibv_dev.device.ops = ocrdma_dev_ops;
 	list_node_init(&dev->entry);
 	pthread_mutex_lock(&ocrdma_dev_list_lock);
 	list_add_tail(&ocrdma_dev_list, &dev->entry);

--- a/providers/ocrdma/ocrdma_main.h
+++ b/providers/ocrdma/ocrdma_main.h
@@ -54,7 +54,7 @@
 struct ocrdma_qp;
 
 struct ocrdma_device {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 	struct ocrdma_qp **qp_tbl;
 	pthread_mutex_t dev_lock;
 	pthread_spinlock_t flush_q_lock;
@@ -265,8 +265,6 @@ static inline struct ocrdma_ah *get_ocrdma_ah(struct ibv_ah *ibah)
 {
 	return get_ocrdma_xxx(ah, ah);
 }
-
-struct ibv_device *ocrdma_driver_init(const char *, int);
 
 void ocrdma_init_ahid_tbl(struct ocrdma_devctx *ctx);
 int ocrdma_query_device(struct ibv_context *, struct ibv_device_attr *);

--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -112,7 +112,7 @@ struct qelr_buf {
 };
 
 struct qelr_device {
-	struct ibv_device ibv_dev;
+	struct verbs_device ibv_dev;
 };
 
 struct qelr_devctx {

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -280,5 +280,5 @@ found:
 static __attribute__ ((constructor))
 void qelr_register_driver(void)
 {
-	ibv_register_driver("qelr", qelr_driver_init);
+	verbs_register_driver("qelr", qelr_driver_init);
 }

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -114,7 +114,7 @@ static struct ibv_context_ops qelr_ctx_ops = {
 	.async_event = qelr_async_event,
 };
 
-static struct ibv_device_ops qelr_dev_ops = {
+static struct verbs_device_ops qelr_dev_ops = {
 	.alloc_context = qelr_alloc_context,
 	.free_context = qelr_free_context
 };
@@ -272,7 +272,7 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = qelr_dev_ops;
+	dev->ibv_dev.ops = &qelr_dev_ops;
 
 	return &dev->ibv_dev;
 }

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -231,8 +231,8 @@ static void qelr_free_context(struct ibv_context *ibctx)
 	free(ctx);
 }
 
-struct ibv_device *qelr_driver_init(const char *uverbs_sys_path,
-				    int abi_version)
+static struct verbs_device *qelr_driver_init(const char *uverbs_sys_path,
+					     int abi_version)
 {
 	char value[16];
 	struct qelr_device *dev;
@@ -265,16 +265,14 @@ found:
 		return NULL;
 	}
 
-	dev = malloc(sizeof(*dev));
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		qelr_err("%s() Fatal: fail allocate device for libqedr\n",
 			 __func__);
 		return NULL;
 	}
 
-	bzero(dev, sizeof(*dev));
-
-	dev->ibv_dev.ops = qelr_dev_ops;
+	dev->ibv_dev.device.ops = qelr_dev_ops;
 
 	return &dev->ibv_dev;
 }

--- a/providers/qedr/qelr_main.h
+++ b/providers/qedr/qelr_main.h
@@ -40,8 +40,6 @@
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>
 
-struct ibv_device *qelr_driver_init(const char *, int);
-
 int qelr_query_device(struct ibv_context *, struct ibv_device_attr *);
 int qelr_query_port(struct ibv_context *, uint8_t, struct ibv_port_attr *);
 

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -922,5 +922,5 @@ static struct verbs_device *rxe_driver_init(const char *uverbs_sys_path,
 static __attribute__ ((constructor))
 void rxe_register_driver(void)
 {
-	ibv_register_driver("rxe", rxe_driver_init);
+	verbs_register_driver("rxe", rxe_driver_init);
 }

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -886,7 +886,7 @@ static void rxe_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops rxe_dev_ops = {
+static struct verbs_device_ops rxe_dev_ops = {
 	.alloc_context = rxe_alloc_context,
 	.free_context = rxe_free_context,
 };
@@ -913,7 +913,7 @@ static struct verbs_device *rxe_driver_init(const char *uverbs_sys_path,
 		return NULL;
 	}
 
-	dev->ibv_dev.device.ops = rxe_dev_ops;
+	dev->ibv_dev.ops = &rxe_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -891,8 +891,8 @@ static struct ibv_device_ops rxe_dev_ops = {
 	.free_context = rxe_free_context,
 };
 
-static struct ibv_device *rxe_driver_init(const char *uverbs_sys_path,
-					  int abi_version)
+static struct verbs_device *rxe_driver_init(const char *uverbs_sys_path,
+					    int abi_version)
 {
 	struct rxe_device *dev;
 	char value[16];
@@ -905,7 +905,7 @@ static struct ibv_device *rxe_driver_init(const char *uverbs_sys_path,
 	if (strncmp(value, "rxe", 3))
 		return NULL;
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr,
 			"rxe: Fatal: couldn't allocate device for %s\n",
@@ -913,7 +913,7 @@ static struct ibv_device *rxe_driver_init(const char *uverbs_sys_path,
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = rxe_dev_ops;
+	dev->ibv_dev.device.ops = rxe_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;

--- a/providers/rxe/rxe.h
+++ b/providers/rxe/rxe.h
@@ -43,7 +43,7 @@ enum rdma_network_type {
 };
 
 struct rxe_device {
-	struct ibv_device	ibv_dev;
+	struct verbs_device	ibv_dev;
 	int	abi_version;
 };
 

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -110,7 +110,7 @@ enum {
 };
 
 struct pvrdma_device {
-	struct ibv_device		ibv_dev;
+	struct verbs_device		ibv_dev;
 	int				page_size;
 	int				abi_version;
 };

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -225,5 +225,5 @@ static struct verbs_device *pvrdma_driver_init(const char *uverbs_sys_path,
 
 static __attribute__((constructor)) void pvrdma_register_driver(void)
 {
-	ibv_register_driver("pvrdma", pvrdma_driver_init);
+	verbs_register_driver("pvrdma", pvrdma_driver_init);
 }

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -162,7 +162,7 @@ static void pvrdma_free_context(struct ibv_context *ibctx)
 	free(context);
 }
 
-static struct ibv_device_ops pvrdma_dev_ops = {
+static struct verbs_device_ops pvrdma_dev_ops = {
 	.alloc_context = pvrdma_alloc_context,
 	.free_context  = pvrdma_free_context
 };
@@ -207,7 +207,7 @@ static struct pvrdma_device *pvrdma_driver_init_shared(
 
 	dev->abi_version = abi_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
-	dev->ibv_dev.device.ops = pvrdma_dev_ops;
+	dev->ibv_dev.ops = &pvrdma_dev_ops;
 
 	return dev;
 }

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -198,7 +198,7 @@ static struct pvrdma_device *pvrdma_driver_init_shared(
 		return NULL;
 	}
 
-	dev = malloc(sizeof(*dev));
+	dev = calloc(1, sizeof(*dev));
 	if (!dev) {
 		fprintf(stderr, PFX "couldn't allocate device for %s\n",
 			uverbs_sys_path);
@@ -207,13 +207,13 @@ static struct pvrdma_device *pvrdma_driver_init_shared(
 
 	dev->abi_version = abi_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
-	dev->ibv_dev.ops = pvrdma_dev_ops;
+	dev->ibv_dev.device.ops = pvrdma_dev_ops;
 
 	return dev;
 }
 
-static struct ibv_device *pvrdma_driver_init(const char *uverbs_sys_path,
-					     int abi_version)
+static struct verbs_device *pvrdma_driver_init(const char *uverbs_sys_path,
+					       int abi_version)
 {
 	struct pvrdma_device *dev = pvrdma_driver_init_shared(uverbs_sys_path,
 							      abi_version);


### PR DESCRIPTION
Now that the provider API is private there is no reason to have two different ways to register a driver. Consolidate everything into verbs_register_driver.

This approach is simplified by not also forcing a change to the new context allocation protocol, which is a bit more complex.