### PR TITLE
cbuild: Do not return a failure exit code on success

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -782,6 +782,4 @@ if __name__ == '__main__':
     if git_top != ".git":
         os.chdir(os.path.dirname(git_top));
 
-    if not args.func(args):
-        sys.exit(100);
-    sys.exit(0);
+    args.func(args):


### PR DESCRIPTION
Any failure should throw an exception and the return code from the
cmd_* functions should be ignored. This bogus if statement is hold
over from an earlier revision of this script.

Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>

This supersedes #190 