### PR TITLE
travis: Limit checkpatch checks on pull requests only

### DIFF
--- a/buildlib/travis-checkpatch
+++ b/buildlib/travis-checkpatch
@@ -17,7 +17,7 @@ if [ "x$TRAVIS_COMMIT_RANGE" != "x" ]; then
 	wget -q https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/checkpatch.pl \
 	        https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/spelling.txt
 	DIR_FOR_PATCHES_TO_CHECK=$(mktemp -d)
-	git format-patch --no-cover-letter $TRAVIS_COMMIT_RANGE -o $DIR_FOR_PATCHES_TO_CHECK/
+	git format-patch --no-cover-letter $TRAVIS_COMMIT_RANGE ^$TRAVIS_BRANCH -o $DIR_FOR_PATCHES_TO_CHECK/
 	CHECKPATCH_OPT="--no-tree --ignore PREFER_KERNEL_TYPES,FILE_PATH_CHANGES,EXECUTE_PERMISSIONS,USE_NEGATIVE_ERRNO,CONST_STRUCT $DIR_FOR_PATCHES_TO_CHECK/*"
 	perl checkpatch.pl $CHECKPATCH_OPT
 	if [ $? -ne 0 ]; then

--- a/buildlib/travis-checkpatch
+++ b/buildlib/travis-checkpatch
@@ -2,6 +2,12 @@
 # Copyright 2017 Mellanox Technologies Ltd.
 # Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
+
+if [ "x$TRAVIS_EVENT_TYPE" != "xpull_request" ]; then
+	# Peform checkpatch checks on pull requests only
+	exit 0
+fi
+
 # The below "set" is commented, because the checkpatch.pl returns 1 (error) for warnings too.
 # And the rdma-core code is not mature enough to be warning safe
 # set -e


### PR DESCRIPTION
Checkpatch is not always reliable and it forces us to merge pull
requests despite the fact that they are marked as failed.

The travis triggers for every such merge and propagates such wrong
status to master branch.

Let's avoid this check on any type of git update except pull request.

Signed-off-by: Leon Romanovsky <leon@kernel.org>