### PR TITLE
travis: relax checkpatch checks by skipping warnings

### DIFF
--- a/buildlib/travis-checkpatch
+++ b/buildlib/travis-checkpatch
@@ -2,7 +2,9 @@
 # Copyright 2017 Mellanox Technologies Ltd.
 # Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
-set -e
+# The below "set" is commented, because the checkpatch.pl returns 1 (error) for warnings too.
+# And the rdma-core code is not mature enough to be warning safe
+# set -e
 
 if [ $TRAVIS_COMMIT_RANGE != "" ]; then
 	cd buildlib/
@@ -10,5 +12,13 @@ if [ $TRAVIS_COMMIT_RANGE != "" ]; then
 	wget https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/spelling.txt
 	DIR_FOR_PATCHES_TO_CHECK=$(mktemp -d)
 	git format-patch --no-cover-letter $TRAVIS_COMMIT_RANGE -o $DIR_FOR_PATCHES_TO_CHECK/
-	perl checkpatch.pl --no-tree --ignore PREFER_KERNEL_TYPES,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS,USE_NEGATIVE_ERRNO $DIR_FOR_PATCHES_TO_CHECK/*
+	CHECKPATCH_OPT="--no-tree --ignore PREFER_KERNEL_TYPES,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS,USE_NEGATIVE_ERRNO $DIR_FOR_PATCHES_TO_CHECK/*"
+	perl checkpatch.pl $CHECKPATCH_OPT
+	if [ $? -ne 0 ]; then
+		# We rerun checkpatch to simplify parsing and to understand if we failed for errors
+		# For example, the output on some arbitrary patchset of the following line without awk is:
+		# total: 1 errors, 3 warnings, 42 lines checked
+		NUMB_ERRRORS=$(perl checkpatch.pl --terse $CHECKPATCH_OPT | awk 'BEGIN {FS = "total:"} ; {sum+=$2} END {print sum}')
+		exit $NUMB_ERRRORS
+	fi
 fi


### PR DESCRIPTION
The commit ecc5ff0c5090 ("travis: Enforce kernel coding style on rdma-core")
was proven as too optimistic, but the quality of rdma-core doesn't allow
us to treat warnings as errors.

The following patch relaxes the checks for the warnings.

Signed-off-by: Leon Romanovsky <leon@kernel.org>