### PR TITLE
verbs: Introduce flow steering drop action

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1823,6 +1823,9 @@ static int ib_spec_to_kern_spec(struct ibv_flow_spec *ib_spec,
 			sizeof(struct ibv_kern_spec_action_tag);
 		kern_spec->flow_tag.tag_id = ib_spec->flow_tag.tag_id;
 		break;
+	case IBV_FLOW_SPEC_ACTION_DROP:
+		kern_spec->drop.size = sizeof(struct ibv_kern_spec_action_drop);
+		break;
 	default:
 		return EINVAL;
 	}

--- a/libibverbs/kern-abi.h
+++ b/libibverbs/kern-abi.h
@@ -938,6 +938,12 @@ struct ibv_kern_spec_tunnel {
 	struct ibv_kern_tunnel_filter mask;
 };
 
+struct ibv_kern_spec_action_drop {
+	__u32  type;
+	__u16  size;
+	__u16 reserved;
+};
+
 struct ibv_kern_spec {
 	union {
 		struct {
@@ -952,6 +958,7 @@ struct ibv_kern_spec {
 		struct ibv_kern_spec_ipv6 ipv6;
 		struct ibv_kern_spec_tunnel tunnel;
 		struct ibv_kern_spec_action_tag flow_tag;
+		struct ibv_kern_spec_action_drop drop;
 	};
 };
 

--- a/libibverbs/man/ibv_create_flow.3
+++ b/libibverbs/man/ibv_create_flow.3
@@ -69,6 +69,7 @@ IBV_FLOW_SPEC_UDP                       = 0x41,   /* Flow specification of UDP h
 IBV_FLOW_SPEC_VXLAN_TUNNEL             	= 0x50,   /* Flow specification of VXLAN header */
 IBV_FLOW_SPEC_INNER                    	= 0x100,  /* Flag making L2/L3/L4 specifications to be applied on the inner header */
 IBV_FLOW_SPEC_ACTION_TAG                = 0x1000, /* Action tagging matched packet */
+IBV_FLOW_SPEC_ACTION_DROP               = 0x1001, /* Action dropping matched packet */
 .in -8
 };
 .br

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1233,7 +1233,8 @@ enum ibv_flow_spec_type {
 	IBV_FLOW_SPEC_UDP		= 0x41,
 	IBV_FLOW_SPEC_VXLAN_TUNNEL	= 0x50,
 	IBV_FLOW_SPEC_INNER		= 0x100,
-	IBV_FLOW_SPEC_ACTION_TAG	= 0x1000
+	IBV_FLOW_SPEC_ACTION_TAG	= 0x1000,
+	IBV_FLOW_SPEC_ACTION_DROP	= 0x1001,
 };
 
 struct ibv_flow_eth_filter {
@@ -1326,6 +1327,11 @@ struct ibv_flow_spec_action_tag {
 	uint32_t  tag_id;
 };
 
+struct ibv_flow_spec_action_drop {
+	enum ibv_flow_spec_type  type;
+	uint16_t  size;
+};
+
 struct ibv_flow_spec {
 	union {
 		struct {
@@ -1339,6 +1345,7 @@ struct ibv_flow_spec {
 		struct ibv_flow_spec_ipv6 ipv6;
 		struct ibv_flow_spec_tunnel tunnel;
 		struct ibv_flow_spec_action_tag flow_tag;
+		struct ibv_flow_spec_action_drop drop;
 	};
 };
 


### PR DESCRIPTION
Allows a user space application to create a drop flow specification.

This is the complementary user space part of the kernel code that was merged
into 4.12.
