### PR TITLE
Various related fixes for daemons

### DIFF
--- a/debian/iwpmd.install
+++ b/debian/iwpmd.install
@@ -2,5 +2,5 @@ etc/init.d/iwpmd
 etc/iwpmd.conf
 lib/systemd/system/iwpmd.service
 usr/bin/iwpmd
-usr/share/man/man1/iwpmd.1
+usr/share/man/man8/iwpmd.8
 usr/share/man/man5/iwpmd.conf.5

--- a/iwpmd/CMakeLists.txt
+++ b/iwpmd/CMakeLists.txt
@@ -9,7 +9,7 @@ target_link_libraries(iwpmd LINK_PRIVATE
   )
 
 rdma_man_pages(
-  iwpmd.1.in
+  iwpmd.8.in
   iwpmd.conf.5.in
   )
 

--- a/iwpmd/iwarp_pm_server.c
+++ b/iwpmd/iwarp_pm_server.c
@@ -1400,7 +1400,7 @@ int main(int argc, char *argv[])
 	FILE *fp;
 	int ret = EXIT_FAILURE;
 
-	openlog("iWarpPortMapper", LOG_CONS | LOG_PID, LOG_DAEMON);
+	openlog(NULL, LOG_NDELAY | LOG_CONS | LOG_PID, LOG_DAEMON);
 
 	daemonize_iwpm_server();
 

--- a/iwpmd/iwarp_pm_server.c
+++ b/iwpmd/iwarp_pm_server.c
@@ -1358,39 +1358,14 @@ iwarp_port_mapper_exit:
  */ 
 static void daemonize_iwpm_server(void)
 {
-	pid_t pid, sid;
-
-	/* check if already a daemon */
-	if (getppid() == 1) return;
-
-    	pid = fork();
-    	if (pid < 0) {
-		syslog(LOG_WARNING, "daemonize_iwpm_server: Couldn't fork a new process\n");
-        	exit(EXIT_FAILURE);
-    	}
-
-    	/* exit the parent process */
-	if (pid > 0)
-        	exit(EXIT_SUCCESS);
-
+	if (daemon(0, 0) != 0) {
+		syslog(LOG_ERR, "Failed to daemonize\n");
+		exit(EXIT_FAILURE);
+	}
 	umask(0); /* change file mode mask */
-	sid = setsid();	/* create a new session, new group, no tty */
-	if (sid < 0) {
-    		syslog(LOG_WARNING, "daemonize_iwpm_server: Couldn't create new session\n");
-        	exit(EXIT_FAILURE);
-    	}
-
-    	if ((chdir("/")) < 0) {
-		syslog(LOG_WARNING, "daemonize_iwpm_server: Couldn't change the current directory\n");
-        	exit(EXIT_FAILURE);
-   	}
 
 	syslog(LOG_WARNING, "daemonize_iwpm_server: Starting iWarp Port Mapper V%d process\n",
 				iwpm_version);
-	/* close standard IO streams */
-	close(STDIN_FILENO);
-	close(STDOUT_FILENO);
-	close(STDERR_FILENO);
 }
 
 int main(int argc, char *argv[])

--- a/iwpmd/iwpmd.8.in
+++ b/iwpmd/iwpmd.8.in
@@ -45,6 +45,10 @@ which then releases the TCP port.
 The message exchange between iwpmd and the iWARP Connection Manager
 (between user space and kernel space) is implemented using netlink
 sockets.
+.SH OPTIONS
+.sp
+\fB\-s, \-\-systemd\fP
+Enable systemd integration.
 .SH "SIGNALS"
 SIGUSR1 will force a dump of the current mappings
 to the system message log.

--- a/iwpmd/iwpmd.8.in
+++ b/iwpmd/iwpmd.8.in
@@ -1,4 +1,4 @@
-.TH "iwpmd" 1 "2016-09-16" "iwpmd" "iwpmd" iwpmd
+.TH "iwpmd" 8 "2016-09-16" "iwpmd" "iwpmd" iwpmd
 .SH NAME
 iwpmd \- port mapping services for iWARP.
 .SH SYNOPSIS

