### PR TITLE
Sparse Code Changes

### DIFF
--- a/librdmacm/cma.h
+++ b/librdmacm/cma.h
@@ -69,12 +69,12 @@ static inline void fastlock_destroy(fastlock_t *lock)
 }
 static inline void fastlock_acquire(fastlock_t *lock)
 {
-	if (atomic_fetch_add(&lock->cnt, 1) > 1)
+	if (atomic_fetch_add(&lock->cnt, 1) > 0)
 		sem_wait(&lock->sem);
 }
 static inline void fastlock_release(fastlock_t *lock)
 {
-	if (atomic_fetch_sub(&lock->cnt, 1) > 0)
+	if (atomic_fetch_sub(&lock->cnt, 1) > 1)
 		sem_post(&lock->sem);
 }
 

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -1013,7 +1013,7 @@ int close(int socket)
 			return ret;
 	}
 
-	if (atomic_fetch_sub(&fdi->refcnt, 1))
+	if (atomic_fetch_sub(&fdi->refcnt, 1) != 1)
 		return 0;
 
 	idm_clear(&idm, socket);

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -899,7 +899,7 @@ static int rs_create_ep(struct rsocket *rs)
 
 static void rs_release_iomap_mr(struct rs_iomap_mr *iomr)
 {
-	if (atomic_fetch_sub(&iomr->refcnt, 1))
+	if (atomic_fetch_sub(&iomr->refcnt, 1) != 1)
 		return;
 
 	dlist_remove(&iomr->entry);

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -56,23 +56,12 @@
 #include <sys/mman.h>
 #include <infiniband/driver.h>
 #include <ccan/minmax.h>
+#include <util/compiler.h>
 
 #define BIT(nr) (1UL << (nr))
 
 #include "pvrdma-abi-fix.h"
 #include "pvrdma_ring.h"
-
-#ifndef likely
-#define likely(x)	__builtin_expect(!!(x), 1)
-#else
-#define likely(x)	(x)
-#endif
-
-#ifndef unlikely
-#define unlikely(x)	__builtin_expect(!!(x), 0)
-#else
-#define unlikely(x)	(x)
-#endif
 
 #define PFX "pvrdma: "
 


### PR DESCRIPTION
This is the rest of the code change stuff from the core libraries that sparse did not like.

There is one bug fix in here, the missing swap on INADDR_LOOPBACK.