### PR TITLE
ARM 64bit build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,11 +35,18 @@ addons:
       - python
       - valgrind
       - sparse
+      - wget
 
       # 32 bit support packages
       - gcc-multilib
       - lib32gcc-6-dev
 
+before_script:
+  - export LATEST_GCC_LINARO_URL=`wget -qO - https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/ | grep -o '<a href=['"'"'"].*gcc-linaro-.*x86_64_aarch64-linux-gnu.tar.xz['"'"'"]'  |  sed -e 's/^<a href=["'"'"']//' -e 's/["'"'"']$//'`
+  - export LATEST_GCC_LINARO_TAR=`basename $LATEST_GCC_LINARO_URL`
+  - wget -q http://releases.linaro.org/$LATEST_GCC_LINARO_URL
+  - mkdir $HOME/aarch64 && tar xf $LATEST_GCC_LINARO_TAR -C $HOME/aarch64 --strip 1
+  - rm $LATEST_GCC_LINARO_TAR
 script:
   - buildlib/travis-build
   - buildlib/github-release

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -244,6 +244,12 @@ class travis(APTEnvironment):
         cmds.append("RUN " + " && ".join(scmds));
         return cmds;
 
+    def get_before_script(self):
+        """Return a list of commands to run from before_script"""
+        cmds = ["RUN useradd -ms /bin/bash travis && \\"
+                "su -l -c %s"%(pipes.quote(" && ".join(self.yaml["before_script"]))) + " travis"];
+        return cmds
+
     def get_docker_file(self):
         # First this to get apt-add-repository
         self.pkgs = {"software-properties-common"}
@@ -255,6 +261,9 @@ class travis(APTEnvironment):
         # Package list from the travis.yml
         res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s"%(
             " ".join(sorted(self.yaml["addons"]["apt"]["packages"]))));
+
+        # Adding before_script commands
+        res.lines.extend(self.get_before_script())
 
         return res;
 
@@ -534,17 +543,18 @@ def run_travis_build(args,env):
                                    "--git-dir",os.path.join(opwd,".git"),
                                    "reset","--hard","HEAD"]);
 
-        home = os.path.join(os.path.sep,"home",os.getenv("LOGNAME"));
+        home = os.path.join(os.path.sep,"home","travis");
+        home_build = os.path.join(os.path.sep,home,"build");
 
         opts = [
             "run",
             "--read-only",
             "--rm=true",
-            "-v","%s:%s"%(tmpdir,home),
-            "-w",os.path.join(home,"src"),
-            "-u",str(os.getuid()),
+            "-v","%s:%s"%(tmpdir, home_build),
+            "-w",os.path.join(home_build,"src"),
+            "-u","travis",
             "-e","HOME=%s"%(home),
-            "-e","TMPDIR=%s"%(os.path.join(home,"tmp")),
+            "-e","TMPDIR=%s"%(os.path.join(home_build,"tmp")),
         ];
 
         # Load the commands from the travis file
@@ -564,7 +574,7 @@ def run_travis_build(args,env):
         if args.run_shell:
             opts.append("/bin/bash");
         else:
-            opts.extend(["/bin/bash",os.path.join(home,"go.sh")]);
+            opts.extend(["/bin/bash",os.path.join(home_build,"go.sh")]);
 
         docker_cmd(args,*opts);
 

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -5,7 +5,7 @@ set -e
 # Echo all commands to Travis log
 set -x
 
-mkdir build-clang build32 build-sparse
+mkdir build-clang build32 build-sparse build-aarch64
 
 # Build with latest clang first
 cd build-clang
@@ -18,6 +18,11 @@ cd ../build32
 # travis's trusty is not configured in a way that enables all 32 bit
 # packages. We could fix this with some sudo stuff.. For now turn off libnl
 CC=gcc-6 CFLAGS="-Werror -m32" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0
+ninja
+
+# aarch64 build to check compilation on ARM 64bit platform
+cd ../build-aarch64
+CC=$HOME/aarch64/bin/aarch64-linux-gnu-gcc CFLAGS="-Werror -Wno-maybe-uninitialized" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0
 ninja
 
 # Run sparse on the subdirectories which are sparse clean


### PR DESCRIPTION
This is a follow up on the conversation with Leon during OFA workshop.
The patch uses Linaro cross-compilation tool-chain to build aarch64 rdma-core.
In the process, I also discovered an issue in mthca provider which caused travis failure on aarch64.