### PR TITLE
libqedr: Refactor post_send

### DIFF
--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -236,13 +236,11 @@ struct qelr_qp {
 		uint8_t wqe_size;
 	} *rqe_wr_id;
 
-	struct qelr_edpm			edpm;
 	uint8_t					prev_wqe_size;
 	uint32_t				max_inline_data;
 	uint32_t				qp_id;
 	int					sq_sig_all;
 	int					atomic_supported;
-
 };
 
 static inline struct qelr_devctx *get_qelr_ctx(struct ibv_context *ibctx)


### PR DESCRIPTION
Refactor post send by creating a function that posts a single WR
that is invoked from a loop, early all WRs validity checks so that
WR posting won't even start if it is invalid, and move the edpm
structure outside of the QP structure as a preparation for dpm.

Version 2 differences:
 * updated to the latest rdma-core (post udma barriers)
 * re-directs a debug print to cxt->dbg_fp (rather stderr)

Signed-off-by: Ram Amrani <Ram.Amrani@cavium.com>
Signed-off-by: Ariel Elior <Ariel.Elior@cavium.com>
