### PR TITLE
Rework the verb init scheme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(PACKAGE_VERSION "16")
 # When this is changed the values in these files need changing too:
 #   debian/libibverbs1.symbols
 #   libibverbs/libibverbs.map
-set(IBVERBS_PABI_VERSION "15")
+set(IBVERBS_PABI_VERSION "16")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -1,7 +1,7 @@
 libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
- (symver)IBVERBS_PRIVATE_15 15
+ (symver)IBVERBS_PRIVATE_16 16
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -129,8 +129,6 @@ struct verbs_device_ops {
 			       struct ibv_context *ctx);
 
 	struct verbs_device *(*alloc_device)(struct verbs_sysfs_dev *sysfs_dev);
-	struct verbs_device *(*init_device)(const char *uverbs_sys_path,
-					    int abi_version);
 	void (*uninit_device)(struct verbs_device *device);
 };
 

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -367,22 +367,14 @@ static struct verbs_device *try_driver(const struct verbs_device_ops *ops,
 	struct ibv_device *dev;
 	char value[16];
 
-	if (ops->alloc_device) {
-		if (!match_device(ops, sysfs_dev))
-			return NULL;
+	if (!match_device(ops, sysfs_dev))
+		return NULL;
 
-		vdev = ops->alloc_device(sysfs_dev);
-		if (!vdev) {
-			fprintf(stderr, PFX
-				"Fatal: couldn't allocate device for %s\n",
-				sysfs_dev->ibdev_path);
-			return NULL;
-		}
-	} else {
-		vdev =
-		    ops->init_device(sysfs_dev->sysfs_path, sysfs_dev->abi_ver);
-		if (!vdev)
-			return NULL;
+	vdev = ops->alloc_device(sysfs_dev);
+	if (!vdev) {
+		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
+			sysfs_dev->ibdev_path);
+		return NULL;
 	}
 
 	vdev->ops = ops;

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -174,11 +174,6 @@ static void bnxt_re_uninit_context(struct verbs_device *vdev,
 	}
 }
 
-static struct verbs_device_ops bnxt_re_dev_ops = {
-	.init_context = bnxt_re_init_context,
-	.uninit_context = bnxt_re_uninit_context,
-};
-
 static struct verbs_device *bnxt_re_driver_init(const char *uverbs_sys_path,
 						int abi_version)
 {
@@ -220,12 +215,14 @@ found:
 	dev->vdev.sz = sizeof(*dev);
 	dev->vdev.size_of_context =
 		sizeof(struct bnxt_re_context) - sizeof(struct ibv_context);
-	dev->vdev.ops = &bnxt_re_dev_ops;
 
 	return &dev->vdev;
 }
 
-static __attribute__((constructor)) void bnxt_re_register_driver(void)
-{
-	verbs_register_driver("bnxt_re", bnxt_re_driver_init);
-}
+static const struct verbs_device_ops bnxt_re_dev_ops = {
+	.name = "bnxt_re",
+	.init_device = bnxt_re_driver_init,
+	.init_context = bnxt_re_init_context,
+	.uninit_context = bnxt_re_uninit_context,
+};
+PROVIDER_DRIVER(bnxt_re_dev_ops);

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -173,12 +173,6 @@ static void iwch_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops iwch_dev_ops = {
-	.alloc_context = iwch_alloc_context,
-	.free_context = iwch_free_context,
-	.uninit_device = iwch_uninit_device
-};
-
 static struct verbs_device *cxgb3_driver_init(const char *uverbs_sys_path,
 					      int abi_version)
 {
@@ -259,7 +253,6 @@ found:
 	}
 
 	pthread_spin_init(&dev->lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.ops = &iwch_dev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->abi_version = abi_version;
 
@@ -290,7 +283,11 @@ err1:
 	return NULL;
 }
 
-static __attribute__((constructor)) void cxgb3_register_driver(void)
-{
-	verbs_register_driver("cxgb3", cxgb3_driver_init);
-}
+static const struct verbs_device_ops iwch_dev_ops = {
+	.name = "cxgb3",
+	.init_device = cxgb3_driver_init,
+	.uninit_device = iwch_uninit_device,
+	.alloc_context = iwch_alloc_context,
+	.free_context = iwch_free_context,
+};
+PROVIDER_DRIVER(iwch_dev_ops);

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -466,6 +466,10 @@ found:
 	PDBG("%s found vendor %d device %d type %d\n",
 	     __FUNCTION__, vendor, device, CHELSIO_CHIP_VERSION(hca_table[i].device >> 8));
 
+	c4iw_page_size = sysconf(_SC_PAGESIZE);
+	c4iw_page_shift = long_log2(c4iw_page_size);
+	c4iw_page_mask = ~(c4iw_page_size - 1);
+
 	dev = calloc(1, sizeof *dev);
 	if (!dev) {
 		return NULL;
@@ -515,14 +519,7 @@ static const struct verbs_device_ops c4iw_dev_ops = {
 	.alloc_context = c4iw_alloc_context,
 	.free_context = c4iw_free_context,
 };
-
-static __attribute__((constructor)) void cxgb4_register_driver(void)
-{
-	c4iw_page_size = sysconf(_SC_PAGESIZE);
-	c4iw_page_shift = long_log2(c4iw_page_size);
-	c4iw_page_mask = ~(c4iw_page_size - 1);
-	verbs_register_driver(&c4iw_dev_ops);
-}
+PROVIDER_DRIVER(c4iw_dev_ops);
 
 #ifdef STATS
 void __attribute__ ((destructor)) cs_fini(void);

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -180,47 +180,50 @@ static void hf11_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device *hfi1_driver_init(const char *uverbs_sys_path,
-					     int abi_version)
+static bool hfi1_device_match(struct verbs_sysfs_dev *sysfs_dev)
 {
+	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
 	char			value[8];
-	struct hfi1_device    *dev;
 	unsigned                vendor, device;
 	int                     i;
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
 				value, sizeof value) < 0)
