### PR TITLE
util: Fix mmio_flush_writes for SPARC and S390x

### DIFF
--- a/util/udma_barrier.h
+++ b/util/udma_barrier.h
@@ -192,6 +192,7 @@
 #define mmio_flush_writes() asm volatile("dsb st" ::: "memory");
 #elif defined(__sparc__) || defined(__s390x__)
 #define mmio_flush_writes() asm volatile("" ::: "memory")
+#else
 #error No architecture specific memory barrier defines found!
 #endif
 


### PR DESCRIPTION
Due to a missing #else, udma_barrier.h failed on sparc and s390x

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>
Reviewed-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>