### PR TITLE
Add thread domain support

### DIFF
--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -405,4 +405,29 @@ static inline bool check_comp_mask(uint64_t input, uint64_t supported)
 
 int ibv_query_gid_type(struct ibv_context *context, uint8_t port_num,
 		       unsigned int index, enum ibv_gid_type *type);
+
+static inline int
+ibv_check_alloc_parent_domain(struct ibv_parent_domain_init_attr *attr)
+{
+	/* A valid protection domain must be set */
+	if (!attr->pd) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Initialize the ibv_pd which is being used as a parent_domain. From the
+ * perspective of the core code the new ibv_pd is completely interchangable
+ * with the passed contained_pd.
+ */
+static inline void ibv_initialize_parent_domain(struct ibv_pd *parent_domain,
+						struct ibv_pd *contained_pd)
+{
+	parent_domain->context = contained_pd->context;
+	parent_domain->handle = contained_pd->handle;
+}
+
 #endif /* INFINIBAND_DRIVER_H */

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,5 +1,6 @@
 rdma_man_pages(
   ibv_alloc_mw.3
+  ibv_alloc_parent_domain.3
   ibv_alloc_pd.3
   ibv_alloc_td.3
   ibv_asyncwatch.1

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,6 +1,7 @@
 rdma_man_pages(
   ibv_alloc_mw.3
   ibv_alloc_pd.3
+  ibv_alloc_td.3
   ibv_asyncwatch.1
   ibv_attach_mcast.3
   ibv_bind_mw.3
@@ -62,6 +63,7 @@ rdma_man_pages(
 rdma_alias_man_pages(
   ibv_alloc_mw.3 ibv_dealloc_mw.3
   ibv_alloc_pd.3 ibv_dealloc_pd.3
+  ibv_alloc_td.3 ibv_dealloc_td.3
   ibv_attach_mcast.3 ibv_detach_mcast.3
   ibv_create_ah.3 ibv_destroy_ah.3
   ibv_create_ah_from_wc.3 ibv_init_ah_from_wc.3

--- a/libibverbs/man/ibv_alloc_parent_domain.3
+++ b/libibverbs/man/ibv_alloc_parent_domain.3
@@ -1,0 +1,74 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH IBV_ALLOC_PARENT_DOMAIN 3 2017-11-06 libibverbs "Libibverbs Programmer's Manual"
+.SH "NAME"
+ibv_alloc_parent_domain(), ibv_dealloc_pd() \- allocate and deallocate the parent domain object
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/verbs.h>
+.sp
+.BI "struct ibv_pd *ibv_alloc_parent_domain(struct ibv_context "*context" ", struct ibv_domain_init_attr " "*attr");
+.sp
+.SH "DESCRIPTION"
+.B ibv_alloc_parent_domain()
+allocates a parent domain object for the RDMA device context
+.I context\fR.
+.sp
+The parent domain object extends the normal protection domain with additional
+objects, such as a thread domain.
+.sp
+A parent domain is completely interchangable with the
+.I
+struct ibv_pd
+used to create it, and can be used as an input argument to any function accepting a
+.I
+struct ibv_pd.
+.sp
+The behavior of each verb may be different if the verb is passed a parent
+domain
+.I
+struct ibv_pd
+that contains a
+.I
+struct ibv_td pointer\fR.
+For instance the verb my choose to share resources
+between objects using the same thread domain. The exact behavior is provider
+dependent.
+.sp
+The
+.I attr
+argument specifies the following:
+.PP
+.nf
+struct ibv_parent_domain_init_attr {
+.in +8
+struct ibv_pd *pd; /* referance to a protection domain, can't be NULL */
+struct ibv_td *td; /* referance to a thread domain, or NULL */
+uint32_t comp_mask;
+.in -8
+};
+.fi
+.PP
+.sp
+.B ibv_dealloc_pd()
+will deallocate the parent domain as its exposed as an ibv_pd
+.I pd\fR.
+All resources created with the parent domain
+should be destroyed prior to deallocating the parent domain\fR.
+.SH "RETURN VALUE"
+.B ibv_alloc_parent_domain()
+returns a pointer to the allocated struct
+.I ibv_pd
+object, or NULL if the request fails (and sets errno to indicate the failure reason).
+.sp
+.SH "SEE ALSO"
+.BR ibv_alloc_parent_domain (3),
+.BR ibv_dealloc_pd (3),
+.BR ibv_alloc_pd (3),
+.BR ibv_alloc_td (3)
+.SH "AUTHORS"
+.TP
+Alex Rosenbaum <alexr@mellanox.com>
+.TP
+Yishai Hadas <yishaih@mellanox.com>

--- a/libibverbs/man/ibv_alloc_td.3
+++ b/libibverbs/man/ibv_alloc_td.3
@@ -1,0 +1,61 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH IBV_ALLOC_TD 3 2017-11-06 libibverbs "Libibverbs Programmer's Manual"
+.SH "NAME"
+ibv_alloc_td(), ibv_dealloc_td() \- allocate and deallocate thread domain object
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/verbs.h>
+.sp
+.BI "struct ibv_td *ibv_alloc_td(struct ibv_context " "*context" ,
+.BI "                            struct ibv_td_init_attr " "*init_attr" );
+.sp
+.BI "int ibv_dealloc_td(struct ibv_td " "*td");
+.fi
+.SH "DESCRIPTION"
+.B ibv_alloc_td()
+allocates a thread domain object for the RDMA device context
+.I context\fR.
+.sp
+The thread domain object defines how the verbs libraries and provider will use
+locks and additional hardware capabilities to achieve best performance for
+handling multi-thread or single-thread protection.  An application assigns
+verbs resources to a thread domain when it creates a verbs object.
+.sp
+If the
+.I
+ibv_td
+object is specified then any objects created under this thread domain will
+disable internal locking designed to protect against concurrent access to that
+object from multiple user threads. By default all verbs objects are safe for
+multi-threaded access, whether or not a thread domain is specified.
+.sp
+A
+.I struct ibv_td
+can be added to a parent domain via
+.B ibv_alloc_parent_domain()
+and then the parent domain can be used to create verbs objects.
+.sp
+.B ibv_dealloc_td()
+will deallocate the thread domain
+.I td\fR.
+All resources created with the
+.I td
+should be destroyed prior to deallocating the
+.I td\fR.
+.SH "RETURN VALUE"
+.B ibv_alloc_td()
+returns a pointer to the allocated struct
+.I ibv_td
+object, or NULL if the request fails (and sets errno to indicate the failure reason).
+.sp
+.B ibv_dealloc_td()
+returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+.SH "SEE ALSO"
+.BR ibv_alloc_parent_domain (3),
+.SH "AUTHORS"
+.TP
+Alex Rosenbaum <alexr@mellanox.com>
+.TP
+Yishai Hadas <yishaih@mellanox.com>

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1632,6 +1632,12 @@ struct ibv_cq_init_attr_ex {
 	uint32_t		flags;
 };
 
+struct ibv_parent_domain_init_attr {
+	struct ibv_pd *pd; /* referance to a protection domain object, can't be NULL */
+	struct ibv_td *td; /* referance to a thread domain object, or NULL */
+	uint32_t comp_mask;
+};
+
 enum ibv_values_mask {
 	IBV_VALUES_MASK_RAW_CLOCK	= 1 << 0,
 	IBV_VALUES_MASK_RESERVED	= 1 << 1
@@ -1644,6 +1650,8 @@ struct ibv_values_ex {
 
 struct verbs_context {
 	/*  "grows up" - new fields go here */
+	struct ibv_pd *(*alloc_parent_domain)(struct ibv_context *context,
+					      struct ibv_parent_domain_init_attr *attr);
 	int (*dealloc_td)(struct ibv_td *td);
 	struct ibv_td *(*alloc_td)(struct ibv_context *context, struct ibv_td_init_attr *init_attr);
 	int (*modify_cq)(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
@@ -2224,6 +2232,24 @@ static inline int ibv_dealloc_td(struct ibv_td *td)
 		return ENOSYS;
 
 	return vctx->dealloc_td(td);
+}
+
+/**
+ * ibv_alloc_parent_domain - Allocate a parent domain
+ */
+static inline struct ibv_pd *
+ibv_alloc_parent_domain(struct ibv_context *context,
+			struct ibv_parent_domain_init_attr *attr)
+{
+	struct verbs_context *vctx;
+
+	vctx = verbs_get_ctx_op(context, alloc_parent_domain);
+	if (!vctx) {
+		errno = ENOSYS;
+		return NULL;
+	}
+
+	return vctx->alloc_parent_domain(context, attr);
 }
 
 /**

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -48,6 +48,7 @@ uint64_t        comp_mask; /* Use enum mlx5dv_context_comp_mask */
 struct mlx5dv_cqe_comp_caps     cqe_comp_caps;
 struct mlx5dv_sw_parsing_caps sw_parsing_caps;
 uint32_t	tunnel_offloads_caps;
+uint32_t        max_dynamic_bfregs /* max blue-flame registers that can be dynamiclly allocated */
 .in -8
 };
 
@@ -73,7 +74,8 @@ MLX5DV_CONTEXT_MASK_CQE_COMPRESION      = 1 << 0,
 MLX5DV_CONTEXT_MASK_SWP                 = 1 << 1,
 MLX5DV_CONTEXT_MASK_STRIDING_RQ         = 1 << 2,
 MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS     = 1 << 3,
-MLX5DV_CONTEXT_MASK_RESERVED            = 1 << 4,
+MLX5DV_CONTEXT_MASK_DYN_BFREGS          = 1 << 4,
+MLX5DV_CONTEXT_MASK_RESERVED            = 1 << 5,
 .in -8
 };
 

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -44,6 +44,7 @@ enum {
 	MLX5_QP_FLAG_SIGNATURE		= 1 << 0,
 	MLX5_QP_FLAG_SCATTER_CQE	= 1 << 1,
 	MLX5_QP_FLAG_TUNNEL_OFFLOADS	= 1 << 2,
+	MLX5_QP_FLAG_BFREG_INDEX	= 1 << 3,
 };
 
 enum {
@@ -203,7 +204,7 @@ struct mlx5_create_qp {
 	__u32				rq_wqe_shift;
 	__u32				flags;
 	__u32                           uidx;
-	__u32                           reserved;
+	__u32                           bfreg_index;
 	/* SQ buffer address - used for Raw Packet QP */
 	__u64                           sq_buf_addr;
 };

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -101,6 +101,8 @@ struct mlx5_alloc_ucontext_resp {
 	__u64				hca_core_clock_offset;
 	__u32				log_uar_size;
 	__u32				num_uars_per_page;
+	__u32				num_dyn_bfregs;
+	__u32				reserved3;
 };
 
 struct mlx5_create_ah_resp {

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1028,6 +1028,7 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	v_ctx->modify_cq = mlx5_modify_cq;
 	v_ctx->alloc_td = mlx5_alloc_td;
 	v_ctx->dealloc_td = mlx5_dealloc_td;
+	v_ctx->alloc_parent_domain = mlx5_alloc_parent_domain;
 
 	memset(&device_attr, 0, sizeof(device_attr));
 	if (!mlx5_query_device_ex(ctx, NULL, &device_attr,

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -651,6 +651,11 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_DYN_BFREGS) {
+		attrs_out->max_dynamic_bfregs = mctx->num_dyn_bfregs;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_DYN_BFREGS;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1026,6 +1026,8 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	v_ctx->destroy_rwq_ind_table = mlx5_destroy_rwq_ind_table;
 	v_ctx->post_srq_ops = mlx5_post_srq_ops;
 	v_ctx->modify_cq = mlx5_modify_cq;
+	v_ctx->alloc_td = mlx5_alloc_td;
+	v_ctx->dealloc_td = mlx5_dealloc_td;
 
 	memset(&device_attr, 0, sizeof(device_attr));
 	if (!mlx5_query_device_ex(ctx, NULL, &device_attr,

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1087,6 +1087,12 @@ static void mlx5_cleanup_context(struct verbs_device *device,
 	int page_size = to_mdev(ibctx->device)->page_size;
 	int i;
 
+	for (i = context->start_dyn_bfregs_index;
+	      i < context->start_dyn_bfregs_index + context->num_dyn_bfregs; i++) {
+		if (context->bfs[i].uar)
+			munmap(context->bfs[i].uar, page_size);
+	}
+
 	free(context->count_dyn_bfregs);
 	free(context->bfs);
 	for (i = 0; i < MLX5_MAX_UARS; ++i) {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -320,6 +320,12 @@ struct mlx5_buf {
 	enum mlx5_alloc_type		type;
 };
 
+struct mlx5_td {
+	struct ibv_td			ibv_td;
+	struct mlx5_bf			*bf;
+	atomic_int			refcount;
+};
+
 struct mlx5_pd {
 	struct ibv_pd			ibv_pd;
 	uint32_t			pdn;
@@ -568,6 +574,11 @@ static inline struct mlx5_srq *to_msrq(struct ibv_srq *ibsrq)
 	return container_of(vsrq, struct mlx5_srq, vsrq);
 }
 
+static inline struct mlx5_td *to_mtd(struct ibv_td *ibtd)
+{
+	return to_mxxx(td, td);
+}
+
 static inline struct mlx5_qp *to_mqp(struct ibv_qp *ibqp)
 {
 	struct verbs_qp *vqp = (struct verbs_qp *)ibqp;
@@ -752,6 +763,9 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 int mlx5_post_srq_ops(struct ibv_srq *srq,
 		      struct ibv_ops_wr *wr,
 		      struct ibv_ops_wr **bad_wr);
+
+struct ibv_td *mlx5_alloc_td(struct ibv_context *context, struct ibv_td_init_attr *init_attr);
+int mlx5_dealloc_td(struct ibv_td *td);
 
 static inline void *mlx5_find_uidx(struct mlx5_context *ctx, uint32_t uidx)
 {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -469,6 +469,10 @@ struct mlx5_bf {
 	unsigned			buf_size;
 	unsigned			uuarn;
 	off_t				uar_mmap_offset;
+	/* The virtual address of the mmaped uar, applicable for the dynamic use case */
+	void				*uar;
+	/* Index in the dynamic bfregs portion */
+	uint32_t			bfreg_dyn_index;
 };
 
 struct mlx5_mr {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -294,6 +294,10 @@ struct mlx5_context {
 	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps	striding_rq_caps;
 	uint32_t			tunnel_offloads_caps;
+	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
+	uint32_t			num_dyn_bfregs;
+	uint32_t			*count_dyn_bfregs;
+	uint32_t			start_dyn_bfregs_index;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -58,7 +58,8 @@ enum {
 
 enum {
 	MLX5_MMAP_GET_CONTIGUOUS_PAGES_CMD = 1,
-	MLX5_MMAP_GET_CORE_CLOCK_CMD    = 5
+	MLX5_MMAP_GET_CORE_CLOCK_CMD    = 5,
+	MLX5_MMAP_ALLOC_WC		= 6,
 };
 
 enum {
@@ -222,6 +223,7 @@ struct mlx5_spinlock {
 enum mlx5_uar_type {
 	MLX5_UAR_TYPE_REGULAR,
 	MLX5_UAR_TYPE_NC,
+	MLX5_UAR_TYPE_REGULAR_DYN,
 };
 
 struct mlx5_uar_info {
@@ -800,6 +802,8 @@ struct ibv_pd *mlx5_alloc_parent_domain(struct ibv_context *context,
 					struct ibv_parent_domain_init_attr *attr);
 
 
+void *mlx5_mmap(struct mlx5_uar_info *uar, int index,
+		int cmd_fd, int page_size, int uar_type);
 static inline void *mlx5_find_uidx(struct mlx5_context *ctx, uint32_t uidx)
 {
 	int tind = uidx >> MLX5_UIDX_TABLE_SHIFT;
@@ -871,6 +875,11 @@ static inline void set_order(int order, off_t *offset)
 static inline void set_index(int index, off_t *offset)
 {
 	set_arg(index, offset);
+}
+
+static inline void set_extended_index(int index, off_t *offset)
+{
+	*offset |= (index & 0xff) | ((index >> 8) << 16);
 }
 
 static inline uint8_t calc_sig(void *wqe, int size)

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -62,7 +62,8 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_SWP			= 1 << 1,
 	MLX5DV_CONTEXT_MASK_STRIDING_RQ		= 1 << 2,
 	MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS	= 1 << 3,
-	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 4,
+	MLX5DV_CONTEXT_MASK_DYN_BFREGS		= 1 << 4,
+	MLX5DV_CONTEXT_MASK_RESERVED		= 1 << 5,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -100,6 +101,7 @@ struct mlx5dv_context {
 	struct mlx5dv_sw_parsing_caps sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps striding_rq_caps;
 	uint32_t	tunnel_offloads_caps;
+	uint32_t	max_dynamic_bfregs;
 };
 
 enum mlx5dv_context_flags {


### PR DESCRIPTION
This series enables grouping verbs objects together for the purpose of optimizing the behavior of the driver in a multi-threaded environment.
The first use of this will be for mlx5 to group UAR registers in a way that avoids needing locking on the post send path.
The series follows an RFC and a detailed discussion over it in the ML, the matching kernel side was sent to rdma-next for 4.16.