### PR TITLE
mlx4 rss

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -3,6 +3,7 @@ libmlx4.so.1 ibverbs-providers #MINVER#
  mlx4dv_init_obj@MLX4_1.0 15
  mlx4dv_query_device@MLX4_1.0 15
  mlx4dv_create_qp@MLX4_1.0 15
+ mlx4dv_set_context_attr@MLX4_1.0 15
 libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.0@MLX5_1.0 13
  MLX5_1.1@MLX5_1.1 14

--- a/providers/mlx4/cq.c
+++ b/providers/mlx4/cq.c
@@ -229,7 +229,7 @@ static inline int mlx4_parse_cqe(struct mlx4_cq *cq,
 		if (!srq)
 			return CQ_POLL_ERR;
 	} else {
-		if (!*cur_qp || (qpn != (*cur_qp)->verbs_qp.qp.qp_num)) {
+		if (!*cur_qp || (qpn != (*cur_qp)->qpn_cache)) {
 			/*
 			 * We do not have to take the QP table lock here,
 			 * because CQs will be locked while QPs are removed
@@ -239,7 +239,8 @@ static inline int mlx4_parse_cqe(struct mlx4_cq *cq,
 			if (!*cur_qp)
 				return CQ_POLL_ERR;
 		}
-		srq = ((*cur_qp)->verbs_qp.qp.srq) ? to_msrq((*cur_qp)->verbs_qp.qp.srq) : NULL;
+		srq = ((*cur_qp)->type == MLX4_RSC_TYPE_SRQ) ?
+			to_msrq((*cur_qp)->verbs_qp.qp.srq) : NULL;
 	}
 
 	pwr_id = lazy ? &cq->ibv_cq.wr_id : &wc->wr_id;

--- a/providers/mlx4/libmlx4.map
+++ b/providers/mlx4/libmlx4.map
@@ -5,5 +5,6 @@ MLX4_1.0 {
 		mlx4dv_init_obj;
 		mlx4dv_query_device;
 		mlx4dv_create_qp;
+		mlx4dv_set_context_attr;
 	local: *;
 };

--- a/providers/mlx4/man/mlx4dv_init_obj.3
+++ b/providers/mlx4/man/mlx4dv_init_obj.3
@@ -83,6 +83,26 @@ uint64_t        comp_mask;
 .in -8
 };
 
+struct mlx4dv_rwq {
+.in +8
+__be32          *rdb;
+struct {
+.in +8
+uint32_t        wqe_cnt;
+int             wqe_shift;
+int             offset;
+.in -8
+} rq;
+struct {
+.in +8
+void            *buf;
+size_t          length;
+.in -8
+} buf;
+uint64_t        comp_mask;
+.in -8
+};
+
 struct mlx4dv_obj {
 .in +8
 struct {

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -159,4 +159,23 @@ struct mlx4_create_qp_resp_ex {
 	struct ibv_create_qp_resp_ex	ibv_resp;
 };
 
+struct mlx4_drv_create_wq {
+	__u64		buf_addr;
+	__u64		db_addr;
+	__u8		log_range_size;
+	__u8		reserved[3];
+	__u32		comp_mask;
+};
+
+struct mlx4_create_wq {
+	struct ibv_create_wq		ibv_cmd;
+	struct mlx4_drv_create_wq	drv;
+};
+
+struct mlx4_modify_wq {
+	struct ibv_modify_wq	ibv_cmd;
+	__u32			comp_mask;
+	__u32			reserved;
+};
+
 #endif /* MLX4_ABI_H */

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -141,6 +141,20 @@ struct mlx4_create_qp {
 	__u32				inl_recv_sz;
 };
 
+struct mlx4_create_qp_drv_ex_rss {
+	__u64		hash_fields_mask; /* enum ibv_rx_hash_fields */
+	__u8		hash_function; /* enum ibv_rx_hash_function_flags */
+	__u8		reserved[7];
+	__u8		hash_key[40];
+	__u32		comp_mask;
+	__u32		reserved1;
+};
+
+struct mlx4_create_qp_ex_rss {
+	struct ibv_create_qp_ex		 ibv_cmd;
+	struct mlx4_create_qp_drv_ex_rss drv_ex;
+};
+
 struct mlx4_create_qp_drv_ex {
 	__u64		buf_addr;
 	__u64		db_addr;

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -419,6 +419,24 @@ static int mlx4dv_get_srq(struct ibv_srq *srq_in,
 	return 0;
 }
 
+static int mlx4dv_get_rwq(struct ibv_wq *wq_in, struct mlx4dv_rwq *wq_out)
+{
+	struct mlx4_qp *mqp = wq_to_mqp(wq_in);
+
+	wq_out->comp_mask = 0;
+
+	wq_out->buf.buf = mqp->buf.buf;
+	wq_out->buf.length = mqp->buf.length;
+
+	wq_out->rdb = mqp->db;
+
+	wq_out->rq.wqe_cnt = mqp->rq.wqe_cnt;
+	wq_out->rq.wqe_shift = mqp->rq.wqe_shift;
+	wq_out->rq.offset = mqp->rq.offset;
+
+	return 0;
+}
+
 int mlx4dv_init_obj(struct mlx4dv_obj *obj, uint64_t obj_type)
 {
 	int ret = 0;
@@ -429,6 +447,8 @@ int mlx4dv_init_obj(struct mlx4dv_obj *obj, uint64_t obj_type)
 		ret = mlx4dv_get_cq(obj->cq.in, obj->cq.out);
 	if (!ret && (obj_type & MLX4DV_OBJ_SRQ))
 		ret = mlx4dv_get_srq(obj->srq.in, obj->srq.out);
+	if (!ret && (obj_type & MLX4DV_OBJ_RWQ))
+		ret = mlx4dv_get_rwq(obj->rwq.in, obj->rwq.out);
 
 	return ret;
 }

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -256,6 +256,9 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	verbs_set_ctx_op(verbs_ctx, create_cq_ex, mlx4_create_cq_ex);
 	verbs_set_ctx_op(verbs_ctx, query_device_ex, mlx4_query_device_ex);
 	verbs_set_ctx_op(verbs_ctx, query_rt_values, mlx4_query_rt_values);
+	verbs_set_ctx_op(verbs_ctx, create_wq, mlx4_create_wq);
+	verbs_set_ctx_op(verbs_ctx, modify_wq, mlx4_modify_wq);
+	verbs_set_ctx_op(verbs_ctx, destroy_wq, mlx4_destroy_wq);
 
 	return 0;
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -259,6 +259,8 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	verbs_set_ctx_op(verbs_ctx, create_wq, mlx4_create_wq);
 	verbs_set_ctx_op(verbs_ctx, modify_wq, mlx4_modify_wq);
 	verbs_set_ctx_op(verbs_ctx, destroy_wq, mlx4_destroy_wq);
+	verbs_set_ctx_op(verbs_ctx, create_rwq_ind_table, mlx4_create_rwq_ind_table);
+	verbs_set_ctx_op(verbs_ctx, destroy_rwq_ind_table, mlx4_destroy_rwq_ind_table);
 
 	return 0;
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -443,3 +443,20 @@ int mlx4dv_query_device(struct ibv_context *ctx_in,
 
 	return 0;
 }
+
+int mlx4dv_set_context_attr(struct ibv_context *context,
+			    enum mlx4dv_set_ctx_attr_type attr_type,
+			    void *attr)
+{
+	struct mlx4_context *ctx = to_mctx(context);
+
+	switch (attr_type) {
+	case MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ:
+		ctx->log_wqs_range_sz = *((uint8_t *)attr);
+		break;
+	default:
+		return ENOTSUP;
+	}
+
+	return 0;
+}

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -198,6 +198,11 @@ struct mlx4_wq {
 	int				offset;
 };
 
+enum mlx4_rsc_type {
+	MLX4_RSC_TYPE_QP	= 0,
+	MLX4_RSC_TYPE_RSS_QP	= 1,
+};
+
 struct mlx4_qp {
 	union {
 		struct verbs_qp		verbs_qp;
@@ -216,6 +221,7 @@ struct mlx4_qp {
 	struct mlx4_wq			rq;
 
 	uint8_t				link_layer;
+	uint8_t				type; /* enum mlx4_rsc_type */
 	uint32_t			qp_cap_cache;
 };
 

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -411,5 +411,8 @@ struct ibv_wq *mlx4_create_wq(struct ibv_context *context,
 			      struct ibv_wq_init_attr *attr);
 int mlx4_modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *attr);
 int mlx4_destroy_wq(struct ibv_wq *wq);
+struct ibv_rwq_ind_table *mlx4_create_rwq_ind_table(struct ibv_context *context,
+						    struct ibv_rwq_ind_table_init_attr *init_attr);
+int mlx4_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table);
 
 #endif /* MLX4_H */

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -201,6 +201,7 @@ struct mlx4_wq {
 enum mlx4_rsc_type {
 	MLX4_RSC_TYPE_QP	= 0,
 	MLX4_RSC_TYPE_RSS_QP	= 1,
+	MLX4_RSC_TYPE_SRQ	= 2,
 };
 
 struct mlx4_qp {
@@ -223,6 +224,7 @@ struct mlx4_qp {
 	uint8_t				link_layer;
 	uint8_t				type; /* enum mlx4_rsc_type */
 	uint32_t			qp_cap_cache;
+	uint32_t			qpn_cache;
 };
 
 struct mlx4_ah {
@@ -420,5 +422,7 @@ int mlx4_destroy_wq(struct ibv_wq *wq);
 struct ibv_rwq_ind_table *mlx4_create_rwq_ind_table(struct ibv_context *context,
 						    struct ibv_rwq_ind_table_init_attr *init_attr);
 int mlx4_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table);
+int mlx4_post_wq_recv(struct ibv_wq *ibwq, struct ibv_recv_wr *wr,
+		      struct ibv_recv_wr **bad_wr);
 
 #endif /* MLX4_H */

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -498,5 +498,16 @@ void mlx4dv_set_data_seg(struct mlx4_wqe_data_seg *seg,
 int mlx4dv_query_device(struct ibv_context *ctx_in,
 			struct mlx4dv_context *attrs_out);
 
-#endif /* _MLX4DV_H_ */
+enum mlx4dv_set_ctx_attr_type {
+	/* Attribute type uint8_t */
+	MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ	= 0,
+};
 
+/*
+ * Returns 0 on success, or the value of errno on failure
+ * (which indicates the failure reason).
+ */
+int mlx4dv_set_context_attr(struct ibv_context *context,
+			    enum mlx4dv_set_ctx_attr_type attr_type,
+			    void *attr);
+#endif /* _MLX4DV_H_ */

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -197,6 +197,20 @@ struct mlx4dv_srq {
 	uint64_t			comp_mask;
 };
 
+struct mlx4dv_rwq {
+	__be32			*rdb;
+	struct {
+		uint32_t	wqe_cnt;
+		int		wqe_shift;
+		int		offset;
+	} rq;
+	struct {
+		void			*buf;
+		size_t			length;
+	} buf;
+	uint64_t		comp_mask;
+};
+
 struct mlx4dv_obj {
 	struct {
 		struct ibv_qp		*in;
@@ -210,12 +224,17 @@ struct mlx4dv_obj {
 		struct ibv_srq		*in;
 		struct mlx4dv_srq	*out;
 	} srq;
+	struct {
+		struct ibv_wq		*in;
+		struct mlx4dv_rwq	*out;
+	} rwq;
 };
 
 enum mlx4dv_obj_type {
 	MLX4DV_OBJ_QP	= 1 << 0,
 	MLX4DV_OBJ_CQ	= 1 << 1,
 	MLX4DV_OBJ_SRQ	= 1 << 2,
+	MLX4DV_OBJ_RWQ	= 1 << 3,
 };
 
 /*

--- a/providers/mlx4/qp.c
+++ b/providers/mlx4/qp.c
@@ -650,13 +650,13 @@ void mlx4_calc_sq_wqe_size(struct ibv_qp_cap *cap, enum ibv_qp_type type,
 		; /* nothing */
 }
 
-int mlx4_alloc_qp_buf(struct ibv_context *context, struct ibv_qp_cap *cap,
+int mlx4_alloc_qp_buf(struct ibv_context *context, uint32_t max_recv_sge,
 		      enum ibv_qp_type type, struct mlx4_qp *qp,
 		      struct mlx4dv_qp_init_attr *mlx4qp_attr)
 {
 	int wqe_size;
 
-	qp->rq.max_gs	 = cap->max_recv_sge;
+	qp->rq.max_gs	 = max_recv_sge;
 	wqe_size = qp->rq.max_gs * sizeof(struct mlx4_wqe_data_seg);
 	if (mlx4qp_attr &&
 	    mlx4qp_attr->comp_mask & MLX4DV_QP_INIT_ATTR_MASK_INL_RECV &&

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -1441,3 +1441,58 @@ int mlx4_destroy_wq(struct ibv_wq *ibwq)
 
 	return 0;
 }
+
+struct ibv_rwq_ind_table *mlx4_create_rwq_ind_table(struct ibv_context *context,
+						    struct ibv_rwq_ind_table_init_attr *init_attr)
+{
+	struct ibv_create_rwq_ind_table *cmd;
+	struct ibv_create_rwq_ind_table_resp resp = {};
+	struct ibv_rwq_ind_table *ind_table;
+	uint32_t required_tbl_size;
+	unsigned int num_tbl_entries;
+	int cmd_size;
+	int err;
+
+	num_tbl_entries = 1 << init_attr->log_ind_tbl_size;
+	/* Data must be u64 aligned */
+	required_tbl_size =
+		(num_tbl_entries * sizeof(uint32_t)) < sizeof(uint64_t) ?
+			sizeof(uint64_t) : (num_tbl_entries * sizeof(uint32_t));
+
+	cmd_size = required_tbl_size + sizeof(*cmd);
+	cmd = calloc(1, cmd_size);
+	if (!cmd)
+		return NULL;
+
+	ind_table = calloc(1, sizeof(*ind_table));
+	if (!ind_table)
+		goto free_cmd;
+
+	err = ibv_cmd_create_rwq_ind_table(context, init_attr, ind_table, cmd,
+					   cmd_size, cmd_size, &resp,
+					   sizeof(resp), sizeof(resp));
+	if (err)
+		goto err;
+
+	free(cmd);
+	return ind_table;
+
+err:
+	free(ind_table);
+free_cmd:
+	free(cmd);
+	return NULL;
+}
+
+int mlx4_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
+{
+	int ret;
+
+	ret = ibv_cmd_destroy_rwq_ind_table(rwq_ind_table);
+
+	if (ret && !cleanup_on_fatal(ret))
+		return ret;
+
+	free(rwq_ind_table);
+	return 0;
+}

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -976,6 +976,9 @@ static struct ibv_qp *create_qp_ex(struct ibv_context *context,
 	else
 		qp->sq_signal_bits = 0;
 
+	qp->qpn_cache = qp->verbs_qp.qp.qp_num;
+	qp->type = attr->srq ? MLX4_RSC_TYPE_SRQ : MLX4_RSC_TYPE_QP;
+
 	return &qp->verbs_qp.qp;
 
 err_destroy:
@@ -1472,6 +1475,10 @@ struct ibv_wq *mlx4_create_wq(struct ibv_context *context,
 	qp->rq.max_gs  = attr->max_sge;
 
 	qp->wq.state = IBV_WQS_RESET;
+
+	qp->wq.post_recv = mlx4_post_wq_recv;
+
+	qp->qpn_cache = qp->wq.wq_num;
 
 	return &qp->wq;
 


### PR DESCRIPTION
This patch set  implements the RSS related verbs in mlx4, the matching kernel part was already merged into 4.14.