### PR TITLE
Fix an inaccuracies about return value of rdma_getaddrinfo in manpage

### DIFF
--- a/librdmacm/man/rdma_getaddrinfo.3
+++ b/librdmacm/man/rdma_getaddrinfo.3
@@ -26,8 +26,36 @@ Resolves the destination node and service address and returns
 information needed to establish communication.  Provides the
 RDMA functional equivalent to getaddrinfo.
 .SH "RETURN VALUE"
-Returns 0 on success, or -1 on error.  If an error occurs, errno will be
-set to indicate the failure reason.
+Returns 0 on success, or one of the following nonzero error codes:
+.IP "RAI_ADDRFAMILY" 12
+The specified network host does not have any network addresses in the
+requested address family.
+.IP "RAI_AGAIN" 12
+The name server returned a temporary failure indication. Try again later.
+.IP "RAI_BADFLAGS" 12
+hints.ai_flags contains invalid flags.
+.IP "RAI_FAIL" 12
+The name server returned a permanent failure indication.
+.IP "RAI_FAMILY" 12
+The requested address family is not supported.
+.IP "RAI_MEMORY" 12
+Out of memory.
+.IP "RAI_NODATA" 12
+The specified network host exists, but does not have any network addresses
+defined.
+.IP "RAI_NONAME" 12
+The node or service is not known; or both node and service are NULL.
+.IP "RAI_SERVICE" 12
+The requested service is not available for the requested QP type. It may be
+available through another QP type.
+.IP "RAI_QPTYPE" 12
+The requested socket type is not supported. This could occur, for example,
+if hints.ai_qptype and hints.ai_port_space are inconsistent (e.g., IBV_QPT_UD
+and RDMA_PS_TCP, respectively).
+.IP "EAI_SYSTEM" 12
+Other system error, check errno for details.
+The gai_strerror() function translates these error codes to a human readable
+string, suitable for error reporting.
 .SH "NOTES"
 Either node, service, or hints must be provided.  If hints are provided, the
 operation will be controlled by hints.ai_flags.  If RAI_PASSIVE is
@@ -46,7 +74,7 @@ Indicates that the results will be used on the passive/listening
 side of a connection.
 .IP "RAI_NUMERICHOST" 12
 If specified, then the node parameter, if provided, must be a numerical
-network address.  This flag suppresses any lengthy address resolution. 
+network address.  This flag suppresses any lengthy address resolution.
 .IP "RAI_NOROUTE" 12
 If set, this flag suppresses any lengthy route resolution.
 .IP "RAI_FAMILY" 12
@@ -57,7 +85,7 @@ Address family for the source and destination address.  Supported families
 are: AF_INET, AF_INET6, and AF_IB.
 .IP "ai_qp_type" 12
 Indicates the type of RDMA QP used for communication.  Supported types are:
-IBV_UD (unreliable datagram) and IBV_RC (reliable connected).
+IBV_QPT_UD (unreliable datagram) and IBV_QPT_RC (reliable connected).
 .IP "ai_port_space" 12
 RDMA port space in use.  Supported values are: RDMA_PS_UDP, RDMA_PS_TCP,
 and RDMA_PS_IB.

--- a/librdmacm/rdma_cma.h
+++ b/librdmacm/rdma_cma.h
@@ -35,6 +35,7 @@
 #define RDMA_CMA_H
 
 #include <netinet/in.h>
+#include <netdb.h>
 #include <sys/socket.h>
 #include <infiniband/verbs.h>
 #include <infiniband/sa.h>
@@ -84,6 +85,32 @@ enum rdma_port_space {
  * RDMA CM.
  */
 #define RDMA_UDP_QKEY 0x01234567
+
+/* Error values for `rdma_getaddrinfo' function.  */
+#define RAI_NONAME		EAI_NONAME	/* NAME or SERVICE is unknown */
+#define RAI_AGAIN		EAI_AGAIN	/* Temporary failure in name resolution */
+#define RAI_FAIL		EAI_FAIL	/* Non-recoverable failure in name res */
+#define RAI_NOFAMILY		EAI_FAMILY	/* `ai_family' not supported */
+#define RAI_QPTYPE		EAI_SOCKTYPE	/* `ai_qptype' not supported */
+#define RAI_SERVICE		EAI_SERVICE	/* SERVICE not supported for `ai_qptype' */
+#define RAI_MEMORY		EAI_MEMORY	/* Memory allocation failure */
+#define RAI_OVERFLOW		EAI_OVERFLOW	/* Argument buffer overflow */
+#ifdef __USE_GNU
+# define RAI_NODATA		EAI_NODATA	/* No address associated with NAM */
+# define RAI_ADDRFAMILY		EAI_ADDRFAMILY	/* Address family for NAME not supported */
+# define RAI_EINPROGRESS	EAI_INPROGRESS	/* Processing request in progress */
+# define RAI_CANCELED		EAI_CANCELED	/* Request canceled */
+# define RAI_NOTCANCELED	EAI_NOTCANCELED /* Request not canceled */
+# define RAI_ALLDONE		EAI_ALLDONE	/* All requests done */
+# define RAI_INTR		EAI_INTR	/* Interrupted by a signal */
+# define RAI_IDN_ENCODE		EAI_IDN_ENCODE	/* IDN encoding failed */
+#endif
+/*
+ * rdma_getaddrinfo returns -1 (EAI_BADFLAGS in terms
+ * of getaddrinfo) and set system error in `errno'
+ */
+#define RAI_SYSTEM		EAI_BADFLAGS	/* System error returned in `errno' */
+#define RAI_BADFLAGS		EAI_SYSTEM	/* Invalid value for `ai_flags' field */
 
 struct rdma_ib_addr {
 	union ibv_gid	sgid;


### PR DESCRIPTION
Added definition of possible error codes (the same as for getaddrinfo).

Signed-off-by: Dmitry Gladkov <dmitry.gladkov@intel.com>