### PR TITLE
debian: Let rmda-core conflict with infiniband-diags < 2.0.0

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,8 @@ Homepage: https://github.com/linux-rdma/rdma-core
 Package: rdma-core
 Architecture: linux-any
 Depends: ${misc:Depends}, ${shlibs:Depends}
+Breaks: infiniband-diags (<< 2.0.0)
+Replaces: infiniband-diags (<< 2.0.0)
 Description: RDMA core userspace infrastructure and documentation
  rdma-core provides the basic boot time support (eg systemd integration)
  for systems that use the Linux kernel's RDMA subystem.


### PR DESCRIPTION
rdma-core ships /usr/sbin/rdma-ndd which was part of infiniband-diags until versions 2.0.0. Thus rdma-core and infiniband-diags < 2.0.0 cannot be installed in parallel and needs to declare a conflict.