### PR TITLE
Implement "status" command for Debian srptools init script

### DIFF
--- a/COPYING.md
+++ b/COPYING.md
@@ -53,7 +53,7 @@ Default Dual License.
 Unmarked ancillary files may be available under a Dual License: GPLv2 or
 OpenIB.org BSD (FreeBSD variant).
 
-## Tools (iwpmd, srp_deamon, ibacm)
+## Tools (iwpmd, srp_daemon, ibacm)
 
 All compilable source code (.c and .h files) are available under the Default
 Dual License.

--- a/debian/control
+++ b/debian/control
@@ -329,8 +329,7 @@ Description: Examples for the librdmacm library
 
 Package: srptools
 Architecture: linux-any
-Depends: infiniband-diags,
-         lsb-base (>= 3.2-14~),
+Depends: lsb-base (>= 3.2-14~),
          ${misc:Depends},
          ${shlibs:Depends}
 Description: Tools for Infiniband attached storage (SRP)

--- a/debian/srptools.default
+++ b/debian/srptools.default
@@ -1,10 +1,10 @@
-#How often should srpdeamon  rescan the fabric (seconds)
+# How often should srp_daemon rescan the fabric (seconds).
 RETRIES=60
 
-#Where should srp-deamon log to
+# Where should srp_daemon log to.
 LOG=/var/log/srp_daemon.log
 
-# What ports should srp-deamon be started on.
+# What ports should srp_daemon be started on.
 # Format is CA:port
 # ALL or NONE will run on all ports on none
 # respectively

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -24,6 +24,10 @@ LOG_DEFAULT=/var/log/srp_daemon.log
 
 [ -f /etc/default/srptools ] &&  . /etc/default/srptools
 
+max() {
+    echo $(($1 > $2 ? $1 : $2))
+}
+
 run_daemon() {
     local STATUS
 
@@ -41,7 +45,7 @@ run_daemon() {
               --exec $DAEMON -- -e -c -n \
 	      -i "${HCA_ID}" -p "${PORT}" -R "${RETRIES:-${RETRIES_DEFAULT}}" \
 	      >> "${LOG:-${LOG_DEFAULT}}" 2>&1 &
-        RETVAL=$?
+        RETVAL=$(max "$RETVAL" $?)
     fi
 }
 
@@ -65,19 +69,31 @@ for_all_ports() {
     fi
 }
 
-start_daemon () {
+start_daemon() {
+    local RETVAL=0
+
     if [ "$PORTS" = "NONE" ] ; then
 	echo "srptools disabled."
 	exit 0
     fi
 
     for_all_ports run_daemon
+    case $RETVAL in
+	0) log_success_msg "started $DAEMON";;
+	*) log_failure_msg "failed to start $DAEMON";;
+    esac
+    return $RETVAL
 }
 
 stop_daemon() {
-    local PORTS=ALL
+    local RETVAL=0 PORTS=ALL
 
-    for_all_ports 'start-stop-daemon --stop --quiet --oknodo -m --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}"; RETVAL=$?'
+    for_all_ports 'start-stop-daemon --stop --quiet --oknodo -m --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}"; RETVAL=$(max $RETVAL $?)'
+    case $RETVAL in
+	0) log_success_msg "stopped $DAEMON";;
+	*) log_failure_msg "failed to stop $DAEMON";;
+    esac
+    return $RETVAL
 }
 
 case "$1" in

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -9,13 +9,14 @@
 # Description:       Discovers SRP scsi over infiniband targets.
 ### END INIT INFO
 
-[ -x /usr/sbin/srp_daemon ] || exit 0
-
+DAEMON=/usr/sbin/srp_daemon
 IBDIR=/sys/class/infiniband
 
 PORTS=""
 RETRIES=""
 LOG=""
+
+[ -x $DAEMON ] || exit 0
 
 . /lib/lsb/init-functions
 
