### PR TITLE
librdmacm: Make return value from ucma_init consist

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -202,8 +202,10 @@ int ucma_init(void)
 
 	fastlock_init(&idm_lock);
 	ret = check_abi_version();
-	if (ret)
+	if (ret) {
+		ret = ERR(EPERM);
 		goto err1;
+	}
 
 	dev_list = ibv_get_device_list(&dev_cnt);
 	if (!dev_list) {


### PR DESCRIPTION
When check_abi_version fails we must be consist with rest of exit flows
of the function and return -1 and set errno with the actual error code.

Signed-off-by: Yuval Shaia <yuval.shaia@oracle.com>