### PR TITLE
qedr: Configure byte_len in read/send WC

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -1583,6 +1583,7 @@ static int process_req(struct qelr_qp *qp, struct qelr_cq *cq, int num_entries,
 		case IBV_WC_RDMA_READ:
 		case IBV_WC_SEND:
 		case IBV_WC_BIND_MW:
+			wc->byte_len = qp->wqe_wr_id[qp->sq.cons].bytes_len;
 			DP_VERBOSE(cxt->dbg_fp, QELR_MSG_CQ,
 				   "POLL REQ CQ: IBV_WC_RDMA_READ / IBV_WC_SEND\n");
 			break;


### PR DESCRIPTION
Configure the byte_len field in the work completions of the RDMA READ
and RDMA SEND as it was never set.

Fixes: c0965e4fe6fe ("libqedr (qelr) verbs")

Signed-off-by: Ram Amrani <Ram.Amrani@cavium.com>