### PR TITLE
Eliminate BEGIN_C_DECLS and END_C_DECLS macros in libibverbs and libibumad headers

### DIFF
--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -41,14 +41,8 @@
 #include <linux/types.h> /* __be16, __be32 and __be64 */
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 typedef __be16 __attribute__((deprecated)) be16_t;
 typedef __be32 __attribute__((deprecated)) be32_t;
@@ -259,5 +253,7 @@ static inline __attribute__((deprecated)) uint64_t htonll(uint64_t x) { return h
 #define htonll htonll
 #endif
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _UMAD_H */

--- a/libibumad/umad_cm.h
+++ b/libibumad/umad_cm.h
@@ -37,14 +37,8 @@
 #include <infiniband/umad_types.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 /* Communication management attributes */
 enum {
@@ -63,5 +57,7 @@ enum {
 	UMAD_CM_ATTR_SPR		= 0x001C,
 };
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _UMAD_CM_H */

--- a/libibumad/umad_sa.h
+++ b/libibumad/umad_sa.h
@@ -39,14 +39,8 @@
 #include <infiniband/umad_types.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 /* SA specific methods */
 enum {
@@ -144,5 +138,7 @@ struct umad_sa_packet {
 	uint8_t 		data[UMAD_LEN_SA_DATA]; /* network-byte order */
 };
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _UMAD_SA_H */

--- a/libibumad/umad_sm.h
+++ b/libibumad/umad_sm.h
@@ -41,14 +41,8 @@
 #include <infiniband/umad_types.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 enum {
 	UMAD_SMP_DIRECTION		= 0x8000,
@@ -124,5 +118,7 @@ struct umad_smp {
 	uint8_t  return_path[UMAD_SMP_MAX_HOPS];
 };
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _UMAD_SM_H */

--- a/libibumad/umad_str.h
+++ b/libibumad/umad_str.h
@@ -37,14 +37,8 @@
 #include <infiniband/umad.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 const char * umad_class_str(uint8_t mgmt_class);
 const char * umad_method_str(uint8_t mgmt_class, uint8_t method);
@@ -53,5 +47,7 @@ const char * umad_attribute_str(uint8_t mgmt_class, __be16 attr_id);
 const char * umad_common_mad_status_str(__be16 status);
 const char * umad_sa_mad_status_str(__be16 status);
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif /* _UMAD_STR_H */

--- a/libibumad/umad_types.h
+++ b/libibumad/umad_types.h
@@ -41,14 +41,8 @@
 #include <infiniband/umad.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 #define UMAD_BASE_VERSION		1
 #define UMAD_QKEY			0x80010000
@@ -213,5 +207,7 @@ umad_class_resp_time(struct umad_class_port_info *cpi)
 			 & UMAD_CLASS_RESP_TIME_MASK);
 }
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _UMAD_TYPES_H */

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -42,14 +42,6 @@
 #include <config.h>
 #include <stdbool.h>
 
-#ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else /* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif /* __cplusplus */
-
 struct verbs_device;
 
 enum verbs_xrcd_mask {

--- a/libibverbs/marshall.h
+++ b/libibverbs/marshall.h
@@ -39,14 +39,8 @@
 #include <rdma/ib_user_sa.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else /* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif /* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 void ibv_copy_qp_attr_from_kern(struct ibv_qp_attr *dst,
 				struct ibv_kern_qp_attr *src);
@@ -60,6 +54,8 @@ void ibv_copy_path_rec_from_kern(struct ibv_sa_path_rec *dst,
 void ibv_copy_path_rec_to_kern(struct ib_user_path_rec *dst,
 			       struct ibv_sa_path_rec *src);
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* INFINIBAND_MARSHALL_H */

--- a/libibverbs/tm_types.h
+++ b/libibverbs/tm_types.h
@@ -37,14 +37,8 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else				/* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif				/* __cplusplus */
-
-BEGIN_C_DECLS
+extern "C" {
+#endif
 
 enum ibv_tmh_op {
 	IBV_TMH_NO_TAG	      = 0,
@@ -66,5 +60,7 @@ struct ibv_rvh {
 	__be32		len;
 };
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 #endif				/* _TM_TYPES_H */

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -48,21 +48,16 @@
 #include <limits>
 #endif
 
-#ifdef __cplusplus
-#  define BEGIN_C_DECLS extern "C" {
-#  define END_C_DECLS   }
-#else /* !__cplusplus */
-#  define BEGIN_C_DECLS
-#  define END_C_DECLS
-#endif /* __cplusplus */
-
 #if __GNUC__ >= 3
 #  define __attribute_const __attribute__((const))
 #else
 #  define __attribute_const
 #endif
 
-BEGIN_C_DECLS
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 union ibv_gid {
 	uint8_t			raw[16];
@@ -2535,7 +2530,9 @@ static inline int ibv_is_qpt_supported(uint32_t caps, enum ibv_qp_type qpt)
 	return !!(caps & (1 << qpt));
 }
 
-END_C_DECLS
+#ifdef __cplusplus
+}
+#endif
 
 #  undef __attribute_const
 


### PR DESCRIPTION

to reduce symbol pollution

Replace these macros with open coding

Signed-off-by: Hal Rosenstock <hal@mellanox.com>