### PR TITLE
verbs: Do not block QP attr_masks used by older kernels

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1182,10 +1182,10 @@ int ibv_cmd_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 	struct ibv_query_qp_resp resp;
 
 	/*
-	 * Masks over IBV_QP_DEST_QPN are not supported by
-	 * that not extended command.
+	 * Starting with IBV_QP_RATE_LIMIT the attribute must go through the
+	 * _ex path.
 	 */
-	if (attr_mask & ~((IBV_QP_DEST_QPN << 1) - 1))
+	if (attr_mask & ~(IBV_QP_RATE_LIMIT - 1))
 		return EOPNOTSUPP;
 
 	IBV_INIT_CMD_RESP(cmd, cmd_size, QUERY_QP, &resp, sizeof resp);
@@ -1352,10 +1352,10 @@ int ibv_cmd_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		      struct ibv_modify_qp *cmd, size_t cmd_size)
 {
 	/*
-	 * Masks over IBV_QP_DEST_QPN are only supported by
-	 * ibv_cmd_modify_qp_ex.
+	 * Starting with IBV_QP_RATE_LIMIT the attribute must go through the
+	 * _ex path.
 	 */
-	if (attr_mask & ~((IBV_QP_DEST_QPN << 1) - 1))
+	if (attr_mask & ~(IBV_QP_RATE_LIMIT - 1))
 		return EOPNOTSUPP;
 
 	IBV_INIT_CMD(cmd, cmd_size, MODIFY_QP);

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -909,6 +909,13 @@ enum ibv_qp_attr_mask {
 	IBV_QP_PATH_MIG_STATE		= 1 << 18,
 	IBV_QP_CAP			= 1 << 19,
 	IBV_QP_DEST_QPN			= 1 << 20,
+	/* These bits were supported on older kernels, but never exposed from
+	   libibverbs:
+	_IBV_QP_SMAC   			= 1 << 21,
+	_IBV_QP_ALT_SMAC		= 1 << 22,
+	_IBV_QP_VID    			= 1 << 23,
+	_IBV_QP_ALT_VID 		= 1 << 24,
+	*/
 	IBV_QP_RATE_LIMIT		= 1 << 25,
 };
 


### PR DESCRIPTION
At least the RDMA CM in 4.3 will give user space structs with these bits
set. Those kernels require user space to pass those set bits back to the
kernel. Blocking them causes RDMA CM to be unusable on older kernels.

Fixes: 3ca7a1031486 ("ibverbs: Add support for packet pacing")
Reported-by: Ram Amrani <Ram.Amrani@cavium.com>
Signed-off-by: Jason Gunthorpe <jgunthorpe@ziepe.ca>