### PR TITLE
verbs: Add support for delay drop ability in a WQ

### DIFF
--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -410,6 +410,8 @@ static void print_raw_packet_caps(uint32_t raw_packet_caps)
 		printf("\t\t\t\t\tScatter FCS offload\n");
 	if (raw_packet_caps & IBV_RAW_PACKET_CAP_IP_CSUM)
 		printf("\t\t\t\t\tIP csum offload\n");
+	if (raw_packet_caps & IBV_RAW_PACKET_CAP_DELAY_DROP)
+		printf("\t\t\t\t\tDelay drop\n");
 }
 
 static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)

--- a/libibverbs/man/ibv_create_wq.3
+++ b/libibverbs/man/ibv_create_wq.3
@@ -39,9 +39,10 @@ uint32_t                   create_flags    /* Creation flags for this WQ, use en
 .nf
 enum ibv_wq_flags {
 .in +8
-IBV_WQ_FLAGS_CVLAN_STRIPPING		= 1 << 0, /* CVLAN field will be stripped from incoming packets */
-IBV_WQ_FLAGS_SCATTER_FCS		= 1 << 1, /* FCS field will be scattered to host memory */
-IBV_WQ_FLAGS_RESERVED			= 1 << 2,
+IBV_WQ_FLAGS_CVLAN_STRIPPING            = 1 << 0, /* CVLAN field will be stripped from incoming packets */
+IBV_WQ_FLAGS_SCATTER_FCS                = 1 << 1, /* FCS field will be scattered to host memory */
+IBV_WQ_FLAGS_DELAY_DROP                 = 1 << 2, /* Packets won't be dropped immediately if no receive WQEs */
+IBV_WQ_FLAGS_RESERVED                   = 1 << 3,
 .in -8
 };
 .nf

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -257,6 +257,7 @@ enum ibv_raw_packet_caps {
 	IBV_RAW_PACKET_CAP_CVLAN_STRIPPING	= 1 << 0,
 	IBV_RAW_PACKET_CAP_SCATTER_FCS		= 1 << 1,
 	IBV_RAW_PACKET_CAP_IP_CSUM		= 1 << 2,
+	IBV_RAW_PACKET_CAP_DELAY_DROP		= 1 << 3,
 };
 
 struct ibv_device_attr_ex {
@@ -682,7 +683,8 @@ enum ibv_wq_init_attr_mask {
 enum ibv_wq_flags {
 	IBV_WQ_FLAGS_CVLAN_STRIPPING		= 1 << 0,
 	IBV_WQ_FLAGS_SCATTER_FCS		= 1 << 1,
-	IBV_WQ_FLAGS_RESERVED			= 1 << 2,
+	IBV_WQ_FLAGS_DELAY_DROP			= 1 << 2,
+	IBV_WQ_FLAGS_RESERVED			= 1 << 3,
 };
 
 struct ibv_wq_init_attr {


### PR DESCRIPTION
This patch is the supplementary part of the kernel part that was accepted
upstream into 4.14. It enables the delay drop option on a WQ.