### PR TITLE
debian: Keep rxe.md in rdma-core directory

### DIFF
--- a/debian/rdma-core.install
+++ b/debian/rdma-core.install
@@ -7,7 +7,7 @@ usr/lib/truescale-serdes.cmds
 usr/sbin/rdma-ndd
 usr/share/doc/rdma-core/MAINTAINERS
 usr/share/doc/rdma-core/README.md
-usr/share/doc/rdma-core/rxe.md usr/share/doc/rdma-core/
+usr/share/doc/rdma-core/rxe.md
 usr/share/man/man7/rxe.7
 usr/share/man/man8/rdma-ndd.8
 usr/share/man/man8/rxe_cfg.8


### PR DESCRIPTION
After moving rxe.md into rdma-core, keep the documentation file in /usr/share/doc/rdma-core instead of moving it to /usr/share/doc/ibverbs-providers/

Fixes: 5c6372e6f17 ("Move rxe_cfg to the rdma-core package")