### PR TITLE
verbs: Corrected description of max_sge and max_sge_rd

### DIFF
--- a/libibverbs/man/ibv_query_device.3
+++ b/libibverbs/man/ibv_query_device.3
@@ -33,8 +33,8 @@ uint32_t                hw_ver;                 /* Hardware version */
 int                     max_qp;                 /* Maximum number of supported QPs */
 int                     max_qp_wr;              /* Maximum number of outstanding WR on any work queue */
 int                     device_cap_flags;       /* HCA capabilities mask */
-int                     max_sge;                /* Maximum number of s/g per WR for non-RD QPs */
-int                     max_sge_rd;             /* Maximum number of s/g per WR for RD QPs */
+int                     max_sge;                /* Maximum number of s/g per WR for SQ & RQ of QP for non RDMA Read operations */
+int                     max_sge_rd;             /* Maximum number of s/g per WR for RDMA Read operations */
 int                     max_cq;                 /* Maximum number of supported CQs */
 int                     max_cqe;                /* Maximum number of CQE capacity per CQ */
 int                     max_mr;                 /* Maximum number of supported MRs */


### PR DESCRIPTION
This patch corrects ambiguity in documentation of max_sge and max_sge_rd
fields. 