### PR TITLE
libibumad/umad.c: In get_port, ignore sysfs rate file errors

### DIFF
--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -150,8 +150,7 @@ static int get_port(const char *ca_name, const char *dir, int portnum, umad_port
 		goto clean;
 	if (sys_read_uint(port_dir, SYS_PORT_PHY_STATE, &port->phys_state) < 0)
 		goto clean;
-	if (sys_read_uint(port_dir, SYS_PORT_RATE, &port->rate) < 0)
-		goto clean;
+	sys_read_uint(port_dir, SYS_PORT_RATE, &port->rate);
 	if (sys_read_uint(port_dir, SYS_PORT_CAPMASK, &capmask) < 0)
 		goto clean;
 


### PR DESCRIPTION
This can cause ibpanic in ibstat when width is not set properly
as can occur when QSPF is not plugged into port.

ibpanic: [7851] main: stat of IB device 'mlx5_1' failed: Invalid argument

It's caused by kernel sysfs.c:show_rate returning -EINVAL
and that error being treated as failure in umad.c:get_port.
With this change, Rate is displayed as 0 with ibstat for this scenario.

Signed-off-by: Hal Rosenstock <hal@mellanox.com>