@@ -33,7 +34,7 @@ run_daemon() {
 	# function causes us to lose stdout, which is where it logs to
         nohup start-stop-daemon --start --quiet -m \
 	      --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}" \
-              --exec /usr/sbin/srp_daemon -- -e -c -n \
+              --exec $DAEMON -- -e -c -n \
 	      -i "${HCA_ID}" -p "${PORT}" -R "${RETRIES}" >> "$LOG" 2>&1 &
         RETVAL=$?
     fi

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -14,7 +14,9 @@ IBDIR=/sys/class/infiniband
 
 PORTS=""
 RETRIES=""
+RETRIES_DEFAULT=60
 LOG=""
+LOG_DEFAULT=/var/log/srp_daemon.log
 
 [ -x $DAEMON ] || exit 0
 
@@ -35,7 +37,8 @@ run_daemon() {
         nohup start-stop-daemon --start --quiet -m \
 	      --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}" \
               --exec $DAEMON -- -e -c -n \
-	      -i "${HCA_ID}" -p "${PORT}" -R "${RETRIES}" >> "$LOG" 2>&1 &
+	      -i "${HCA_ID}" -p "${PORT}" -R "${RETRIES:-${RETRIES_DEFAULT}}" \
+	      >> "${LOG:-${LOG_DEFAULT}}" 2>&1 &
         RETVAL=$?
     fi
 }

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -96,12 +96,36 @@ stop_daemon() {
     return $RETVAL
 }
 
+check_status() {
+    local pidfile=$1 pid
+
+    [ -e "$pidfile" ] || return 3 # not running
+    pid=$(<"$pidfile")
+    [ -n "$pid" ] || return 3 # not running
+    [ -d "/proc/$pid" ] || return 1 # not running and pid file exists
+    return 0 # running
+}
+
+daemon_status() {
+    local RETVAL=0
+
+    for_all_ports 'check_status /var/run/srp_daemon.${HCA_ID}.${PORT} $DAEMON; RETVAL=$(max $RETVAL $?)'
+    case $RETVAL in
+	0) log_success_msg "$DAEMON is running";;
+	*) log_failure_msg "$DAEMON is not running";;
+    esac
+    return $RETVAL
+}
+
 case "$1" in
     start)
 	start_daemon
 	;;
     stop)
 	stop_daemon
