### PR TITLE
verbs: Fix C++ compilation break

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -82,7 +82,12 @@ union ibv_gid {
 
 #define vext_field_avail(type, fld, sz) (offsetof(type, fld) < (sz))
 
-static void *__VERBS_ABI_IS_EXTENDED = (void *)UINTPTR_MAX;
+#ifdef __cplusplus
+#include <limits>
+#define __VERBS_ABI_IS_EXTENDED ((void *)std::numeric_limits<uintptr_t>::max())
+#else
+#define __VERBS_ABI_IS_EXTENDED ((void *)UINTPTR_MAX)
+#endif
 
 enum ibv_node_type {
 	IBV_NODE_UNKNOWN	= -1,


### PR DESCRIPTION
The commit 983f80191923 ("verbs: fix compilation error with ICC") fixed
warning by using UINTPTR_MAX, however such change breaks compilation
of C++ applications.

On some systems, the stdint.h contains the following ifdef to protect UINTPTR_MAX
"#if !defined __cplusplus || defined __STDC_LIMIT_MACROS"

The simple inclusion of <cstdint> header is not enough too to fix
compilation error, because that file was added in C++11 standard and
it produces following error while using it:

/usr/include/c++/4.8.2/bits/c++0x_warning.h:32:2: error: #error This file requires
compiler and library support for the ISO C++ 2011 standard. This support is currently
experimental, and must be enabled with the -std=c++11 or -std=gnu++11 compiler options.

So let's fix C++ compilation break by using numeric_limits to avoid __STDC_LIMIT_MACROS.

Fixes: 983f80191923 ("verbs: fix compilation error with ICC")
Signed-off-by: Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>
Cc: Nelio Laranjeiro <nelio.laranjeiro@6wind.com>
Cc: Adrien Mazarguil <adrien.mazarguil@6wind.com>
Cc: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.de>