### PR TITLE
sd_notify for daemons

### DIFF
--- a/buildlib/fixup-include/systemd-sd-daemon.h
+++ b/buildlib/fixup-include/systemd-sd-daemon.h
@@ -9,3 +9,8 @@ static inline int sd_is_socket(int fd, int family, int type, int listening)
 {
 	return 0;
 }
+
+static inline int sd_notify(int unset_environment, const char *state)
+{
+	return 0;
+}

--- a/ibacm/ibacm.service.in
+++ b/ibacm/ibacm.service.in
@@ -5,6 +5,7 @@ After=opensm.service
 Wants=ibacm.socket
 
 [Service]
+Type=notify
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/ibacm --systemd
 
 [Install]

--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -1721,6 +1721,9 @@ static void acm_server(bool systemd)
 	if (ret)
 		acm_log(1, "Warn - Netlink init failed\n");
 
+	if (systemd)
+		sd_notify(0, "READY=1");
+
 	while (1) {
 		n = (int) listen_socket;
 		FD_ZERO(&readfds);

--- a/iwpmd/CMakeLists.txt
+++ b/iwpmd/CMakeLists.txt
@@ -4,6 +4,7 @@ rdma_sbin_executable(iwpmd
   iwarp_pm_server.c
   )
 target_link_libraries(iwpmd LINK_PRIVATE
+  ${SYSTEMD_LIBRARIES}
   ${NL_LIBRARIES}
   ${CMAKE_THREAD_LIBS_INIT}
   )

--- a/iwpmd/iwarp_pm_server.c
+++ b/iwpmd/iwarp_pm_server.c
@@ -32,6 +32,7 @@
  */
 
 #include "config.h"
+#include <systemd/sd-daemon.h>
 #include <getopt.h>
 #include "iwarp_pm.h"
 
@@ -1447,6 +1448,10 @@ int main(int argc, char *argv[])
 
 	known_clients = init_iwpm_clients(&iwarp_clients[0]);
 	send_iwpm_mapinfo_request(netlink_sock, &iwarp_clients[0], known_clients);
+
+	if (systemd)
+		sd_notify(0, "READY=1");
+
 	iwarp_port_mapper(); /* start iwarp port mapper process */
 
 	free_iwpm_mapped_ports();

--- a/iwpmd/iwpmd.service.in
+++ b/iwpmd/iwpmd.service.in
@@ -5,6 +5,7 @@ Requires=rdma-load-modules@iwpmd.service
 After=network.target rdma-load-modules@iwpmd.service
 
 [Service]
+Type=notify
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/iwpmd --systemd
 LimitNOFILE=102400
 

--- a/rdma-ndd/CMakeLists.txt
+++ b/rdma-ndd/CMakeLists.txt
@@ -7,7 +7,10 @@ rdma_sbin_executable(rdma-ndd
   rdma-ndd.c
   )
 
-target_link_libraries(rdma-ndd LINK_PRIVATE ${UDEV_LIBRARIES})
+target_link_libraries(rdma-ndd LINK_PRIVATE
+  ${SYSTEMD_LIBRARIES}
+  ${UDEV_LIBRARIES}
+  )
 
 # FIXME Autogenerate from the .rst
 rdma_man_pages(

--- a/rdma-ndd/rdma-ndd.8.in
+++ b/rdma-ndd/rdma-ndd.8.in
@@ -78,6 +78,9 @@ Run in the foreground instead of as a daemon
 .sp
 \fB\-d, \-\-debugging\fP
 Log additional debugging information to syslog
+.sp
+\fB\-\-systemd\fP
+Enable systemd integration.
 .SH AUTHOR
 .INDENT 0.0
 .TP

--- a/rdma-ndd/rdma-ndd.8.in.rst
+++ b/rdma-ndd/rdma-ndd.8.in.rst
@@ -74,6 +74,9 @@ Run in the foreground instead of as a daemon
 **-d, --debugging**
 Log additional debugging information to syslog
 
+**--systemd**
+Enable systemd integration.
+
 
 AUTHOR
 ======

--- a/rdma-ndd/rdma-ndd.service.in
+++ b/rdma-ndd/rdma-ndd.service.in
@@ -3,6 +3,7 @@ Description=RDMA Node Description Daemon
 Documentation=man:rdma-ndd
 
 [Service]
+Type=notify
 Restart=always
-ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/rdma-ndd -f
+ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/rdma-ndd --systemd
 


### PR DESCRIPTION
This adds calls to sd_notify for iwpmd, ibacm and rdma-ndd daemons.

This allows systemd to know when the daemon has completed startup and is ready to act. This is a necessary element to solve bootup races.

The choice is to use sd_notify instead of Type=forking, mainly because most of our daemons are using threads and moving the fork point till after the threads are setup (where sd_notify is placed) is a major change in daemon design..