### PR TITLE
ABI consistency check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,8 @@ addons:
       - valgrind
       - sparse
       - wget
+      - abi-compliance-checker
+      - abi-dumper
 
       # 32 bit support packages
       - gcc-multilib

--- a/Documentation/stable.md
+++ b/Documentation/stable.md
@@ -63,3 +63,27 @@ Note that for Option 3, if the patch deviates from the original upstream patch (
 ## Versioning
 
 See versioning.md for setting package version on a stable branch.
+
+
+## Creating a stable branch
+
+Stable branch should be created from a release tag of the master branch.
+The first thing to do on a master branch is to commit the mainstream release ABI infos
+so that latters patches/fixes can be checked against this reference.
+
+To do that, the creator of the branch should run
+```
+./buildlib/cbuild build-images travis
+mkdir ABI
+touch ABI/.gitignore
+git add ABI/.gitignore
+git commit -m "ABI Files"
+./buildlib/cbuild pkg travis
+git add ABI/*
+git commit --amend
+```
+
+'cbuild pkg travis' will fail as the ABI verification step files, but it will
+produce the ABI reference files.
+
+Note that the ABI directory must NOT be committed at any point in the master branch.

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -38,6 +38,7 @@ useful for debugging certain kinds of build problems."""
 
 import argparse
 import collections
+import filecmp
 import grp
 import imp
 import inspect
@@ -557,6 +558,25 @@ subprocess.check_call(["debian/rules","debian/rules","binary"]);
                 shutil.move(os.path.join(tmpdir,I),
                             os.path.join("..",I));
 
+def copy_abi_files(src):
+    """Retrieve the current ABI files and place them in the source tree."""
+    if not os.path.isdir(src):
+        return;
+
+    for path,jnk,files in os.walk(src):
+        for I in files:
+            if not I.startswith("current-"):
+                continue;
+
+            ref_fn = os.path.join("ABI",I[8:]);
+            cur_fn = os.path.join(src, path, I);
+
+            if os.path.isfile(ref_fn) and filecmp.cmp(ref_fn,cur_fn,False):
+                continue;
+
+            print "Changed ABI File: ", ref_fn;
+            shutil.copy(cur_fn, ref_fn);
+
 def run_travis_build(args,env):
     with private_tmp(args) as tmpdir:
         os.mkdir(os.path.join(tmpdir,"src"));
@@ -615,7 +635,12 @@ def run_travis_build(args,env):
         else:
             opts.extend(["/bin/bash",os.path.join(home_build,"go.sh")]);
 
-        docker_cmd(args,*opts);
+        try:
+            docker_cmd(args,*opts);
+        except subprocess.CalledProcessError, e:
+            copy_abi_files(os.path.join(tmpdir, "src/ABI"));
+            raise;
+        copy_abi_files(os.path.join(tmpdir, "src/ABI"));
 
 def args_pkg(parser):
     parser.add_argument("ENV",action=ToEnvAction,choices=env_choices());

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -9,6 +9,7 @@ import re
 import shutil
 import subprocess
 import tempfile
+import sys
 from contextlib import contextmanager;
 
 def get_src_dir():
@@ -143,6 +144,51 @@ def test_verbs_private(args):
 
 # -------------------------------------------------------------------------
 
+def check_abi(args,fn):
+    g1 = re.match(r"lib([^.]+).so\.(.+)\.(.+)",fn);
+    g2 = re.match(r"lib([^.]+).so\.(.+\..+)",fn);
+    if g1 is None or g2 is None:
+        raise ValueError("Library has unknown file name format %r"%(fn));
+
+    ref_fn = os.path.join(args.SRC,"ABI",fn + ".dump");
+    cur_fn = os.path.join(args.SRC,"ABI","current-" + fn + ".dump");
+    subprocess.check_call(["abi-dumper",
+                           "-lver",g2.group(1),
+                           fn,
+                           "-o",cur_fn]);
+
+    if not os.path.exists(ref_fn):
+        print >> sys.stderr, "ABI file does not exist for %r"%(ref_fn);
+        return False;
+
+    subprocess.check_call(["abi-compliance-checker",
+                           "-l",g1.group(1),
+                           "-old",ref_fn,
+                           "-new",cur_fn]);
+
+    return True;
+
+def test_verbs_uapi(args):
+    """Compare the ABI output from 'abi-dumper' between what is present in git and
+    what was built in this tree.  This allows us to detect changes in ABI on
+    the -stable branch."""
+
+    # User must provide the ABI dir in the source tree
+    if not os.path.isdir(os.path.join(args.SRC,"ABI")):
+        print "ABI check skipped, no ABI/ directory.";
+        return;
+
+    libd = os.path.join(args.BUILD,"lib");
+    success = True;
+    with inDirectory(libd):
+        for fn in os.listdir("."):
+            if not os.path.islink(fn) and re.match(r"lib.+\.so\..+\..+",fn):
+                success = success & check_abi(args,fn);
+
+    assert success == True;
+
+# -------------------------------------------------------------------------
+
 def is_obsolete(fn):
     """True if the header is obsolete and should not be compiled anyhow."""
     with open(fn) as F:
@@ -197,6 +243,7 @@ args = parser.parse_args();
 
 if args.SRC is None:
     args.SRC = get_src_dir();
+args.SRC = os.path.abspath(args.SRC);
 args.PACKAGE_VERSION = get_package_version(args);
 
 funcs = globals();


### PR DESCRIPTION
Add scripts to generate an ABI dump and compare against a ref.
Both tools (abi-dumper and abi-consistency-check) were imported as the
system version do not work on Travis.
Travis will automatically do that if a ref is present.
Ref should be added at stable-* branch creation (see doc update)

It seems the 1st patch is too big for the ML. So a PR will have to do.