### PR TITLE
Improve configuration and building for uClibc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,7 +185,6 @@ RDMA_AddOptCFlag(NO_STRICT_ALIASING_FLAGS HAVE_NO_STRICT_ALIASING
 # supported so it really doesn't work right if this isn't available. Thus hard
 # require it.
 CHECK_C_SOURCE_COMPILES("
- #define _GNU_SOURCE
  #include <sys/types.h>
  #include <sys/stat.h>
  #include <sys/socket.h>
@@ -195,6 +194,26 @@ CHECK_C_SOURCE_COMPILES("
     socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
     return 0;
  }" HAS_CLOEXEC)
+
+if (NOT HAS_CLOEXEC)
+# At least uclibc wrongly hides this POSIX constant behind _GNU_SOURCE
+CHECK_C_SOURCE_COMPILES("
+ #define _GNU_SOURCE
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/socket.h>
+ #include <fcntl.h>
+ int main(int argc,const char *argv[]) {
+    open(\".\",O_RDONLY | O_CLOEXEC);
+    socket(AF_INET, SOCK_STREAM | SOCK_CLOEXEC, 0);
+    return 0;
+ }" HAS_CLOEXEC_GNU_SOURCE)
+  if (HAS_CLOEXEC_GNU_SOURCE)
+    set(HAS_CLOEXEC 1)
+    add_definitions("-D_GNU_SOURCE=")
+  endif()
+endif()
+
 if (NOT HAS_CLOEXEC)
   message(FATAL_ERROR "O_CLOEXEC/SOCK_CLOEXEC/fopen(..,\"e\") support is required but not found")
 endif()

--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -30,7 +30,6 @@
  * SOFTWARE.
  */
 
-#define _GNU_SOURCE
 #include <config.h>
 
 #include <stdlib.h>


### PR DESCRIPTION
In commit 83a8a7bd4cf "Fix configuration and building with uClibc"
we simply inserted _GNU_SOURCE definitions in configuration utility
and one source file which uses O_CLOEXEC. This solved compilation
issue against uClibc but strictly speaking that was improper solution
because O_CLOEXEC became a part of POSIX 2008 still uClibc library was
never updated accordingly and still believes it's a glibc's extension.

Essentially the most correct solution is to update uClibc and that
should be done anyways yet another short-term solution is try to
figure out if with defined _GNU_SOURCE O_CLOEXEC flags gets recognized
by the toolchain and then add built-wise definition of _GNU_SOURCE.

That way we keep sources pristine while achieving initial goal.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
Signed-off-by: Alexey Brodkin <abrodkin@synopsys.com>