### PR TITLE
libqedr: fix bugs introduced in "sparse fixes"

### DIFF
--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -285,6 +285,7 @@ static inline struct qelr_cq *get_qelr_cq(struct ibv_cq *ibcq)
 	(((value) >> (name ## _SHIFT)) & name ## _MASK)
 
 #define ROCE_WQE_ELEM_SIZE	sizeof(struct rdma_sq_sge)
+#define RDMA_WQE_BYTES		(16)
 
 #define QELR_RESP_IMM (RDMA_CQE_RESPONDER_IMM_FLG_MASK <<	\
 			RDMA_CQE_RESPONDER_IMM_FLG_SHIFT)


### PR DESCRIPTION
Fix byte swapping function (pointer must advance).
Fix WQE size to be multiples of 16 bytes, not 8 bytes.
Pass a pointer to wqe_size to allow it to be updated.
Update the immediate value before the wqe is copied.

Fixes: 259ddded0e16 ("libqedr: fix sparse warnings")

Signed-off-by: Ram Amrani <Ram.Amrani@cavium.com>