### PR TITLE
debian: Squash changelog to be one entry

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,5 @@
 rdma-core (14-1) unstable; urgency=low
 
-  * Bump version.
-
- -- Leon Romanovsky <leon@kernel.org>  Sat, 25 Mar 2017 14:29:00 -0600
-
-rdma-core (13-1) unstable; urgency=low
   * New version.
   * Adding debian/copyright.
   * Close ITP (Closes: #848971).


### PR DESCRIPTION
The debian's changelog is managed outside of rdma-core upstream package
and hence there is no need to add entry to it, just update version only.

Signed-off-by: Leon Romanovsky <leon@kernel.org>