### PR TITLE
Mlx5 misc

### DIFF
--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -177,7 +177,7 @@ static inline int handle_responder_lazy(struct mlx5_cq *cq, struct mlx5_cqe64 *c
 		else if (cqe->op_own & MLX5_INLINE_SCATTER_64)
 			err = mlx5_copy_to_recv_wqe(qp, wqe_ctr, cqe - 1,
 						    be32toh(cqe->byte_cnt));
-}
+	}
 
 	return err;
 }
@@ -227,8 +227,6 @@ static inline int handle_responder(struct ibv_wc *wc, struct mlx5_cqe64 *cqe,
 	}
 	if (err)
 		return err;
-
-	wc->byte_len = be32toh(cqe->byte_cnt);
 
 	switch (cqe->op_own >> 4) {
 	case MLX5_CQE_RESP_WR_IMM:

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -78,6 +78,8 @@ static struct {
 	HCA(MELLANOX, 4122),	/* ConnectX-5 Ex VF */
 	HCA(MELLANOX, 4123),    /* ConnectX-6 */
 	HCA(MELLANOX, 4124),	/* ConnectX-6 VF */
+	HCA(MELLANOX, 41682),	/* BlueField integrated ConnectX-5 network controller */
+	HCA(MELLANOX, 41683),	/* BlueField integrated ConnectX-5 network controller VF */
 };
 
 uint32_t mlx5_debug_mask = 0;

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -317,7 +317,7 @@ static uint8_t wq_sig(struct mlx5_wqe_ctrl_seg *ctrl)
 }
 
 #ifdef MLX5_DEBUG
-void dump_wqe(FILE *fp, int idx, int size_16, struct mlx5_qp *qp)
+static void dump_wqe(FILE *fp, int idx, int size_16, struct mlx5_qp *qp)
 {
 	uint32_t *uninitialized_var(p);
 	int i, j;


### PR DESCRIPTION
This patchset handles misc issues in the mlx5 driver:
Patch #1: Few cleanup fixes.
Patch #2  Update the supported PCI devices list.