### PR TITLE
Fix configuration and building with uClibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,7 @@ RDMA_AddOptCFlag(NO_STRICT_ALIASING_FLAGS HAVE_NO_STRICT_ALIASING
 # supported so it really doesn't work right if this isn't available. Thus hard
 # require it.
 CHECK_C_SOURCE_COMPILES("
+ #define _GNU_SOURCE
  #include <sys/types.h>
  #include <sys/stat.h>
  #include <sys/socket.h>

--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -30,6 +30,7 @@
  * SOFTWARE.
  */
 
+#define _GNU_SOURCE
 #include <config.h>
 
 #include <stdlib.h>


### PR DESCRIPTION
In uClibc some flags are not defined by default.
And that's the case for O_CLOEXEC for example, see
https://cgit.uclibc-ng.org/cgi/cgit/uclibc-ng.git/tree/libc/sysdeps/linux/arm/bits/fcntl.h#n52

Its definition only happens if _GNU_SOURCE is defined.
Thus users of O_CLOEXEC must define _GNU_SOURCE before inclusion of
related headers.

This solves configuration issue:
-------------------------->8---------------------
-- Performing Test HAS_CLOEXEC
-- Performing Test HAS_CLOEXEC - Failed
CMake Error at CMakeLists.txt:198 (message):
  O_CLOEXEC/SOCK_CLOEXEC/fopen(..,"e") support is required but not found

-- Configuring incomplete, errors occurred!
-------------------------->8---------------------

And later compilation issue:
-------------------------->8---------------------
.../librdmacm/cma.c: In function 'rdma_create_event_channel':
.../librdmacm/cma.c:369:57: error: 'O_CLOEXEC' undeclared (first use in this function)
  channel->fd = open("/dev/infiniband/rdma_cm", O_RDWR | O_CLOEXEC);
                                                         ^~~~~~~~~
-------------------------->8---------------------

Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>