### PR TITLE
Primarily add some missing librdmacm man pages

### DIFF
--- a/debian/rdmacm-utils.install
+++ b/debian/rdmacm-utils.install
@@ -11,6 +11,7 @@ usr/bin/rstream
 usr/bin/ucmatose
 usr/bin/udaddy
 usr/bin/udpong
+usr/share/man/man1/cmtime.1
 usr/share/man/man1/mckey.1
 usr/share/man/man1/rcopy.1
 usr/share/man/man1/rdma_client.1
@@ -22,3 +23,4 @@ usr/share/man/man1/rping.1
 usr/share/man/man1/rstream.1
 usr/share/man/man1/ucmatose.1
 usr/share/man/man1/udaddy.1
+usr/share/man/man1/udpong.1

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -640,6 +640,7 @@ int main(int argc, char **argv)
 			printf("\t[-b bind_address]\n");
 			printf("\t[-c connections]\n");
 			printf("\t[-p port_number]\n");
+			printf("\t[-r retries]\n");
 			printf("\t[-t timeout_ms]\n");
 			exit(1);
 		}

--- a/librdmacm/man/CMakeLists.txt
+++ b/librdmacm/man/CMakeLists.txt
@@ -1,4 +1,5 @@
 rdma_man_pages(
+  cmtime.1
   mckey.1
   rcopy.1
   rdma_accept.3

--- a/librdmacm/man/CMakeLists.txt
+++ b/librdmacm/man/CMakeLists.txt
@@ -61,4 +61,5 @@ rdma_man_pages(
   rstream.1
   ucmatose.1
   udaddy.1
+  udpong.1
   )

--- a/librdmacm/man/cmtime.1
+++ b/librdmacm/man/cmtime.1
@@ -1,0 +1,50 @@
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.TH "CMTIME" 1 "2017-04-28" "librdmacm" "librdmacm" librdmacm
+.SH NAME
+cmtime \- RDMA CM connection steps timing test.
+.SH SYNOPSIS
+.sp
+.nf
+\fIcmtime\fR [-s server_address] [-b bind_address]
+			[-c connections] [-p port_number]
+			[-r retries] [-t timeout_ms]
+.fi
+.SH "DESCRIPTION"
+Determines min and max times for various "steps" in RDMA CM
+connection setup and teardown between a client and server
+application.
+
+"Steps" that are timed are: create id, bind address, resolve address,
+resolve route, create qp, connect, disconnect, and destroy.
+.SH "OPTIONS"
+.TP
+\-s server_address
+The network name or IP address of the server system listening for
+connections.  The used name or address must route over an RDMA device.
+This option must be specified by the client.
+.TP
+\-b bind_address
+The local network address to bind to.
+.TP
+\-c connections
+The number of connections to establish between the client and
+server.  (default 100)
+.TP
+\-p port_number
+The server's port number.
+.TP
+\-r retries
+Number of retries when resolving address or route.  (default 2)
+.TP
+\-t timeout_ms
+Timeout in millseconds (ms) when resolving address or
+route.  (default 2000 - 2 seconds)
+.SH "NOTES"
+Basic usage is to start cmtime on a server system, then run
+cmtime -s server_name on a client system.
+.P
+Because this test maps RDMA resources to userspace, users must ensure
+that they have available system resources and permissions.  See the
+libibverbs README file for additional details.
+.SH "SEE ALSO"
+rdma_cm(7)

--- a/librdmacm/man/rstream.1
+++ b/librdmacm/man/rstream.1
@@ -34,7 +34,7 @@ exchanged between the client and server.  (default 1000)
 .TP
 \-C transfer_count
 The number of messages to transfer from the client to the server and
-back again on each iteration.  (default 1)
+back again on each iteration.  (default 1000)
 .TP
 \-S transfer_size
 The size of each send transfer, in bytes.  (default 1000)  If 'all'

--- a/librdmacm/man/udpong.1
+++ b/librdmacm/man/udpong.1
@@ -1,0 +1,62 @@
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.TH "UDPONG" 1 "2017-04-28" "librdmacm" "librdmacm" librdmacm
+.SH NAME
+udpong \- unreliable datagram streaming over RDMA ping-pong test.
+.SH SYNOPSIS
+.sp
+.nf
+\fIudpong\fR [-s server_address] [-b bind_address]
+			[-B buffer_size] [-C transfer_count]
+			[-S transfer_size] [-p server_port] [-T test_option]
+.fi
+.SH "DESCRIPTION"
+Uses unreliable datagram streaming over RDMA protocol (rsocket) to
+connect and exchange data between a client and server application.
+.SH "OPTIONS"
+.TP
+\-s server_address
+The network name or IP address of the server system listening for
+connections.  The used name or address must route over an RDMA device.
+This option must be specified by the client.
+.TP
+\-b bind_address
+The local network address to bind to.
+.TP
+\-B buffer_size
+Indicates the size of the send and receive network buffers.
+.TP
+\-C transfer_count
+The number of messages to transfer from the client to the server and
+back again on each iteration.  (default 1000)
+.TP
+\-S transfer_size
+The size of each send transfer, in bytes.  (default 1000)
+.TP
+\-p server_port
+The server's port number.
+.TP
+\-T test_option
+Specifies test parameters.  Available options are:
+.P
+s | socket  - uses standard socket calls to transfer data
+.P
+a | async - uses asynchronous operation (e.g. select / poll)
+.P
+b | blocking - uses blocking calls
+.P
+n | nonblocking - uses non-blocking calls
+.P
+e | echo - server echoes all messages
+.SH "NOTES"
+Basic usage is to start udpong on a server system, then run
+udpong -s server_name on a client system.  udpong
+will run a series of latency and bandwidth performance tests.
+Specifying a different transfer_count or transfer_size
+will run a user customized test using default values where none
+have been specified.
+.P
+Because this test maps RDMA resources to userspace, users must ensure
+that they have available system resources and permissions.  See the
+libibverbs README file for additional details.
+.SH "SEE ALSO"
+rdma_cm(7)


### PR DESCRIPTION
Needed for Debian release

Also, a couple of trivial fixes:
Fix transfer_count default in rstream man page
Add retries option to usage in cmtime example