### PR TITLE
libqedr: Add iWARP support for user-space lib

### DIFF
--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -192,6 +192,8 @@ struct qelr_qp_hwq_info {
 	void					*db;      /* Doorbell address */
 	void					*edpm_db;
 	union db_prod32				db_data;  /* Doorbell data */
+	void					*iwarp_db2;
+	union db_prod32				iwarp_db2_data;
 
 	uint16_t				icid;
 };


### PR DESCRIPTION
I've adhered to the checkpatch and sparse complaints.
Added myself as signoff.
I will address the writel/mmio_write issue in a separate patch.

Thank you,
Ram

---
Introduce IS_IWARP / IS_ROCE macros for libqedr as there are no global
macros for this in rdma-core.
There is a second doorbell required for RQ.
QP states in user lib are not updated, as they are updated implicitly by
the driver and not driven by modify_qp as they are in ib / roce.
For this reason, decisions based on states are encapsulated in IS_ROCE.

Signed-off-by: Michal Kalderon <Michal.Kalderon@cavium.com>
Signed-off-by: Ram Amrani <Ram.Amrani@cavium.com>