### PR TITLE
libbnxt_re: Critical bug fix series

### DIFF
--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -43,6 +43,8 @@
 
 #define BNXT_RE_ABI_VERSION 1
 
+#define BNXT_RE_FULL_FLAG_DELTA        0x80
+
 enum bnxt_re_wr_opcode {
 	BNXT_RE_WR_OPCD_SEND		= 0x00,
 	BNXT_RE_WR_OPCD_SEND_IMM	= 0x01,

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -159,6 +159,15 @@ static void bnxt_re_uninit_context(struct verbs_device *vdev,
 	if (cntx->shpg)
 		munmap(cntx->shpg, dev->pg_size);
 	pthread_spin_destroy(&cntx->fqlock);
+
+	/* Un-map DPI only for the first PD that was
+	 * allocated in this context.
+	 */
+	if (cntx->udpi.dbpage && cntx->udpi.dbpage != MAP_FAILED) {
+		pthread_spin_destroy(&cntx->udpi.db_lock);
+		munmap(cntx->udpi.dbpage, dev->pg_size);
+		cntx->udpi.dbpage = NULL;
+	}
 }
 
 static struct verbs_device_ops bnxt_re_dev_ops = {

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -54,6 +54,8 @@
 
 #define DEV	"bnxt_re : "
 
+#define BNXT_RE_UD_QP_HW_STALL 0x400000
+
 struct bnxt_re_dpi {
 	__u32 dpindx;
 	__u64 *dbpage;
@@ -113,6 +115,7 @@ struct bnxt_re_qp {
 	uint32_t tbl_indx;
 	uint32_t sq_psn;
 	uint32_t pending_db;
+	uint64_t wqe_cnt;
 	uint16_t mtu;
 	uint16_t qpst;
 	uint8_t qptyp;

--- a/providers/bnxt_re/memory.h
+++ b/providers/bnxt_re/memory.h
@@ -49,6 +49,14 @@ struct bnxt_re_queue {
 	uint32_t head;
 	uint32_t tail;
 	uint32_t stride;
+	/* Represents the difference between the real queue depth allocated in
+	 * HW and the user requested queue depth and is used to correctly flag
+	 * queue full condition based on user supplied queue depth.
+	 * This value can vary depending on the type of queue and any HW
+	 * requirements that mandate keeping a fixed gap between the producer
+	 * and the consumer indices in the queue
+	 */
+	uint32_t diff;
 	pthread_spinlock_t qlock;
 };
 
@@ -86,7 +94,7 @@ static inline void iowrite32(__u32 *dst, __le32 *src)
 /* Basic queue operation */
 static inline uint32_t bnxt_re_is_que_full(struct bnxt_re_queue *que)
 {
-	return (((que->tail + 1) & (que->depth - 1)) == que->head);
+	return (((que->diff + que->tail) & (que->depth - 1)) == que->head);
 }
 
 static inline uint32_t bnxt_re_is_que_empty(struct bnxt_re_queue *que)

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1081,6 +1081,11 @@ static int bnxt_re_build_send_sqe(struct bnxt_re_qp *qp, void *wqe,
 	} else {
 		qesize = wr->num_sge;
 	}
+	/* HW requires wqe size has room for atleast one sge even if none was
+	 * supplied by application
+	 */
+	if (!wr->num_sge)
+		qesize++;
 	qesize += (bnxt_re_get_sqe_hdr_sz() >> 4);
 	hdrval |= (qesize & BNXT_RE_HDR_WS_MASK) << BNXT_RE_HDR_WS_SHIFT;
 	hdr->rsv_ws_fl_wt |= htole32(hdrval);
@@ -1259,6 +1264,11 @@ static int bnxt_re_build_rqe(struct bnxt_re_qp *qp, struct ibv_recv_wr *wr,
 
 	len = bnxt_re_build_sge(sge, wr->sg_list, wr->num_sge, false);
 	wqe_sz = wr->num_sge + (bnxt_re_get_rqe_hdr_sz() >> 4); /* 16B align */
+	/* HW requires wqe size has room for atleast one sge even if none was
+	 * supplied by application
+	 */
+	if (!wr->num_sge)
+		wqe_sz++;
 	hdrval = BNXT_RE_WR_OPCD_RECV;
 	hdrval |= ((wqe_sz & BNXT_RE_HDR_WS_MASK) << BNXT_RE_HDR_WS_SHIFT);
 	hdr->rsv_ws_fl_wt = htole32(hdrval);


### PR DESCRIPTION
[PATCH 0/5] libbnxt_re: Critical bug fix series

These are set of bug fix patches for the libbnxt_re user
space RDMA provider library. This patch series goes
hand-in-hand with recent bnxt_re kernel driver bug fixes.

Devesh Sharma (2):
  libbnxt_re: unmap DB page during uninit ucontext
  libbnxt_re: reset head and tail when moving to RST

Somnath Kotur (3):
  libbnxt_re: sq needs to be augmented by 128B
  libbnxt_re: fix wqe size for the 0-len posting
  libbnxt_re: move rts to rts after a threshold

 providers/bnxt_re/bnxt_re-abi.h |  2 +
 providers/bnxt_re/main.c        |  9 +++++
 providers/bnxt_re/main.h        |  3 ++
 providers/bnxt_re/memory.h      | 10 ++++-
 providers/bnxt_re/verbs.c       | 81 +++++++++++++++++++++++++++++++----------
 5 files changed, 84 insertions(+), 21 deletions(-)