### PR TITLE
Add tunnel support

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -14,4 +14,5 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_query_device@MLX5_1.0 13
  mlx5dv_create_cq@MLX5_1.1 14
  mlx5dv_set_context_attr@MLX5_1.2 15
+ mlx5dv_create_qp@MLX5_1.3 16
  mlx5dv_create_wq@MLX5_1.3 16

--- a/libibverbs/man/ibv_create_qp_ex.3
+++ b/libibverbs/man/ibv_create_qp_ex.3
@@ -72,6 +72,26 @@ uint64_t               rx_hash_fields_mask;    /* RX fields that should particip
 .in -8
 };
 .fi
+
+.nf
+enum ibv_rx_hash_fields {
+.in +8
+IBV_RX_HASH_SRC_IPV4            = 1 << 0,
+IBV_RX_HASH_DST_IPV4            = 1 << 1,
+IBV_RX_HASH_SRC_IPV6            = 1 << 2,
+IBV_RX_HASH_DST_IPV6            = 1 << 3,
+IBV_RX_HASH_SRC_PORT_TCP        = 1 << 4,
+IBV_RX_HASH_DST_PORT_TCP        = 1 << 5,
+IBV_RX_HASH_SRC_PORT_UDP        = 1 << 6,
+IBV_RX_HASH_DST_PORT_UDP        = 1 << 7,
+/* When using tunneling protocol, e.g. VXLAN, then we have an inner (encapsulated packet) and outer.
+ * For applying RSS on the inner packet, then the following field should be set with one of the L3/L4 fields.
+*/
+IBV_RX_HASH_INNER		= (1UL << 31),
+.in -8
+};
+.fi
+
 .PP
 The function
 .B ibv_create_qp_ex()

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -241,7 +241,8 @@ enum ibv_rx_hash_fields {
 	IBV_RX_HASH_SRC_PORT_TCP	= 1 << 4,
 	IBV_RX_HASH_DST_PORT_TCP	= 1 << 5,
 	IBV_RX_HASH_SRC_PORT_UDP	= 1 << 6,
-	IBV_RX_HASH_DST_PORT_UDP	= 1 << 7
+	IBV_RX_HASH_DST_PORT_UDP	= 1 << 7,
+	IBV_RX_HASH_INNER		= (1UL << 31),
 };
 
 struct ibv_rss_caps {

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -20,5 +20,6 @@ MLX5_1.2 {
 
 MLX5_1.3 {
 	global:
+		mlx5dv_create_qp;
 		mlx5dv_create_wq;
 } MLX5_1.2;

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -47,6 +47,7 @@ uint64_t        flags;
 uint64_t        comp_mask; /* Use enum mlx5dv_context_comp_mask */
 struct mlx5dv_cqe_comp_caps     cqe_comp_caps;
 struct mlx5dv_sw_parsing_caps sw_parsing_caps;
+uint32_t	tunnel_offloads_caps;
 .in -8
 };
 
@@ -71,7 +72,8 @@ enum mlx5dv_context_comp_mask {
 MLX5DV_CONTEXT_MASK_CQE_COMPRESION      = 1 << 0,
 MLX5DV_CONTEXT_MASK_SWP                 = 1 << 1,
 MLX5DV_CONTEXT_MASK_STRIDING_RQ         = 1 << 2,
-MLX5DV_CONTEXT_MASK_RESERVED            = 1 << 3,
+MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS     = 1 << 3,
+MLX5DV_CONTEXT_MASK_RESERVED            = 1 << 4,
 .in -8
 };
 
@@ -84,6 +86,17 @@ MLX5DV_SW_PARSING_CSUM    = 1 << 1,
 MLX5DV_SW_PARSING_LSO     = 1 << 2,
 .in -8
 };
