### PR TITLE
travis: Enforce kernel coding style on rdma-core

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,7 @@ before_script:
   - rm $LATEST_GCC_LINARO_TAR
 script:
   - buildlib/travis-build
+  - buildlib/travis-checkpatch
   - buildlib/github-release
 deploy:
   # Deploy assets to Github releases

--- a/buildlib/travis-checkpatch
+++ b/buildlib/travis-checkpatch
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright 2017 Mellanox Technologies Ltd.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
+
+set -e
+
+if [ $TRAVIS_COMMIT_RANGE != "" ]; then
+	cd buildlib/
+	wget https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/checkpatch.pl
+	wget https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/spelling.txt
+	DIR_FOR_PATCHES_TO_CHECK=$(mktemp -d)
+	git format-patch --no-cover-letter $TRAVIS_COMMIT_RANGE -o $DIR_FOR_PATCHES_TO_CHECK/
+	perl checkpatch.pl --no-tree --ignore PREFER_KERNEL_TYPES,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS $DIR_FOR_PATCHES_TO_CHECK/*
+fi


### PR DESCRIPTION
The rdma-core library is tightly coupled to the linux-rdma kernel
and developed mostly by the same kernel developers. Enforcement of
the same coding style as used for kernel development has potential
to reduce errors and improve readability.

Despite the fact that checkpatch is written as general tool, the
differences between kernel and user space requires from us to
skip kernel types, file movement and execute permissions checks.

Signed-off-by: Leon Romanovsky <leon@kernel.org>