### PR TITLE
Add a minor version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 set(PACKAGE_NAME "RDMA")
 
 # See Documentation/versioning.md
-set(PACKAGE_VERSION "16")
+set(PACKAGE_VERSION "16.0")
 # When this is changed the values in these files need changing too:
 #   debian/libibverbs1.symbols
 #   libibverbs/libibverbs.map

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -150,8 +150,8 @@ def check_abi(args,fn):
     if g1 is None or g2 is None:
         raise ValueError("Library has unknown file name format %r"%(fn));
 
-    ref_fn = os.path.join(args.SRC,"ABI",fn + ".dump");
-    cur_fn = os.path.join(args.SRC,"ABI","current-" + fn + ".dump");
+    ref_fn = os.path.join(args.SRC,"ABI",g1.group(1) + ".dump");
+    cur_fn = os.path.join(args.SRC,"ABI","current-" + g1.group(1) + ".dump");
     subprocess.check_call(["abi-dumper",
                            "-lver",g2.group(1),
                            fn,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-rdma-core (16-1) unstable; urgency=low
+rdma-core (16.0-1) unstable; urgency=low
 
   * New upstream release.
 

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 16
+Version: 16.0
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -19,7 +19,7 @@
 %bcond_without  systemd
 %define         git_ver %{nil}
 Name:           rdma-core
-Version:        16
+Version:        16.0
 Release:        0
 Summary:        RDMA core userspace libraries and daemons
 License:        GPL-2.0 or BSD-2-Clause


### PR DESCRIPTION
Minor version are required for releases on stable branches.
They cannot be included in PACKAGE_VERSION as it would change library names.

- Add PACKAGE_MINOR_VERSION to CMakeList.txt
- Generate PACKAGE_VERSION.PACKAGE_MINOR_VERSION in version string in cbuild.
- Update spec file version to 16.0

Signed-off-by: Nicolas Morey-Chaisemartin <NMoreyChaisemartin@suse.com>