### PR TITLE
More srp_daemon/libibumad changes involving BUILD_ASSERT

### DIFF
--- a/libibumad/tests/umad_compile_test.c
+++ b/libibumad/tests/umad_compile_test.c
@@ -52,7 +52,19 @@ int main(int argc, char *argv[])
 	BUILD_ASSERT(__alignof__(union umad_gid) == 4);
 #endif
 
+	/* umad_types.h structure checks */
+	BUILD_ASSERT(sizeof(struct umad_hdr) == 24);
+	BUILD_ASSERT(sizeof(struct umad_rmpp_hdr) == 12);
+	BUILD_ASSERT(sizeof(struct umad_packet) == 256);
+	BUILD_ASSERT(sizeof(struct umad_rmpp_packet) == 256);
+	BUILD_ASSERT(sizeof(struct umad_vendor_packet) == 256);
 	BUILD_ASSERT(sizeof(struct umad_class_port_info) == 72);
 	BUILD_ASSERT(offsetof(struct umad_class_port_info, redirgid) == 8);
 	BUILD_ASSERT(offsetof(struct umad_class_port_info, trapgid) == 40);
+
+	/* umad_sm.h structure check */
+	BUILD_ASSERT(sizeof(struct umad_smp) == 256);
+
+	/* umad_sa.h structure check */
+	BUILD_ASSERT(sizeof(struct umad_sa_packet) == 256);
 }

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -2044,20 +2044,20 @@ int main(int argc, char *argv[])
 	 * Hide these checks for sparse because these checks fail with
 	 * older versions of sparse.
 	 */
-	STATIC_ASSERT(sizeof(ib_sa_mad_t) == 256);
-	STATIC_ASSERT(sizeof(ib_path_rec_t) == 64);
-	STATIC_ASSERT(sizeof(ib_mad_t) == 24);
-	STATIC_ASSERT(sizeof(ib_inform_info_t) == 36);
-	STATIC_ASSERT(sizeof(ib_mad_notice_attr_t) == 80);
-	STATIC_ASSERT(offsetof(ib_mad_notice_attr_t,
-			       data_details.ntc_64_67.gid) == 16);
+	BUILD_ASSERT(sizeof(ib_sa_mad_t) == 256);
+	BUILD_ASSERT(sizeof(ib_path_rec_t) == 64);
+	BUILD_ASSERT(sizeof(ib_mad_t) == 24);
+	BUILD_ASSERT(sizeof(ib_inform_info_t) == 36);
+	BUILD_ASSERT(sizeof(ib_mad_notice_attr_t) == 80);
+	BUILD_ASSERT(offsetof(ib_mad_notice_attr_t,
+			      data_details.ntc_64_67.gid) == 16);
 #endif
-	STATIC_ASSERT(sizeof(struct srp_dm_mad) == 256);
-	STATIC_ASSERT(sizeof(struct srp_dm_rmpp_sa_mad) == 256);
-	STATIC_ASSERT(sizeof(struct srp_sa_node_rec) == 108);
-	STATIC_ASSERT(sizeof(struct srp_sa_port_info_rec) == 58);
-	STATIC_ASSERT(sizeof(struct srp_dm_iou_info) == 132);
-	STATIC_ASSERT(sizeof(struct srp_dm_ioc_prof) == 128);
+	BUILD_ASSERT(sizeof(struct srp_dm_mad) == 256);
+	BUILD_ASSERT(sizeof(struct srp_dm_rmpp_sa_mad) == 256);
+	BUILD_ASSERT(sizeof(struct srp_sa_node_rec) == 108);
+	BUILD_ASSERT(sizeof(struct srp_sa_port_info_rec) == 58);
+	BUILD_ASSERT(sizeof(struct srp_dm_iou_info) == 132);
+	BUILD_ASSERT(sizeof(struct srp_dm_ioc_prof) == 128);
 
 	ret = pipe(wakeup_pipe);
 	if (ret < 0) {

--- a/srp_daemon/srp_daemon.h
+++ b/srp_daemon/srp_daemon.h
@@ -42,17 +42,10 @@
 #include <infiniband/verbs.h>
 #include <infiniband/umad.h>
 #include <linux/types.h>	/* __be16, __be32 and __be64 */
+#include <ccan/build_assert.h>
 
 #include "config.h"
 #include "srp_ib_types.h"
-
-#ifdef __cplusplus
-template <bool b> struct vki_static_assert { int m_bitfield:(2*b-1); };
-#define STATIC_ASSERT(expr) \
-	(void)(sizeof(vki_static_assert<(expr)>) - sizeof(int))
-#else
-#define STATIC_ASSERT(expr) (void)(sizeof(struct { int:-!(expr); }))
-#endif
 
 /* a CMP b. See also the BSD macro timercmp(). */
 #define ts_cmp(a, b, CMP)			\


### PR DESCRIPTION
srp_daemon/srp_daemon.[h c]: Replace open coded STATIC_ASSERT with ccan BUILD_ASSERT

libibumad: Add additional umad structure checks to umad_compile_test.c