### PR TITLE
srp_daemon: Rework systemd integration

### DIFF
--- a/debian/libibumad3.install
+++ b/debian/libibumad3.install
@@ -1,1 +1,2 @@
 usr/lib/*/libibumad*.so.*
+lib/udev/rules.d/libibumad.rules

--- a/debian/srptools.install
+++ b/debian/srptools.install
@@ -1,6 +1,7 @@
 etc/srp_daemon.conf
 lib/systemd/system/srp_daemon.service
 lib/systemd/system/srp_daemon_port@.service
+lib/udev/rules.d/srp_daemon.rules
 usr/lib/srp_daemon/start_on_all_ports
 usr/sbin/ibsrpdm
 usr/sbin/srp_daemon

--- a/debian/srptools.install
+++ b/debian/srptools.install
@@ -1,6 +1,11 @@
 etc/srp_daemon.conf
+lib/systemd/system/srp_daemon.service
+lib/systemd/system/srp_daemon_port@.service
+usr/lib/srp_daemon/start_on_all_ports
 usr/sbin/ibsrpdm
 usr/sbin/srp_daemon
 usr/share/doc/rdma-core/ibsrpdm.md usr/share/doc/srptools/
 usr/share/man/man1/ibsrpdm.1
 usr/share/man/man1/srp_daemon.1
+usr/share/man/man5/srp_daemon.service.5
+usr/share/man/man5/srp_daemon_port@.service.5

--- a/libibumad/CMakeLists.txt
+++ b/libibumad/CMakeLists.txt
@@ -14,3 +14,8 @@ rdma_library(ibumad libibumad.map
   umad.c
   umad_str.c
   )
+
+rdma_subst_install(FILES libibumad.udev-rules
+  RENAME libibumad.rules
+  DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
+

--- a/libibumad/libibumad.udev-rules
+++ b/libibumad/libibumad.udev-rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="infiniband_mad", TAG+="systemd", ENV{SYSTEMD_ALIAS}="/dev/infiniband/umad/$attr{ibdev}:$attr{port}"

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -403,6 +403,7 @@ rm -rf %{buildroot}/%{_initrddir}/
 
 %files -n libibumad
 %{_libdir}/libibumad*.so.*
+%{_udevrulesdir}/libibumad.rules
 
 %files -n librdmacm
 %{_libdir}/librdmacm*.so.*

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -273,9 +273,6 @@ bin/ib_acme -D . -O
 install -D -m0644 ibacm_opts.cfg %{buildroot}%{_sysconfdir}/rdma/
 install -D -m0644 redhat/ibacm.service %{buildroot}%{_unitdir}/
 
-# srp_daemon
-install -D -m0644 redhat/srp_daemon.service %{buildroot}%{_unitdir}/
-
 # Delete the package's init.d scripts
 rm -rf %{buildroot}/%{_initrddir}/
 
@@ -442,11 +439,14 @@ rm -rf %{buildroot}/%{_initrddir}/
 
 %files -n srp_daemon
 %config(noreplace) %{_sysconfdir}/srp_daemon.conf
+%{_libexecdir}/srp_daemon/start_on_all_ports
 %{_unitdir}/srp_daemon.service
+%{_unitdir}/srp_daemon_port@.service
 %{_sbindir}/ibsrpdm
 %{_sbindir}/srp_daemon
-%{_sbindir}/srp_daemon.sh
 %{_sbindir}/run_srp_daemon
 %{_mandir}/man1/ibsrpdm.1*
 %{_mandir}/man1/srp_daemon.1*
+%{_mandir}/man5/srp_daemon.service.5*
+%{_mandir}/man5/srp_daemon_port@.service.5*
 %doc %{_docdir}/%{name}-%{version}/ibsrpdm.md

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -445,6 +445,7 @@ rm -rf %{buildroot}/%{_initrddir}/
 %{_sbindir}/ibsrpdm
 %{_sbindir}/srp_daemon
 %{_sbindir}/run_srp_daemon
+%{_udevrulesdir}/srp_daemon.rules
 %{_mandir}/man1/ibsrpdm.1*
 %{_mandir}/man1/srp_daemon.1*
 %{_mandir}/man5/srp_daemon.service.5*

--- a/srp_daemon/CMakeLists.txt
+++ b/srp_daemon/CMakeLists.txt
@@ -43,6 +43,8 @@ rdma_subst_install(FILES srp_daemon_port@.service.in
 
 install(FILES srp_daemon.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 
+install(FILES srp_daemon.rules DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
+
 # FIXME: The ib init.d file should really be included in rdma-core as well.
 set(RDMA_SERVICE "openibd" CACHE STRING "init.d file service name to order srpd after")
 # NOTE: These defaults are for CentOS, packagers should override.

--- a/srp_daemon/CMakeLists.txt
+++ b/srp_daemon/CMakeLists.txt
@@ -3,6 +3,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NO_STRICT_ALIASING_FLAGS}")
 rdma_man_pages(
   ibsrpdm.1
   srp_daemon.1.in
+  srp_daemon.service.5
+  srp_daemon_port@.service.5
   )
 
 rdma_sbin_executable(srp_daemon
@@ -24,6 +26,20 @@ rdma_subst_install(FILES "srp_daemon.sh.in"
   DESTINATION "${CMAKE_INSTALL_SBINDIR}"
   RENAME "srp_daemon.sh"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
+
+install(FILES start_on_all_ports
+  DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/srp_daemon"
+  PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
+
+rdma_subst_install(FILES srp_daemon.service.in
+  DESTINATION "${CMAKE_INSTALL_SYSTEMD_SERVICEDIR}"
+  RENAME srp_daemon.service
+  PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
+
+rdma_subst_install(FILES srp_daemon_port@.service.in
+  DESTINATION "${CMAKE_INSTALL_SYSTEMD_SERVICEDIR}"
+  RENAME srp_daemon_port@.service
+  PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 install(FILES srp_daemon.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 

--- a/srp_daemon/srp_daemon.1.in
+++ b/srp_daemon/srp_daemon.1.in
@@ -5,7 +5,7 @@
 srp_daemon \- Discovers SRP targets in an InfiniBand Fabric
 
 .SH SYNOPSIS
-.B srp_daemon\fR [\fB-vVcaeon\fR] [\fB-d \fIumad-device\fR | \fB-i \fIinfiniband-device\fR [\fB-p \fIport-num\fR]] [\fB-t \fItimeout(ms)\fR] [\fB-r \fIretries\fR] [\fB-R \fIrescan-time\fR] [\fB-f \fIrules-file\fR]
+.B srp_daemon\fR [\fB-vVcaeon\fR] [\fB-d \fIumad-device\fR | \fB-i \fIinfiniband-device\fR [\fB-p \fIport-num\fR] | \fB-j \fIdev:port\fR] [\fB-t \fItimeout(ms)\fR] [\fB-r \fIretries\fR] [\fB-R \fIrescan-time\fR] [\fB-f \fIrules-file\fR]
 
 
 .SH DESCRIPTION
@@ -41,13 +41,20 @@ Print more verbose output
 Print even more verbose output (debug mode)
 .TP
 \fB\-i\fR \fIinfiniband-device\fR
-Work on \fIinfiniband-device\fR. This option should not be used with -d.
+Work on \fIinfiniband-device\fR. This option should not be used with -d nor
+with -j.
 .TP
 \fB\-p\fR \fIport-num\fR
-Work on port \fIport-num\fR (default 1). This option must be used with -i and should not be used with -d.
+Work on port \fIport-num\fR (default 1). This option must be used with -i and
+should not be used with -d nor with -j.
+.TP
+\fB\-j\fR \fIdev:port\fR
+Work on port number \fIport\fR of InfiniBand device \fIdev\fR. This option
+should not be used with -d, -i nor with -p.
 .TP
 \fB\-d\fR \fIumad-device\fR
-Use device file \fIumad-device\fR (default /dev/infiniband/umad0) This option should not be used with -i or -p.
+Use device file \fIumad-device\fR (default /dev/infiniband/umad0) This option
+should not be used with -i, -p nor with -j.
 .TP
 \fB\-c\fR
 Generate output suitable for piping directly to a

--- a/srp_daemon/srp_daemon.1.in
+++ b/srp_daemon/srp_daemon.1.in
@@ -5,18 +5,30 @@
 srp_daemon \- Discovers SRP targets in an InfiniBand Fabric
 
 .SH SYNOPSIS
-.B srp_daemon [-vVcaeon] [-d \fIumad-device\fR | -i \fIinfiniband-device\fR [-p \fIport-num\fR]] [-t \fItimeout(ms)\fR] [-r \fIretries\fR] [-R \fIRescan-time\fR] [-f \fIrules-File\fR]
+.B srp_daemon\fR [\fB-vVcaeon\fR] [\fB-d \fIumad-device\fR | \fB-i \fIinfiniband-device\fR [\fB-p \fIport-num\fR]] [\fB-t \fItimeout(ms)\fR] [\fB-r \fIretries\fR] [\fB-R \fIrescan-time\fR] [\fB-f \fIrules-file\fR]
 
 
 .SH DESCRIPTION
 .PP
 Discovers and connects to InfiniBand SCSI RDMA Protocol (SRP) targets in an IB fabric.
 
-Each srp_daemon instance operates on one local port. Upon boot it performs a full rescan of the fabric then waits for an srp_daemon event. An srp_daemon event can be a join of a new machine to the fabric, a change in the capabilities of a machine, an SA change, or an expiration of a predefined timeout.
+Each srp_daemon instance operates on one local port. Upon boot it performs a
+full rescan of the fabric and then waits for an srp_daemon event. An
+srp_daemon event can be a join of a new machine to the fabric, a change in the
+capabilities of a machine, an SA change, or an expiration of a predefined
+timeout.
 
-When a new machine joins the fabric, srp_daemon checks if it is a target. When there is a change of capabilities, srp_daemon checks if the machine has turned into a target. When there is an SA change or a timeout expiration, srp_daemon performs a full rescan of the fabric.
+When a new machine joins the fabric, srp_daemon checks if it is an SRP
+target. When there is a change of capabilities, srp_daemon checks if the
+machine has turned into an SRP target. When there is an SA change or a timeout
+expiration, srp_daemon performs a full rescan of the fabric.
 
-For each target srp_daemon finds, it checks if it should connect to this target according to its rules (default rules file is @CMAKE_INSTALL_FULL_SYSCONFDIR@/srp_daemon.conf) and if it is already connected to the local port. If it should connect to this target and if it is not connected yet, srp_daemon can either print the target details or connect to it.
+For each target srp_daemon finds, it checks if it should connect to this
+target according to its rules (the default rules file is
+@CMAKE_INSTALL_FULL_SYSCONFDIR@/srp_daemon.conf) and if it is already
+connected to the local port. If it should connect to this target and if it is
+not connected yet, srp_daemon can either print the target details or connect
+to it.
 
 .SH OPTIONS
 
@@ -42,24 +54,25 @@ Generate output suitable for piping directly to a
 /sys/class/infiniband_srp/srp\-<device>\-<port>/add_target file. 
 .TP
 \fB\-a\fR
-Prints all the targets in the fabric, not only targets that are not connected through the local port. (The same as ibsrpdm.)
+Prints all the targets in the fabric, not only targets that are not connected
+through the local port. This is the same behavior as that of ibsrpdm.
 .TP
 \fB\-e\fR
 Execute the connection command, i.e., make the connection to the target.
 .TP
 \fB\-o\fR
-Perform only one rescan and exit. (The same as ibsrpdm.)
+Perform only one rescan and exit just like ibsrpdm.
 .TP
-\fB\-R\fR \fIRescan-time\fR
-Force a complete rescan every \fIRescan-time\fR seconds. If -R is not specified, no timeout rescans will be performed.
+\fB\-R\fR \fIrescan-time\fR
+Force a complete rescan every \fIrescan-time\fR seconds. If -R is not specified, no timeout rescans will be performed.
 .TP
-\fB\-T\fR \fIretry-Timeout\fR
-Retries to connect to existing target after \fIretry-Timeout\fR seconds. If -R is not specified, uses 5 Seconds timeout. if retry-Timeout is 0, will not try to reconnect. The reason srp_daemon retries to connect to the target is because there may be a rare scnerio in which srp_daemon will try to connect to add a target when the target is about to be removed, but is not removed yet.
+\fB\-T\fR \fIretry-timeout\fR
+Retries to connect to existing target after \fIretry-timeout\fR seconds. If -R is not specified, uses 5 Seconds timeout. if retry-timeout is 0, will not try to reconnect. The reason srp_daemon retries to connect to the target is because there may be a rare scnerio in which srp_daemon will try to connect to add a target when the target is about to be removed, but is not removed yet.
 .TP
-\fB\-f\fR \fIrules-File\fR
-Decide to which targets to connect according to the rules in \fIrules-File\fR. 
+\fB\-f\fR \fIrules-file\fR
+Decide to which targets to connect according to the rules in \fIrules-file\fR.
 If \fB\-f\fR is not specified, uses the default rules file @CMAKE_INSTALL_FULL_SYSCONFDIR@/srp_daemon.conf.
-Each line in the \fIrules-File\fR is a rule which can be either an allow connection or a disallow connection according to 
+Each line in the \fIrules-file\fR is a rule which can be either an allow connection or a disallow connection according to
 the first character in the line (a or d accordingly). The rest of the line is values for id_ext, ioc_guid, dgid, 
 service_id. Please take a look at the example section for an example of the file. srp_daemon decide whether to allow or disallow each target according  to first rule that match the target. If no rule matches the target, the target is allowed and will be connected. In an allow rule it is possible to set attributes for the connection to the target. Supported attributes are max_cmd_per_lun and max_sect.
 .TP
@@ -74,7 +87,7 @@ New format - use also initiator_ext in the connection command.
 
 .SH FILES
 @CMAKE_INSTALL_FULL_SYSCONFDIR@/srp_daemon.conf -
-Default rules configuration file that indicates to which targets to connect. Can be overridden using the \fB\-f\fR \fIrules-File\fR option. 
+Default rules configuration file that indicates to which targets to connect. Can be overridden using the \fB\-f\fR \fIrules-file\fR option.
 Each line in this file is a rule which can be either an allow connection or a disallow connection according to 
 the first character in the line (a or d accordingly). The rest of the line is values for id_ext, ioc_guid, dgid, 
 service_id. Please take a look at the example section for an example of the file. srp_daemon decide whether to allow or disallow each target according  to first rule that match the target. If no rule matches the target, the target is allowed and will be connected. In an allow rule it is possible to set attributes for the connection to the target. Supported attributes are max_cmd_per_lun and max_sect.

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -226,6 +226,7 @@ static void usage(const char *argv0)
 	fprintf(stderr, "-d <umad device>	use umad Device \n");
 	fprintf(stderr, "-i <infiniband device>	use InfiniBand device \n");
 	fprintf(stderr, "-p <port_num>		use Port num \n");
+	fprintf(stderr, "-j <dev>:<port_num>	use the IB dev / port_num combination \n");
 	fprintf(stderr, "-R <rescan time>	perform complete Rescan every <rescan time> seconds\n");
 	fprintf(stderr, "-T <retry timeout>	Retries to connect to existing target after Timeout of <retry timeout> seconds\n");
 	fprintf(stderr, "-l <tl_retry timeout>	Transport retry count before failing IO. should be in range [2..7], (default 2)\n");
@@ -1623,7 +1624,7 @@ static int get_config(struct config_t *conf, int argc, char *argv[])
 	while (1) {
 		int c;
 
-		c = getopt(argc, argv, "caveod:i:p:t:r:R:T:l:Vhnf:");
+		c = getopt(argc, argv, "caveod:i:j:p:t:r:R:T:l:Vhnf:");
 		if (c == -1)
 			break;
 
@@ -1643,6 +1644,19 @@ static int get_config(struct config_t *conf, int argc, char *argv[])
 			if (conf->port_num == 0) {
 				pr_err("Bad port number %s\n", optarg);
 				return -1;
+			}
+			break;
+		case 'j': {
+			char dev[32];
+			int port_num;
+
+			if (sscanf(optarg, "%31[^:]:%d", dev, &port_num) != 2) {
+				pr_err("Bad dev:port specification %s\n",
+				       optarg);
+				return -1;
+			}
+			conf->dev_name = strdup(dev);
+			conf->port_num = port_num;
 			}
 			break;
 		case 'c':

--- a/srp_daemon/srp_daemon.rules
+++ b/srp_daemon/srp_daemon.rules
@@ -1,0 +1,1 @@
+ACTION=="add", SUBSYSTEM=="infiniband_mad", PROGRAM:="/usr/bin/systemctl show srp_daemon -p ActiveState", RESULT=="ActiveState=active", ENV{SYSTEMD_WANTS}+="srp_daemon_port@$attr{ibdev}:$attr{port}.service"

--- a/srp_daemon/srp_daemon.service.5
+++ b/srp_daemon/srp_daemon.service.5
@@ -1,0 +1,30 @@
+'\" t
+.TH "SRP_DAEMON\&.SERVICE" "5" "" "srp_daemon" "srp_daemon.service"
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+srp_daemon.service \- srp_daemon systemd service that controls all ports
+.SH "SYNOPSIS"
+.PP
+srp_daemon\&.service
+.SH "DESCRIPTION"
+.PP
+The srp_daemon\&.service controls whether or not any srp_daemon processes are
+running. Although no srp_daemon processes are controlled directly by the
+srp_daemon\&.service, this service controls whether or not any
+srp_daemon_port@\&.service are allowed to be active. Each
+srp_daemon_port@\&.service controls one srp_daemon process.
+
+.SH "SEE ALSO"
+.PP
+\fBsrp_daemon\fR(1),
+\fBsrp_daemon_port@.service\fR(5),
+\fBsystemctl\fR(1)

--- a/srp_daemon/srp_daemon.service.in
+++ b/srp_daemon/srp_daemon.service.in
@@ -1,17 +1,14 @@
 [Unit]
-Description=Start or stop the daemon that attaches to SRP devices
+Description=Daemon that discovers and logs in to SRP target systems
 Documentation=man:srp_daemon file:/etc/rdma/rdma.conf file:/etc/srp_daemon.conf
 DefaultDependencies=false
 Conflicts=emergency.target emergency.service
-Requires=rdma.service
-Wants=opensm.service
-After=rdma.service opensm.service
-After=network.target
 Before=remote-fs-pre.target
 
 [Service]
-Type=simple
-ExecStart=/usr/sbin/srp_daemon.sh
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=@CMAKE_INSTALL_LIBEXECDIR@/srp_daemon/start_on_all_ports
 
 [Install]
 WantedBy=remote-fs-pre.target

--- a/srp_daemon/srp_daemon.service.in
+++ b/srp_daemon/srp_daemon.service.in
@@ -9,6 +9,11 @@ Before=remote-fs-pre.target
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=@CMAKE_INSTALL_LIBEXECDIR@/srp_daemon/start_on_all_ports
+MemoryDenyWriteExecute=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+RestrictRealtime=yes
 
 [Install]
 WantedBy=remote-fs-pre.target

--- a/srp_daemon/srp_daemon.sh.in
+++ b/srp_daemon/srp_daemon.sh.in
@@ -31,35 +31,35 @@
 shopt -s nullglob
 
 prog=@CMAKE_INSTALL_FULL_SBINDIR@/srp_daemon
-params=$@
+params=("$@")
 ibdir="/sys/class/infiniband"
 rescan_interval=60
-pids=""
-pidfile=@CMAKE_INSTALL_FULL_RUNDIR@/srp_daemon.sh.pid
+pids=()
+pidfile="@CMAKE_INSTALL_FULL_RUNDIR@/srp_daemon.sh.pid"
 mypid=$$
 
 trap_handler()
 {
-    if [ -n "$pids" ]; then
-        kill -15 $pids > /dev/null 2>&1
-        wait $pids
+    if [ "${#pids[@]}" ]; then
+        kill -15 "${pids[@]}" > /dev/null 2>&1
+        wait "${pids[@]}"
     fi
-    logger -i -t "$(basename $0)" "killing $prog."
-    /bin/rm -f $pidfile
+    logger -i -t "$(basename "$0")" "killing $prog."
+    /bin/rm -f "$pidfile"
     exit 0
 }
 
 # Check if there is another copy running of srp_daemon.sh
-if [ -f $pidfile ]; then
-    if [ -e /proc/$(cat $pidfile 2>/dev/null)/status ]; then
-        echo "$(basename $0) is already running. Exiting."
+if [ -f "$pidfile" ]; then
+    if [ -e "/proc/$(cat "$pidfile" 2>/dev/null)/status" ]; then
+        echo "$(basename "$0") is already running. Exiting."
         exit 1
     else
-        /bin/rm -f $pidfile
+        /bin/rm -f "$pidfile"
     fi
 fi
 
-if ! echo $mypid > $pidfile; then
+if ! echo $mypid > "$pidfile"; then
     echo "Creating $pidfile for pid $mypid failed"
     exit 1
 fi
@@ -72,12 +72,12 @@ do
 done
 
 for d in ${ibdir}_mad/umad*; do
-    hca_id="$(<$d/ibdev)"
-    port="$(<$d/port)"
+    hca_id="$(<"$d/ibdev")"
+    port="$(<"$d/port")"
     add_target="${ibdir}_srp/srp-${hca_id}-${port}/add_target"
     if [ -e "${add_target}" ]; then
-        ${prog} -e -c -n -i ${hca_id} -p ${port} -R ${rescan_interval} ${params} >/dev/null 2>&1 &
-        pids="$pids $!"
+        ${prog} -e -c -n -i "${hca_id}" -p "${port}" -R "${rescan_interval}" "${params[@]}" >/dev/null 2>&1 &
+        pids+=($!)
     fi
 done
 

--- a/srp_daemon/srp_daemon_port@.service.5
+++ b/srp_daemon/srp_daemon_port@.service.5
@@ -1,0 +1,49 @@
+'\" t
+.TH "SRP_DAEMON_PORT@\&.SERVICE" "5" "" "srp_daemon" "srp_daemon_port@.service"
+.\" -----------------------------------------------------------------
+.\" * set default formatting
+.\" -----------------------------------------------------------------
+.\" disable hyphenation
+.nh
+.\" disable justification (adjust text to left margin only)
+.ad l
+.\" -----------------------------------------------------------------
+.\" * MAIN CONTENT STARTS HERE *
+.\" -----------------------------------------------------------------
+.SH "NAME"
+srp_daemon_port@.service \- srp_daemon_port@ systemd service that controls a
+single port
+.SH "SYNOPSIS"
+.PP
+srp_daemon_port@\&.service
+.SH "DESCRIPTION"
+.PP
+The srp_daemon_port@\&.service controls whether or not an srp_daemon process
+is monitoring the RDMA port specified as template argument. The format for the
+RDMA port name is \fIdev:port\fR where \fIdev\fR is the name of an RDMA device
+and \fIport\fR is an port number starting from one. Starting an instance of
+this template will start an srp_daemon process. Stopping an instance of this
+template will stop the srp_daemon process for the specified port. It can be
+prevented that srp_daemon is started for a certain port by masking the
+corresponding systemd service, e.g. \fBsystemctl mask
+srp_daemon_port@mlx4_0:1\fR.
+
+A list of all RDMA device and port number pairs can be obtained e.g. as follows:
+.PP
+.nf
+.RS
+$ (cd /sys/class/infiniband >&/dev/null && for p in */ports/*; do
+   [ -e "$p" ] && echo "${p/\\/ports\\//:}"; done)
+mlx4_0:1
+mlx4_0:2
+mlx4_1:1
+mlx4_1:2
+.RE
+.fi
+.PP
+
+.SH "SEE ALSO"
+.PP
+\fBsrp_daemon\fR(1),
+\fBsrp_daemon.service\fR(5),
+\fBsystemctl\fR(1)

--- a/srp_daemon/srp_daemon_port@.service.in
+++ b/srp_daemon/srp_daemon_port@.service.in
@@ -1,0 +1,15 @@
+[Unit]
+Description=SRP daemon that monitors port %i
+Documentation=man:srp_daemon file:/etc/rdma/rdma.conf file:/etc/srp_daemon.conf
+DefaultDependencies=false
+Conflicts=emergency.target emergency.service
+After=srp_daemon.service dev-infiniband-umad-%i.device network.target
+BindsTo=srp_daemon.service dev-infiniband-umad-%i.device
+Before=remote-fs-pre.target
+
+[Service]
+Type=simple
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/srp_daemon -e -c -n -j %I -R 60
+
+[Install]
+WantedBy=remote-fs-pre.target

--- a/srp_daemon/srp_daemon_port@.service.in
+++ b/srp_daemon/srp_daemon_port@.service.in
@@ -10,6 +10,15 @@ Before=remote-fs-pre.target
 [Service]
 Type=simple
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/srp_daemon -e -c -n -j %I -R 60
+MemoryDenyWriteExecute=yes
+PrivateNetwork=yes
+PrivateTmp=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectKernelModules=yes
+ProtectSystem=full
+RestrictRealtime=yes
+SystemCallFilter=~@clock @cpu-emulation @debug @keyring @module @mount @obsolete @raw-io
 
 [Install]
 WantedBy=remote-fs-pre.target

--- a/srp_daemon/start_on_all_ports
+++ b/srp_daemon/start_on_all_ports
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+for p in /sys/class/infiniband/*/ports/*; do
+    [ -e "$p" ] || continue
+    p=${p#/sys/class/infiniband/}
+    nohup /usr/bin/systemctl start "srp_daemon_port@${p/\/ports\//:}" </dev/null >&/dev/null &
+done


### PR DESCRIPTION
Split srp_daemon.service into srp_daemon.service and the srp_daemon_port@.service template. The former does not start any srp_daemon process but controls the latter. srp_daemon_port@.service instances are started automatically upon hot-add of an RDMA port to support hot-plugging.