### PR TITLE
mlx5: Fix the barriers in mlx5_arm_cq

### DIFF
--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1281,16 +1281,16 @@ int mlx5_arm_cq(struct ibv_cq *ibvcq, int solicited)
 
 	/*
 	 * Make sure that the doorbell record in host memory is
-	 * written before ringing the doorbell via PCI MMIO.
+	 * written before ringing the doorbell via PCI WC MMIO.
 	 */
-	udma_to_device_barrier();
+	mmio_wc_start();
 
 	doorbell[0] = htonl(sn << 28 | cmd | ci);
 	doorbell[1] = htonl(cq->cqn);
 
 	mlx5_write64(doorbell, ctx->uar[0] + MLX5_CQ_DOORBELL, &ctx->lock32);
 
-	mmio_ordered_writes_hack();
+	mmio_flush_writes();
 
 	return 0;
 }


### PR DESCRIPTION
Yishai explains that this is writing to WC memory in uar, so it needs
to use the WC access pattern.

This increases the leading barrier to wc_wmb()

Fixes: b6cf27b267c4 ("mlx5: Update to use new udma write barriers")
Reviewed-by: Yishai Hadas <yishaih@dev.mellanox.co.il>
Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>