### PR TITLE
Eliminate ClassPortInfo duplication between libibumad and srp_daemon

### DIFF
--- a/libibumad/tests/CMakeLists.txt
+++ b/libibumad/tests/CMakeLists.txt
@@ -3,3 +3,5 @@ target_link_libraries(umad_reg2 LINK_PRIVATE ibumad)
 
 rdma_test_executable(umad_register2 umad_register2.c)
 target_link_libraries(umad_register2 LINK_PRIVATE ibumad)
+
+rdma_test_executable(umad_compile_test umad_compile_test.c)

--- a/libibumad/tests/umad_compile_test.c
+++ b/libibumad/tests/umad_compile_test.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies LTD. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#include <config.h>
+
+#include <stddef.h>
+#include <endian.h>
+#include <ccan/build_assert.h>
+#include <infiniband/umad.h>
+#include <infiniband/umad_types.h>
+#include <infiniband/umad_sm.h>
+#include <infiniband/umad_sa.h>
+#include <infiniband/umad_cm.h>
+
+int main(int argc, char *argv[])
+{
+#ifndef __CHECKER__
+	/*
+	 * Hide these checks for sparse because these checks fail with
+	 * older versions of sparse.
+	 */
+	BUILD_ASSERT(__alignof__(union umad_gid) == 4);
+#endif
+
+	BUILD_ASSERT(sizeof(struct umad_class_port_info) == 72);
+	BUILD_ASSERT(offsetof(struct umad_class_port_info, redirgid) == 8);
+	BUILD_ASSERT(offsetof(struct umad_class_port_info, trapgid) == 40);
+}