-		return NULL;
+		return false;
 	sscanf(value, "%i", &vendor);
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
 				value, sizeof value) < 0)
-		return NULL;
+		return false;
 	sscanf(value, "%i", &device);
 
 	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
 		if (vendor == hca_table[i].vendor &&
 		    device == hca_table[i].device)
-			goto found;
+			return true;
 
-	return NULL;
+	return false;
+}
 
-found:
+static struct verbs_device *hfi1_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
+{
+	struct hfi1_device    *dev;
+
 	dev = calloc(1, sizeof(*dev));
-	if (!dev) {
-		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
-			uverbs_sys_path);
+	if (!dev)
 		return NULL;
-	}
 
-	dev->abi_version = abi_version;
+	dev->abi_version = sysfs_dev->abi_ver;
 
 	return &dev->ibv_dev;
 }
 
 static const struct verbs_device_ops hfi1_dev_ops = {
 	.name = "hfi1verbs",
-	.init_device = hfi1_driver_init,
+	.match_min_abi_version = 0,
+	.match_max_abi_version = INT_MAX,
+	.match_device = hfi1_device_match,
+	.alloc_device = hfi1_device_alloc,
 	.uninit_device  = hf11_uninit_device,
 	.alloc_context = hfi1_alloc_context,
 	.free_context = hfi1_free_context,

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -180,12 +180,6 @@ static void hf11_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops hfi1_dev_ops = {
-	.alloc_context	= hfi1_alloc_context,
-	.free_context	= hfi1_free_context,
-	.uninit_device  = hf11_uninit_device
-};
-
 static struct verbs_device *hfi1_driver_init(const char *uverbs_sys_path,
 					     int abi_version)
 {
@@ -219,13 +213,16 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &hfi1_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;
 }
 
-static __attribute__((constructor)) void hfi1_register_driver(void)
-{
-	verbs_register_driver("hfi1verbs", hfi1_driver_init);
-}
+static const struct verbs_device_ops hfi1_dev_ops = {
+	.name = "hfi1verbs",
+	.init_device = hfi1_driver_init,
+	.uninit_device  = hf11_uninit_device,
+	.alloc_context = hfi1_alloc_context,
+	.free_context = hfi1_free_context,
+};
+PROVIDER_DRIVER(hfi1_dev_ops);

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -180,12 +180,6 @@ static void hns_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops hns_roce_dev_ops = {
-	.alloc_context = hns_roce_alloc_context,
-	.free_context	= hns_roce_free_context,
-	.uninit_device = hns_uninit_device
-};
-
 static struct verbs_device *hns_roce_driver_init(const char *uverbs_sys_path,
 						 int abi_version)
 {
@@ -223,14 +217,17 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &hns_roce_dev_ops;
 	dev->u_hw = (struct hns_roce_u_hw *)u_hw;
 	dev->hw_version = hw_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	return &dev->ibv_dev;
 }
 
-static __attribute__((constructor)) void hns_roce_register_driver(void)
-{
-	verbs_register_driver("hns", hns_roce_driver_init);
-}
+static const struct verbs_device_ops hns_roce_dev_ops = {
+	.name = "hns",
+	.init_device = hns_roce_driver_init,
+	.uninit_device = hns_uninit_device,
+	.alloc_context = hns_roce_alloc_context,
+	.free_context = hns_roce_free_context,
+};
+PROVIDER_DRIVER(hns_roce_dev_ops);

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -44,20 +44,18 @@
 #define HID_LEN			15
 #define DEV_MATCH_LEN		128
 
-static const struct {
-	char	 hid[HID_LEN];
-	void	 *data;
-	int	 version;
-} acpi_table[] = {
+struct hca_ent {
+	const char *str;
+	struct hns_roce_u_hw *data;
+	int version;
+};
+
+static const struct hca_ent acpi_table[] = {
 	 {"acpi:HISI00D1:", &hns_roce_u_hw_v1, HNS_ROCE_HW_VER1},
 	 {},
 };
 
-static const struct {
-	char	 compatible[DEV_MATCH_LEN];
-	void	 *data;
-	int	 version;
-} dt_table[] = {
+static const struct hca_ent dt_table[] = {
 	{"hisilicon,hns-roce-v1", &hns_roce_u_hw_v1, HNS_ROCE_HW_VER1},
 	{},
 };
@@ -180,52 +178,53 @@ static void hns_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device *hns_roce_driver_init(const char *uverbs_sys_path,
-						 int abi_version)
+static bool hns_device_match(struct verbs_sysfs_dev *sysfs_dev)
 {
-	struct hns_roce_device  *dev;
+	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
 	char			 value[128];
 	int			 i;
-	void			 *u_hw;
-	int			 hw_version;
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/modalias",
 				value, sizeof(value)) > 0)
 		for (i = 0; i < sizeof(acpi_table) / sizeof(acpi_table[0]); ++i)
-			if (!strcmp(value, acpi_table[i].hid)) {
-				u_hw = acpi_table[i].data;
-				hw_version = acpi_table[i].version;
-				goto found;
+			if (!strcmp(value, acpi_table[i].str)) {
+				sysfs_dev->provider_data =
+				    (void *)&acpi_table[i];
+				return true;
 			}
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/of_node/compatible",
 				value, sizeof(value)) > 0)
 		for (i = 0; i < sizeof(dt_table) / sizeof(dt_table[0]); ++i)
-			if (!strcmp(value, dt_table[i].compatible)) {
-				u_hw = dt_table[i].data;
-				hw_version = dt_table[i].version;
-				goto found;
+			if (!strcmp(value, dt_table[i].str)) {
+				sysfs_dev->provider_data = (void *)&dt_table[i];
+				return true;
 			}
 
-	return NULL;
+	return false;
+}
 
-found:
+static struct verbs_device *hns_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
+{
+	struct hns_roce_device  *dev;
+	const struct hca_ent *hca_ent = sysfs_dev->provider_data;
+
 	dev = calloc(1, sizeof(*dev));
-	if (!dev) {
-		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
-			uverbs_sys_path);
+	if (!dev)
 		return NULL;
-	}
 
-	dev->u_hw = (struct hns_roce_u_hw *)u_hw;
-	dev->hw_version = hw_version;
+	dev->u_hw = hca_ent->data;
+	dev->hw_version = hca_ent->version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	return &dev->ibv_dev;
 }
 
 static const struct verbs_device_ops hns_roce_dev_ops = {
 	.name = "hns",
-	.init_device = hns_roce_driver_init,
+	.match_min_abi_version = 0,
+	.match_max_abi_version = INT_MAX,
+	.match_device = hns_device_match,
+	.alloc_device = hns_device_alloc,
 	.uninit_device = hns_uninit_device,
 	.alloc_context = hns_roce_alloc_context,
 	.free_context = hns_roce_free_context,

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -170,6 +170,7 @@ struct hns_roce_qp {
 };
 
 struct hns_roce_u_hw {
+	uint32_t hw_version;
 	int (*poll_cq)(struct ibv_cq *ibvcq, int ne, struct ibv_wc *wc);
 	int (*arm_cq)(struct ibv_cq *ibvcq, int solicited);
 	int (*post_send)(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,

--- a/providers/hns/hns_roce_u_hw_v1.c
+++ b/providers/hns/hns_roce_u_hw_v1.c
@@ -829,6 +829,7 @@ out:
 }
 
 struct hns_roce_u_hw hns_roce_u_hw_v1 = {
+	.hw_version = HNS_ROCE_HW_VER1,
 	.poll_cq = hns_roce_u_v1_poll_cq,
 	.arm_cq = hns_roce_u_v1_arm_cq,
 	.post_send = hns_roce_u_v1_post_send,

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -215,12 +215,6 @@ static void i40iw_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops i40iw_udev_ops = {
-	.alloc_context	= i40iw_ualloc_context,
-	.free_context	= i40iw_ufree_context,
-	.uninit_device  = i40iw_uninit_device
-};
-
 /**
  * i40iw_driver_init - create device struct and provide callback routines for user context
  * @uverbs_sys_path: sys path
@@ -256,13 +250,16 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &i40iw_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = I40IW_HW_PAGE_SIZE;
 	return &dev->ibv_dev;
 }
 
-static __attribute__ ((constructor)) void i40iw_register_driver(void)
-{
-	verbs_register_driver("i40iw", i40iw_driver_init);
-}
+static const struct verbs_device_ops i40iw_udev_ops = {
+	.name = "i40iw",
+	.init_device = i40iw_driver_init,
+	.uninit_device  = i40iw_uninit_device,
+	.alloc_context = i40iw_ualloc_context,
+	.free_context = i40iw_ufree_context,
+};
+PROVIDER_DRIVER(i40iw_udev_ops);

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -50,16 +50,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-#define INTEL_HCA(v, d, t)		\
-	{ .vendor = v,		\
-	  .device = d,		\
-	  .type = INTEL_ ## t }
-
-static struct hca_ent {
-	unsigned int vendor;
-	unsigned int device;
-	enum i40iw_uhca_type type;
-} hca_table[] = {
+#define INTEL_HCA(v, d, t) VERBS_PCI_MATCH(v, d, (void *)(INTEL_##t))
+static const struct verbs_match_ent hca_table[] = {
 #ifdef I40E_DEV_ID_X722_A0
 	INTEL_HCA(I40E_INTEL_VENDOR_ID, I40E_DEV_ID_X722_A0, i40iw),
 #endif
@@ -96,6 +88,7 @@ static struct hca_ent {
 #ifdef I40E_DEV_ID_X722_FPGA_VF
 	INTEL_HCA(I40E_INTEL_VENDOR_ID, I40E_DEV_ID_X722_FPGA_VF, i40iw),
 #endif
+	{}
 };
 
 static struct ibv_context *i40iw_ualloc_context(struct ibv_device *, int);
@@ -215,48 +208,16 @@ static void i40iw_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-/**
- * i40iw_driver_init - create device struct and provide callback routines for user context
- * @uverbs_sys_path: sys path
- * @abi_version: not used
- */
-static bool i40iw_device_match(struct verbs_sysfs_dev *sysfs_dev)
-{
-	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
-	char value[16];
-	unsigned int vendor, device;
-	int i;
-
-	if ((ibv_read_sysfs_file(uverbs_sys_path, "device/vendor", value, sizeof(value)) < 0) ||
-	    (sscanf(value, "%i", &vendor) != 1))
-		return false;
-
-	if ((ibv_read_sysfs_file(uverbs_sys_path, "device/device", value, sizeof(value)) < 0) ||
-	    (sscanf(value, "%i", &device) != 1))
-		return false;
-
-	for (i = 0; i < sizeof(hca_table) / sizeof(hca_table[0]); ++i) {
-		if (vendor == hca_table[i].vendor &&
-		    device == hca_table[i].device) {
-			sysfs_dev->provider_data = &hca_table[i];
-			return true;
-		}
-	}
-
-	return false;
-}
-
 static struct verbs_device *
 i40iw_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 {
 	struct i40iw_udevice *dev;
-	struct hca_ent *hca_ent = sysfs_dev->provider_data;
 
 	dev = calloc(1, sizeof(*dev));
 	if (!dev)
 		return NULL;
 
-	dev->hca_type = hca_ent->type;
+	dev->hca_type = (uintptr_t)sysfs_dev->match->driver_data;
 	dev->page_size = I40IW_HW_PAGE_SIZE;
 	return &dev->ibv_dev;
 }
@@ -265,7 +226,7 @@ static const struct verbs_device_ops i40iw_udev_ops = {
 	.name = "i40iw",
 	.match_min_abi_version = 0,
 	.match_max_abi_version = INT_MAX,
-	.match_device = i40iw_device_match,
+	.match_table = hca_table,
 	.alloc_device = i40iw_device_alloc,
 	.uninit_device  = i40iw_uninit_device,
 	.alloc_context = i40iw_ualloc_context,

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -179,12 +179,6 @@ static void ipath_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops ipath_dev_ops = {
-	.alloc_context	= ipath_alloc_context,
-	.free_context	= ipath_free_context,
-	.uninit_device  = ipath_uninit_device
-};
-
 static struct verbs_device *ipath_driver_init(const char *uverbs_sys_path,
 					      int abi_version)
 {
@@ -218,13 +212,16 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &ipath_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;
 }
 
-static __attribute__((constructor)) void ipath_register_driver(void)
-{
-	verbs_register_driver("ipathverbs", ipath_driver_init);
-}
+static const struct verbs_device_ops ipath_dev_ops = {
+	.name = "ipathverbs",
+	.init_device = ipath_driver_init,
+	.uninit_device  = ipath_uninit_device,
+	.alloc_context = ipath_alloc_context,
+	.free_context = ipath_free_context,
+};
+PROVIDER_DRIVER(ipath_dev_ops);

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -73,19 +73,15 @@
 #define PCI_DEVICE_ID_INFINIPATH_7322		0x7322
 #endif
 
-#define HCA(v, d) \
-	{ .vendor = PCI_VENDOR_ID_##v,			\
-	  .device = PCI_DEVICE_ID_INFINIPATH_##d }
-
-static struct {
-	unsigned		vendor;
-	unsigned		device;
-} hca_table[] = {
+#define HCA(v, d)                                                              \
+	VERBS_PCI_MATCH(PCI_VENDOR_ID_##v, PCI_DEVICE_ID_INFINIPATH_##d, NULL)
+static const struct verbs_match_ent hca_table[] = {
 	HCA(PATHSCALE,	HT),
 	HCA(PATHSCALE,	PE800),
 	HCA(QLOGIC,	6220),
 	HCA(QLOGIC,	7220),
 	HCA(QLOGIC,	7322),
+	{}
 };
 
 static struct ibv_context_ops ipath_ctx_ops = {
@@ -179,31 +175,6 @@ static void ipath_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static bool ipath_device_match(struct verbs_sysfs_dev *sysfs_dev)
-{
-	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
-	char			value[8];
-	unsigned                vendor, device;
-	int                     i;
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
-				value, sizeof value) < 0)
-		return false;
-	sscanf(value, "%i", &vendor);
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
-				value, sizeof value) < 0)
-		return false;
-	sscanf(value, "%i", &device);
-
-	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
-		if (vendor == hca_table[i].vendor &&
-		    device == hca_table[i].device)
-			return true;
-
-	return false;
-}
-
 static struct verbs_device *
 ipath_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 {
@@ -222,7 +193,7 @@ static const struct verbs_device_ops ipath_dev_ops = {
 	.name = "ipathverbs",
 	.match_min_abi_version = 0,
 	.match_max_abi_version = INT_MAX,
-	.match_device = ipath_device_match,
+	.match_table = hca_table,
 	.alloc_device = ipath_device_alloc,
 	.uninit_device  = ipath_uninit_device,
 	.alloc_context = ipath_alloc_context,

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -286,50 +286,41 @@ static void mlx4_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device *mlx4_driver_init(const char *uverbs_sys_path, int abi_version)
+static bool mlx4_device_match(struct verbs_sysfs_dev *sysfs_dev)
 {
+	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
 	char			value[8];
-	struct mlx4_device    *dev;
 	unsigned		vendor, device;
 	int			i;
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
 				value, sizeof value) < 0)
-		return NULL;
+		return false;
 	vendor = strtol(value, NULL, 16);
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
 				value, sizeof value) < 0)
-		return NULL;
+		return false;
 	device = strtol(value, NULL, 16);
 
 	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
 		if (vendor == hca_table[i].vendor &&
 		    device == hca_table[i].device)
-			goto found;
+			return true;
 
-	return NULL;
+	return false;
+}
 
-found:
-	if (abi_version < MLX4_UVERBS_MIN_ABI_VERSION ||
-	    abi_version > MLX4_UVERBS_MAX_ABI_VERSION) {
-		fprintf(stderr, PFX "Fatal: ABI version %d of %s is not supported "
-			"(min supported %d, max supported %d)\n",
-			abi_version, uverbs_sys_path,
-			MLX4_UVERBS_MIN_ABI_VERSION,
-			MLX4_UVERBS_MAX_ABI_VERSION);
-		return NULL;
-	}
+static struct verbs_device *mlx4_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
+{
+	struct mlx4_device *dev;
 
 	dev = calloc(1, sizeof *dev);
-	if (!dev) {
-		fprintf(stderr, PFX "Fatal: couldn't allocate device for %s\n",
-			uverbs_sys_path);
+	if (!dev)
 		return NULL;
-	}
 
 	dev->page_size   = sysconf(_SC_PAGESIZE);
-	dev->abi_version = abi_version;
+	dev->abi_version = sysfs_dev->abi_ver;
 
 	dev->verbs_dev.sz = sizeof(*dev);
 	dev->verbs_dev.size_of_context =
@@ -340,7 +331,10 @@ found:
 
 static const struct verbs_device_ops mlx4_dev_ops = {
 	.name = "mlx4",
-	.init_device = mlx4_driver_init,
+	.match_min_abi_version = MLX4_UVERBS_MIN_ABI_VERSION,
+	.match_max_abi_version = MLX4_UVERBS_MAX_ABI_VERSION,
+	.match_device = mlx4_device_match,
+	.alloc_device = mlx4_device_alloc,
 	.uninit_device = mlx4_uninit_device,
 	.init_context = mlx4_init_context,
 	.uninit_context = mlx4_uninit_context,

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -286,12 +286,6 @@ static void mlx4_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops mlx4_dev_ops = {
-	.init_context = mlx4_init_context,
-	.uninit_context = mlx4_uninit_context,
-	.uninit_device = mlx4_uninit_device
-};
-
 static struct verbs_device *mlx4_driver_init(const char *uverbs_sys_path, int abi_version)
 {
 	char			value[8];
@@ -337,7 +331,6 @@ found:
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->abi_version = abi_version;
 
-	dev->verbs_dev.ops = &mlx4_dev_ops;
 	dev->verbs_dev.sz = sizeof(*dev);
 	dev->verbs_dev.size_of_context =
 		sizeof(struct mlx4_context) - sizeof(struct ibv_context);
@@ -345,10 +338,14 @@ found:
 	return &dev->verbs_dev;
 }
 
-static __attribute__((constructor)) void mlx4_register_driver(void)
-{
-	verbs_register_driver("mlx4", mlx4_driver_init);
-}
+static const struct verbs_device_ops mlx4_dev_ops = {
+	.name = "mlx4",
+	.init_device = mlx4_driver_init,
+	.uninit_device = mlx4_uninit_device,
+	.init_context = mlx4_init_context,
+	.uninit_context = mlx4_uninit_context,
+};
+PROVIDER_DRIVER(mlx4_dev_ops);
 
 static int mlx4dv_get_qp(struct ibv_qp *qp_in,
 			 struct mlx4dv_qp *qp_out)

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -49,14 +49,8 @@ int mlx4_cleanup_upon_device_fatal = 0;
 #define PCI_VENDOR_ID_MELLANOX			0x15b3
 #endif
 
-#define HCA(v, d) \
-	{ .vendor = PCI_VENDOR_ID_##v,			\
-	  .device = d }
-
-static struct {
-	unsigned		vendor;
-	unsigned		device;
-} hca_table[] = {
+#define HCA(v, d) VERBS_PCI_MATCH(PCI_VENDOR_ID_##v, d, NULL)
+static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x6340),	/* MT25408 "Hermon" SDR */
 	HCA(MELLANOX, 0x634a),	/* MT25408 "Hermon" DDR */
 	HCA(MELLANOX, 0x6354),	/* MT25408 "Hermon" QDR */
@@ -84,6 +78,7 @@ static struct {
 	HCA(MELLANOX, 0x100e),	/* MT27551 Family */
 	HCA(MELLANOX, 0x100f),	/* MT27560 Family */
 	HCA(MELLANOX, 0x1010),	/* MT27561 Family */
+	{}
 };
 
 static struct ibv_context_ops mlx4_ctx_ops = {
@@ -286,31 +281,6 @@ static void mlx4_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static bool mlx4_device_match(struct verbs_sysfs_dev *sysfs_dev)
-{
-	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
-	char			value[8];
-	unsigned		vendor, device;
-	int			i;
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
-				value, sizeof value) < 0)
-		return false;
-	vendor = strtol(value, NULL, 16);
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
-				value, sizeof value) < 0)
-		return false;
-	device = strtol(value, NULL, 16);
-
-	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
-		if (vendor == hca_table[i].vendor &&
-		    device == hca_table[i].device)
-			return true;
-
-	return false;
-}
-
 static struct verbs_device *mlx4_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 {
 	struct mlx4_device *dev;
@@ -333,7 +303,7 @@ static const struct verbs_device_ops mlx4_dev_ops = {
 	.name = "mlx4",
 	.match_min_abi_version = MLX4_UVERBS_MIN_ABI_VERSION,
 	.match_max_abi_version = MLX4_UVERBS_MAX_ABI_VERSION,
-	.match_device = mlx4_device_match,
+	.match_table = hca_table,
 	.alloc_device = mlx4_device_alloc,
 	.uninit_device = mlx4_uninit_device,
 	.init_context = mlx4_init_context,

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1026,12 +1026,6 @@ static void mlx5_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops mlx5_dev_ops = {
-	.init_context = mlx5_init_context,
-	.uninit_context = mlx5_cleanup_context,
-	.uninit_device = mlx5_uninit_device
-};
-
 static struct verbs_device *mlx5_driver_init(const char *uverbs_sys_path,
 					     int abi_version)
 {
@@ -1078,7 +1072,6 @@ found:
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->driver_abi_ver = abi_version;
 
-	dev->verbs_dev.ops = &mlx5_dev_ops;
 	dev->verbs_dev.sz = sizeof(*dev);
 	dev->verbs_dev.size_of_context = sizeof(struct mlx5_context) -
 		sizeof(struct ibv_context);
@@ -1086,7 +1079,11 @@ found:
 	return &dev->verbs_dev;
 }
 
-static __attribute__((constructor)) void mlx5_register_driver(void)
-{
-	verbs_register_driver("mlx5", mlx5_driver_init);
-}
+static const struct verbs_device_ops mlx5_dev_ops = {
+	.name = "mlx5",
+	.init_device = mlx5_driver_init,
+	.uninit_device = mlx5_uninit_device,
+	.init_context = mlx5_init_context,
+	.uninit_context = mlx5_cleanup_context,
+};
+PROVIDER_DRIVER(mlx5_dev_ops);

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -216,12 +216,6 @@ static void mthca_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops mthca_dev_ops = {
-	.alloc_context = mthca_alloc_context,
-	.free_context  = mthca_free_context,
-	.uninit_device = mthca_uninit_device
-};
-
 static struct verbs_device *mthca_driver_init(const char *uverbs_sys_path,
 					    int abi_version)
 {
@@ -261,14 +255,17 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &mthca_dev_ops;
 	dev->hca_type    = hca_table[i].type;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 
 	return &dev->ibv_dev;
 }
 
-static __attribute__((constructor)) void mthca_register_driver(void)
-{
-	verbs_register_driver("mthca", mthca_driver_init);
-}
+static const struct verbs_device_ops mthca_dev_ops = {
+	.name = "mthca",
+	.init_device = mthca_driver_init,
+	.uninit_device = mthca_uninit_device,
+	.alloc_context = mthca_alloc_context,
+	.free_context = mthca_free_context,
+};
+PROVIDER_DRIVER(mthca_dev_ops);

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -72,16 +72,10 @@
 #define PCI_VENDOR_ID_TOPSPIN			0x1867
 #endif
 
-#define HCA(v, d, t) \
-	{ .vendor = PCI_VENDOR_ID_##v,			\
-	  .device = PCI_DEVICE_ID_MELLANOX_##d,		\
-	  .type = MTHCA_##t }
-
-static struct hca_ent {
-	unsigned		vendor;
-	unsigned		device;
-	enum mthca_hca_type	type;
-} hca_table[] = {
+#define HCA(v, d, t)                                                           \
+	VERBS_PCI_MATCH(PCI_VENDOR_ID_##v, PCI_DEVICE_ID_MELLANOX_##d,         \
+			(void *)(MTHCA_##t))
+static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, TAVOR,	    TAVOR),
 	HCA(MELLANOX, ARBEL_COMPAT, TAVOR),
 	HCA(MELLANOX, ARBEL,	    ARBEL),
@@ -92,6 +86,7 @@ static struct hca_ent {
 	HCA(TOPSPIN,  ARBEL,	    ARBEL),
 	HCA(TOPSPIN,  SINAI_OLD,    ARBEL),
 	HCA(TOPSPIN,  SINAI,	    ARBEL),
+	{}
 };
 
 static struct ibv_context_ops mthca_ctx_ops = {
@@ -216,44 +211,16 @@ static void mthca_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static bool mthca_device_match(struct verbs_sysfs_dev *sysfs_dev)
-{
-	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
-	char			value[8];
-	unsigned                vendor, device;
-	int                     i;
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
-				value, sizeof value) < 0)
-		return false;
-	sscanf(value, "%i", &vendor);
-
-	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
-				value, sizeof value) < 0)
-		return false;
-	sscanf(value, "%i", &device);
-
-	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
-		if (vendor == hca_table[i].vendor &&
-		    device == hca_table[i].device) {
-			sysfs_dev->provider_data = &hca_table[i];
-			return true;
-		}
-
-	return false;
-}
-
 static struct verbs_device *
 mthca_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 {
 	struct mthca_device    *dev;
-	struct hca_ent *hca_ent = sysfs_dev->provider_data;
 
 	dev = calloc(1, sizeof(*dev));
 	if (!dev)
 		return NULL;
 
-	dev->hca_type    = hca_ent->type;
+	dev->hca_type    = (uintptr_t)sysfs_dev->match->driver_data;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 
 	return &dev->ibv_dev;
@@ -263,7 +230,7 @@ static const struct verbs_device_ops mthca_dev_ops = {
 	.name = "mthca",
 	.match_min_abi_version = 0,
 	.match_max_abi_version = MTHCA_UVERBS_ABI_VERSION,
-	.match_device = mthca_device_match,
+	.match_table = hca_table,
 	.alloc_device = mthca_device_alloc,
 	.uninit_device = mthca_uninit_device,
 	.alloc_context = mthca_alloc_context,

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -191,13 +191,6 @@ static void nes_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops nes_udev_ops = {
-	.alloc_context = nes_ualloc_context,
-	.free_context = nes_ufree_context,
-	.uninit_device = nes_uninit_device
-};
-
-
 /**
  * nes_driver_init
  */
@@ -243,7 +236,6 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &nes_udev_ops;
 	dev->hca_type = hca_table[i].type;
 	dev->page_size = sysconf(_SC_PAGESIZE);
 
@@ -252,13 +244,11 @@ found:
 	return &dev->ibv_dev;
 }
 
-
-/**
- * nes_register_driver
- */
-static __attribute__((constructor)) void nes_register_driver(void)
-{
-	/* fprintf(stderr, PFX "nes_register_driver: call ibv_register_driver()\n"); */
-
-	verbs_register_driver("nes", nes_driver_init);
-}
+static const struct verbs_device_ops nes_udev_ops = {
+	.name = "nes",
+	.init_device = nes_driver_init,
+	.uninit_device = nes_uninit_device,
+	.alloc_context = nes_ualloc_context,
+	.free_context = nes_ufree_context,
+};
+PROVIDER_DRIVER(nes_udev_ops);

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -60,7 +60,7 @@ long int page_size;
 	  .device = d,    \
 	  .type = NETEFFECT_##t }
 
-static struct {
+static struct hca_ent {
 	unsigned vendor;
 	unsigned device;
 	enum nes_uhca_type type;
@@ -191,37 +191,40 @@ static void nes_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-/**
- * nes_driver_init
- */
-static struct verbs_device *nes_driver_init(const char *uverbs_sys_path,
-					    int abi_version)
+static bool nes_device_match(struct verbs_sysfs_dev *sysfs_dev)
 {
+	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
 	char value[16];
-	struct nes_udevice *dev;
 	unsigned vendor, device;
 	int i;
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
-			value, sizeof(value)) < 0) {
-		return NULL;
-	}
+			value, sizeof(value)) < 0)
+		return false;
 	sscanf(value, "%i", &vendor);
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
-			value, sizeof(value)) < 0) {
-		return NULL;
-	}
+			value, sizeof(value)) < 0)
+		return false;
 	sscanf(value, "%i", &device);
 
 	for (i = 0; i < sizeof hca_table / sizeof hca_table[0]; ++i)
 		if (vendor == hca_table[i].vendor &&
-				device == hca_table[i].device)
-			goto found;
+		    device == hca_table[i].device) {
+			sysfs_dev->provider_data = &hca_table[i];
+			return true;
+		}
 
