### PR TITLE
mlx4: Add inline-receive support

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -1,6 +1,8 @@
 libmlx4.so.1 ibverbs-providers #MINVER#
  MLX4_1.0@MLX4_1.0 15
  mlx4dv_init_obj@MLX4_1.0 15
+ mlx4dv_query_device@MLX4_1.0 15
+ mlx4dv_create_qp@MLX4_1.0 15
 libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.0@MLX5_1.0 13
  MLX5_1.1@MLX5_1.1 14

--- a/providers/mlx4/libmlx4.map
+++ b/providers/mlx4/libmlx4.map
@@ -3,5 +3,7 @@
 MLX4_1.0 {
 	global:
 		mlx4dv_init_obj;
+		mlx4dv_query_device;
+		mlx4dv_create_qp;
 	local: *;
 };

--- a/providers/mlx4/man/CMakeLists.txt
+++ b/providers/mlx4/man/CMakeLists.txt
@@ -1,4 +1,5 @@
 rdma_man_pages(
   mlx4dv_init_obj.3
+  mlx4dv_query_device.3
   mlx4dv.7
 )

--- a/providers/mlx4/man/mlx4dv_query_device.3
+++ b/providers/mlx4/man/mlx4dv_query_device.3
@@ -1,0 +1,42 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org (MIT) - See COPYING.md
+.\"
+.TH MLX4DV_QUERY_DEVICE 3 2017-06-27 1.0.0
+.SH "NAME"
+mlx4dv_query_device \- Query device capabilities specific to mlx4
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/mlx4dv.h>
+.sp
+.BI "int mlx4dv_query_device(struct ibv_context *ctx_in,
+.BI "                        struct mlx4dv_context *attrs_out);
+.fi
+.SH "DESCRIPTION"
+.B mlx4dv_query_device()
+Query mlx4 specific device information that is usable via the direct verbs interface.
+.PP
+This function returns a version and compatibility mask. The version represents
+the format of the internal hardware structures that mlx4dv.h exposes.
+Future additions of new fields to the existing structures are handled by
+the comp_mask field.
+.PP
+.nf
+struct mlx4dv_context {
+.in +8
+uint8_t         version;
+uint32_t        max_inl_recv_sz; /* Maximum supported size of inline receive  */
+uint64_t        comp_mask;
+.in -8
+};
+
+.fi
+.SH "RETURN VALUE"
+0 on success or the value of errno on failure (which indicates the failure reason).
+.SH "NOTES"
+ * Compatibility mask (comp_mask) is an in/out field.
+.SH "SEE ALSO"
+.BR mlx4dv (7),
+.BR ibv_query_device (3)
+.SH "AUTHORS"
+.TP
+Maor Gottlieb <maorg@mellanox.com>

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -104,6 +104,8 @@ struct mlx4_query_device_ex_resp {
 	__u32				comp_mask;
 	__u32				response_length;
 	__u64				hca_core_clock_offset;
+	__u32				max_inl_recv_sz;
+	__u32				reserved;
 };
 
 struct mlx4_query_device_ex {
@@ -135,7 +137,8 @@ struct mlx4_create_qp {
 	__u8				log_sq_bb_count;
 	__u8				log_sq_stride;
 	__u8				sq_no_prefetch;	/* was reserved in ABI 2 */
-	__u8				reserved[5];
+	__u8				reserved;
+	__u32				inl_recv_sz;
 };
 
 struct mlx4_create_qp_drv_ex {

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -427,3 +427,16 @@ int mlx4dv_init_obj(struct mlx4dv_obj *obj, uint64_t obj_type)
 
 	return ret;
 }
+
+int mlx4dv_query_device(struct ibv_context *ctx_in,
+			struct mlx4dv_context *attrs_out)
+{
+	struct mlx4_context *mctx = to_mctx(ctx_in);
+
+	attrs_out->version   = 0;
+	attrs_out->comp_mask = 0;
+
+	attrs_out->max_inl_recv_sz = mctx->max_inl_recv_sz;
+
+	return 0;
+}

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -133,6 +133,7 @@ struct mlx4_context {
 		uint8_t                 offset_valid;
 	} core_clock;
 	void			       *hca_core_clock;
+	uint32_t			max_inl_recv_sz;
 };
 
 struct mlx4_buf {
@@ -385,7 +386,8 @@ int mlx4_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
 void mlx4_calc_sq_wqe_size(struct ibv_qp_cap *cap, enum ibv_qp_type type,
 			   struct mlx4_qp *qp);
 int mlx4_alloc_qp_buf(struct ibv_context *context, struct ibv_qp_cap *cap,
-		       enum ibv_qp_type type, struct mlx4_qp *qp);
+		       enum ibv_qp_type type, struct mlx4_qp *qp,
+		       struct mlx4dv_qp_init_attr *mlx4qp_attr);
 void mlx4_set_sq_sizes(struct mlx4_qp *qp, struct ibv_qp_cap *cap,
 		       enum ibv_qp_type type);
 struct mlx4_qp *mlx4_find_qp(struct mlx4_context *ctx, uint32_t qpn);

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -379,6 +379,29 @@ struct mlx4_wqe_atomic_seg {
 	__be64			compare;
 };
 
+enum mlx4dv_qp_init_attr_mask {
+	MLX4DV_QP_INIT_ATTR_MASK_INL_RECV	= 1 << 0,
+	MLX4DV_QP_INIT_ATTR_MASK_RESERVED	= 1 << 1,
+};
+
+struct mlx4dv_qp_init_attr {
+	uint64_t comp_mask; /* Use enum mlx4dv_qp_init_attr_mask */
+	uint32_t inl_recv_sz;
+};
+
+struct ibv_qp *mlx4dv_create_qp(struct ibv_context *context,
+				struct ibv_qp_init_attr_ex *attr,
+				struct mlx4dv_qp_init_attr *mlx4_qp_attr);
+
+/*
+ * Direct verbs device-specific attributes
+ */
+struct mlx4dv_context {
+	uint8_t		version;
+	uint32_t	max_inl_recv_sz;
+	uint64_t	comp_mask;
+};
+
 /*
  * Control segment - contains some control information for the current WQE.
  *
@@ -465,5 +488,15 @@ void mlx4dv_set_data_seg(struct mlx4_wqe_data_seg *seg,
 	seg->lkey       = htobe32(lkey);
 	seg->addr       = htobe64(address);
 }
+
+/* Most device capabilities are exported by ibv_query_device(...),
+ * but there is HW device-specific information which is important
+ * for data-path, but isn't provided.
+ *
+ * Return 0 on success.
+ */
+int mlx4dv_query_device(struct ibv_context *ctx_in,
+			struct mlx4dv_context *attrs_out);
+
 #endif /* _MLX4DV_H_ */
 


### PR DESCRIPTION
Add mlx4 support for inline-receive, the matching kernel part was already merged into 4.14.