--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -61,6 +61,7 @@ typedef __be64 __attribute__((deprecated)) be64_t;
  */
 union umad_gid {
 	uint8_t		raw[16];
+	__be16		raw_be16[8];
 	struct {
 		__be64	subnet_prefix;
 		__be64	interface_id;

--- a/libibumad/umad_types.h
+++ b/libibumad/umad_types.h
@@ -175,13 +175,19 @@ struct umad_class_port_info {
 	uint8_t class_ver;
 	__be16  cap_mask;
 	__be32  cap_mask2_resp_time;
-	uint8_t redir_gid[16]; /* network byte order */
+	union {
+		uint8_t redir_gid[16]; /* network byte order */
+		union umad_gid redirgid;
+	};
 	__be32  redir_tc_sl_fl;
 	__be16  redir_lid;
 	__be16  redir_pkey;
 	__be32  redir_qp;
 	__be32  redir_qkey;
-	uint8_t trap_gid[16]; /* network byte order */
+	union {
+		uint8_t trap_gid[16]; /* network byte order */
+		union umad_gid trapgid;
+	};
 	__be32  trap_tc_sl_fl;
 	__be16  trap_lid;
 	__be16  trap_pkey;

--- a/libibumad/umad_types.h
+++ b/libibumad/umad_types.h
@@ -176,7 +176,7 @@ struct umad_class_port_info {
 	__be16  cap_mask;
 	__be32  cap_mask2_resp_time;
 	union {
-		uint8_t redir_gid[16]; /* network byte order */
+		uint8_t redir_gid[16] __attribute__((deprecated)); /* network byte order */
 		union umad_gid redirgid;
 	};
 	__be32  redir_tc_sl_fl;
@@ -185,7 +185,7 @@ struct umad_class_port_info {
 	__be32  redir_qp;
 	__be32  redir_qkey;
 	union {
-		uint8_t trap_gid[16]; /* network byte order */
+		uint8_t trap_gid[16] __attribute__((deprecated)); /* network byte order */
 		union umad_gid trapgid;
 	};
 	__be32  trap_tc_sl_fl;

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -2051,14 +2051,11 @@ int main(int argc, char *argv[])
 	STATIC_ASSERT(sizeof(ib_mad_notice_attr_t) == 80);
 	STATIC_ASSERT(offsetof(ib_mad_notice_attr_t,
 			       data_details.ntc_64_67.gid) == 16);
-
-	STATIC_ASSERT(__alignof__(union umad_gid) == 4);
 #endif
 	STATIC_ASSERT(sizeof(struct srp_dm_mad) == 256);
 	STATIC_ASSERT(sizeof(struct srp_dm_rmpp_sa_mad) == 256);
 	STATIC_ASSERT(sizeof(struct srp_sa_node_rec) == 108);
 	STATIC_ASSERT(sizeof(struct srp_sa_port_info_rec) == 58);
-	STATIC_ASSERT(sizeof(struct umad_class_port_info) == 72);
 	STATIC_ASSERT(sizeof(struct srp_dm_iou_info) == 132);
 	STATIC_ASSERT(sizeof(struct srp_dm_ioc_prof) == 128);
 

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -822,7 +822,7 @@ static int set_class_port_info(struct umad_resources *umad_res, uint16_t dlid)
 	}
 
 	for (i = 0; i < 8; ++i)
-		((__be16 *) cpi->trapgid.raw)[i] = htobe16(strtol(val + i * 5, NULL, 16));
+		cpi->trapgid.raw_be16[i] = htobe16(strtol(val + i * 5, NULL, 16));
 
 	if (send_and_get(umad_res->portid, umad_res->agent, &out_mad, &in_mad, 0) < 0)
 		return -1;

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -822,7 +822,7 @@ static int set_class_port_info(struct umad_resources *umad_res, uint16_t dlid)
 	}
 
 	for (i = 0; i < 8; ++i)
-		((__be16 *) cpi->trap_gid)[i] = htobe16(strtol(val + i * 5, NULL, 16));
+		((__be16 *) cpi->trapgid.raw)[i] = htobe16(strtol(val + i * 5, NULL, 16));
 
 	if (send_and_get(umad_res->portid, umad_res->agent, &out_mad, &in_mad, 0) < 0)
 		return -1;

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -61,6 +61,7 @@
 #include <signal.h>
 #include <sys/syslog.h>
 #include <infiniband/umad.h>
+#include <infiniband/umad_types.h>
 #include "srp_ib_types.h"
 
 #include "srp_daemon.h"
@@ -774,7 +775,7 @@ static int check_sm_cap(struct umad_resources *umad_res, int *mask_match)
 {
 	srp_ib_user_mad_t		out_mad, in_mad;
 	struct srp_dm_rmpp_sa_mad      *in_sa_mad;
-	struct srp_class_port_info     *cpi;
+	struct umad_class_port_info    *cpi;
 	int				ret;
 
 	in_sa_mad  = get_data_ptr(in_mad);
@@ -797,7 +798,7 @@ static int set_class_port_info(struct umad_resources *umad_res, uint16_t dlid)
 {
 	srp_ib_user_mad_t		in_mad, out_mad;
 	struct srp_dm_mad	       *out_dm_mad, *in_dm_mad;
-	struct srp_class_port_info     *cpi;
+	struct umad_class_port_info     *cpi;
 	char val[64];
 	int i;
 
@@ -2057,7 +2058,7 @@ int main(int argc, char *argv[])
 	STATIC_ASSERT(sizeof(struct srp_dm_rmpp_sa_mad) == 256);
 	STATIC_ASSERT(sizeof(struct srp_sa_node_rec) == 108);
 	STATIC_ASSERT(sizeof(struct srp_sa_port_info_rec) == 58);
-	STATIC_ASSERT(sizeof(struct srp_class_port_info) == 72);
+	STATIC_ASSERT(sizeof(struct umad_class_port_info) == 72);
 	STATIC_ASSERT(sizeof(struct srp_dm_iou_info) == 132);
 	STATIC_ASSERT(sizeof(struct srp_dm_ioc_prof) == 128);
 

--- a/srp_daemon/srp_daemon.h
+++ b/srp_daemon/srp_daemon.h
@@ -219,26 +219,6 @@ struct srp_sa_port_info_rec {
 	uint8_t		error_threshold;
 };
 
-struct srp_class_port_info {
-	uint8_t		base_version;
-	uint8_t		class_version;
-	__be16		cap_mask;
-	uint8_t		reserved1[3];
-	uint8_t		resp_time;
-	uint8_t		redir_gid[16];
-	__be32		redir_tc_sl_fl;
-	__be16		redir_lid;
-	__be16		redir_pkey;
-	__be32		redir_qpn;
-	__be32		redir_qkey;
-	uint8_t		trap_gid[16];
-	__be32		trap_tc_sl_fl;
-	__be16		trap_lid;
-	__be16		trap_pkey;
-	__be32		trap_hl_qpn;
-	__be32		trap_qkey;
-};
-
 struct srp_dm_iou_info {
 	__be16		change_id;
 	uint8_t		max_controllers;


### PR DESCRIPTION
Use umad_class_port_info rather than srp_class_port_info in SRP daemon.

In umad_class_port_info, use umad_gid unions and deprecate original [redir trap]_gid fields.

Follow on to Bart's work in PR #104 