-	return NULL;
+	return false;
+}
 
-found:
+static struct verbs_device *
+nes_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
+{
+	struct nes_udevice *dev;
+	struct hca_ent *hca_ent = sysfs_dev->provider_data;
+	char value[16];
+
 	if (ibv_read_sysfs_file("/sys/module/iw_nes", "parameters/debug_level",
 			value, sizeof(value)) > 0) {
 		sscanf(value, "%u", &nes_debug_level);
@@ -231,12 +234,10 @@ found:
 	}
 
 	dev = calloc(1, sizeof(*dev));
-	if (!dev) {
-		nes_debug(NES_DBG_INIT, "Fatal: couldn't allocate device for libnes\n");
+	if (!dev)
 		return NULL;
-	}
 
-	dev->hca_type = hca_table[i].type;
+	dev->hca_type = hca_ent->type;
 	dev->page_size = sysconf(_SC_PAGESIZE);
 
 	nes_debug(NES_DBG_INIT, "libnes initialized\n");
@@ -246,7 +247,10 @@ found:
 
 static const struct verbs_device_ops nes_udev_ops = {
 	.name = "nes",
-	.init_device = nes_driver_init,
+	.match_min_abi_version = 0,
+	.match_max_abi_version = INT_MAX,
+	.match_device = nes_device_match,
+	.alloc_device = nes_device_alloc,
 	.uninit_device = nes_uninit_device,
 	.alloc_context = nes_ualloc_context,
 	.free_context = nes_ufree_context,

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -107,12 +107,6 @@ static void ocrdma_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops ocrdma_dev_ops = {
-	.alloc_context = ocrdma_alloc_context,
-	.free_context = ocrdma_free_context,
-	.uninit_device = ocrdma_uninit_device
-};
-
 /*
  * ocrdma_alloc_context
  */
@@ -225,18 +219,17 @@ found:
 	bzero(dev->qp_tbl, OCRDMA_MAX_QP * sizeof(struct ocrdma_qp *));
 	pthread_mutex_init(&dev->dev_lock, NULL);
 	pthread_spin_init(&dev->flush_q_lock, PTHREAD_PROCESS_PRIVATE);
-	dev->ibv_dev.ops = &ocrdma_dev_ops;
 	return &dev->ibv_dev;
 qp_err:
 	free(dev);
 	return NULL;
 }
 
-/*
- * ocrdma_register_driver
- */
-static __attribute__ ((constructor))
-void ocrdma_register_driver(void)
-{
-	verbs_register_driver("ocrdma", ocrdma_driver_init);
-}
+static const struct verbs_device_ops ocrdma_dev_ops = {
+	.name = "ocrdma",
+	.init_device = ocrdma_driver_init,
+	.uninit_device = ocrdma_uninit_device,
+	.alloc_context = ocrdma_alloc_context,
+	.free_context = ocrdma_free_context,
+};
+PROVIDER_DRIVER(ocrdma_dev_ops);

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -227,53 +227,50 @@ static void qelr_free_context(struct ibv_context *ibctx)
 	free(ctx);
 }
 
