### PR TITLE
verbs: Add missing string decode for IBV_EVENT_WQ_FATAL

### DIFF
--- a/libibverbs/enum_strs.c
+++ b/libibverbs/enum_strs.c
@@ -87,7 +87,8 @@ const char *ibv_event_type_str(enum ibv_event_type event)
 		[IBV_EVENT_SRQ_LIMIT_REACHED]	= "SRQ limit reached",
 		[IBV_EVENT_QP_LAST_WQE_REACHED]	= "last WQE reached",
 		[IBV_EVENT_CLIENT_REREGISTER]	= "client reregistration",
-		[IBV_EVENT_GID_CHANGE]		= "GID table change"
+		[IBV_EVENT_GID_CHANGE]		= "GID table change",
+		[IBV_EVENT_WQ_FATAL]		= "WQ fatal"
 	};
 
 	if (event < IBV_EVENT_CQ_ERR || event > IBV_EVENT_GID_CHANGE)


### PR DESCRIPTION
The enum value was added without adding an entry to event_type_str[].

Signed-off-by: Roland Dreier <roland@purestorage.com>