### PR TITLE
rping: Add config to bind to source IP address like ping.

### DIFF
--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -141,6 +141,7 @@ struct rping_cb {
 	sem_t sem;
 
 	struct sockaddr_storage sin;
+	struct sockaddr_storage ssource;
 	__be16 port;			/* dst port in NBO */
 	int verbose;			/* verbose logging */
 	int count;			/* ping count */
@@ -1039,7 +1040,12 @@ static int rping_bind_client(struct rping_cb *cb)
 	else
 		((struct sockaddr_in6 *) &cb->sin)->sin6_port = cb->port;
 
-	ret = rdma_resolve_addr(cb->cm_id, NULL, (struct sockaddr *) &cb->sin, 2000);
+	if (cb->ssource.ss_family) 
+		ret = rdma_resolve_addr(cb->cm_id, (struct sockaddr *) &cb->ssource,
+					(struct sockaddr *) &cb->sin, 2000);
+	else
+		ret = rdma_resolve_addr(cb->cm_id, NULL, (struct sockaddr *) &cb->sin, 2000);
+
 	if (ret) {
 		perror("rdma_resolve_addr");
 		return ret;
@@ -1140,9 +1146,10 @@ static void usage(const char *name)
 {
 	printf("%s -s [-vVd] [-S size] [-C count] [-a addr] [-p port]\n", 
 	       basename(name));
-	printf("%s -c [-vVd] [-S size] [-C count] -a addr [-p port]\n", 
+	printf("%s -c [-vVd] [-S size] [-C count] [-I addr] -a addr [-p port]\n", 
 	       basename(name));
 	printf("\t-c\t\tclient side\n");
+	printf("\t-I\t\tSource address to bind to for client.\n");
 	printf("\t-s\t\tserver side.  To bind to any address with IPv6 use -a ::0\n");
 	printf("\t-v\t\tdisplay ping data to stdout\n");
 	printf("\t-V\t\tvalidate ping data\n");
@@ -1174,10 +1181,13 @@ int main(int argc, char *argv[])
 	sem_init(&cb->sem, 0, 0);
 
 	opterr = 0;
-	while ((op=getopt(argc, argv, "a:Pp:C:S:t:scvVd")) != -1) {
+	while ((op=getopt(argc, argv, "a:I:Pp:C:S:t:scvVd")) != -1) {
 		switch (op) {
 		case 'a':
 			ret = get_addr(optarg, (struct sockaddr *) &cb->sin);
+			break;
+		case 'I':
+			ret = get_addr(optarg, (struct sockaddr *) &cb->ssource);
 			break;
 		case 'P':
 			persistent_server = 1;

--- a/librdmacm/man/rping.1
+++ b/librdmacm/man/rping.1
@@ -7,7 +7,7 @@ rping \- RDMA CM connection and RDMA ping-pong test.
 .nf
 \fIrping\fR -s [-v] [-V] [-d] [-P] [-a address] [-p port]
 		[-C message_count] [-S message_size]
-\fIrping\fR -c [-v] [-V] [-d] -a address [-p port]
+\fIrping\fR -c [-v] [-V] [-d] [-I address] -a address [-p port]
 		[-C message_count] [-S message_size]
 .fi
 .SH "DESCRIPTION"
@@ -26,6 +26,10 @@ Run as the client.
 On the server, specifies the network address to bind the connection to.
 To bind to any address with IPv6 use -a ::0 .
 On the client, specifies the server address to connect to.
+.TP
+\-I address
+The address to bind to as the source IP address to use. This is useful
+if you have multiple addresses on the same network or complex routing.
 .TP
 \-p
 Port number for listening server.


### PR DESCRIPTION
This is useful if you have multiple adapters on the same
network or have custom routing that you want to test.

Signed-off-by: Robert LeBlanc <robert@leblancnet.us>