+
+.PP
+.nf
+enum mlx5dv_tunnel_offloads {
+.in +8
+MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_VXLAN  = 1 << 0,
+MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_GRE    = 1 << 1,
+MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_GENEVE = 1 << 2,
+.in -8
+};
+
 .fi
 .SH "RETURN VALUE"
 0 on success or the value of errno on failure (which indicates the failure reason).

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -312,6 +312,8 @@ struct mlx5_query_device_ex_resp {
 	__u32				flags; /* Use enum mlx5_query_dev_resp_flags */
 	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 	struct mlx5_striding_rq_caps	striding_rq_caps;
+	__u32				tunnel_offloads_caps;
+	__u32				reserved;
 };
 
 #endif /* MLX5_ABI_H */

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -43,6 +43,7 @@
 enum {
 	MLX5_QP_FLAG_SIGNATURE		= 1 << 0,
 	MLX5_QP_FLAG_SCATTER_CQE	= 1 << 1,
+	MLX5_QP_FLAG_TUNNEL_OFFLOADS	= 1 << 2,
 };
 
 enum {
@@ -182,7 +183,7 @@ struct mlx5_create_qp_ex_rss {
 	__u8 reserved[6];
 	__u8 rx_hash_key[128];
 	__u32   comp_mask;
-	__u32   reserved1;
+	__u32   create_flags;
 };
 
 struct mlx5_create_qp_resp_ex {

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -646,6 +646,11 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_STRIDING_RQ;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS) {
+		attrs_out->tunnel_offloads_caps = mctx->tunnel_offloads_caps;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -293,6 +293,7 @@ struct mlx5_context {
 	struct mlx5dv_ctx_allocators	extern_alloc;
 	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps	striding_rq_caps;
+	uint32_t			tunnel_offloads_caps;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -61,7 +61,8 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_CQE_COMPRESION	= 1 << 0,
 	MLX5DV_CONTEXT_MASK_SWP			= 1 << 1,
 	MLX5DV_CONTEXT_MASK_STRIDING_RQ		= 1 << 2,
-	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 3,
+	MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS	= 1 << 3,
+	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 4,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -82,6 +83,12 @@ struct mlx5dv_striding_rq_caps {
 	uint32_t supported_qpts;
 };
 
+enum mlx5dv_tunnel_offloads {
+	MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_VXLAN	= 1 << 0,
+	MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_GRE	= 1 << 1,
+	MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_GENEVE	= 1 << 2,
+};
+
 /*
  * Direct verbs device-specific attributes
  */
@@ -92,6 +99,7 @@ struct mlx5dv_context {
 	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 	struct mlx5dv_sw_parsing_caps sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps striding_rq_caps;
+	uint32_t	tunnel_offloads_caps;
 };
 
 enum mlx5dv_context_flags {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -126,6 +126,23 @@ struct mlx5dv_cq_init_attr {
 struct ibv_cq_ex *mlx5dv_create_cq(struct ibv_context *context,
 				   struct ibv_cq_init_attr_ex *cq_attr,
 				   struct mlx5dv_cq_init_attr *mlx5_cq_attr);
+
+enum mlx5dv_qp_create_flags {
+	MLX5DV_QP_CREATE_TUNNEL_OFFLOADS = 1 << 0,
+};
+
+enum mlx5dv_qp_init_attr_mask {
+	MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS	= 1 << 0,
+};
+
+struct mlx5dv_qp_init_attr {
+	uint64_t comp_mask;	/* Use enum mlx5dv_qp_init_attr_mask */
+	uint32_t create_flags;	/* Use enum mlx5dv_qp_create_flags */
+};
+
+struct ibv_qp *mlx5dv_create_qp(struct ibv_context *context,
+				struct ibv_qp_init_attr_ex *qp_attr,
+				struct mlx5dv_qp_init_attr *mlx5_qp_attr);
 /*
  * Most device capabilities are exported by ibv_query_device(...),
  * but there is HW device-specific information which is important

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2214,6 +2214,7 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	mctx->cqe_comp_caps = resp.cqe_comp_caps;
 	mctx->sw_parsing_caps = resp.sw_parsing_caps;
 	mctx->striding_rq_caps = resp.striding_rq_caps.caps;
+	mctx->tunnel_offloads_caps = resp.tunnel_offloads_caps;
 
 	if (resp.flags & MLX5_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_CQE_128B_COMP;


### PR DESCRIPTION
This series is the supplementary part of the kernel series that was merged into 4.15.

It introduces the following support for tunneling packets:
1) RSS on the tunneled packet.
2) Tunneling offloads support for mlx5 devices via the DV API.