### PR TITLE
verbs: Encode the private ABI version number in verbs_register_driver

### DIFF
--- a/buildlib/config.h.in
+++ b/buildlib/config.h.in
@@ -25,6 +25,7 @@
 
 #define VERBS_PROVIDER_DIR "@VERBS_PROVIDER_DIR@"
 #define VERBS_PROVIDER_SUFFIX "@IBVERBS_PROVIDER_SUFFIX@"
+#define IBVERBS_PABI_VERSION @IBVERBS_PABI_VERSION@
 
 // FIXME This has been supported in compilers forever, we should just fail to build on such old systems.
 #cmakedefine HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE 1

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -39,6 +39,7 @@
 #include <infiniband/verbs.h>
 #include <infiniband/kern-abi.h>
 #include <ccan/list.h>
+#include <config.h>
 
 #ifdef __cplusplus
 #  define BEGIN_C_DECLS extern "C" {
@@ -128,6 +129,16 @@ verbs_get_device(const struct ibv_device *dev)
 
 typedef struct verbs_device *(*verbs_driver_init_func)(const char *uverbs_sys_path,
 						       int abi_version);
+
+/* Wire the IBVERBS_PRIVATE version number into the verbs_register_driver
+ * symbol name.  This guarentees we link to the correct set of symbols even if
+ * statically linking or using a dynmic linker with symbol versioning turned
+ * off.
+ */
+#define ___make_verbs_register_driver(x) verbs_register_driver_ ## x
+#define __make_verbs_register_driver(x)  ___make_verbs_register_driver(x)
+#define verbs_register_driver __make_verbs_register_driver(IBVERBS_PABI_VERSION)
+
 void verbs_register_driver(const char *name, verbs_driver_init_func init_func);
 void verbs_init_cq(struct ibv_cq *cq, struct ibv_context *context,
 		       struct ibv_comp_channel *channel,

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -137,6 +137,6 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_resize_cq;
 		ibv_query_gid_type;
 		ibv_register_driver;
-		verbs_register_driver;
+		verbs_register_driver_@IBVERBS_PABI_VERSION@;
 		verbs_init_cq;
 };


### PR DESCRIPTION
This causes the symbol table to look like:

   208: 000000000000c000   142 FUNC    GLOBAL DEFAULT   13 verbs_register_driver_15@@IBVERBS_PRIVATE_15

Which encodes the expected private ABI version inside the symbol name
as well as with the symbol version.

This ensures that the ABI version is checked even if the linking
environment does not include symbol versions, for instance if an
end user is linking a provider static library to the system dynamic
libibverbs.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>