### PR TITLE
vmw_pvrdma: Add SRQ support

### DIFF
--- a/buildlib/fixup-include/rdma-vmw_pvrdma-abi.h
+++ b/buildlib/fixup-include/rdma-vmw_pvrdma-abi.h
@@ -57,6 +57,8 @@
 #define PVRDMA_UAR_CQ_ARM_SOL		BIT(29)		/* Arm solicited bit. */
 #define PVRDMA_UAR_CQ_ARM		BIT(30)		/* Arm bit. */
 #define PVRDMA_UAR_CQ_POLL		BIT(31)		/* Poll bit. */
+#define PVRDMA_UAR_SRQ_OFFSET		8		/* SRQ doorbell. */
+#define PVRDMA_UAR_SRQ_RECV		BIT(30)		/* Recv bit. */
 
 enum pvrdma_wr_opcode {
 	PVRDMA_WR_RDMA_WRITE,
@@ -157,6 +159,8 @@ struct pvrdma_resize_cq {
 
 struct pvrdma_create_srq {
 	__u64 buf_addr;
+	__u32 buf_size;
+	__u32 reserved;
 };
 
 struct pvrdma_create_srq_resp {

--- a/providers/vmw_pvrdma/pvrdma-abi-fix.h
+++ b/providers/vmw_pvrdma/pvrdma-abi-fix.h
@@ -69,6 +69,16 @@ struct user_pvrdma_create_cq_resp {
 	struct pvrdma_create_cq_resp	udata;
 };
 
+struct user_pvrdma_create_srq {
+	struct ibv_create_srq		ibv_cmd;
+	struct pvrdma_create_srq	udata;
+};
+
+struct user_pvrdma_create_srq_resp {
+	struct ibv_create_srq_resp	ibv_resp;
+	struct pvrdma_create_srq_resp	udata;
+};
+
 struct user_pvrdma_create_qp {
 	struct ibv_create_qp		ibv_cmd;
 	struct pvrdma_create_qp		udata;

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -135,6 +135,21 @@ struct pvrdma_cq {
 	uint32_t			cqn;
 };
 
+struct pvrdma_srq {
+	struct ibv_srq			ibv_srq;
+	struct pvrdma_buf		buf;
+	pthread_spinlock_t		lock;
+	uint64_t			*wrid;
+	uint32_t			srqn;
+	int				wqe_cnt;
+	int				wqe_size;
+	int				max_gs;
+	int				wqe_shift;
+	struct pvrdma_ring_state	*ring_state;
+	uint16_t			counter;
+	int				offset;
+};
+
 struct pvrdma_wq {
 	uint64_t			*wrid;
 	pthread_spinlock_t		lock;
@@ -156,6 +171,7 @@ struct pvrdma_qp {
 	int				sq_spare_wqes;
 	struct pvrdma_wq		sq;
 	struct pvrdma_wq		rq;
+	int				is_srq;
 };
 
 struct pvrdma_ah {
@@ -198,6 +214,11 @@ static inline struct pvrdma_cq *to_vcq(struct ibv_cq *ibcq)
 	return container_of(ibcq, struct pvrdma_cq, ibv_cq);
 }
 
+static inline struct pvrdma_srq *to_vsrq(struct ibv_srq *ibsrq)
+{
+	return container_of(ibsrq, struct pvrdma_srq, ibv_srq);
+}
+
 static inline struct pvrdma_qp *to_vqp(struct ibv_qp *ibqp)
 {
 	return container_of(ibqp, struct pvrdma_qp, ibv_qp);
@@ -216,6 +237,11 @@ static inline void pvrdma_write_uar_qp(void *uar, unsigned value)
 static inline void pvrdma_write_uar_cq(void *uar, unsigned value)
 {
 	*(__le32 *)(uar + PVRDMA_UAR_CQ_OFFSET) = htole32(value);
+}
+
+static inline void pvrdma_write_uar_srq(void *uar, unsigned int value)
+{
+	*(__le32 *)(uar + PVRDMA_UAR_SRQ_OFFSET) = htole32(value);
 }
 
 static inline int ibv_send_flags_to_pvrdma(int flags)
@@ -300,6 +326,21 @@ struct pvrdma_qp *pvrdma_find_qp(struct pvrdma_context *ctx,
 int pvrdma_store_qp(struct pvrdma_context *ctx, uint32_t qpn,
 		    struct pvrdma_qp *qp);
 void pvrdma_clear_qp(struct pvrdma_context *ctx, uint32_t qpn);
+
+struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
+				  struct ibv_srq_init_attr *attr);
+int pvrdma_modify_srq(struct ibv_srq *srq, struct ibv_srq_attr *attr,
+		      int attr_mask);
+int pvrdma_query_srq(struct ibv_srq *srq,
+		     struct ibv_srq_attr *attr);
+int pvrdma_destroy_srq(struct ibv_srq *srq);
+int pvrdma_alloc_srq_buf(struct pvrdma_device *dev,
+			 struct ibv_srq_attr *attr,
+			 struct pvrdma_srq *srq);
+int pvrdma_post_srq_recv(struct ibv_srq *ibsrq,
+			 struct ibv_recv_wr *wr,
+			 struct ibv_recv_wr **bad_wr);
+void pvrdma_init_srq_queue(struct pvrdma_srq *srq);
 
 struct ibv_ah *pvrdma_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr);
 int pvrdma_destroy_ah(struct ibv_ah *ah);

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -69,6 +69,12 @@ static struct ibv_context_ops pvrdma_ctx_ops = {
 	.modify_qp = pvrdma_modify_qp,
 	.destroy_qp = pvrdma_destroy_qp,
 
+	.create_srq = pvrdma_create_srq,
+	.modify_srq = pvrdma_modify_srq,
+	.query_srq = pvrdma_query_srq,
+	.destroy_srq = pvrdma_destroy_srq,
+	.post_srq_recv = pvrdma_post_srq_recv,
+
 	.post_send = pvrdma_post_send,
 	.post_recv = pvrdma_post_recv,
 	.create_ah = pvrdma_create_ah,

--- a/providers/vmw_pvrdma/pvrdma_ring.h
+++ b/providers/vmw_pvrdma/pvrdma_ring.h
@@ -47,7 +47,6 @@
 #ifndef __PVRDMA_RING_H__
 #define __PVRDMA_RING_H__
 
-#include <stdint.h>
 #include <linux/types.h>
 
 #define PVRDMA_INVALID_IDX	-1	/* Invalid index. */


### PR DESCRIPTION
Enable userlevel applications to use SRQs.

Reviewed-by: Adit Ranadive <aditr@vmware.com>
Reviewed-by: Aditya Sarwade <asarwade@vmware.com>
Reviewed-by: Jorgen Hansen <jhansen@vmware.com>
Reviewed-by: Nitish Bhat <bnitish@vmware.com>
Signed-off-by: Bryan Tan <bryantan@vmware.com>