+	;;
+    status)
+	daemon_status
 	;;
     restart | reload | force-reload )
 	stop_daemon

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -25,11 +25,13 @@ LOG_DEFAULT=/var/log/srp_daemon.log
 [ -f /etc/default/srptools ] &&  . /etc/default/srptools
 
 run_daemon() {
+    local STATUS
+
     # srp_daemon wedges if we start it on a port which is not up
 
-    STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
+    STATUS=$(<"${IBDIR}/${HCA_ID}/ports/${PORT}/state")
 
-    if [ "$STATUS" = "State: Active" ] &&
+    if [ "$STATUS" = "4: ACTIVE" ] &&
        [ "$(<"${IBDIR}/${HCA_ID}/ports/$PORT/link_layer")" = InfiniBand ]; then
 
 	# srp does not background itself; using the start-stop-daemon background

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -21,7 +21,25 @@ LOG=""
 
 [ -f /etc/default/srptools ] &&  . /etc/default/srptools
 
-start_daemon() {
+run_daemon() {
+    # srp_daemon wedges if we start it on a port which is not up
+
+    STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
+
+    if [ "$STATUS" = "State: Active" ] ; then
+        echo "Starting srp on $HCA_ID $PORT"
+
+	# srp does not background itself; using the start-stop-daemon background
+	# function causes us to lose stdout, which is where it logs to
+        nohup start-stop-daemon --start --quiet -m \
+	      --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}" \
+              --exec /usr/sbin/srp_daemon -- -e -c -n \
+	      -i "${HCA_ID}" -p "${PORT}" -R "${RETRIES}" >> "$LOG" 2>&1 &
+        RETVAL=$?
+    fi
+}
+
+start_daemon () {
     if [ "$PORTS" = "NONE" ] ; then
 	echo "srptools disabled."
 	exit 0
@@ -42,24 +60,6 @@ start_daemon() {
 	PORT=`echo $ADAPTER | awk -F:  '{print $2}'`
 	run_daemon
     done
-}
-
-run_daemon() {
-    # srp_daemon wedges if we start it on a port which is not up
-
-    STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
-
-    if [ "$STATUS" = "State: Active" ] ; then
-        echo "Starting srp on $HCA_ID $PORT"
-
-	# srp does not background itself; using the start-stop-daemon background
-	# function causes us to lose stdout, which is where it logs to
-        nohup start-stop-daemon --start --quiet -m \
-	      --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT} \
-              --exec  /usr/sbin/srp_daemon -- -e -c -n \
-	      -i ${HCA_ID} -p ${PORT} -R ${RETRIES} >> $LOG 2>&1 &
-        RETVAL=$?
-    fi
 }
 
 stop_daemon() {

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -21,71 +21,68 @@ LOG=""
 
 [ -f /etc/default/srptools ] &&  . /etc/default/srptools
 
-start_daemon () {
+start_daemon() {
+    if [ "$PORTS" = "NONE" ] ; then
+	echo "srptools disabled."
+	exit 0
+    fi
 
-if [ "$PORTS" = "NONE" ] ; then
-echo "srptools disabled."
-exit 0
-fi
+    if [ "$PORTS" = "ALL" ]  ; then
+	for HCA_ID in `/bin/ls -1 ${IBDIR}`
+	do
+	    for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
+            do
+		run_daemon
+	    done
+	done
+    fi
 
-
-if [ "$PORTS" = "ALL" ]  ; then
-    for HCA_ID in `/bin/ls -1 ${IBDIR}`
-      do
-      for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
-        do
-        run_daemon
-      done
+    for ADAPTER in $PORTS ; do
+	HCA_ID=`echo $ADAPTER | awk -F: '{print $1}'`
+	PORT=`echo $ADAPTER | awk -F:  '{print $2}'`
+	run_daemon
     done
-fi
-
-
-for ADAPTER in $PORTS ; do
-    HCA_ID=`echo $ADAPTER | awk -F: '{print $1}'`
-    PORT=`echo $ADAPTER | awk -F:  '{print $2}'`
-    run_daemon
-done
 }
-
 
 run_daemon() {
-# srp_daemon wedges if we start it on a port which is not up
+    # srp_daemon wedges if we start it on a port which is not up
 
-        STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
+    STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
 
-        if [ "$STATUS" = "State: Active" ] ; then
-            echo "Starting srp on $HCA_ID $PORT"
+    if [ "$STATUS" = "State: Active" ] ; then
+        echo "Starting srp on $HCA_ID $PORT"
 
-# srp does not background itself; using the start-stop-daemon background function
-# causes us to lose stdout, which is where it logs to
-            nohup start-stop-daemon --start --quiet -m --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT} \
-            --exec  /usr/sbin/srp_daemon -- -e -c -n -i ${HCA_ID} -p ${PORT} -R ${RETRIES}   >> $LOG 2>&1 &
-            RETVAL=$?
-        fi
+	# srp does not background itself; using the start-stop-daemon background
+	# function causes us to lose stdout, which is where it logs to
+        nohup start-stop-daemon --start --quiet -m \
+	      --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT} \
+              --exec  /usr/sbin/srp_daemon -- -e -c -n \
+	      -i ${HCA_ID} -p ${PORT} -R ${RETRIES} >> $LOG 2>&1 &
+        RETVAL=$?
+    fi
 }
 
-stop_daemon () {
-     for HCA_ID in `/bin/ls -1 ${IBDIR}`
-      do
-      for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
+stop_daemon() {
+    for HCA_ID in `/bin/ls -1 ${IBDIR}`
+    do
+	for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
         do
-        start-stop-daemon --stop --quiet --oknodo -m --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT}
-        RETVAL=$?
-      done
+            start-stop-daemon --stop --quiet --oknodo -m \
+			      --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT}
+            RETVAL=$?
+	done
     done
 }
 
