### PR TITLE
Debian copyright review

### DIFF
--- a/buildlib/FindLDSymVer.cmake
+++ b/buildlib/FindLDSymVer.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 # find_package helper to detect symbol version support in the compiler and
 # linker. If supported then LDSYMVER_MODE will be set to GNU
 

--- a/buildlib/FindUDev.cmake
+++ b/buildlib/FindUDev.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 find_library(LIBUDEV_LIBRARY NAMES udev libudev)
 

--- a/buildlib/RDMA_BuildType.cmake
+++ b/buildlib/RDMA_BuildType.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2015 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2015 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 function(RDMA_BuildType)
   set(build_types Debug Release RelWithDebInfo MinSizeRel)

--- a/buildlib/RDMA_DoFixup.cmake
+++ b/buildlib/RDMA_DoFixup.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 # Execute a header fixup based on NOT_NEEDED for HEADER
 

--- a/buildlib/RDMA_EnableCStd.cmake
+++ b/buildlib/RDMA_EnableCStd.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 # cmake does not have way to do this even slightly sanely until CMP0056
 function(RDMA_CHECK_C_LINKER_FLAG FLAG CACHE_VAR)

--- a/buildlib/RDMA_LinuxHeaders.cmake
+++ b/buildlib/RDMA_LinuxHeaders.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 # Check that the system kernel headers are new enough, if not replace the
 # headers with our internal copy.

