### PR TITLE
mlx4: Extend mlx4dv_get_cq to return uar

### DIFF
--- a/providers/mlx4/man/mlx4dv_init_obj.3
+++ b/providers/mlx4/man/mlx4dv_init_obj.3
@@ -62,7 +62,8 @@ uint32_t        *set_ci_db;
 uint32_t        *arm_db;
 int             arm_sn;
 int             cqe_size;
-uint64_t        comp_mask;
+uint64_t        comp_mask; /* Use enum mlx4dv_cq_comp_mask */
+void            *cq_uar;
 .in -8
 };
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -375,8 +375,9 @@ static int mlx4dv_get_cq(struct ibv_cq *cq_in,
 			 struct mlx4dv_cq *cq_out)
 {
 	struct mlx4_cq *mcq = to_mcq(cq_in);
+	struct mlx4_context *mctx = to_mctx(cq_in->context);
+	uint64_t mask_out = 0;
 
-	cq_out->comp_mask = 0;
 	cq_out->buf.buf = mcq->buf.buf;
 	cq_out->buf.length = mcq->buf.length;
 	cq_out->cqn = mcq->cqn;
@@ -388,6 +389,12 @@ static int mlx4dv_get_cq(struct ibv_cq *cq_in,
 
 	mcq->flags |= MLX4_CQ_FLAGS_DV_OWNED;
 
+	if (cq_out->comp_mask & MLX4DV_CQ_MASK_UAR) {
+		cq_out->cq_uar = mctx->uar;
+		mask_out |= MLX4DV_CQ_MASK_UAR;
+	}
+
+	cq_out->comp_mask = mask_out;
 	return 0;
 }
 

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -166,6 +166,10 @@ struct mlx4dv_qp {
 	uint64_t		comp_mask;
 };
 
+enum mlx4dv_cq_comp_mask {
+	MLX4DV_CQ_MASK_UAR		= 1 << 0,
+};
+
 struct mlx4dv_cq {
 	struct {
 		void			*buf;
@@ -178,7 +182,9 @@ struct mlx4dv_cq {
 	int				arm_sn;
 	int				cqe_size;
 	uint64_t			comp_mask;
+	void				*cq_uar;
 };
+
 struct mlx4dv_srq {
 	struct {
 		void			*buf;


### PR DESCRIPTION
Extend mlx4dv_get_cq to return cq_uar to enable applications
direct access as part of arm_cq flow.