### PR TITLE
libibverb/examples: Add command line option to enable buffer validation

### DIFF
--- a/libibverbs/examples/uc_pingpong.c
+++ b/libibverbs/examples/uc_pingpong.c
@@ -53,6 +53,7 @@ enum {
 };
 
 static int page_size;
+static int validate_buf;
 
 struct pingpong_context {
 	struct ibv_context	*context;
@@ -61,7 +62,7 @@ struct pingpong_context {
 	struct ibv_mr		*mr;
 	struct ibv_cq		*cq;
 	struct ibv_qp		*qp;
-	void			*buf;
+	char			*buf;
 	int			 size;
 	int			 send_flags;
 	int			 rx_depth;
@@ -524,6 +525,7 @@ static void usage(const char *argv0)
 	printf("  -l, --sl=<sl>          service level value\n");
 	printf("  -e, --events           sleep on CQ events (default poll)\n");
 	printf("  -g, --gid-idx=<gid index> local port gid index\n");
+	printf("  -c, --chk              validate received buffer\n");
 }
 
 int main(int argc, char *argv[])
@@ -566,11 +568,12 @@ int main(int argc, char *argv[])
 			{ .name = "sl",       .has_arg = 1, .val = 'l' },
 			{ .name = "events",   .has_arg = 0, .val = 'e' },
 			{ .name = "gid-idx",  .has_arg = 1, .val = 'g' },
+			{ .name = "chk",      .has_arg = 0, .val = 'c' },
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:l:eg:",
-							long_options, NULL);
+		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:l:eg:c:",
+				long_options, NULL);
 		if (c == -1)
 			break;
 
@@ -625,6 +628,10 @@ int main(int argc, char *argv[])
 
 		case 'g':
 			gidx = strtol(optarg, NULL, 0);
+			break;
+
+		case 'c':
+			validate_buf = 1;
 			break;
 
 		default:
@@ -731,6 +738,10 @@ int main(int argc, char *argv[])
 	ctx->pending = PINGPONG_RECV_WRID;
 
 	if (servername) {
+		if (validate_buf)
+			for (int i = 0; i < size; i += page_size)
+				ctx->buf[i] = i / page_size % sizeof(char);
+
 		if (pp_post_send(ctx)) {
 			fprintf(stderr, "Couldn't post send\n");
 			return 1;
@@ -840,6 +851,13 @@ int main(int argc, char *argv[])
 		       bytes, usec / 1000000., bytes * 8. / usec);
 		printf("%d iters in %.2f seconds = %.2f usec/iter\n",
 		       iters, usec / 1000000., usec / iters);
+
+		if ((!servername) && (validate_buf)) {
+			for (int i = 0; i < size; i += page_size)
+				if (ctx->buf[i] != i / page_size % sizeof(char))
+					printf("invalid data in page %d\n",
+					       i / page_size);
+		}
 	}
 
 	ibv_ack_cq_events(ctx->cq, num_cq_events);

--- a/libibverbs/man/ibv_rc_pingpong.1
+++ b/libibverbs/man/ibv_rc_pingpong.1
@@ -60,6 +60,9 @@ use on demand paging
 .TP
 \fB\-t\fR, \fB\-\-ts\fR
 get CQE with timestamp
+.TP
+\fB\-c\fR, \fB\-\-chk\fR
+validate received buffer
 
 .SH SEE ALSO
 .BR ibv_uc_pingpong (1),

--- a/libibverbs/man/ibv_srq_pingpong.1
+++ b/libibverbs/man/ibv_srq_pingpong.1
@@ -58,6 +58,9 @@ completions)
 .TP
 \fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
 local port \fIGIDINDEX\fR
+.TP
+\fB\-c\fR, \fB\-\-chk\fR
+validate received buffer
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),

--- a/libibverbs/man/ibv_uc_pingpong.1
+++ b/libibverbs/man/ibv_uc_pingpong.1
@@ -53,6 +53,9 @@ completions)
 .TP
 \fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
 local port \fIGIDINDEX\fR
+.TP
+\fB\-c\fR, \fB\-\-chk\fR
+validate received buffer
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),

--- a/libibverbs/man/ibv_ud_pingpong.1
+++ b/libibverbs/man/ibv_ud_pingpong.1
@@ -49,6 +49,9 @@ completions)
 .TP
 \fB\-g\fR, \fB\-\-gid-idx\fR=\fIGIDINDEX\fR
 local port \fIGIDINDEX\fR
+.TP
+\fB\-c\fR, \fB\-\-chk\fR
+validate received buffer
 
 .SH SEE ALSO
 .BR ibv_rc_pingpong (1),


### PR DESCRIPTION
To ease debugging of data-path issues a recv buffer validation is needed.

Signed-off-by: Yuval Shaia <yuval.shaia@oracle.com>