### PR TITLE
Debian packaging changes from libibumad review

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -79,7 +79,7 @@ Description: InfiniBand Communication Manager (CM) library
 Package: libibcm1-dbg
 Section: debug
 Architecture: linux-any
-Depends: ${misc:Depends}
+Depends: libibcm1 (= ${binary:Version}), ${misc:Depends}
 Description: Debug symbols for the libibcm1 library
  libibcm provides a userspace implementation of an InfiniBand
  Communication Manager (CM). The CM handles both connection
@@ -117,7 +117,7 @@ Description: InfiniBand Userspace Management Datagram (uMAD) library
 Package: libibumad3-dbg
 Section: debug
 Architecture: linux-any
-Depends: ${misc:Depends}
+Depends: libibumad3 (= ${binary:Version}), ${misc:Depends}
 Description: Debug symbols for the libibumad3 library
  libibumad provides userspace Infiniband Management Datagram (uMAD)
  functions which sit on top of the uMAD modules in the kernel.

--- a/debian/control
+++ b/debian/control
@@ -80,12 +80,12 @@ Package: libibcm1-dbg
 Section: debug
 Architecture: linux-any
 Depends: ${misc:Depends}
-Description: InfiniBand Communication Manager (CM) library
+Description: Debug symbols for the libibcm1 library
  libibcm provides a userspace implementation of an InfiniBand
  Communication Manager (CM). The CM handles both connection
  establishment as well as service ID resolution.
  .
- This package contains the debugging symbols associated with
+ This package contains the debug symbols associated with
  libibcm1. They will automatically be used by gdb for debugging
  libibcm-related issues.
 
@@ -118,12 +118,12 @@ Package: libibumad3-dbg
 Section: debug
 Architecture: linux-any
 Depends: ${misc:Depends}
-Description: InfiniBand Userspace Management Datagram (uMAD) library
+Description: Debug symbols for the libibumad3 library
  libibumad provides userspace Infiniband Management Datagram (uMAD)
  functions which sit on top of the uMAD modules in the kernel.
  These are used by InfiniBand diagnostic and management tools.
  .
- This package contains the debugging symbols associated with
+ This package contains the debug symbols associated with
  libibumad3. They will automatically be used by gdb for debugging
  libibumad-related issues.
 
@@ -168,7 +168,7 @@ Section: debug
 Architecture: linux-any
 Multi-Arch: same
 Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}
-Description: Debugging symbols for the libibverbs library
+Description: Debug symbols for the libibverbs library
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and
  the RDMA Protocol Verbs Specification.  iWARP ethernet NICs support
@@ -178,7 +178,7 @@ Description: Debugging symbols for the libibverbs library
  hardware access from userspace (kernel bypass), and libibverbs
  supports this when available.
  .
- This package contains the debugging symbols associated with
+ This package contains the debug symbols associated with
  libibverbs1. They will automatically be used by gdb for debugging
  libibverbs-related issues.
 
@@ -226,7 +226,7 @@ Package: librdmacm1-dbg
 Section: debug
 Architecture: linux-any
 Depends: librdmacm1 (= ${binary:Version}), ${misc:Depends}
-Description: Debugging symbols for the librdmacm library
+Description: Debug symbols for the librdmacm library
  librdmacm is a library that allows applications to set up reliable
  connected and unreliable datagram transfers when using RDMA adapters.
  It provides a transport-neutral interface in the sense that the same
@@ -240,7 +240,7 @@ Description: Debugging symbols for the librdmacm library
  provided by libibverbs, which provides the interface used to actually
  transfer data.
  .
- This package contains the debugging symbols associated with
+ This package contains the debug symbols associated with
  librdmacm1. They will automatically be used by gdb for debugging
  librdmacm-related issues.
 

--- a/debian/control
+++ b/debian/control
@@ -1,8 +1,7 @@
 Source: rdma-core
 Maintainer: Linux RDMA Mailing List <linux-rdma@vger.kernel.org>
-Uploaders:
- Benjamin Drung <benjamin.drung@profitbricks.com>,
- Talat Batheesh <talatb@mellanox.com>
+Uploaders: Benjamin Drung <benjamin.drung@profitbricks.com>,
+           Talat Batheesh <talatb@mellanox.com>
 Section: net
 Priority: extra
 Build-Depends: cmake (>= 2.8.11),
@@ -296,7 +295,10 @@ Description: Examples for the librdmacm library
 
 Package: srptools
 Architecture: linux-any
-Depends: infiniband-diags, lsb-base (>= 3.2-14~), ${misc:Depends}, ${shlibs:Depends}
+Depends: infiniband-diags,
+         lsb-base (>= 3.2-14~),
+         ${misc:Depends},
+         ${shlibs:Depends}
 Description: Tools for Infiniband attached storage (SRP)
  In conjunction with the kernel ib_srp driver, srptools allows you to
  discover and use Infiniband attached storage devices which use the
@@ -304,7 +306,10 @@ Description: Tools for Infiniband attached storage (SRP)
 
 Package: iwpmd
 Architecture: linux-any
-Depends: infiniband-diags, lsb-base (>= 3.2-14~), ${misc:Depends}, ${shlibs:Depends}
+Depends: infiniband-diags,
+         lsb-base (>= 3.2-14~),
+         ${misc:Depends},
+         ${shlibs:Depends}
 Description: Userspace component for iWarp RDMA services
  iwpmd provides a userspace service for iWarp drivers to claim
  tcp ports through the standard socket interface.

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -1,6 +1,6 @@
 libmlx5.so.1 ibverbs-providers #MINVER#
- MLX5_1.0@MLX5_1.0 13-1
- MLX5_1.1@MLX5_1.1 14-1
- mlx5dv_init_obj@MLX5_1.0 13-1
- mlx5dv_query_device@MLX5_1.0 13-1
- mlx5dv_create_cq@MLX5_1.1 14-1
+ MLX5_1.0@MLX5_1.0 13
+ MLX5_1.1@MLX5_1.1 14
+ mlx5dv_init_obj@MLX5_1.0 13
+ mlx5dv_query_device@MLX5_1.0 13
+ mlx5dv_create_cq@MLX5_1.1 14

--- a/debian/libibverbs-dev.install
+++ b/debian/libibverbs-dev.install
@@ -1,13 +1,13 @@
 usr/include/infiniband/arch.h
 usr/include/infiniband/kern-abi.h
+usr/include/infiniband/mlx5dv.h
 usr/include/infiniband/opcode.h
 usr/include/infiniband/sa-kern-abi.h
 usr/include/infiniband/sa.h
 usr/include/infiniband/verbs.h
-usr/include/infiniband/mlx5dv.h
 usr/lib/*/libibverbs*.so
-usr/share/man/man3/mlx5dv_*.3
-usr/share/man/man7/mlx5dv.7
 usr/share/man/man3/ibv_*
 usr/share/man/man3/mbps_to_ibv_rate.3
+usr/share/man/man3/mlx5dv_*.3
 usr/share/man/man3/mult_to_ibv_rate.3
+usr/share/man/man7/mlx5dv.7


### PR DESCRIPTION
Here are some Debian packaging changes that I found while reviewing the changes from libibumad 	1.3.10.2-2 to rdma-core.