### PR TITLE
libhns: Add rereg mr interface in userspace

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -118,6 +118,7 @@ static struct ibv_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	context->ibv_ctx.ops.alloc_pd	   = hns_roce_u_alloc_pd;
 	context->ibv_ctx.ops.dealloc_pd    = hns_roce_u_free_pd;
 	context->ibv_ctx.ops.reg_mr	   = hns_roce_u_reg_mr;
+	context->ibv_ctx.ops.rereg_mr	   = hns_roce_u_rereg_mr;
 	context->ibv_ctx.ops.dereg_mr	   = hns_roce_u_dereg_mr;
 
 	context->ibv_ctx.ops.create_cq     = hns_roce_u_create_cq;

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -254,6 +254,8 @@ int hns_roce_u_free_pd(struct ibv_pd *pd);
 
 struct ibv_mr *hns_roce_u_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 				 int access);
+int hns_roce_u_rereg_mr(struct ibv_mr *mr, int flags, struct ibv_pd *pd,
+			void *addr, size_t length, int access);
 int hns_roce_u_dereg_mr(struct ibv_mr *mr);
 
 struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -150,6 +150,17 @@ struct ibv_mr *hns_roce_u_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	return mr;
 }
 
+int hns_roce_u_rereg_mr(struct ibv_mr *mr, int flags, struct ibv_pd *pd,
+			void *addr, size_t length, int access)
+{
+	struct ibv_rereg_mr cmd;
+	struct ibv_rereg_mr_resp resp;
+
+	return ibv_cmd_rereg_mr(mr, flags, addr, length, (uintptr_t)addr,
+				access, pd, &cmd, sizeof(cmd), &resp,
+				sizeof(resp));
+}
+
 int hns_roce_u_dereg_mr(struct ibv_mr *mr)
 {
 	int ret;


### PR DESCRIPTION
This patch adds the rereg mr verbs in userspace.

Signed-off-by: Shaobo Xu <xushaobo2@huawei.com>
Signed-off-by: Lijun Ou <oulijun@huawei.com>
Signed-off-by: Wei Hu (Xavier) <xavier.huwei@huawei.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>