### PR TITLE
mlx5: Fix device context allocation

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1006,7 +1006,7 @@ found:
 		return NULL;
 	}
 
-	dev = malloc(sizeof *dev);
+	dev = calloc(1, sizeof *dev);
 	if (!dev) {
 		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
 			uverbs_sys_path);


### PR DESCRIPTION
Use calloc to allocate device context so the unset bytes are zero.
When building a *non* release mode (i.e. without DCMAKE_BUILD_TYPE=Release)
the below assert is applicable and might raise:
assert(dev->_ops._dummy1).

Fix below commit to use calloc instead of malloc for mlx5 as well.

Fixes: 85c449528709 ("providers: Make every provider allocate a
verbs_device")
Signed-off-by: Artemy Kovalyov <artemyko@mellanox.com>
Reviewed-by: Yishai Hadas <yishaih@mellanox.com>