### PR TITLE
iwpmd: Return existing mapping if port reused on active side

### DIFF
--- a/iwpmd/iwarp_pm.h
+++ b/iwpmd/iwarp_pm.h
@@ -53,6 +53,7 @@
 #include <netlink/msg.h>
 #include <ccan/list.h>
 #include <rdma/rdma_netlink.h>
+#include <stdatomic.h>
 
 #define IWARP_PM_PORT          3935
 #define IWARP_PM_VER_SHIFT     6
@@ -138,7 +139,7 @@ typedef struct iwpm_mapped_port {
 	struct sockaddr_storage	    local_addr;
 	struct sockaddr_storage	    mapped_addr;
 	int			    wcard;
-	int			    ref_cnt; /* the number of owners, if wcard */
+	_Atomic(int)		    ref_cnt; /* the number of owners */
 } iwpm_mapped_port;
 
 typedef struct iwpm_wire_msg {
@@ -250,8 +251,6 @@ void remove_iwpm_mapped_port(iwpm_mapped_port *);
 void print_iwpm_mapped_ports(void);
 
 void free_iwpm_port(iwpm_mapped_port *);
-
-int free_iwpm_wcard_mapping(iwpm_mapped_port *);
 
 iwpm_mapping_request *create_iwpm_map_request(struct nlmsghdr *, struct sockaddr_storage *,
 					struct sockaddr_storage *, __u64, int, iwpm_send_msg *);


### PR DESCRIPTION
Port-mapper returns a duplicate mapping error and no
mapped port if an attempt is made to add a mapping for
a new connection which re-uses the local port on active side.
Fix this by finding the existing  mapping for the re-used
local port and return the mapped port. Also, change ref_cnt
in struct iwpm_port to be atomic and use it to track the
references to a mapping.

Signed-off-by: Shiraz Saleem <shiraz.saleem@intel.com>
Signed-off-by: Tatyana Nikolova <tatyana.e.nikolova@intel.com>
Reviewed-by: Steve Wise <swise@opengridcomputing.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>