### PR TITLE
Correct broken cmake test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -210,7 +210,7 @@ CHECK_C_SOURCE_COMPILES("
 # Note, when using sparse the gcc stdatomic.h produces sparse errors
 CHECK_C_SOURCE_COMPILES("
  #include <stdatomic.h>
- int main(int argc,const char *argv[]) { return 0}"
+ int main(int argc,const char *argv[]) { return 0; }"
   HAVE_STDATOMIC
   FAIL_REGEX "error")
 RDMA_DoFixup("${HAVE_STDATOMIC}" "stdatomic.h")


### PR DESCRIPTION
The sparse introduction patch did not get enough testing, this broke
native stdatomic detection on all systems.

Fixes: eaceda6636cc ("buildlib/fixup-include/endian.h: Introduce this header file")
Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>