-
 case "$1" in
-
-start)
-start_daemon
-;;
-stop)
-stop_daemon
-;;
-restart | reload | force-reload )
-stop_daemon
-start_daemon
-;;
+    start)
+	start_daemon
+	;;
+    stop)
+	stop_daemon
+	;;
+    restart | reload | force-reload )
+	stop_daemon
+	start_daemon
+	;;
 esac

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -49,7 +49,7 @@ done
 
 
 run_daemon() {
-# SRP deamon wedges if we start it on a port which is not up
+# srp_daemon wedges if we start it on a port which is not up
 
         STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
 

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -29,8 +29,8 @@ run_daemon() {
 
     STATUS=`/usr/sbin/ibstat $HCA_ID $PORT | grep "State:"`
 
-    if [ "$STATUS" = "State: Active" ] ; then
-        echo "Starting srp on $HCA_ID $PORT"
+    if [ "$STATUS" = "State: Active" ] &&
+       [ "$(<"${IBDIR}/${HCA_ID}/ports/$PORT/link_layer")" = InfiniBand ]; then
 
 	# srp does not background itself; using the start-stop-daemon background
 	# function causes us to lose stdout, which is where it logs to

--- a/debian/srptools.init
+++ b/debian/srptools.init
@@ -43,39 +43,39 @@ run_daemon() {
     fi
 }
 
+# Evaluate shell command $1 for every port in $PORTS
+for_all_ports() {
+    local cmd=$1 p
+
+    if [ "$PORTS" = "ALL" ]; then
+	for p in ${IBDIR}/*/ports/*; do
+	    [ -e "$p" ] || continue
+	    PORT=$(basename "$p")
+	    HCA_ID=$(basename "$(dirname "$(dirname "$p")")")
+	    eval "$cmd"
+	done
+    else
+	for ADAPTER in $PORTS; do
+	    HCA_ID=${ADAPTER%%:*}
+	    PORT=${ADAPTER#${HCA_ID}:}
+	    [ -n "$HCA_ID" ] && [ -n "$PORT" ] && eval "$cmd"
+	done
+    fi
+}
+
 start_daemon () {
     if [ "$PORTS" = "NONE" ] ; then
 	echo "srptools disabled."
 	exit 0
     fi
 
-    if [ "$PORTS" = "ALL" ]  ; then
-	for HCA_ID in `/bin/ls -1 ${IBDIR}`
-	do
-	    for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
-            do
-		run_daemon
-	    done
-	done
-    fi
-
-    for ADAPTER in $PORTS ; do
-	HCA_ID=`echo $ADAPTER | awk -F: '{print $1}'`
-	PORT=`echo $ADAPTER | awk -F:  '{print $2}'`
-	run_daemon
-    done
+    for_all_ports run_daemon
 }
 
 stop_daemon() {
-    for HCA_ID in `/bin/ls -1 ${IBDIR}`
-    do
-	for PORT in `/bin/ls -1 ${IBDIR}/${HCA_ID}/ports/`
-        do
-            start-stop-daemon --stop --quiet --oknodo -m \
-			      --pidfile /var/run/srp_daemon.${HCA_ID}.${PORT}
-            RETVAL=$?
-	done
-    done
+    local PORTS=ALL
+
+    for_all_ports 'start-stop-daemon --stop --quiet --oknodo -m --pidfile "/var/run/srp_daemon.${HCA_ID}.${PORT}"; RETVAL=$?'
 }
 
 case "$1" in


### PR DESCRIPTION
As discussed on the linux-rdma mailing list, add support for querying the status of the srp_daemon(s) to the srptools init script.