### PR TITLE
libqedr: fix sparse warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -421,7 +421,7 @@ add_subdirectory(providers/mlx5/man) # NO SPARSE
 add_subdirectory(providers/mthca) # NO SPARSE
 add_subdirectory(providers/nes) # NO SPARSE
 add_subdirectory(providers/ocrdma)
-add_subdirectory(providers/qedr) # NO SPARSE
+add_subdirectory(providers/qedr)
 add_subdirectory(providers/vmw_pvrdma) # NO SPARSE
 endif()
 

--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -197,9 +197,9 @@ struct qelr_qp_hwq_info {
 };
 
 struct qelr_rdma_ext {
-	uint64_t remote_va;
-	uint32_t remote_key;
-	uint32_t dma_length;
+	__be64	remote_va;
+	__be32	remote_key;
+	__be32	dma_length;
 };
 
 /* rdma extension, invalidate / immediate data + padding, inline data... */


### PR DESCRIPTION
Patch 1:
  Properly use __be and __le types and their conversions.
  Do not use values stored in firmware structures.

Patch 2:
Enable sparse for libqedr.