--- a/iwpmd/iwpmd.conf.5.in
+++ b/iwpmd/iwpmd.conf.5.in
@@ -17,4 +17,4 @@ nl_sock_rbuf_size=419430400
 .SH "FILES"
 @CMAKE_INSTALL_FULL_SYSCONFDIR@/iwpmd.conf
 .SH "SEE ALSO"
-iwpmd(1)
+iwpmd(8)

--- a/iwpmd/iwpmd.service
+++ b/iwpmd/iwpmd.service
@@ -4,9 +4,8 @@ Documentation=man:iwpmd file:/etc/iwpmd.conf
 After=network.target
 
 [Service]
-ExecStart=/usr/bin/iwpmd
+ExecStart=/usr/bin/iwpmd --systemd
 LimitNOFILE=102400
-KillMode=process
 
 [Install]
 WantedBy=multi-user.target

--- a/rdma-ndd/rdma-ndd.c
+++ b/rdma-ndd/rdma-ndd.c
@@ -289,15 +289,14 @@ int main(int argc, char *argv[])
 	openlog(NULL, LOG_NDELAY | LOG_CONS | LOG_PID, LOG_DAEMON);
 
 	while (1) {
-		int opt_idx = 0;
-		static struct option long_opts[] = {
+		static const struct option long_opts[] = {
 			{ "foreground",   0, NULL, 'f' },
 			{ "help",         0, NULL, 'h' },
 			{ "debug",        0, NULL, 'd' },
 			{ }
 		};
 
-		int c = getopt_long(argc, argv, "fh", long_opts, &opt_idx);
+		int c = getopt_long(argc, argv, "fh", long_opts, NULL);
 		if (c == -1)
 			break;
 

--- a/rdma-ndd/rdma-ndd.c
+++ b/rdma-ndd/rdma-ndd.c
@@ -286,7 +286,7 @@ int main(int argc, char *argv[])
 {
 	bool foreground = false;
 
-	openlog("rdma-ndd", LOG_PID, LOG_DAEMON);
+	openlog(NULL, LOG_NDELAY | LOG_CONS | LOG_PID, LOG_DAEMON);
 
 	while (1) {
 		int opt_idx = 0;

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -394,7 +394,7 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %{_bindir}/iwpmd
 %{_unitdir}/iwpmd.service
 %config(noreplace) %{_sysconfdir}/iwpmd.conf
-%{_mandir}/man1/iwpmd.*
+%{_mandir}/man8/iwpmd.*
 %{_mandir}/man5/iwpmd.*
 
 %files -n libibcm

--- a/srp_daemon/srp_daemon.1.in
+++ b/srp_daemon/srp_daemon.1.in
@@ -91,6 +91,9 @@ Perform \fIretries\fR retries on each send to MAD (default: 3 retries).
 .TP
 \fB\-n\fR
 New format - use also initiator_ext in the connection command.
+.TP
+\fB\--systemd\fR
+Enable systemd integration.
 
 .SH FILES
 @CMAKE_INSTALL_FULL_SYSCONFDIR@/srp_daemon.conf -

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -2053,7 +2053,7 @@ static int ibsrpdm(int argc, char *argv[])
 	ret = set_conf_dev_and_port(umad_dev, config);
 	if (ret) {
 		pr_err("Failed to build config\n");
-		return 1;
+		goto out;
 	}
 
 	umad_init();
@@ -2076,7 +2076,7 @@ static int ibsrpdm(int argc, char *argv[])
 	free_res(res);
 umad_done:
 	umad_done();
-
+out:
 	free_config(config);
 
 	return ret;

--- a/srp_daemon/srp_daemon_port@.service.in
+++ b/srp_daemon/srp_daemon_port@.service.in
@@ -9,7 +9,7 @@ Before=remote-fs-pre.target
 
 [Service]
 Type=simple
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/srp_daemon -e -c -n -j %I -R 60
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/srp_daemon --systemd -e -c -n -j %I -R 60
 MemoryDenyWriteExecute=yes
 PrivateNetwork=yes
 PrivateTmp=yes


### PR DESCRIPTION
These were found during my kernel-boot work
- Broadly make iwpmd work sanely as a daemon with systemd, do not fork, use the right daemon name
  for syslog, and do not send stderr to /dev/null
- Fix duplicated log messages in srp_daemon by removing LOG_PERROR when in systemd mode

@bvanassche @tatyana-en @larrystevenwise  