### PR TITLE
Vendor cq data

### DIFF
--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -28,6 +28,7 @@ struct ibv_comp_channel *channel;          /* Completion channel where completio
 int                     comp_vector;       /* Completion vector used to signal completion events. Must be >= 0 and < context->num_comp_vectors. */
 uint64_t                wc_flags;          /* The wc_flags that should be returned in ibv_poll_cq_ex. Or'ed bit of enum ibv_wc_flags_ex. */
 uint32_t                comp_mask;         /* compatibility mask (extended verb). */
+void                    *vendor_data;      /* Vendor private data for creating a CQ. */
 .in -8
 };
 
@@ -44,6 +45,7 @@ enum ibv_wc_flags_ex {
 
 enum ibv_cq_init_attr_mask {
         IBV_CQ_INIT_ATTR_MASK_FLAGS             = 1 << 0,
+	IBV_CQ_INIT_ATTR_MASK_VENDOR_DATA       = 1 << 1,
 };
 
 enum ibv_create_cq_attr_flags {

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1399,7 +1399,8 @@ struct ibv_context {
 
 enum ibv_cq_init_attr_mask {
 	IBV_CQ_INIT_ATTR_MASK_FLAGS	= 1 << 0,
-	IBV_CQ_INIT_ATTR_MASK_RESERVED	= 1 << 1
+	IBV_CQ_INIT_ATTR_MASK_VENDOR_DATA = 1 << 1,
+	IBV_CQ_INIT_ATTR_MASK_RESERVED	= 1 << 2
 };
 
 enum ibv_create_cq_attr_flags {
@@ -1430,6 +1431,8 @@ struct ibv_cq_init_attr_ex {
 	 * enum ibv_create_cq_attr_flags
 	 */
 	uint32_t		flags;
+	/* Vendor private data for creating a CQ */
+	void			*vendor_data;
 };
 
 enum ibv_values_mask {

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -35,6 +35,7 @@ enum mlx5dv_context_flags {
  * This flag indicates if CQE version 0 or 1 is needed.
  */
  MLX5DV_CONTEXT_FLAGS_CQE_V1 = (1 << 0),
+ MLX5DV_CONTEXT_FLAGS_MPW    = (1 << 1), /* Multi packet WQE is supported or not */
 .in -8
 };
 .fi

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -118,6 +118,9 @@ struct mlx5_create_cq {
 	__u64				buf_addr;
 	__u64				db_addr;
 	__u32				cqe_size;
+	__u8				cqe_comp_en;
+	__u8				cqe_comp_res_format;
+	__u16				reserved;
 };
 
 struct mlx5_create_cq_resp {

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -263,6 +263,11 @@ struct mlx5_rss_caps {
 	__u8 reserved[7];
 };
 
+struct mlx5_packet_pacing_caps {
+	struct ibv_packet_pacing_caps caps;
+	__u32  reserved;
+};
+
 struct mlx5_query_device_ex_resp {
 	struct ibv_query_device_resp_ex ibv_resp;
 	__u32				comp_mask;
@@ -270,7 +275,7 @@ struct mlx5_query_device_ex_resp {
 	struct ibv_tso_caps		tso_caps;
 	struct mlx5_rss_caps            rss_caps; /* vendor data channel */
 	__u64				reserved_cqe_comp;
-	struct ibv_packet_pacing_caps	packet_pacing_caps;
+	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 };
 
 #endif /* MLX5_ABI_H */

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -276,6 +276,8 @@ struct mlx5_query_device_ex_resp {
 	struct mlx5_rss_caps            rss_caps; /* vendor data channel */
 	__u64				reserved_cqe_comp;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
+	__u32				support_multi_pkt_send_wqe;
+	__u32				reserved;
 };
 
 #endif /* MLX5_ABI_H */

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -34,6 +34,7 @@
 #define MLX5_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include "mlx5dv.h"
 
 #define MLX5_UVERBS_MIN_ABI_VERSION	1
 #define MLX5_UVERBS_MAX_ABI_VERSION	1
@@ -274,7 +275,7 @@ struct mlx5_query_device_ex_resp {
 	__u32				response_length;
 	struct ibv_tso_caps		tso_caps;
 	struct mlx5_rss_caps            rss_caps; /* vendor data channel */
-	__u64				reserved_cqe_comp;
+	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	__u32				support_multi_pkt_send_wqe;
 	__u32				reserved;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -612,12 +612,17 @@ static int mlx5_map_internal_clock(struct mlx5_device *mdev,
 int mlx5dv_query_device(struct ibv_context *ctx_in,
 			 struct mlx5dv_context *attrs_out)
 {
+	struct mlx5_context *mctx = to_mctx(ctx_in);
+
 	attrs_out->comp_mask = 0;
 	attrs_out->version   = 0;
 	attrs_out->flags     = 0;
 
-	if (to_mctx(ctx_in)->cqe_version == MLX5_CQE_VERSION_V1)
+	if (mctx->cqe_version == MLX5_CQE_VERSION_V1)
 		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_CQE_V1;
+
+	if (mctx->vendor_cap_flags & MLX5_VENDOR_CAP_FLAGS_MPW)
+		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_MPW;
 
 	return 0;
 }
@@ -827,6 +832,7 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	}
 
 	context->cmds_supp_uhw = resp.cmds_supp_uhw;
+	context->vendor_cap_flags = 0;
 
 	pthread_mutex_init(&context->qp_table_mutex, NULL);
 	pthread_mutex_init(&context->srq_table_mutex, NULL);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -613,8 +613,8 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 			 struct mlx5dv_context *attrs_out)
 {
 	struct mlx5_context *mctx = to_mctx(ctx_in);
+	uint64_t comp_mask_out = 0;
 
-	attrs_out->comp_mask = 0;
 	attrs_out->version   = 0;
 	attrs_out->flags     = 0;
 
@@ -623,6 +623,13 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 
 	if (mctx->vendor_cap_flags & MLX5_VENDOR_CAP_FLAGS_MPW)
 		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_MPW;
+
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_CQE_COMPRESION) {
+		attrs_out->cqe_comp_caps = mctx->cqe_comp_caps;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_CQE_COMPRESION;
+	}
+
+	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;
 }

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -263,6 +263,7 @@ struct mlx5_context {
 	int				cmds_supp_uhw;
 	uint32_t			uar_size;
 	uint64_t			vendor_cap_flags; /* Use enum mlx5_vendor_cap_flags */
+	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -180,6 +180,10 @@ enum {
 	MLX5_USER_CMDS_SUPP_UHW_CREATE_AH    = 1 << 1,
 };
 
+enum mlx5_vendor_cap_flags {
+	MLX5_VENDOR_CAP_FLAGS_MPW		= 1 << 0,
+};
+
 struct mlx5_resource {
 	enum mlx5_rsc_type	type;
 	uint32_t		rsn;
@@ -258,6 +262,7 @@ struct mlx5_context {
 	struct ibv_tso_caps		cached_tso_caps;
 	int				cmds_supp_uhw;
 	uint32_t			uar_size;
+	uint64_t			vendor_cap_flags; /* Use enum mlx5_vendor_cap_flags */
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -292,10 +292,20 @@ struct mlx5_cqe64 {
 	uint8_t		op_own;
 };
 
+enum mlx5dv_create_cq_vendor_data_mask {
+	MLX5DV_CREATE_CQ_MASK_COMPRESSED_CQE	= 1 << 0,
+	MLX5DV_CREATE_CQ_MASK_RESERVED		= 1 << 1,
+};
+
 enum mlx5dv_cqe_comp_res_format {
 	MLX5DV_CQE_RES_FORMAT_HASH		= 1 << 0,
 	MLX5DV_CQE_RES_FORMAT_CSUM		= 1 << 1,
 	MLX5DV_CQE_RES_FORMAT_RESERVED		= 1 << 2,
+};
+
+struct mlx5dv_create_cq_vendor_data {
+	uint64_t comp_mask; /* Use enum mlx5dv_create_cq_vendor_data_mask */
+	uint8_t cqe_comp_res_format; /* Use enum mlx5dv_cqe_comp_res_format */
 };
 
 static MLX5DV_ALWAYS_INLINE

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -58,6 +58,16 @@ enum {
 	MLX5_SND_DBR	= 1,
 };
 
+enum mlx5dv_context_comp_mask {
+	MLX5DV_CONTEXT_MASK_CQE_COMPRESION	= 1 << 0,
+	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 1,
+};
+
+struct mlx5dv_cqe_comp_caps {
+	uint32_t max_num;
+	uint32_t supported_format; /* enum mlx5dv_cqe_comp_res_format */
+};
+
 /*
  * Direct verbs device-specific attributes
  */
@@ -65,6 +75,7 @@ struct mlx5dv_context {
 	uint8_t		version;
 	uint64_t	flags;
 	uint64_t	comp_mask;
+	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 };
 
 enum mlx5dv_context_flags {
@@ -279,6 +290,12 @@ struct mlx5_cqe64 {
 	uint16_t	wqe_counter;
 	uint8_t		signature;
 	uint8_t		op_own;
+};
+
+enum mlx5dv_cqe_comp_res_format {
+	MLX5DV_CQE_RES_FORMAT_HASH		= 1 << 0,
+	MLX5DV_CQE_RES_FORMAT_CSUM		= 1 << 1,
+	MLX5DV_CQE_RES_FORMAT_RESERVED		= 1 << 2,
 };
 
 static MLX5DV_ALWAYS_INLINE

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -71,7 +71,8 @@ enum mlx5dv_context_flags {
 	/*
 	 * This flag indicates if CQE version 0 or 1 is needed.
 	 */
-	MLX5DV_CONTEXT_FLAGS_CQE_V1 = (1 << 0),
+	MLX5DV_CONTEXT_FLAGS_CQE_V1	= (1 << 0),
+	MLX5DV_CONTEXT_FLAGS_MPW	= (1 << 1),
 };
 
 /*

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1927,6 +1927,8 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	if (resp.support_multi_pkt_send_wqe)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_MPW;
 
+	mctx->cqe_comp_caps = resp.cqe_comp_caps;
+
 	major     = (raw_fw_ver >> 32) & 0xffff;
 	minor     = (raw_fw_ver >> 16) & 0xffff;
 	sub_minor = raw_fw_ver & 0xffff;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -332,7 +332,8 @@ enum {
 };
 
 enum {
-	CREATE_CQ_SUPPORTED_COMP_MASK = IBV_CQ_INIT_ATTR_MASK_FLAGS
+	CREATE_CQ_SUPPORTED_COMP_MASK = IBV_CQ_INIT_ATTR_MASK_FLAGS |
+					IBV_CQ_INIT_ATTR_MASK_VENDOR_DATA
 };
 
 enum {
@@ -350,6 +351,8 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	int				ret;
 	int				ncqe;
 	FILE *fp = to_mctx(context)->dbg_fp;
+	struct mlx5dv_create_cq_vendor_data *vendor_data;
+	struct mlx5_context *mctx = to_mctx(context);
 
 	if (!cq_attr->cqe) {
 		mlx5_dbg(fp, MLX5_DBG_CQ, "CQE invalid\n");
@@ -427,6 +430,36 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	cmd.buf_addr = (uintptr_t) cq->buf_a.buf;
 	cmd.db_addr  = (uintptr_t) cq->dbrec;
 	cmd.cqe_size = cqe_sz;
+
+	if (cq_attr->comp_mask & IBV_CQ_INIT_ATTR_MASK_VENDOR_DATA) {
+		if (!(cq_attr->vendor_data)) {
+			mlx5_dbg(fp, MLX5_DBG_CQ, "Vendor data is requried\n");
+			errno = EINVAL;
+			goto err_db;
+		}
+
+		vendor_data = (struct mlx5dv_create_cq_vendor_data *)(cq_attr->vendor_data);
+
+		if (vendor_data->comp_mask & ~(MLX5DV_CREATE_CQ_MASK_RESERVED - 1)) {
+			mlx5_dbg(fp, MLX5_DBG_CQ,
+				 "Unsupported vendor comp_mask for create_cq\n");
+			errno = EINVAL;
+			goto err_db;
+		}
+
+		if (vendor_data->comp_mask & MLX5DV_CREATE_CQ_MASK_COMPRESSED_CQE) {
+			if (mctx->cqe_comp_caps.max_num &&
+			    (vendor_data->cqe_comp_res_format &
+			     mctx->cqe_comp_caps.supported_format)) {
+				cmd.cqe_comp_en = 1;
+				cmd.cqe_comp_res_format = vendor_data->cqe_comp_res_format;
+			} else {
+				mlx5_dbg(fp, MLX5_DBG_CQ, "CQE Compression is not supported\n");
+				errno = EINVAL;
+				goto err_db;
+			}
+		}
+	}
 
 	ret = ibv_cmd_create_cq(context, ncqe - 1, cq_attr->channel,
 				cq_attr->comp_vector,

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1924,6 +1924,9 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	attr->rss_caps.rx_hash_function = resp.rss_caps.rx_hash_function;
 	attr->packet_pacing_caps = resp.packet_pacing_caps.caps;
 
+	if (resp.support_multi_pkt_send_wqe)
+		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_MPW;
+
 	major     = (raw_fw_ver >> 32) & 0xffff;
 	minor     = (raw_fw_ver >> 16) & 0xffff;
 	sub_minor = raw_fw_ver & 0xffff;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1922,7 +1922,7 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	attr->tso_caps = resp.tso_caps;
 	attr->rss_caps.rx_hash_fields_mask = resp.rss_caps.rx_hash_fields_mask;
 	attr->rss_caps.rx_hash_function = resp.rss_caps.rx_hash_function;
-	attr->packet_pacing_caps = resp.packet_pacing_caps;
+	attr->packet_pacing_caps = resp.packet_pacing_caps.caps;
 
 	major     = (raw_fw_ver >> 32) & 0xffff;
 	minor     = (raw_fw_ver >> 16) & 0xffff;


### PR DESCRIPTION
Enable mlx5 vendor functionality to align user space with its kernel part that was accepted into 4.10. 