### PR TITLE
Small verbs fixes

### DIFF
--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -50,8 +50,6 @@
 #include <util/util.h>
 #include "ibverbs.h"
 
-#pragma GCC diagnostic ignored "-Wmissing-prototypes"
-
 int abi_ver;
 
 struct ibv_sysfs_dev {

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -66,9 +66,6 @@ static struct {
 	UCNA(EMULEX, GEN1), UCNA(EMULEX, GEN2), UCNA(EMULEX, GEN2_VF)
 };
 
-static LIST_HEAD(ocrdma_dev_list);
-static pthread_mutex_t ocrdma_dev_list_lock = PTHREAD_MUTEX_INITIALIZER;
-
 static struct ibv_context *ocrdma_alloc_context(struct ibv_device *, int);
 static void ocrdma_free_context(struct ibv_context *);
 
@@ -229,10 +226,6 @@ found:
 	pthread_mutex_init(&dev->dev_lock, NULL);
 	pthread_spin_init(&dev->flush_q_lock, PTHREAD_PROCESS_PRIVATE);
 	dev->ibv_dev.ops = &ocrdma_dev_ops;
-	list_node_init(&dev->entry);
-	pthread_mutex_lock(&ocrdma_dev_list_lock);
-	list_add_tail(&ocrdma_dev_list, &dev->entry);
-	pthread_mutex_unlock(&ocrdma_dev_list_lock);
 	return &dev->ibv_dev;
 qp_err:
 	free(dev);

--- a/providers/ocrdma/ocrdma_main.h
+++ b/providers/ocrdma/ocrdma_main.h
@@ -58,7 +58,6 @@ struct ocrdma_device {
 	struct ocrdma_qp **qp_tbl;
 	pthread_mutex_t dev_lock;
 	pthread_spinlock_t flush_q_lock;
-	struct list_node entry;
 	int id;
 	int gen;
 	uint32_t wqe_size;

--- a/util/util.h
+++ b/util/util.h
@@ -3,14 +3,17 @@
 #define UTIL_UTIL_H
 
 #include <stdbool.h>
+#include <sys/types.h>
 
 /* Return true if the snprintf succeeded, false if there was truncation or
  * error */
+static inline bool __good_snprintf(size_t len, int rc)
+{
+	return (rc < len && rc >= 0);
+}
+
 #define check_snprintf(buf, len, fmt, ...)                                     \
-	({                                                                     \
-		int rc = snprintf(buf, len, fmt, ##__VA_ARGS__);               \
-		(rc < len && rc >= 0);                                         \
-	})
+	__good_snprintf(len, snprintf(buf, len, fmt, ##__VA_ARGS__))
 
 /* a CMP b. See also the BSD macro timercmp(). */
 #define ts_cmp(a, b, CMP)			\


### PR DESCRIPTION
This is a precursor to a larger series. The big item switches verbs/init.c to use ccan lists and slightly reworks how the earlier patch to update the device list works.