### PR TITLE
srp_daemon/srp_daemon.c: Don't rely on attribute offset in get_shared_pkeys

### DIFF
--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -632,8 +632,8 @@ recv:
 			ret = umad_status(in_mad);
 			if (ret) {
 				pr_err(
-					"bad MAD status (%u) from lid %d\n",
-					ret, (uint16_t) be16toh(out_mad->hdr.addr.lid));
+					"bad MAD status (%u) from lid %#x\n",
+					ret, be16toh(out_mad->hdr.addr.lid));
 				return -ret;
 			}
 
@@ -935,7 +935,7 @@ static int do_port(struct resources *res, uint16_t pkey, uint16_t dlid,
 
 	ret = get_iou_info(umad_res, dlid, &iou_info);
 	if (ret < 0) {
-		pr_err("failed to get iou info for dlid %x\n", dlid);
+		pr_err("failed to get iou info for dlid %#x\n", dlid);
 		goto out;
 	}
 
@@ -1214,7 +1214,7 @@ static int do_dm_port_list(struct resources *res)
 		num_pkeys = get_shared_pkeys(res, be16toh(port_info->endport_lid),
 					     pkeys);
 		if (num_pkeys < 0) {
-			pr_err("failed to get shared P_Keys with LID %x\n",
+			pr_err("failed to get shared P_Keys with LID %#x\n",
 			       be16toh(port_info->endport_lid));
 			free(in_mad_buf);
 			return num_pkeys;
@@ -1235,7 +1235,7 @@ void handle_port(struct resources *res, uint16_t pkey, uint16_t lid, uint64_t h_
 	uint64_t subnet_prefix;
 	int isdm;
 
- 	pr_debug("enter handle_port for lid %d\n", lid);
+	pr_debug("enter handle_port for lid %#x\n", lid);
 	if (get_port_info(umad_res, lid, &subnet_prefix, &isdm))
 		return;
 
@@ -1292,7 +1292,7 @@ static int do_full_port_list(struct resources *res)
 		num_pkeys = get_shared_pkeys(res, be16toh(node->lid),
 					     pkeys);
 		if (num_pkeys < 0) {
-			pr_err("failed to get shared P_Keys with LID %x\n",
+			pr_err("failed to get shared P_Keys with LID %#x\n",
 			       be16toh(node->lid));
 			free(in_mad_buf);
 			return num_pkeys;
@@ -2188,7 +2188,7 @@ catas_start:
 					/* unexpected error - do a full rescan */
 					schedule_rescan(res->sync_res, 0);
 				else {
-					pr_debug("lid is %d\n", lid);
+					pr_debug("lid is %#x\n", lid);
 
 					srp_sleep(0, 100);
 					handle_port(res, pkey, lid,

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -1134,8 +1134,6 @@ static int get_shared_pkeys(struct resources *res,
 
 		/* Mark components: DLID, SLID, PKEY */
 		out_sa_mad->comp_mask = htobe64(1 << 4 | 1 << 5 | 1 << 13);
-		out_sa_mad->rmpp_hdr.rmpp_version = UMAD_RMPP_VERSION;
-		out_sa_mad->rmpp_hdr.rmpp_type = 1;
 		path_rec = (struct ib_path_rec *)out_sa_mad->data;
 		path_rec->slid = htobe16(local_port_lid);
 		path_rec->dlid = htobe16(dest_port_lid);

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -1102,7 +1102,6 @@ static int get_shared_pkeys(struct resources *res,
 	struct umad_sa_packet	       *out_sa_mad, *in_sa_mad;
 	struct ib_path_rec	       *path_rec;
 	ssize_t len;
-	int size;
 	int i, num_pkeys = 0;
 	uint16_t pkey;
 	uint16_t local_port_lid = get_port_lid(res->ud_res->ib_ctx,
@@ -1147,14 +1146,6 @@ static int get_shared_pkeys(struct resources *res,
 				   node_table_response_size);
 		if (len < 0)
 			goto err;
-
-		size = ib_get_attr_size(in_sa_mad->attr_offset);
-		if (!size) {
-			if (config->verbose)
-				printf("PathRec Query did not find any targets "
-				       "over P_Key %x\n", pkey);
-			continue;
-		}
 
 		path_rec = (struct ib_path_rec *)in_sa_mad->data;
 		pkeys[num_pkeys++] = be16toh(path_rec->pkey);

--- a/srp_daemon/srp_handle_traps.c
+++ b/srp_daemon/srp_handle_traps.c
@@ -561,9 +561,9 @@ static int register_to_trap(struct sync_resources *sync_res,
 	static uint64_t trans_id = 0x0000FFFF;
 
 	if (subscribe)
-		pr_debug("Registering to trap:%d (sm in %d)\n", trap_num, dest_lid);
+		pr_debug("Registering to trap:%d (sm in %#x)\n", trap_num, dest_lid);
 	else
-		pr_debug("Deregistering from trap:%d (sm in %d)\n", trap_num, dest_lid);
+		pr_debug("Deregistering from trap:%d (sm in %#x)\n", trap_num, dest_lid);
 
 	memset(res->send_buf, 0, SEND_SIZE);
 

--- a/srp_daemon/srp_sync.c
+++ b/srp_daemon/srp_sync.c
@@ -171,7 +171,7 @@ void push_lid_to_list(struct sync_resources *res, uint16_t lid, uint16_t pkey)
 
 	for (i=0; i < res->next_task; ++i)
 		if (res->tasks[i].lid == lid && res->tasks[i].pkey == pkey) {
-			pr_debug("lid %d is already in task list\n", lid);
+			pr_debug("lid %#x is already in task list\n", lid);
 			pthread_mutex_unlock(&res->mutex);
 			return;
 		}


### PR DESCRIPTION
get_shared_pkeys has been using SubAdmGet rather than SubAdmGetTable since
commit 2ad09524931dbf98d412e1912c1bdbf22f8ac81d
srp_daemon: Work around SM bug over non-default P_Key support

so RMPP is no longer used in response so it's not safe to
rely on AttributeOffset field. Good MAD status is sufficient
to say that valid PathRecord was returned.

Found-by: Honggang LI <honli@redhat.com>
using embedded subnet manager running on an Intel True Scale
Edge Switch 12300.

This has been broken since srptools-1.0.1 which was first
release containing commit mentioned above.

Also, added trivial patches for:
srp_daemon/srp_daemon.c: Eliminate some unneeded code in get_shared_pkeys
srp_daemon: Use consistent format when printing LID