### PR TITLE
verbs: Fix declaration of C++ include file in C-block

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -45,6 +45,10 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
+#include <limits>
+#endif
+
+#ifdef __cplusplus
 #  define BEGIN_C_DECLS extern "C" {
 #  define END_C_DECLS   }
 #else /* !__cplusplus */
@@ -83,7 +87,6 @@ union ibv_gid {
 #define vext_field_avail(type, fld, sz) (offsetof(type, fld) < (sz))
 
 #ifdef __cplusplus
-#include <limits>
 #define __VERBS_ABI_IS_EXTENDED ((void *)std::numeric_limits<uintptr_t>::max())
 #else
 #define __VERBS_ABI_IS_EXTENDED ((void *)UINTPTR_MAX)


### PR DESCRIPTION
The include of limits.h in case of C++ application throws the following
error during the compilation.

/usr/include/c++/4.8.2/limits:303:3: error: template with C linkage
   template<typename _Tp>
   ^

The reason to such failure is the location of limits.c, it is supposed
to be included outside of C-block, so let's move it to avoid the error.

Fixes: 6a74285158a1 ("verbs: Fix C++ compilation break")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>