### PR TITLE
libbnxt_re bug fix series

### DIFF
--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -366,9 +366,13 @@ static inline uint8_t bnxt_re_to_ibv_wc_status(uint8_t bnxt_wcst,
 static inline uint8_t bnxt_re_is_cqe_valid(struct bnxt_re_cq *cq,
 					   struct bnxt_re_bcqe *hdr)
 {
+	uint8_t valid = 0;
+
+	valid = ((le32toh(hdr->flg_st_typ_ph) &
+		  BNXT_RE_BCQE_PH_MASK) == cq->phase);
 	udma_from_device_barrier();
-	return ((le32toh(hdr->flg_st_typ_ph) &
-		 BNXT_RE_BCQE_PH_MASK) == cq->phase);
+
+	return valid;
 }
 
 static inline void bnxt_re_change_cq_phase(struct bnxt_re_cq *cq)

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1048,6 +1048,8 @@ static void bnxt_re_fill_psns(struct bnxt_re_qp *qp, struct bnxt_re_psns *psns,
 		pkt_cnt = (len / qp->mtu);
 		if (len % qp->mtu)
 			pkt_cnt++;
+		if (len == 0)
+			pkt_cnt = 1;
 		nxt_psn = ((qp->sq_psn + pkt_cnt) & BNXT_RE_PSNS_NPSN_MASK);
 		psns->flg_npsn = htole32(nxt_psn);
 		qp->sq_psn = nxt_psn;


### PR DESCRIPTION
Patch 1: address the memory barrier changes Jason asked while reviewing a similar change in bnxt_re driver.

Patch2: Fixes psn calculations when sending out a zero length packet. This was found during internal testing.