### PR TITLE
mlx5 sw parser

### DIFF
--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -21,11 +21,21 @@ of the internal hardware structures that mlx5dv.h represents. Additions of new f
 structures are handled by comp_mask field.
 .PP
 .nf
+struct mlx5dv_sw_parsing_caps {
+.in +8
+uint32_t sw_parsing_offloads; /* Use enum mlx5dv_sw_parsing_offloads */
+uint32_t supported_qpts;
+.in -8
+};
+.PP
+.nf
 struct mlx5dv_context {
 .in +8
 uint8_t         version;
 uint64_t        flags;
-uint64_t        comp_mask;
+uint64_t        comp_mask; /* Use enum mlx5dv_context_comp_mask */
+struct mlx5dv_cqe_comp_caps     cqe_comp_caps;
+struct mlx5dv_sw_parsing_caps sw_parsing_caps;
 .in -8
 };
 
@@ -38,6 +48,26 @@ enum mlx5dv_context_flags {
  MLX5DV_CONTEXT_FLAGS_OBSOLETE    =  (1 << 1), /* Obsoleted, don't use */
  MLX5DV_CONTEXT_FLAGS_MPW_ALLOWED  = (1 << 2), /* Multi packet WQE is allowed */
  MLX5DV_CONTEXT_FLAGS_ENHANCED_MPW = (1 << 3), /* Enhanced multi packet WQE is supported or not */
+.in -8
+};
+
+.PP
+.nf
+enum mlx5dv_context_comp_mask {
+.in +8
+MLX5DV_CONTEXT_MASK_CQE_COMPRESION      = 1 << 0,
+MLX5DV_CONTEXT_MASK_SWP                 = 1 << 1,
+MLX5DV_CONTEXT_MASK_RESERVED            = 1 << 2,
+.in -8
+};
+
+.PP
+.nf
+enum enum mlx5dv_sw_parsing_offloads {
+.in +8
+MLX5DV_SW_PARSING         = 1 << 0,
+MLX5DV_SW_PARSING_CSUM    = 1 << 1,
+MLX5DV_SW_PARSING_LSO     = 1 << 2,
 .in -8
 };
 .fi

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -289,6 +289,7 @@ struct mlx5_query_device_ex_resp {
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	__u32				support_multi_pkt_send_wqe;
 	__u32				reserved;
+	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 };
 
 #endif /* MLX5_ABI_H */

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -630,6 +630,11 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 	if (mctx->vendor_cap_flags & MLX5_VENDOR_CAP_FLAGS_ENHANCED_MPW)
 		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_ENHANCED_MPW;
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_SWP) {
+		attrs_out->sw_parsing_caps = mctx->sw_parsing_caps;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_SWP;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -272,6 +272,7 @@ struct mlx5_context {
 	uint64_t			vendor_cap_flags; /* Use enum mlx5_vendor_cap_flags */
 	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 	struct mlx5dv_ctx_allocators	extern_alloc;
+	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -58,12 +58,18 @@ enum {
 
 enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_CQE_COMPRESION	= 1 << 0,
-	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 1,
+	MLX5DV_CONTEXT_MASK_SWP			= 1 << 1,
+	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 2,
 };
 
 struct mlx5dv_cqe_comp_caps {
 	uint32_t max_num;
 	uint32_t supported_format; /* enum mlx5dv_cqe_comp_res_format */
+};
+
+struct mlx5dv_sw_parsing_caps {
+	uint32_t sw_parsing_offloads; /* Use enum mlx5dv_sw_parsing_offloads */
+	uint32_t supported_qpts;
 };
 
 /*
@@ -74,6 +80,7 @@ struct mlx5dv_context {
 	uint64_t	flags;
 	uint64_t	comp_mask;
 	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
+	struct mlx5dv_sw_parsing_caps sw_parsing_caps;
 };
 
 enum mlx5dv_context_flags {
@@ -314,6 +321,12 @@ enum mlx5dv_cqe_comp_res_format {
 	MLX5DV_CQE_RES_FORMAT_HASH		= 1 << 0,
 	MLX5DV_CQE_RES_FORMAT_CSUM		= 1 << 1,
 	MLX5DV_CQE_RES_FORMAT_RESERVED		= 1 << 2,
+};
+
+enum mlx5dv_sw_parsing_offloads {
+	MLX5DV_SW_PARSING		= 1 << 0,
+	MLX5DV_SW_PARSING_CSUM		= 1 << 1,
+	MLX5DV_SW_PARSING_LSO		= 1 << 2,
 };
 
 static MLX5DV_ALWAYS_INLINE

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2002,6 +2002,7 @@ int mlx5_query_device_ex(struct ibv_context *context,
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_ENHANCED_MPW;
 
 	mctx->cqe_comp_caps = resp.cqe_comp_caps;
+	mctx->sw_parsing_caps = resp.sw_parsing_caps;
 
 	major     = (raw_fw_ver >> 32) & 0xffff;
 	minor     = (raw_fw_ver >> 16) & 0xffff;


### PR DESCRIPTION
This patch set for mlx5 is the supplementary part of the kernel series that was
accepted upstream into 4.14.  It reports software parsing capabilities through the mlx5 DV API.