--- a/buildlib/RDMA_Sparse.cmake
+++ b/buildlib/RDMA_Sparse.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2017 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2017 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 function(RDMA_CheckSparse)
   # Sparse defines __CHECKER__, but only for the 'sparse pass', which has no

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2015-2016 Obsidian Research Corp. See COPYING.
+# Copyright 2015-2016 Obsidian Research Corp.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 # PYTHON_ARGCOMPLETE_OK
 """cbuild - Build in a docker container
 

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2017 Obsidian Research Corp. See COPYING.
+# Copyright 2017 Obsidian Research Corp.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 """check-build - Run static checks on a build"""
 import argparse
 import inspect

--- a/buildlib/gen-sparse.py
+++ b/buildlib/gen-sparse.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2015-2017 Obsidian Research Corp. See COPYING.
+# Copyright 2015-2017 Obsidian Research Corp.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 import argparse
 import subprocess
 import os

--- a/buildlib/publish_headers.cmake
+++ b/buildlib/publish_headers.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 # Same as publish_headers but does not install them during the install phase
 function(publish_internal_headers DEST)

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Obsidian Research Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Obsidian Research Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 # Helper functions for use in the sub CMakeLists files to make them simpler
 # and more uniform.

--- a/buildlib/relpath
+++ b/buildlib/relpath
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# Copyright 2017 Mellanox Technologies, Inc. See COPYING.
+# Copyright 2017 Mellanox Technologies, Inc.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 import os
 import sys

--- a/buildlib/sparse-include/endian.h
+++ b/buildlib/sparse-include/endian.h
@@ -1,4 +1,5 @@
-/* COPYRIGHT (c) 2017 Obsidian Research Corporation. See COPYING file */
+/* COPYRIGHT (c) 2017 Obsidian Research Corporation.
+   Licensed under BSD (MIT variant) or GPLv2. See COPYING. */
 
 #ifndef _SPARSE_ENDIAN_H_
 #define _SPARSE_ENDIAN_H_

--- a/buildlib/sparse-include/pthread.h
+++ b/buildlib/sparse-include/pthread.h
@@ -1,4 +1,5 @@
-/* COPYRIGHT (c) 2017 Obsidian Research Corporation. See COPYING file */
+/* COPYRIGHT (c) 2017 Obsidian Research Corporation.
+   Licensed under BSD (MIT variant) or GPLv2. See COPYING. */
 
 #ifndef _SPARSE_PTHREAD_H_
 #define _SPARSE_PTHREAD_H_

--- a/buildlib/sparse-include/stdatomic.h
+++ b/buildlib/sparse-include/stdatomic.h
@@ -1,4 +1,5 @@
-/* COPYRIGHT (c) 2017 Obsidian Research Corporation. See COPYING file
+/* COPYRIGHT (c) 2017 Obsidian Research Corporation.
+ * Licensed under BSD (MIT variant) or GPLv2. See COPYING.
  *
  * A version of C11 stdatomic.h that doesn't make spare angry. This doesn't
  * actually work.

--- a/debian/copyright
+++ b/debian/copyright
@@ -225,7 +225,10 @@ Copyright: 2005, Topspin Communications.
 License: BSD-MIT or GPL-2
 
 Files: srp_daemon/srp_daemon.1.in
-       srp_daemon/srpd.in
+Copyright: 2006 Mellanox Technologies.
+License: CPL-1.0 or BSD-2-clause or GPL-2
+
+Files: srp_daemon/srpd.in
        srp_daemon/ibsrpdm.1
 Copyright: disclaimed
 License: BSD-2-clause
@@ -438,3 +441,216 @@ License: MIT
  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
+
+License: CPL-1.0
+ THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS COMMON PUBLIC
+ LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF THE PROGRAM
+ CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+ .
+ 1. DEFINITIONS
+ .
+ "Contribution" means:
+ .
+ a) in the case of the initial Contributor, the initial code and
+ documentation distributed under this Agreement, and
+ .
+ b) in the case of each subsequent Contributor:
+ .
+ i) changes to the Program, and
+ .
+ ii) additions to the Program;
+ .
+ where such changes and/or additions to the Program originate from and are
+ distributed by that particular Contributor. A Contribution 'originates' from a
+ Contributor if it was added to the Program by such Contributor itself or anyone
+ acting on such Contributor's behalf. Contributions do not include additions to
+ the Program which: (i) are separate modules of software distributed in
+ conjunction with the Program under their own license agreement, and (ii) are not
+ derivative works of the Program.
+ .
+ "Contributor" means any person or entity that distributes the Program.
+ .
+ "Licensed Patents " mean patent claims licensable by a Contributor which are
+ necessarily infringed by the use or sale of its Contribution alone or when
+ combined with the Program.
+ .
+ "Program" means the Contributions distributed in accordance with this Agreement.
+ .
+ "Recipient" means anyone who receives the Program under this Agreement,
+ including all Contributors.
+ .
+ 2. GRANT OF RIGHTS
+ .
+ a) Subject to the terms of this Agreement, each Contributor hereby grants
+ Recipient a non-exclusive, worldwide, royalty-free copyright license to
+ reproduce, prepare derivative works of, publicly display, publicly perform,
+ distribute and sublicense the Contribution of such Contributor, if any, and such
+ derivative works, in source code and object code form.
+ .
+ b) Subject to the terms of this Agreement, each Contributor hereby grants
+ Recipient a non-exclusive, worldwide, royalty-free patent license under Licensed
+ Patents to make, use, sell, offer to sell, import and otherwise transfer the
+ Contribution of such Contributor, if any, in source code and object code form.
+ This patent license shall apply to the combination of the Contribution and the
+ Program if, at the time the Contribution is added by the Contributor, such
+ addition of the Contribution causes such combination to be covered by the
+ Licensed Patents. The patent license shall not apply to any other combinations
+ which include the Contribution. No hardware per se is licensed hereunder.
+ .
+ c) Recipient understands that although each Contributor grants the licenses
+ to its Contributions set forth herein, no assurances are provided by any
+ Contributor that the Program does not infringe the patent or other intellectual
+ property rights of any other entity. Each Contributor disclaims any liability to
+ Recipient for claims brought by any other entity based on infringement of
+ intellectual property rights or otherwise. As a condition to exercising the
+ rights and licenses granted hereunder, each Recipient hereby assumes sole
+ responsibility to secure any other intellectual property rights needed, if any.
+ For example, if a third party patent license is required to allow Recipient to
+ distribute the Program, it is Recipient's responsibility to acquire that license
+ before distributing the Program.
+ .
+ d) Each Contributor represents that to its knowledge it has sufficient
+ copyright rights in its Contribution, if any, to grant the copyright license set
+ forth in this Agreement.
+ .
+ 3. REQUIREMENTS
+ .
+ A Contributor may choose to distribute the Program in object code form under its
+ own license agreement, provided that:
+ .
+ a) it complies with the terms and conditions of this Agreement; and
+ .
+ b) its license agreement:
+ .
+ i) effectively disclaims on behalf of all Contributors all warranties and
+ conditions, express and implied, including warranties or conditions of title and
+ non-infringement, and implied warranties or conditions of merchantability and
+ fitness for a particular purpose;
+ .
+ ii) effectively excludes on behalf of all Contributors all liability for
+ damages, including direct, indirect, special, incidental and consequential
+ damages, such as lost profits;
+ .
+ iii) states that any provisions which differ from this Agreement are offered
+ by that Contributor alone and not by any other party; and
+ .
+ iv) states that source code for the Program is available from such
+ Contributor, and informs licensees how to obtain it in a reasonable manner on or
+ through a medium customarily used for software exchange.
+ .
+ When the Program is made available in source code form:
+ .
+ a) it must be made available under this Agreement; and
+ .
+ b) a copy of this Agreement must be included with each copy of the Program.
+ .
+ Contributors may not remove or alter any copyright notices contained within the
+ Program.
+ .
+ Each Contributor must identify itself as the originator of its Contribution, if
+ any, in a manner that reasonably allows subsequent Recipients to identify the
+ originator of the Contribution.
+ .
+ 4. COMMERCIAL DISTRIBUTION
+ .
+ Commercial distributors of software may accept certain responsibilities with
+ respect to end users, business partners and the like. While this license is
+ intended to facilitate the commercial use of the Program, the Contributor who
+ includes the Program in a commercial product offering should do so in a manner
+ which does not create potential liability for other Contributors. Therefore, if
+ a Contributor includes the Program in a commercial product offering, such
+ Contributor ("Commercial Contributor") hereby agrees to defend and indemnify
+ every other Contributor ("Indemnified Contributor") against any losses, damages
+ and costs (collectively "Losses") arising from claims, lawsuits and other legal
+ actions brought by a third party against the Indemnified Contributor to the
+ extent caused by the acts or omissions of such Commercial Contributor in
+ connection with its distribution of the Program in a commercial product
+ offering. The obligations in this section do not apply to any claims or Losses
+ relating to any actual or alleged intellectual property infringement. In order
+ to qualify, an Indemnified Contributor must: a) promptly notify the Commercial
+ Contributor in writing of such claim, and b) allow the Commercial Contributor to
+ control, and cooperate with the Commercial Contributor in, the defense and any
+ related settlement negotiations. The Indemnified Contributor may participate in
+ any such claim at its own expense.
+ .
+ For example, a Contributor might include the Program in a commercial product
+ offering, Product X. That Contributor is then a Commercial Contributor. If that
+ Commercial Contributor then makes performance claims, or offers warranties
+ related to Product X, those performance claims and warranties are such
+ Commercial Contributor's responsibility alone. Under this section, the
+ Commercial Contributor would have to defend claims against the other
+ Contributors related to those performance claims and warranties, and if a court
+ requires any other Contributor to pay any damages as a result, the Commercial
+ Contributor must pay those damages.
+ .
+ 5. NO WARRANTY
+ .
+ EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED ON AN
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+ IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF TITLE,
+ NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE. Each
+ Recipient is solely responsible for determining the appropriateness of using and
+ distributing the Program and assumes all risks associated with its exercise of
+ rights under this Agreement, including but not limited to the risks and costs of
+ program errors, compliance with applicable laws, damage to or loss of data,
+ programs or equipment, and unavailability or interruption of operations.
+ .
+ 6. DISCLAIMER OF LIABILITY
+ .
+ EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR ANY
+ CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT LIMITATION LOST
+ PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ OUT OF THE USE OR DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS
+ GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ .
+ 7. GENERAL
+ .
+ If any provision of this Agreement is invalid or unenforceable under applicable
+ law, it shall not affect the validity or enforceability of the remainder of the
+ terms of this Agreement, and without further action by the parties hereto, such
+ provision shall be reformed to the minimum extent necessary to make such
+ provision valid and enforceable.
+ .
+ If Recipient institutes patent litigation against a Contributor with respect to
+ a patent applicable to software (including a cross-claim or counterclaim in a
+ lawsuit), then any patent licenses granted by that Contributor to such Recipient
+ under this Agreement shall terminate as of the date such litigation is filed. In
+ addition, if Recipient institutes patent litigation against any entity
+ (including a cross-claim or counterclaim in a lawsuit) alleging that the Program
+ itself (excluding combinations of the Program with other software or hardware)
+ infringes such Recipient's patent(s), then such Recipient's rights granted under
+ Section 2(b) shall terminate as of the date such litigation is filed.
+ .
+ All Recipient's rights under this Agreement shall terminate if it fails to
+ comply with any of the material terms or conditions of this Agreement and does
+ not cure such failure in a reasonable period of time after becoming aware of
+ such noncompliance. If all Recipient's rights under this Agreement terminate,
+ Recipient agrees to cease use and distribution of the Program as soon as
+ reasonably practicable. However, Recipient's obligations under this Agreement
+ and any licenses granted by Recipient relating to the Program shall continue and
+ survive.
+ .
+ Everyone is permitted to copy and distribute copies of this Agreement, but in
+ order to avoid inconsistency the Agreement is copyrighted and may only be
+ modified in the following manner. The Agreement Steward reserves the right to
+ publish new versions (including revisions) of this Agreement from time to time.
+ No one other than the Agreement Steward has the right to modify this Agreement.
+ IBM is the initial Agreement Steward. IBM may assign the responsibility to serve
+ as the Agreement Steward to a suitable separate entity. Each new version of the
+ Agreement will be given a distinguishing version number. The Program (including
+ Contributions) may always be distributed subject to the version of the Agreement
+ under which it was received. In addition, after a new version of the Agreement
+ is published, Contributor may elect to distribute the Program (including its
+ Contributions) under the new version. Except as expressly stated in Sections
+ 2(a) and 2(b) above, Recipient receives no rights or licenses to the
+ intellectual property of any Contributor under this Agreement, whether
+ expressly, by implication, estoppel or otherwise. All rights in the Program not
+ expressly granted under this Agreement are reserved.
+ .
+ This Agreement is governed by the laws of the State of New York and the
+ intellectual property laws of the United States of America. No party to this
+ Agreement will bring a legal action under this Agreement more than one year
+ after the cause of action arose. Each party waives its rights to a jury trial in
+ any resulting litigation.

--- a/debian/copyright
+++ b/debian/copyright
@@ -71,13 +71,13 @@ Copyright: 2013-2015, Mellanox Technologies LTD.
 License: BSD-MIT or GPL-2
 
 Files: ibacm/src/acm_util.c
-  ibacm/src/acm_util.h
-  ibacm/src/parse.c
+       ibacm/src/acm_util.h
+       ibacm/src/parse.c
 Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT
 
 Files: ibacm/man/*
-  ibacm/ibacm.init.in
+       ibacm/ibacm.init.in
 Copyright: disclaimed
 License: BSD-2-clause
 
@@ -109,12 +109,12 @@ Copyright: 2017 Mellanox Technologies LTD.
 License: BSD-MIT or GPL-2
 
 Files: libibumad/tests/umad_reg2_compat.c
-  libibumad/tests/umad_register2.c
+       libibumad/tests/umad_register2.c
 Copyright: 2014, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: libibumad/umad.c
-  libibumad/umad.h
+       libibumad/umad.h
 Copyright: 2005-2014, Intel Corporation.
            2004-2009, Voltaire Inc.
 License: BSD-MIT or GPL-2
@@ -169,7 +169,7 @@ Copyright: 2006, 2007, Cisco Systems, Inc.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/arch.h
-  libibverbs/opcode.h
+       libibverbs/opcode.h
 Copyright: 2004-2005, Topspin Communications.
 License: BSD-MIT or GPL-2
 
@@ -180,7 +180,7 @@ Copyright: 2006, Cisco Systems, Inc.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/compat-1_0.c
-  libibverbs/sysfs.c
+       libibverbs/sysfs.c
 Copyright: 2006, 2007, Cisco Systems, Inc.
 License: BSD-MIT or GPL-2
 
@@ -204,7 +204,7 @@ Copyright: 2005, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/examples/pingpong.c
-  libibverbs/examples/pingpong.h
+       libibverbs/examples/pingpong.h
 Copyright: 2005, 2006, Cisco Systems.
 License: BSD-MIT or GPL-2
 
@@ -220,7 +220,7 @@ Copyright: 2005, Topspin Communications.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/marshall.c
-  libibverbs/marshall.h
+       libibverbs/marshall.h
 Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
@@ -237,9 +237,9 @@ Copyright: 2005-2007, Cisco Systems, Inc.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/man/*
-  libibverbs/neigh.h
-  libibverbs/nl1_compat.h
-  libibverbs/neigh.c
+       libibverbs/neigh.h
+       libibverbs/nl1_compat.h
+       libibverbs/neigh.c
 Copyright: disclaimed
 License: BSD-2-clause
 
@@ -248,7 +248,7 @@ Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: librdmacm/examples/riostream.c
-  librdmacm/examples/rstream.c
+       librdmacm/examples/rstream.c
 Copyright: 2013-2015, Mellanox Technologies LTD.
            2009-2014, Intel Corporation.
 License: BSD-MIT or GPL-2
@@ -276,9 +276,9 @@ Copyright: 2004-2016, Chelsio, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/cxgb4/t4_chip_type.h
-  providers/cxgb4/t4_pci_id_tbl.h
-  providers/cxgb4/t4_regs.h
-  providers/cxgb4/t4fw_api.h
+       providers/cxgb4/t4_pci_id_tbl.h
+       providers/cxgb4/t4_regs.h
+       providers/cxgb4/t4fw_api.h
 Copyright: 2003-2015, Chelsio Communications, Inc.
 License: BSD-MIT or GPL-2
 
@@ -423,13 +423,13 @@ Copyright: 2006, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
 Files: srp_daemon/srp_daemon.1.in
-  srp_daemon/srpd.in
-  srp_daemon/ibsrpdm.1
+       srp_daemon/srpd.in
+       srp_daemon/ibsrpdm.1
 Copyright: disclaimed
 License: BSD-2-clause
 
 Files: srp_daemon/srp_daemon.sh.in
-  srp_daemon/srp_handle_traps.c
+       srp_daemon/srp_handle_traps.c
 Copyright: 2006, Mellanox Technologies.
 License: BSD-MIT or GPL-2
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -219,7 +219,7 @@ License: BSD-MIT or GPL-2
 
 Files: providers/vmw_pvrdma/*
 Copyright: 2012-2016 VMware, Inc.
-License: BSD-MIT or GPL-2
+License: BSD-2-clause or GPL-2
 
 Files: rdma-ndd/*
 Copyright: 2004-2016, Intel Corporation.

--- a/debian/copyright
+++ b/debian/copyright
@@ -42,7 +42,7 @@ License: BSD-MIT or GPL-2
 
 Files: buildlib/fixup-include/rdma-vmw_pvrdma-abi.h
 Copyright: 2012-2016 VMware, Inc.
-License: BSD-MIT or GPL-2
+License: BSD-2-clause or GPL-2
 
 Files: buildlib/fixup-include/stdatomic.h
 Copyright: 2011 Ed Schouten <ed@FreeBSD.org>

--- a/debian/copyright
+++ b/debian/copyright
@@ -38,6 +38,7 @@ License: BSD-MIT or GPL-2
 
 Files: buildlib/*
 Copyright: 2015-2017, Obsidian Research Corporation.
+           2016-2017 Mellanox Technologies, Inc
 License: BSD-MIT or GPL-2
 
 Files: buildlib/fixup-include/rdma-vmw_pvrdma-abi.h
@@ -48,18 +49,6 @@ Files: buildlib/fixup-include/stdatomic.h
 Copyright: 2011 Ed Schouten <ed@FreeBSD.org>
                 David Chisnall <theraven@FreeBSD.org>
 License: BSD-2-clause
-
-Files: buildlib/fixup-include/rdma-rdma_user_rxe.h
-Copyright: 2016, Mellanox Technologies Ltd.
-License: BSD-MIT or GPL-2
-
-Files: buildlib/relpath
-Copyright: 2017 Mellanox Technologies, Inc.
-License: BSD-MIT or GPL-2
-
-Files: buildlib/sparse-include/*
-Copyright: 2017 Obsidian Research Corporation.
-License: BSD-MIT or GPL-2
 
 Files: ccan/*
 Copyright: unspecified
@@ -89,77 +78,19 @@ Copyright: 2013-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: libibcm/*
-Copyright: 2005, Topspin Communications.
-           2005-2006, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibcm/cm.h
 Copyright: 2004-2006, Intel Corporation.
+           2004-2005, Topspin Communications.
            2004, Voltaire Corporation.
-           2004, Topspin Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibcm/examples/*
-Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: libibumad/*
-Copyright: 2004-2008, Voltaire Inc.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/tests/umad_compile_test.c
-Copyright: 2017 Mellanox Technologies LTD.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/tests/umad_reg2_compat.c
-       libibumad/tests/umad_register2.c
-Copyright: 2014, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad.c
-       libibumad/umad.h
-Copyright: 2005-2014, Intel Corporation.
+Copyright: 2004-2017, Mellanox Technologies Ltd.
+           2004, Infinicon Corporation.
+           2004-2014, Intel Corporation.
+           2004, Topspin Corporation.
            2004-2009, Voltaire Inc.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_cm.h
-Copyright: 2013-2015, Mellanox Technologies LTD.
-           2009-2014, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_sa.h
-Copyright: 2014, Mellanox Technologies LTD.
-           2006, 2010, Intel Corporation.
-           2005, Voltaire, Inc.
-           2004, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_sm.h
-Copyright: 2013, Oracle and/or its affiliates.
-           2004-2014, Mellanox Technologies Ltd.
-           2004, Voltaire Corporation.
-           2004, Topspin Corporation.
-           2004, Intel Corporation.
-           2004, Infinicon Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_str.c
-Copyright: 2014, Mellanox Technologies LTD.
-        2013, Lawrence Livermore National Security.
-        2004-2005, 2010, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_str.h
-Copyright: 2013, Lawrence Livermore National Security.
-           2004-2005, 2010, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibumad/umad_types.h
-Copyright: 2004-2006, Voltaire Corporation.
-           2004, Topspin Corporation.
-           2004, Mellanox Technologies Ltd.
-           2004, Infinicon Corporation.
-           2004, 2010, Intel Corporation.
+           2013 Lawrence Livermore National Security
+           2013, Oracle and/or its affiliates.
 License: BSD-MIT or GPL-2
 
 Files: libibumad/man/*
@@ -167,76 +98,13 @@ Copyright: disclaimed
 License: BSD-2-clause
 
 Files: libibverbs/*
-Copyright: 2006, 2007, Cisco Systems, Inc.
+Copyright: 2004-2012, Intel Corporation.
            2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/arch.h
-       libibverbs/opcode.h
-Copyright: 2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/cmd.c
-Copyright: 2006, Cisco Systems, Inc.
-           2005, Topspin Communications.
+           2005-2007, Cisco Systems, Inc.
            2005, PathScale, Inc.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/compat-1_0.c
-       libibverbs/sysfs.c
-Copyright: 2006, 2007, Cisco Systems, Inc.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/driver.h
-Copyright: 2005, PathScale, Inc.
-           2005-2006, Cisco Systems, Inc.
-           2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/enum_strs.c
-Copyright: 2008, Lawrence Livermore National Laboratory.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/examples/*
-Copyright: 2004- 2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/examples/devinfo.c
-Copyright: 2005, Mellanox Technologies Ltd.
-           2005, Cisco Systems.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/examples/pingpong.c
-       libibverbs/examples/pingpong.h
-Copyright: 2005, 2006, Cisco Systems.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/examples/xsrq_pingpong.c
-Copyright: 2011, Intel Corporation, Inc.
-           2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/kern-abi.h
-Copyright: 2005, Topspin Communications.
-           2005, PathScale, Inc.
-           2005-2006, Cisco Systems.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/marshall.c
-       libibverbs/marshall.h
-Copyright: 2004-2016, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/sa.h
-Copyright: 2005, Voltaire, Inc.
-           2004, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: libibverbs/verbs.h
-Copyright: 2005-2007, Cisco Systems, Inc.
-           2005, PathScale, Inc.
-           2004, 2011-2012, Intel Corporation.
-           2004-2005, Topspin Communications.
+           2005, Mellanox Technologies Ltd.
+           2005, Voltaire, Inc.
+           2008, Lawrence Livermore National Laboratory.
 License: BSD-MIT or GPL-2
 
 Files: libibverbs/man/*
@@ -247,23 +115,11 @@ Copyright: disclaimed
 License: BSD-2-clause
 
 Files: librdmacm/*
-Copyright: 2004-2016, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: librdmacm/examples/riostream.c
-       librdmacm/examples/rstream.c
-Copyright: 2013-2015, Mellanox Technologies LTD.
-           2009-2014, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: librdmacm/examples/rping.c
-Copyright: 2006, Open Grid Computing, Inc.
-           2005, Ammasso, Inc.
-License: BSD-MIT or GPL-2
-
-Files: librdmacm/rdma_cma.h
 Copyright: 2005-2014, Intel Corporation.
-           2004-2009, Voltaire Inc.
+           2005, Ammasso, Inc.
+           2005, Voltaire Inc.
+           2006, Open Grid Computing, Inc.
+           2014-2015, Mellanox Technologies LTD.
 License: BSD-MIT or GPL-2
 
 Files: librdmacm/docs/rsocket
@@ -274,15 +130,9 @@ Files: librdmacm/man/*
 Copyright: disclaimed
 License: BSD-2-clause
 
-Files: providers/*
-Copyright: 2004-2016, Chelsio, Inc.
-License: BSD-MIT or GPL-2
-
-Files: providers/cxgb4/t4_chip_type.h
-       providers/cxgb4/t4_pci_id_tbl.h
-       providers/cxgb4/t4_regs.h
-       providers/cxgb4/t4fw_api.h
-Copyright: 2003-2015, Chelsio Communications, Inc.
+Files: providers/cxgb3/*
+       providers/cxgb4/*
+Copyright: 2003-2016, Chelsio Communications, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/hfi1verbs/*
@@ -298,32 +148,14 @@ Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: providers/ipathverbs/*
-Copyright: 2006-2009, QLogic Corp.
+Copyright: 2006-2010, QLogic Corp.
            2005, PathScale, Inc.
+           2013, Intel Corporation
 License: BSD-MIT or GPL-2
 
 Files: providers/mlx4/*
-Copyright: 2006-2007, Cisco, Inc.
-License: BSD-MIT or GPL-2
-
-Files: providers/mlx4/cq.c
-Copyright: 2006-2007, Cisco Systems.
-           2005, Topspin Communications.
-           2005, Mellanox Technologies Ltd.
-License: BSD-MIT or GPL-2
-
-Files: providers/mlx4/dbrec.c
 Copyright: 2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: providers/mlx4/mlx4.h
-Copyright: 2005-2007, Cisco Systems.
-           2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: providers/mlx4/qp.c
-Copyright: 2007, Cisco, Inc.
-           2005, Topspin Communications.
+           2005-2007, Cisco, Inc.
            2005, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
@@ -332,55 +164,18 @@ Copyright: disclaimed
 License: BSD-2-clause
 
 Files: providers/mlx5/*
-Copyright: 2012, Mellanox Technologies, Inc.
-License: BSD-MIT or GPL-2
-
-Files: providers/mlx5/bitmap.h
-Copyright: 2000, 2011, Mellanox Technology Inc.
+Copyright: 2010-2017, Mellanox Technologies, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/mthca/*
-Copyright: 2005-2007, Cisco Systems.
-           2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/ah.c
-  providers/mthca/doorbell.h
-  providers/mthca/memfree.c
 Copyright: 2004-2005, Topspin Communications.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/buf.c
-Copyright: 2006-2007, Cisco Systems, Inc.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/cq.c
-Copyright: 2006-2007, Cisco Systems.
-           2005, Topspin Communications.
-           2005, Mellanox Technologies Ltd.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/qp.c
-Copyright: 2005, Topspin Communications.
-           2005, Mellanox Technologies Ltd.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/srq.c
-Copyright: 2005-2006, Cisco Systems.
-License: BSD-MIT or GPL-2
-
-Files: providers/mthca/verbs.c
-Copyright: 2005, Topspin Communications.
            2005-2006, Cisco Systems.
+           2005, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
 Files: providers/nes/*
 Copyright: 2006-2010, Intel Corporation.
            2006, Open Grid Computing, Inc.
-License: BSD-MIT or GPL-2
-
-Files: providers/nes/nes_uverbs.c
-Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: providers/ocrdma/*
@@ -394,11 +189,6 @@ License: BSD-MIT or GPL-2
 Files: providers/rxe/*
 Copyright: 2009-2011, System Fabric Works, Inc.
            2009-2011, Mellanox Technologies Ltd.
-License: BSD-MIT or GPL-2
-
-Files: providers/rxe/rxe.*
-Copyright: 2009, System Fabric Works, Inc.
-           2009, Mellanox Technologies Ltd.
            2006-2007, QLogic Corporation.
            2005, PathScale, Inc.
 License: BSD-MIT or GPL-2
@@ -408,10 +198,6 @@ Copyright: 2012-2016 VMware, Inc.
 License: BSD-MIT or GPL-2
 
 Files: rdma-ndd/*
-Copyright: 2016, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: rdma-ndd/rdma-ndd.c
 Copyright: 2004-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
@@ -430,11 +216,6 @@ Files: srp_daemon/srp_daemon.1.in
        srp_daemon/ibsrpdm.1
 Copyright: disclaimed
 License: BSD-2-clause
-
-Files: srp_daemon/srp_daemon.sh.in
-       srp_daemon/srp_handle_traps.c
-Copyright: 2006, Mellanox Technologies.
-License: BSD-MIT or GPL-2
 
 Files: util/udma_barrier.h
 Copyright: 2005 Topspin Communications.

--- a/debian/copyright
+++ b/debian/copyright
@@ -122,6 +122,19 @@ Copyright: 2005-2014, Intel Corporation.
            2014-2015, Mellanox Technologies LTD.
 License: BSD-MIT or GPL-2
 
+Files: librdmacm/examples/cmtime.c
+       librdmacm/examples/rcopy.c
+       librdmacm/examples/rdma_client.c
+       librdmacm/examples/rdma_server.c
+       librdmacm/examples/rdma_xclient.c
+       librdmacm/examples/rdma_xserver.c
+       librdmacm/examples/riostream.c
+       librdmacm/examples/rstream.c
+       librdmacm/examples/udpong.c
+Copyright: 2005-2014, Intel Corporation.
+           2014-2015, Mellanox Technologies LTD.
+License: BSD-MIT
+
 Files: librdmacm/docs/rsocket
 Copyright: disclaimed
 License: BSD-2-clause

--- a/debian/copyright
+++ b/debian/copyright
@@ -153,7 +153,9 @@ Copyright: 2003-2016, Chelsio Communications, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/hfi1verbs/*
-Copyright: no-info-found
+Copyright: 2005 PathScale, Inc.
+           2006-2009 QLogic Corporation
+           2015 Intel Corporation
 License: BSD-3-clause or GPL-2
 
 Files: providers/hns/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -163,7 +163,7 @@ Copyright: 2016, Hisilicon Limited.
 License: BSD-MIT or GPL-2
 
 Files: providers/i40iw/*
-Copyright: 2004-2016, Intel Corporation.
+Copyright: 2015-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: providers/ipathverbs/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -70,20 +70,19 @@ Copyright: unspecified
 License: MIT
 
 Files: ibacm/*
-Copyright: 2013-2015, Mellanox Technologies LTD.
-           2009-2014, Intel Corporation.
-License: BSD-MIT or GPL-2
-
-Files: ibacm/src/acm_util.c
-       ibacm/src/acm_util.h
-       ibacm/src/parse.c
-Copyright: 2004-2016, Intel Corporation.
+Copyright: 2009-2014, Intel Corporation.
+           2013, Mellanox Technologies LTD.
 License: BSD-MIT
 
 Files: ibacm/man/*
        ibacm/ibacm.init.in
 Copyright: disclaimed
 License: BSD-2-clause
+
+Files: ibacm/CMakeLists.txt
+       ibacm/ibacm_hosts.data
+Copyright: disclaimed
+License: BSD-MIT or GPL-2
 
 Files: iwpmd/*
 Copyright: 2004-2016, Intel Corporation.

--- a/debian/copyright
+++ b/debian/copyright
@@ -219,9 +219,9 @@ Copyright: 1996-2013, Red Hat, Inc.
 License: GPL-2
 
 Files: srp_daemon/*
-Copyright: 2006, Mellanox Technologies Ltd.
+Copyright: 2005, Topspin Communications.
            2006, Cisco Systems, Inc.
-           2005, Topspin Communications.
+           2006, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
 Files: srp_daemon/srp_daemon.1.in

--- a/debian/copyright
+++ b/debian/copyright
@@ -63,7 +63,11 @@ License: BSD-MIT or GPL-2
 
 Files: ccan/*
 Copyright: unspecified
-License: CC0 and MIT
+License: CC0
+
+Files: ccan/list.*
+Copyright: unspecified
+License: MIT
 
 Files: ibacm/*
 Copyright: 2013-2015, Mellanox Technologies LTD.

--- a/debian/copyright
+++ b/debian/copyright
@@ -85,7 +85,7 @@ Copyright: disclaimed
 License: BSD-MIT or GPL-2
 
 Files: iwpmd/*
-Copyright: 2004-2016, Intel Corporation.
+Copyright: 2013-2016, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: libibcm/*

--- a/debian/copyright
+++ b/debian/copyright
@@ -186,6 +186,11 @@ Files: providers/mlx5/*
 Copyright: 2010-2017, Mellanox Technologies, Inc.
 License: BSD-MIT or GPL-2
 
+Files: providers/mlx5/man/*.3
+       providers/mlx5/man/*.7
+Copyright: disclaimed
+License: BSD-MIT
+
 Files: providers/mthca/*
 Copyright: 2004-2005, Topspin Communications.
            2005-2006, Cisco Systems.

--- a/debian/copyright
+++ b/debian/copyright
@@ -143,6 +143,10 @@ Files: librdmacm/man/*
 Copyright: disclaimed
 License: BSD-2-clause
 
+Files: providers/bnxt_re/*
+Copyright: 2015-2017, Broadcom Limited and/or its subsidiaries
+License: BSD-2-clause or GPL-2
+
 Files: providers/cxgb3/*
        providers/cxgb4/*
 Copyright: 2003-2016, Chelsio Communications, Inc.

--- a/rdma-ndd/CMakeLists.txt
+++ b/rdma-ndd/CMakeLists.txt
@@ -1,4 +1,5 @@
-# COPYRIGHT (c) 2016 Intel Corporation. See COPYING file
+# COPYRIGHT (c) 2016 Intel Corporation.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 


### PR DESCRIPTION
I reviewed `debian/copyright` and here are the commits to fix the stuff I found. The top commit adds the license explicitly to the source code that just refers to the COPYING file.

Sadly, following files do not carry a copyright holder and the COPYING file does not define copyright holders for this case.
```
buildlib/config.h.in
buildlib/github-release
buildlib/provider.map
buildlib/travis-build
buildlib/fixup-include/rdma-rdma_netlink.h
buildlib/fixup-include/valgrind-drd.h
buildlib/fixup-include/valgrind-memcheck.h
buildlib/sparse-include/19/netinet-in.h.diff
buildlib/sparse-include/23/sys-socket.h.diff
buildlib/sparse-include/23/netinet-in.h.diff
buildlib/sparse-include/25/netinet-in.h.diff
ccan/CMakeLists.txt
ccan/*
Documentation/*
ibacm/CMakeLists.txt
ibacm/ibacm.init.in
ibacm/ibacm_hosts.data
ibacm/man/*
iwpmd/CMakeLists.txt
iwpmd/iwpmd.1.in
iwpmd/iwpmd.conf
iwpmd/iwpmd.conf.5.in
iwpmd/iwpmd_init
iwpmd/iwpmd.service
libibcm/CMakeLists.txt
libibcm/libibcm.map
libibcm/examples/CMakeLists.txt
libibumad/libibumad.map
libibumad/CMakeLists.txt
libibumad/libibumad.udev-rules
libibumad/man/CMakeLists.txt
libibumad/man/*
libibverbs/CMakeLists.txt
libibverbs/libibverbs.map
libibverbs/sa-kern-abi.h
libibverbs/arch.h
libibverbs/man/*
libibverbs/neigh.h
libibverbs/neigh.c
libibverbs/nl1_compat.h
librdmacm/librspreload.map
librdmacm/CMakeLists.txt
librdmacm/examples/CMakeLists.txt
librdmacm/man/CMakeLists.txt
librdmacm/librdmacm.map
redhat/* (most)
rdma-ndd/rdma-ndd.8.in
rdma-ndd/rdma-ndd.8.in.rst
rdma-ndd/rdma-ndd.rules
rdma-ndd/rdma-ndd.service.in
srp_daemon/CMakeLists.txt
srp_daemon/ibsrpdm.1
srp_daemon/srp_daemon.1.in
srp_daemon/srp_daemon.conf
srp_daemon/srp_daemon_port@.service.5
srp_daemon/srp_daemon_port@.service.in
srp_daemon/srp_daemon.rules
srp_daemon/srp_daemon.service.5
srp_daemon/srp_daemon.service.in
srp_daemon/srpd.in
srp_daemon/start_on_all_ports
util/CMakeLists.txt
util/compiler.h
util/util.h
providers/bnxt_re/CMakeLists.txt
providers/cxgb3/CMakeLists.txt
providers/cxgb4/CMakeLists.txt
providers/hfi1verbs/CMakeLists.txt
providers/hns/CMakeLists.txt
providers/i40iw/CMakeLists.txt
providers/mlx4/CMakeLists.txt
providers/mlx5/CMakeLists.txt
providers/mlx5/libmlx5.map
providers/mlx5/man/CMakeLists.txt
providers/mthca/CMakeLists.txt
providers/nes/CMakeLists.txt
providers/ocrdma/CMakeLists.txt
providers/qedr/CMakeLists.txt
providers/rxe/CMakeLists.txt
providers/rxe/man/CMakeLists.txt
providers/rxe/man/rxe.7
providers/rxe/man/rxe_cfg.8
providers/vmw_pvrdma/CMakeLists.txt
```
I tried to start a discussion on the mailing list: http://marc.info/?l=linux-rdma&m=149848828821106&w=4

Once this copyright holders issue is fixed, I can upload rdma-core to Debian.