-static struct verbs_device *qelr_driver_init(const char *uverbs_sys_path,
-					     int abi_version)
+static bool qelr_device_match(struct verbs_sysfs_dev *sysfs_dev)
 {
+	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
 	char value[16];
-	struct qelr_device *dev;
 	unsigned int vendor, device;
 	int i;
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/vendor",
 				value, sizeof(value)) < 0)
-		return NULL;
+		return false;
 
 	sscanf(value, "%i", &vendor);
 
 	if (ibv_read_sysfs_file(uverbs_sys_path, "device/device",
 				value, sizeof(value)) < 0)
-		return NULL;
+		return false;
 
 	sscanf(value, "%i", &device);
 
 	for (i = 0; i < sizeof(hca_table) / sizeof(hca_table[0]); ++i)
 		if (vendor == hca_table[i].vendor &&
 		    device == hca_table[i].device)
-			goto found;
+			return true;
 
-	return NULL;
-found:
-	if (abi_version != QELR_ABI_VERSION) {
-		fprintf(stderr,
-			"Fatal: libqedr ABI version %d of %s is not supported.\n",
-			abi_version, uverbs_sys_path);
-		return NULL;
-	}
+	return false;
+}
+
+static struct verbs_device *qelr_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
+{
+	struct qelr_device *dev;
 
 	dev = calloc(1, sizeof(*dev));
-	if (!dev) {
-		qelr_err("%s() Fatal: fail allocate device for libqedr\n",
-			 __func__);
+	if (!dev)
 		return NULL;
-	}
 
 	return &dev->ibv_dev;
 }
 
 static const struct verbs_device_ops qelr_dev_ops = {
 	.name = "qedr",
-	.init_device = qelr_driver_init,
+	.match_min_abi_version = QELR_ABI_VERSION,
+	.match_max_abi_version = QELR_ABI_VERSION,
+	.match_device = qelr_device_match,
+	.alloc_device = qelr_device_alloc,
 	.uninit_device = qelr_uninit_device,
 	.alloc_context = qelr_alloc_context,
 	.free_context = qelr_free_context,

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -115,12 +115,6 @@ static void qelr_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops qelr_dev_ops = {
-	.alloc_context = qelr_alloc_context,
-	.free_context = qelr_free_context,
-	.uninit_device = qelr_uninit_device
-};
-
 static void qelr_open_debug_file(struct qelr_devctx *ctx)
 {
 	char *env;
@@ -274,13 +268,14 @@ found:
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &qelr_dev_ops;
-
 	return &dev->ibv_dev;
 }
 
-static __attribute__ ((constructor))
-void qelr_register_driver(void)
-{
-	verbs_register_driver("qelr", qelr_driver_init);
-}
+static const struct verbs_device_ops qelr_dev_ops = {
+	.name = "qedr",
+	.init_device = qelr_driver_init,
+	.uninit_device = qelr_uninit_device,
+	.alloc_context = qelr_alloc_context,
+	.free_context = qelr_free_context,
+};
+PROVIDER_DRIVER(qelr_dev_ops);

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -893,12 +893,6 @@ static void rxe_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops rxe_dev_ops = {
-	.alloc_context = rxe_alloc_context,
-	.free_context = rxe_free_context,
-	.uninit_device = rxe_uninit_device
-};
-
 static struct verbs_device *rxe_driver_init(const char *uverbs_sys_path,
 					    int abi_version)
 {
@@ -921,14 +915,16 @@ static struct verbs_device *rxe_driver_init(const char *uverbs_sys_path,
 		return NULL;
 	}
 
-	dev->ibv_dev.ops = &rxe_dev_ops;
 	dev->abi_version = abi_version;
 
 	return &dev->ibv_dev;
 }
 
-static __attribute__ ((constructor))
-void rxe_register_driver(void)
-{
-	verbs_register_driver("rxe", rxe_driver_init);
-}
+static const struct verbs_device_ops rxe_dev_ops = {
+	.name = "rxe",
+	.init_device = rxe_driver_init,
+	.uninit_device = rxe_uninit_device,
+	.alloc_context = rxe_alloc_context,
+	.free_context = rxe_free_context,
+};
+PROVIDER_DRIVER(rxe_dev_ops);

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -57,6 +57,12 @@
 #include "rxe-abi.h"
 #include "rxe.h"
 
+static const struct verbs_match_ent hca_table[] = {
+	/* FIXME: rxe needs a more reliable way to detect the rxe device */
+	VERBS_NAME_MATCH("rxe", NULL),
+	{},
+};
+
 static int rxe_query_device(struct ibv_context *context,
 			    struct ibv_device_attr *attr)
 {
@@ -893,22 +899,6 @@ static void rxe_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static bool rxe_device_match(struct verbs_sysfs_dev *sysfs_dev)
-{
-	const char *uverbs_sys_path = sysfs_dev->sysfs_path;
-	char value[16];
-
-	/* make sure it is a rxe device */
-	if (ibv_read_sysfs_file(uverbs_sys_path, "ibdev",
-				value, sizeof(value)) < 0)
-		return false;
-
-	if (strncmp(value, "rxe", 3))
-		return false;
-
-	return true;
-}
-
 static struct verbs_device *rxe_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 {
 	struct rxe_device *dev;
@@ -925,7 +915,7 @@ static const struct verbs_device_ops rxe_dev_ops = {
 	.name = "rxe",
 	.match_min_abi_version = 0,
 	.match_max_abi_version = INT_MAX,
-	.match_device = rxe_device_match,
+	.match_table = hca_table,
 	.alloc_device = rxe_device_alloc,
 	.uninit_device = rxe_uninit_device,
 	.alloc_context = rxe_alloc_context,

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -169,12 +169,6 @@ static void pvrdma_uninit_device(struct verbs_device *verbs_device)
 	free(dev);
 }
 
-static struct verbs_device_ops pvrdma_dev_ops = {
-	.alloc_context = pvrdma_alloc_context,
-	.free_context  = pvrdma_free_context,
-	.uninit_device = pvrdma_uninit_device
-};
-
 static struct pvrdma_device *pvrdma_driver_init_shared(
 						const char *uverbs_sys_path,
 						int abi_version)
@@ -215,7 +209,6 @@ static struct pvrdma_device *pvrdma_driver_init_shared(
 
 	dev->abi_version = abi_version;
 	dev->page_size   = sysconf(_SC_PAGESIZE);
-	dev->ibv_dev.ops = &pvrdma_dev_ops;
 
 	return dev;
 }
@@ -231,7 +224,11 @@ static struct verbs_device *pvrdma_driver_init(const char *uverbs_sys_path,
 	return &dev->ibv_dev;
 }
 
-static __attribute__((constructor)) void pvrdma_register_driver(void)
-{
-	verbs_register_driver("pvrdma", pvrdma_driver_init);
-}
+static const struct verbs_device_ops pvrdma_dev_ops = {
+	.name = "pvrdma",
+	.init_device = pvrdma_driver_init,
+	.uninit_device = pvrdma_uninit_device,
+	.alloc_context = pvrdma_alloc_context,
+	.free_context  = pvrdma_free_context,
+};
+PROVIDER_DRIVER(pvrdma_dev_ops);


### PR DESCRIPTION
This changes how verbs providers register with the core and are bound to drivers. 

The end goal is to have textual a list of 'modalias' that each provider supports, similar to the kernel. This list can then ultimately be used to demand load the modules instead of loading every module like we do today.

This series does the work to bring all providers to use common code to match their supported devices, and provides the core code the supported device list. This is done by extending the verbs_driver_ops to include the matching information that the driver needs.

Quite a lot of duplicated driver code is removed in the process, and verbs startup reads fewer sysfs files.