### PR TITLE
Package travis test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,9 @@ addons:
       - gcc-multilib
       - lib32gcc-7-dev
 
+service:
+    - docker
+
 before_script:
   - export LATEST_GCC_LINARO_URL=`wget -qO - https://releases.linaro.org/components/toolchain/binaries/latest/aarch64-linux-gnu/ | grep -o '<a href=['"'"'"].*gcc-linaro-.*x86_64_aarch64-linux-gnu.tar.xz['"'"'"]'  |  sed -e 's/^<a href=["'"'"']//' -e 's/["'"'"']$//'`
   - export LATEST_GCC_LINARO_TAR=`basename $LATEST_GCC_LINARO_URL`
@@ -51,6 +54,7 @@ before_script:
 script:
   - buildlib/travis-build
   - buildlib/travis-checkpatch
+  - buildlib/package-build-test
   - buildlib/github-release
 deploy:
   # Deploy assets to Github releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,6 @@ addons:
       - build-essential
       - clang-4.0
       - cmake
-      - debhelper
-      - dh-systemd
-      - fakeroot
       - gcc
       - gcc-7
       - git

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -181,6 +181,12 @@ class xenial(APTEnvironment):
     name = "ubuntu-16.04";
     aliases = {"xenial"};
 
+class artful(APTEnvironment):
+    docker_parent = "ubuntu:17.10"
+    pkgs = xenial.pkgs
+    name = "ubuntu-17.10";
+    aliases = {"artful"};
+
 class jessie(APTEnvironment):
     docker_parent = "debian:8"
     pkgs = xenial.pkgs;
@@ -325,6 +331,7 @@ environments = [centos6(),
                 travis(),
                 trusty(),
                 xenial(),
+                artful(),
                 jessie(),
                 stretch(),
                 fc26(),

--- a/buildlib/package-build-test
+++ b/buildlib/package-build-test
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# fail on errors
+set -e
+# be verbose
+set -x
+
+# Do not run these tests if we are already inside a container
+if [ -e "/.dockerenv" ] || (grep -q docker /proc/self/cgroup &>/dev/null); then
+       echo "We are running in a container, skipping ..."
+       exit 0
+fi
+
+for OS in centos7 opensuse-42.3
+do
+	echo
+	echo "Checking package build for ${OS} ...."
+	echo
+	buildlib/cbuild build-images ${OS}
+	buildlib/cbuild pkg ${OS}
+done

--- a/buildlib/package-build-test
+++ b/buildlib/package-build-test
@@ -11,7 +11,7 @@ if [ -e "/.dockerenv" ] || (grep -q docker /proc/self/cgroup &>/dev/null); then
        exit 0
 fi
 
-for OS in centos7 opensuse-42.3
+for OS in centos7 opensuse-42.3 artful
 do
 	echo
 	echo "Checking package build for ${OS} ...."

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -45,17 +45,3 @@ rm CMakeCache.txt
 CC=clang-4.0 CFLAGS=-Werror cmake -GNinja ..
 ninja
 cp ../util/udma_barrier.h.old ../util/udma_barrier.h
-
-# Finally run through gcc-7 64 bit through the debian packaging This gives a
-# good clue if patches are changing packaging related things, the RPM stuff
-# will have to be audited by hand.
-
-# When running cmake through debian/rules it is hard to set -Werror,
-# instead force it on by changing the CMakeLists.txt
-cd ..
-echo 'set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")' >> buildlib/RDMA_EnableCStd.cmake
-sed -i -e 's/-DCMAKE_BUILD_TYPE=Release//g' debian/rules
-sed -i -e 's/ninja \(.*\)-v/ninja \1/g' debian/rules
-
-CC=gcc-7 debian/rules build
-fakeroot debian/rules binary


### PR DESCRIPTION
Add ability to test package builds on latest main distributions: CentOS, Ubuntu and SuSE.