### PR TITLE
Revise provider initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ set(PACKAGE_VERSION "17.0")
 # When this is changed the values in these files need changing too:
 #   debian/libibverbs1.symbols
 #   libibverbs/libibverbs.map
-set(IBVERBS_PABI_VERSION "16")
+set(IBVERBS_PABI_VERSION "17")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -1,7 +1,7 @@
 libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
- (symver)IBVERBS_PRIVATE_16 16
+ (symver)IBVERBS_PRIVATE_17 17
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -28,6 +28,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   cmd.c
   compat-1_0.c
   device.c
+  dummy_ops.c
   enum_strs.c
   init.c
   marshall.c

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -44,22 +44,22 @@
 #include "ibverbs.h"
 #include <ccan/minmax.h>
 
-int ibv_cmd_get_context(struct ibv_context *context, struct ibv_get_context *cmd,
-			size_t cmd_size, struct ibv_get_context_resp *resp,
-			size_t resp_size)
+int ibv_cmd_get_context(struct verbs_context *context_ex,
+			struct ibv_get_context *cmd, size_t cmd_size,
+			struct ibv_get_context_resp *resp, size_t resp_size)
 {
 	if (abi_ver < IB_USER_VERBS_MIN_ABI_VERSION)
 		return ENOSYS;
 
 	IBV_INIT_CMD_RESP(cmd, cmd_size, GET_CONTEXT, resp, resp_size);
 
-	if (write(context->cmd_fd, cmd, cmd_size) != cmd_size)
+	if (write(context_ex->context.cmd_fd, cmd, cmd_size) != cmd_size)
 		return errno;
 
 	(void) VALGRIND_MAKE_MEM_DEFINED(resp, resp_size);
 
-	context->async_fd         = resp->async_fd;
-	context->num_comp_vectors = resp->num_comp_vectors;
+	context_ex->context.async_fd = resp->async_fd;
+	context_ex->context.num_comp_vectors = resp->num_comp_vectors;
 
 	return 0;
 }

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -224,6 +224,8 @@ int verbs_init_context(struct verbs_context *context_ex,
 		return -1;
 	}
 
+	verbs_set_ops(context_ex, &verbs_dummy_ops);
+
 	return 0;
 }
 

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -259,29 +259,6 @@ err_free:
 	return NULL;
 }
 
-/* Use the init_context flow to create a verbs_context */
-static struct verbs_context *alloc_context(struct verbs_device *device,
-					   int cmd_fd)
-{
-	struct verbs_context *context;
-
-	context = _verbs_init_and_alloc_context(
-		&device->device, cmd_fd,
-		sizeof(*context) + device->size_of_context, NULL);
-	if (!context)
-		return NULL;
-
-	if (device->ops->init_context(device, &context->context, cmd_fd))
-		goto err_uninit;
-
-	return context;
-
-err_uninit:
-	verbs_uninit_context(context);
-	free(context);
-	return NULL;
-}
-
 LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
 		   struct ibv_context *,
 		   struct ibv_device *device)
@@ -304,15 +281,11 @@ LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
 	if (cmd_fd < 0)
 		return NULL;
 
-	if (!verbs_device->ops->init_context)
-		context_ex = verbs_device->ops->alloc_context(device, cmd_fd);
-	else
-		context_ex = alloc_context(verbs_device, cmd_fd);
-
 	/*
 	 * cmd_fd ownership is transferred into alloc_context, if it fails
 	 * then it closes cmd_fd and returns NULL
 	 */
+	context_ex = verbs_device->ops->alloc_context(device, cmd_fd);
 	if (context_ex == NULL)
 		return NULL;
 
@@ -338,15 +311,7 @@ LATEST_SYMVER_FUNC(ibv_close_device, 1_1, "IBVERBS_1.1",
 {
 	struct verbs_device *verbs_device = verbs_get_device(context->device);
 
-	if (verbs_device->ops->uninit_context) {
-		struct verbs_context *context_ex =
-			container_of(context, struct verbs_context, context);
-
-		verbs_device->ops->uninit_context(verbs_device, context);
-		verbs_uninit_context(context_ex);
-	} else {
-		verbs_device->ops->free_context(context);
-	}
+	verbs_device->ops->free_context(context);
 
 	return 0;
 }

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -162,7 +162,8 @@ static struct ibv_cq_ex *
 __lib_ibv_create_cq_ex(struct ibv_context *context,
 		       struct ibv_cq_init_attr_ex *cq_attr)
 {
-	struct verbs_context *vctx = verbs_get_ctx(context);
+	struct verbs_context *vctx =
+		container_of(context, struct verbs_context, context);
 	struct ibv_cq_ex *cq;
 
 	if (cq_attr->wc_flags & ~IBV_CREATE_CQ_SUP_WC_FLAGS) {
@@ -179,14 +180,115 @@ __lib_ibv_create_cq_ex(struct ibv_context *context,
 	return cq;
 }
 
+/*
+ * Ownership of cmd_fd is transferred into this function, and it will either
+ * be released during the matching call to verbs_uninit_contxt or during the
+ * failure path of this function.
+ */
+int verbs_init_context(struct verbs_context *context_ex,
+		       struct ibv_device *device, int cmd_fd)
+{
+	struct ibv_context *context = &context_ex->context;
+
+	ibverbs_device_hold(device);
+
+	context->device = device;
+	context->cmd_fd = cmd_fd;
+	context->async_fd = -1;
+	pthread_mutex_init(&context->mutex, NULL);
+
+	context_ex->context.abi_compat = __VERBS_ABI_IS_EXTENDED;
+	context_ex->sz = sizeof(*context_ex);
+
+	/*
+	 * In order to maintain backward/forward binary compatibility
+	 * with apps compiled against libibverbs-1.1.8 that use the
+	 * flow steering addition, we need to set the two
+	 * ABI_placeholder entries to match the driver set flow
+	 * entries.  This is because apps compiled against
+	 * libibverbs-1.1.8 use an inline ibv_create_flow and
+	 * ibv_destroy_flow function that looks in the placeholder
+	 * spots for the proper entry points.  For apps compiled
+	 * against libibverbs-1.1.9 and later, the inline functions
+	 * will be looking in the right place.
+	 */
+	context_ex->ABI_placeholder1 =
+		(void (*)(void))context_ex->ibv_create_flow;
+	context_ex->ABI_placeholder2 =
+		(void (*)(void))context_ex->ibv_destroy_flow;
+
+	context_ex->priv = calloc(1, sizeof(context_ex->priv));
+	if (!context_ex->priv) {
+		errno = ENOMEM;
+		close(cmd_fd);
+		return -1;
+	}
+
+	return 0;
+}
+
+/*
+ * Allocate and initialize a context structure. This is called to create the
+ * driver wrapper, and context_offset is the number of bytes into the wrapper
+ * structure where the verbs_context starts.
+ */
+void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,
+				    size_t alloc_size,
+				    struct verbs_context *context_offset)
+{
+	void *drv_context;
+	struct verbs_context *context;
+
+	drv_context = calloc(1, alloc_size);
+	if (!drv_context) {
+		errno = ENOMEM;
+		close(cmd_fd);
+		return NULL;
+	}
+
+	context = (struct verbs_context *)((uint8_t *)drv_context +
+					   (uintptr_t)context_offset);
+
+	if (verbs_init_context(context, device, cmd_fd))
+		goto err_free;
+
+	return drv_context;
+
+err_free:
+	free(drv_context);
+	return NULL;
+}
+
+/* Use the init_context flow to create a verbs_context */
+static struct verbs_context *alloc_context(struct verbs_device *device,
+					   int cmd_fd)
+{
+	struct verbs_context *context;
+
+	context = _verbs_init_and_alloc_context(
+		&device->device, cmd_fd,
+		sizeof(*context) + device->size_of_context, NULL);
+	if (!context)
+		return NULL;
+
+	if (device->ops->init_context(device, &context->context, cmd_fd))
+		goto err_uninit;
+
+	return context;
+
+err_uninit:
+	verbs_uninit_context(context);
+	free(context);
+	return NULL;
+}
+
 LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
 		   struct ibv_context *,
 		   struct ibv_device *device)
 {
 	struct verbs_device *verbs_device = verbs_get_device(device);
 	char *devpath;
-	int cmd_fd, ret;
-	struct ibv_context *context;
+	int cmd_fd;
 	struct verbs_context *context_ex;
 
 	if (asprintf(&devpath, "/dev/infiniband/%s", device->dev_name) < 0)
@@ -202,95 +304,49 @@ LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
 	if (cmd_fd < 0)
 		return NULL;
 
-	if (!verbs_device->ops->init_context) {
-		context = verbs_device->ops->alloc_context(device, cmd_fd);
-		if (!context)
-			goto err;
-	} else {
-		struct verbs_ex_private *priv;
+	if (!verbs_device->ops->init_context)
+		context_ex = verbs_device->ops->alloc_context(device, cmd_fd);
+	else
+		context_ex = alloc_context(verbs_device, cmd_fd);
 
-		/* Library now allocates the context */
-		context_ex = calloc(1, sizeof(*context_ex) +
-				       verbs_device->size_of_context);
-		if (!context_ex) {
-			errno = ENOMEM;
-			goto err;
-		}
+	/*
+	 * cmd_fd ownership is transferred into alloc_context, if it fails
+	 * then it closes cmd_fd and returns NULL
+	 */
+	if (context_ex == NULL)
+		return NULL;
 
-		priv = calloc(1, sizeof(*priv));
-		if (!priv) {
-			errno = ENOMEM;
-			free(context_ex);
-			goto err;
-		}
-
-		context_ex->priv = priv;
-		context_ex->context.abi_compat  = __VERBS_ABI_IS_EXTENDED;
-		context_ex->sz = sizeof(*context_ex);
-
-		context = &context_ex->context;
-		ret = verbs_device->ops->init_context(verbs_device, context, cmd_fd);
-		if (ret)
-			goto verbs_err;
-		/*
-		 * In order to maintain backward/forward binary compatibility
-		 * with apps compiled against libibverbs-1.1.8 that use the
-		 * flow steering addition, we need to set the two
-		 * ABI_placeholder entries to match the driver set flow
-		 * entries.  This is because apps compiled against
-		 * libibverbs-1.1.8 use an inline ibv_create_flow and
-		 * ibv_destroy_flow function that looks in the placeholder
-		 * spots for the proper entry points.  For apps compiled
-		 * against libibverbs-1.1.9 and later, the inline functions
-		 * will be looking in the right place.
-		 */
-		context_ex->ABI_placeholder1 = (void (*)(void)) context_ex->ibv_create_flow;
-		context_ex->ABI_placeholder2 = (void (*)(void)) context_ex->ibv_destroy_flow;
-
-		if (context_ex->create_cq_ex) {
-			priv->create_cq_ex = context_ex->create_cq_ex;
-			context_ex->create_cq_ex = __lib_ibv_create_cq_ex;
-		}
+	if (context_ex->create_cq_ex) {
+		context_ex->priv->create_cq_ex = context_ex->create_cq_ex;
+		context_ex->create_cq_ex = __lib_ibv_create_cq_ex;
 	}
 
-	context->device = device;
-	context->cmd_fd = cmd_fd;
-	pthread_mutex_init(&context->mutex, NULL);
+	return &context_ex->context;
+}
 
-	ibverbs_device_hold(device);
-
-	return context;
-
-verbs_err:
+void verbs_uninit_context(struct verbs_context *context_ex)
+{
 	free(context_ex->priv);
-	free(context_ex);
-err:
-	close(cmd_fd);
-	return NULL;
+	close(context_ex->context.cmd_fd);
+	close(context_ex->context.async_fd);
+	ibverbs_device_put(context_ex->context.device);
 }
 
 LATEST_SYMVER_FUNC(ibv_close_device, 1_1, "IBVERBS_1.1",
 		   int,
 		   struct ibv_context *context)
 {
-	int async_fd = context->async_fd;
-	int cmd_fd   = context->cmd_fd;
-	struct verbs_context *context_ex;
 	struct verbs_device *verbs_device = verbs_get_device(context->device);
-	struct ibv_device *device = context->device;
 
-	context_ex = verbs_get_ctx(context);
-	if (context_ex) {
+	if (verbs_device->ops->uninit_context) {
+		struct verbs_context *context_ex =
+			container_of(context, struct verbs_context, context);
+
 		verbs_device->ops->uninit_context(verbs_device, context);
-		free(context_ex->priv);
-		free(context_ex);
+		verbs_uninit_context(context_ex);
 	} else {
 		verbs_device->ops->free_context(context);
 	}
-
-	close(async_fd);
-	close(cmd_fd);
-	ibverbs_device_put(device);
 
 	return 0;
 }

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -359,8 +359,7 @@ LATEST_SYMVER_FUNC(ibv_get_async_event, 1_1, "IBVERBS_1.1",
 		break;
 	}
 
-	if (context->ops.async_event)
-		context->ops.async_event(event);
+	context->ops.async_event(event);
 
 	return 0;
 }

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -169,6 +169,102 @@ struct verbs_device {
 	struct verbs_sysfs_dev *sysfs;
 };
 
+/*
+ * Must change the PRIVATE IBVERBS_PRIVATE_ symbol if this is changed. This is
+ * the union of every op the driver can support. If new elements are added to
+ * this structure then verbs_dummy_ops must also be updated.
+ *
+ * Keep sorted.
+ */
+struct verbs_context_ops {
+	struct ibv_mw *(*alloc_mw)(struct ibv_pd *pd, enum ibv_mw_type type);
+	struct ibv_pd *(*alloc_pd)(struct ibv_context *context);
+	void (*async_event)(struct ibv_async_event *event);
+	int (*attach_mcast)(struct ibv_qp *qp, const union ibv_gid *gid,
+			    uint16_t lid);
+	int (*bind_mw)(struct ibv_qp *qp, struct ibv_mw *mw,
+		       struct ibv_mw_bind *mw_bind);
+	int (*close_xrcd)(struct ibv_xrcd *xrcd);
+	void (*cq_event)(struct ibv_cq *cq);
+	struct ibv_ah *(*create_ah)(struct ibv_pd *pd,
+				    struct ibv_ah_attr *attr);
+	struct ibv_cq *(*create_cq)(struct ibv_context *context, int cqe,
+				    struct ibv_comp_channel *channel,
+				    int comp_vector);
+	struct ibv_cq_ex *(*create_cq_ex)(
+		struct ibv_context *context,
+		struct ibv_cq_init_attr_ex *init_attr);
+	struct ibv_flow *(*create_flow)(struct ibv_qp *qp,
+					struct ibv_flow_attr *flow_attr);
+	struct ibv_qp *(*create_qp)(struct ibv_pd *pd,
+				    struct ibv_qp_init_attr *attr);
+	struct ibv_qp *(*create_qp_ex)(
+		struct ibv_context *context,
+		struct ibv_qp_init_attr_ex *qp_init_attr_ex);
+	struct ibv_rwq_ind_table *(*create_rwq_ind_table)(
+		struct ibv_context *context,
+		struct ibv_rwq_ind_table_init_attr *init_attr);
+	struct ibv_srq *(*create_srq)(struct ibv_pd *pd,
+				      struct ibv_srq_init_attr *srq_init_attr);
+	struct ibv_srq *(*create_srq_ex)(
+		struct ibv_context *context,
+		struct ibv_srq_init_attr_ex *srq_init_attr_ex);
+	struct ibv_wq *(*create_wq)(struct ibv_context *context,
+				    struct ibv_wq_init_attr *wq_init_attr);
+	int (*dealloc_mw)(struct ibv_mw *mw);
+	int (*dealloc_pd)(struct ibv_pd *pd);
+	int (*dereg_mr)(struct ibv_mr *mr);
+	int (*destroy_ah)(struct ibv_ah *ah);
+	int (*destroy_cq)(struct ibv_cq *cq);
+	int (*destroy_flow)(struct ibv_flow *flow);
+	int (*destroy_qp)(struct ibv_qp *qp);
+	int (*destroy_rwq_ind_table)(struct ibv_rwq_ind_table *rwq_ind_table);
+	int (*destroy_srq)(struct ibv_srq *srq);
+	int (*destroy_wq)(struct ibv_wq *wq);
+	int (*detach_mcast)(struct ibv_qp *qp, const union ibv_gid *gid,
+			    uint16_t lid);
+	int (*get_srq_num)(struct ibv_srq *srq, uint32_t *srq_num);
+	int (*modify_cq)(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
+	int (*modify_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+			 int attr_mask);
+	int (*modify_srq)(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
+			  int srq_attr_mask);
+	int (*modify_wq)(struct ibv_wq *wq, struct ibv_wq_attr *wq_attr);
+	struct ibv_qp *(*open_qp)(struct ibv_context *context,
+				  struct ibv_qp_open_attr *attr);
+	struct ibv_xrcd *(*open_xrcd)(
+		struct ibv_context *context,
+		struct ibv_xrcd_init_attr *xrcd_init_attr);
+	int (*poll_cq)(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc);
+	int (*post_recv)(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+			 struct ibv_recv_wr **bad_wr);
+	int (*post_send)(struct ibv_qp *qp, struct ibv_send_wr *wr,
+			 struct ibv_send_wr **bad_wr);
+	int (*post_srq_ops)(struct ibv_srq *srq, struct ibv_ops_wr *op,
+			    struct ibv_ops_wr **bad_op);
+	int (*post_srq_recv)(struct ibv_srq *srq, struct ibv_recv_wr *recv_wr,
+			     struct ibv_recv_wr **bad_recv_wr);
+	int (*query_device)(struct ibv_context *context,
+			    struct ibv_device_attr *device_attr);
+	int (*query_device_ex)(struct ibv_context *context,
+			       const struct ibv_query_device_ex_input *input,
+			       struct ibv_device_attr_ex *attr,
+			       size_t attr_size);
+	int (*query_port)(struct ibv_context *context, uint8_t port_num,
+			  struct ibv_port_attr *port_attr);
+	int (*query_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr,
+			int attr_mask, struct ibv_qp_init_attr *init_attr);
+	int (*query_rt_values)(struct ibv_context *context,
+			       struct ibv_values_ex *values);
+	int (*query_srq)(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr);
+	struct ibv_mr *(*reg_mr)(struct ibv_pd *pd, void *addr, size_t length,
+				 int access);
+	int (*req_notify_cq)(struct ibv_cq *cq, int solicited_only);
+	int (*rereg_mr)(struct ibv_mr *mr, int flags, struct ibv_pd *pd,
+			void *addr, size_t length, int access);
+	int (*resize_cq)(struct ibv_cq *cq, int cqe);
+};
+
 static inline struct verbs_device *
 verbs_get_device(const struct ibv_device *dev)
 {
@@ -208,6 +304,8 @@ void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,
 int verbs_init_context(struct verbs_context *context_ex,
 		       struct ibv_device *device, int cmd_fd);
 void verbs_uninit_context(struct verbs_context *context);
+void verbs_set_ops(struct verbs_context *vctx,
+		   const struct verbs_context_ops *ops);
 
 void verbs_init_cq(struct ibv_cq *cq, struct ibv_context *context,
 		       struct ibv_comp_channel *channel,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -152,16 +152,9 @@ struct verbs_device_ops {
 
 	bool (*match_device)(struct verbs_sysfs_dev *sysfs_dev);
 
-	/* Old interface, do not use in new code. */
 	struct verbs_context *(*alloc_context)(struct ibv_device *device,
 					       int cmd_fd);
 	void (*free_context)(struct ibv_context *context);
-
-	/* New interface */
-	int (*init_context)(struct verbs_device *device,
-			    struct ibv_context *ctx, int cmd_fd);
-	void (*uninit_context)(struct verbs_device *device,
-			       struct ibv_context *ctx);
 
 	struct verbs_device *(*alloc_device)(struct verbs_sysfs_dev *sysfs_dev);
 	void (*uninit_device)(struct verbs_device *device);
@@ -171,8 +164,6 @@ struct verbs_device_ops {
 struct verbs_device {
 	struct ibv_device device; /* Must be first */
 	const struct verbs_device_ops *ops;
-	size_t	sz;
-	size_t	size_of_context;
 	atomic_int refcount;
 	struct list_node entry;
 	struct verbs_sysfs_dev *sysfs;

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -1,0 +1,469 @@
+/*
+ * Copyright (c) 2017 Mellanox Technologies, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#include <infiniband/driver.h>
+#include "ibverbs.h"
+#include <errno.h>
+
+static struct ibv_mw *alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_pd *alloc_pd(struct ibv_context *context)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static void async_event(struct ibv_async_event *event)
+{
+}
+
+static int attach_mcast(struct ibv_qp *qp, const union ibv_gid *gid,
+			uint16_t lid)
+{
+	return ENOSYS;
+}
+
+static int bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
+		   struct ibv_mw_bind *mw_bind)
+{
+	return ENOSYS;
+}
+
+static int close_xrcd(struct ibv_xrcd *xrcd)
+{
+	return ENOSYS;
+}
+
+static void cq_event(struct ibv_cq *cq)
+{
+}
+
+static struct ibv_ah *create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_cq *create_cq(struct ibv_context *context, int cqe,
+				struct ibv_comp_channel *channel,
+				int comp_vector)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_cq_ex *create_cq_ex(struct ibv_context *context,
+				      struct ibv_cq_init_attr_ex *init_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_flow *create_flow(struct ibv_qp *qp,
+				    struct ibv_flow_attr *flow_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_qp *create_qp(struct ibv_pd *pd,
+				struct ibv_qp_init_attr *attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_qp *create_qp_ex(struct ibv_context *context,
+				   struct ibv_qp_init_attr_ex *qp_init_attr_ex)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_rwq_ind_table *
+create_rwq_ind_table(struct ibv_context *context,
+		     struct ibv_rwq_ind_table_init_attr *init_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_srq *create_srq(struct ibv_pd *pd,
+				  struct ibv_srq_init_attr *srq_init_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_srq *
+create_srq_ex(struct ibv_context *context,
+	      struct ibv_srq_init_attr_ex *srq_init_attr_ex)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_wq *create_wq(struct ibv_context *context,
+				struct ibv_wq_init_attr *wq_init_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static int dealloc_mw(struct ibv_mw *mw)
+{
+	return ENOSYS;
+}
+
+static int dealloc_pd(struct ibv_pd *pd)
+{
+	return ENOSYS;
+}
+
+static int dereg_mr(struct ibv_mr *mr)
+{
+	return ENOSYS;
+}
+
+static int destroy_ah(struct ibv_ah *ah)
+{
+	return ENOSYS;
+}
+
+static int destroy_cq(struct ibv_cq *cq)
+{
+	return ENOSYS;
+}
+
+static int destroy_flow(struct ibv_flow *flow)
+{
+	return ENOSYS;
+}
+
+static int destroy_qp(struct ibv_qp *qp)
+{
+	return ENOSYS;
+}
+
+static int destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
+{
+	return ENOSYS;
+}
+
+static int destroy_srq(struct ibv_srq *srq)
+{
+	return ENOSYS;
+}
+
+static int destroy_wq(struct ibv_wq *wq)
+{
+	return ENOSYS;
+}
+
+static int detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid,
+			uint16_t lid)
+{
+	return ENOSYS;
+}
+
+static int get_srq_num(struct ibv_srq *srq, uint32_t *srq_num)
+{
+	return ENOSYS;
+}
+
+static int modify_cq(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr)
+{
+	return ENOSYS;
+}
+
+static int modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask)
+{
+	return ENOSYS;
+}
+
+static int modify_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
+		      int srq_attr_mask)
+{
+	return ENOSYS;
+}
+
+static int modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *wq_attr)
+{
+	return ENOSYS;
+}
+
+static struct ibv_qp *open_qp(struct ibv_context *context,
+			      struct ibv_qp_open_attr *attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static struct ibv_xrcd *open_xrcd(struct ibv_context *context,
+				  struct ibv_xrcd_init_attr *xrcd_init_attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static int poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc *wc)
+{
+	return ENOSYS;
+}
+
+static int post_recv(struct ibv_qp *qp, struct ibv_recv_wr *wr,
+		     struct ibv_recv_wr **bad_wr)
+{
+	return ENOSYS;
+}
+
+static int post_send(struct ibv_qp *qp, struct ibv_send_wr *wr,
+		     struct ibv_send_wr **bad_wr)
+{
+	return ENOSYS;
+}
+
+static int post_srq_ops(struct ibv_srq *srq, struct ibv_ops_wr *op,
+			struct ibv_ops_wr **bad_op)
+{
+	return ENOSYS;
+}
+
+static int post_srq_recv(struct ibv_srq *srq, struct ibv_recv_wr *recv_wr,
+			 struct ibv_recv_wr **bad_recv_wr)
+{
+	return ENOSYS;
+}
+
+static int query_device(struct ibv_context *context,
+			struct ibv_device_attr *device_attr)
+{
+	return ENOSYS;
+}
+
+static int query_device_ex(struct ibv_context *context,
+			   const struct ibv_query_device_ex_input *input,
+			   struct ibv_device_attr_ex *attr, size_t attr_size)
+{
+	return ENOSYS;
+}
+
+static int query_port(struct ibv_context *context, uint8_t port_num,
+		      struct ibv_port_attr *port_attr)
+{
+	return ENOSYS;
+}
+
+static int query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask,
+		    struct ibv_qp_init_attr *init_attr)
+{
+	return ENOSYS;
+}
+
+static int query_rt_values(struct ibv_context *context,
+			   struct ibv_values_ex *values)
+{
+	return ENOSYS;
+}
+
+static int query_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr)
+{
+	return ENOSYS;
+}
+
+static struct ibv_mr *reg_mr(struct ibv_pd *pd, void *addr, size_t length,
+			     int access)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
+static int req_notify_cq(struct ibv_cq *cq, int solicited_only)
+{
+	return ENOSYS;
+}
+
+static int rereg_mr(struct ibv_mr *mr, int flags, struct ibv_pd *pd, void *addr,
+		    size_t length, int access)
+{
+	errno = ENOSYS;
+	return IBV_REREG_MR_ERR_INPUT;
+}
+
+static int resize_cq(struct ibv_cq *cq, int cqe)
+{
+	return ENOSYS;
+}
+
+/*
+ * Ops in verbs_dummy_ops simply return an ENOSYS error code when called, or
+ * do nothing. They are placed in the ops structures if the provider does not
+ * provide an op for the function.
+ *
+ * NOTE: This deliberately does not use named initializers to trigger a
+ * '-Wmissing-field-initializers' warning if the struct is changed without
+ * changing this.
+ *
+ * Keep sorted.
+ */
+const struct verbs_context_ops verbs_dummy_ops = {
+	alloc_mw,
+	alloc_pd,
+	async_event,
+	attach_mcast,
+	bind_mw,
+	close_xrcd,
+	cq_event,
+	create_ah,
+	create_cq,
+	create_cq_ex,
+	create_flow,
+	create_qp,
+	create_qp_ex,
+	create_rwq_ind_table,
+	create_srq,
+	create_srq_ex,
+	create_wq,
+	dealloc_mw,
+	dealloc_pd,
+	dereg_mr,
+	destroy_ah,
+	destroy_cq,
+	destroy_flow,
+	destroy_qp,
+	destroy_rwq_ind_table,
+	destroy_srq,
+	destroy_wq,
+	detach_mcast,
+	get_srq_num,
+	modify_cq,
+	modify_qp,
+	modify_srq,
+	modify_wq,
+	open_qp,
+	open_xrcd,
+	poll_cq,
+	post_recv,
+	post_send,
+	post_srq_ops,
+	post_srq_recv,
+	query_device,
+	query_device_ex,
+	query_port,
+	query_qp,
+	query_rt_values,
+	query_srq,
+	reg_mr,
+	req_notify_cq,
+	rereg_mr,
+	resize_cq,
+};
+
+/*
+ * Set the ops in a context. If the function pointer in op is NULL then it is
+ * not set. This allows the providers to call the function multiple times in
+ * order to have variations of the ops for different HW configurations.
+ */
+void verbs_set_ops(struct verbs_context *vctx,
+		   const struct verbs_context_ops *ops)
+{
+	struct ibv_context_ops *ctx = &vctx->context.ops;
+
+#define SET_OP(ptr, name)                                                      \
+	do {                                                                   \
+		if (ops->name)                                                 \
+			(ptr)->name = ops->name;                               \
+	} while (0)
+
+#define SET_OP2(ptr, iname, name)                                              \
+	do {                                                                   \
+		if (ops->name)                                                 \
+			(ptr)->iname = ops->name;                              \
+	} while (0)
+
+	SET_OP(ctx, alloc_mw);
+	SET_OP(ctx, alloc_pd);
+	SET_OP(ctx, async_event);
+	SET_OP(ctx, attach_mcast);
+	SET_OP(ctx, bind_mw);
+	SET_OP(vctx, close_xrcd);
+	SET_OP(ctx, cq_event);
+	SET_OP(ctx, create_ah);
+	SET_OP(ctx, create_cq);
+	SET_OP(vctx, create_cq_ex);
+	SET_OP2(vctx, ibv_create_flow, create_flow);
+	SET_OP(ctx, create_qp);
+	SET_OP(vctx, create_qp_ex);
+	SET_OP(vctx, create_rwq_ind_table);
+	SET_OP(ctx, create_srq);
+	SET_OP(vctx, create_srq_ex);
+	SET_OP(vctx, create_wq);
+	SET_OP(ctx, dealloc_mw);
+	SET_OP(ctx, dealloc_pd);
+	SET_OP(ctx, dereg_mr);
+	SET_OP(ctx, destroy_ah);
+	SET_OP(ctx, destroy_cq);
+	SET_OP2(vctx, ibv_destroy_flow, destroy_flow);
+	SET_OP(ctx, destroy_qp);
+	SET_OP(vctx, destroy_rwq_ind_table);
+	SET_OP(ctx, destroy_srq);
+	SET_OP(vctx, destroy_wq);
+	SET_OP(ctx, detach_mcast);
+	SET_OP(vctx, get_srq_num);
+	SET_OP(vctx, modify_cq);
+	SET_OP(ctx, modify_qp);
+	SET_OP(ctx, modify_srq);
+	SET_OP(vctx, modify_wq);
+	SET_OP(vctx, open_qp);
+	SET_OP(vctx, open_xrcd);
+	SET_OP(ctx, poll_cq);
+	SET_OP(ctx, post_recv);
+	SET_OP(ctx, post_send);
+	SET_OP(vctx, post_srq_ops);
+	SET_OP(ctx, post_srq_recv);
+	SET_OP(ctx, query_device);
+	SET_OP(vctx, query_device_ex);
+	SET_OP(ctx, query_port);
+	SET_OP(ctx, query_qp);
+	SET_OP(vctx, query_rt_values);
+	SET_OP(ctx, query_srq);
+	SET_OP(ctx, reg_mr);
+	SET_OP(ctx, req_notify_cq);
+	SET_OP(ctx, rereg_mr);
+	SET_OP(ctx, resize_cq);
+
+#undef SET_OP
+#undef SET_OP2
+}

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -50,6 +50,7 @@ struct ibv_abi_compat_v2 {
 };
 
 extern int abi_ver;
+extern const struct verbs_context_ops verbs_dummy_ops;
 
 int ibverbs_get_device_list(struct list_head *list);
 int ibverbs_init(void);

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -113,6 +113,7 @@ IBVERBS_1.1 {
 IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 	global:
 		/* These historical symbols are now private to libibverbs */
+		_verbs_init_and_alloc_context;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;
 		ibv_cmd_attach_mcast;
@@ -162,6 +163,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_query_gid_type;
 		ibv_register_driver;
 		verbs_register_driver_@IBVERBS_PABI_VERSION@;
+		verbs_uninit_context;
 		verbs_init_cq;
 		ibv_cmd_modify_cq;
 };

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -163,6 +163,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_query_gid_type;
 		ibv_register_driver;
 		verbs_register_driver_@IBVERBS_PABI_VERSION@;
+		verbs_set_ops;
 		verbs_uninit_context;
 		verbs_init_cq;
 		ibv_cmd_modify_cq;

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -269,11 +269,6 @@ LATEST_SYMVER_FUNC(ibv_rereg_mr, 1_1, "IBVERBS_1.1",
 		return IBV_REREG_MR_ERR_INPUT;
 	}
 
-	if (!mr->context->ops.rereg_mr) {
-		errno = ENOSYS;
-		return IBV_REREG_MR_ERR_INPUT;
-	}
-
 	if (flags & IBV_REREG_MR_CHANGE_TRANSLATION) {
 		err = ibv_dontfork_range(addr, length);
 		if (err)
@@ -420,9 +415,6 @@ LATEST_SYMVER_FUNC(ibv_resize_cq, 1_1, "IBVERBS_1.1",
 		   int,
 		   struct ibv_cq *cq, int cqe)
 {
-	if (!cq->context->ops.resize_cq)
-		return ENOSYS;
-
 	return cq->context->ops.resize_cq(cq, cqe);
 }
 
@@ -459,8 +451,7 @@ LATEST_SYMVER_FUNC(ibv_get_cq_event, 1_1, "IBVERBS_1.1",
 	*cq         = (struct ibv_cq *) (uintptr_t) ev.cq_handle;
 	*cq_context = (*cq)->cq_context;
 
-	if ((*cq)->context->ops.cq_event)
-		(*cq)->context->ops.cq_event(*cq);
+	(*cq)->context->ops.cq_event(*cq);
 
 	return 0;
 }
@@ -481,9 +472,6 @@ LATEST_SYMVER_FUNC(ibv_create_srq, 1_1, "IBVERBS_1.1",
 		   struct ibv_srq_init_attr *srq_init_attr)
 {
 	struct ibv_srq *srq;
-
-	if (!pd->context->ops.create_srq)
-		return NULL;
 
 	srq = pd->context->ops.create_srq(pd, srq_init_attr);
 	if (srq) {

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -75,7 +75,7 @@ static const struct verbs_match_ent cna_table[] = {
 	{}
 };
 
-static struct ibv_context_ops bnxt_re_cntx_ops = {
+static const struct verbs_context_ops bnxt_re_cntx_ops = {
 	.query_device  = bnxt_re_query_device,
 	.query_port    = bnxt_re_query_port,
 	.alloc_pd      = bnxt_re_alloc_pd,
@@ -136,7 +136,7 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 	}
 	pthread_mutex_init(&cntx->shlock, NULL);
 
-	cntx->ibvctx.context.ops = bnxt_re_cntx_ops;
+	verbs_set_ops(&cntx->ibvctx, &bnxt_re_cntx_ops);
 
 	return &cntx->ibvctx;
 

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -111,14 +111,15 @@ static int bnxt_re_init_context(struct verbs_device *vdev,
 	struct bnxt_re_cntx_resp resp;
 	struct bnxt_re_dev *dev;
 	struct bnxt_re_context *cntx;
+	struct verbs_context *verbs_ctx = verbs_get_ctx(ibvctx);
 
 	dev = to_bnxt_re_dev(&vdev->device);
 	cntx = to_bnxt_re_context(ibvctx);
 
 	memset(&resp, 0, sizeof(resp));
 	ibvctx->cmd_fd = cmd_fd;
-	if (ibv_cmd_get_context(ibvctx, &cmd, sizeof(cmd),
-				&resp.resp, sizeof(resp)))
+	if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd), &resp.resp,
+				sizeof(resp)))
 		return errno;
 
 	cntx->dev_id = resp.dev_id;

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -179,10 +179,6 @@ bnxt_re_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 	if (!dev)
 		return NULL;
 
-	dev->vdev.sz = sizeof(*dev);
-	dev->vdev.size_of_context =
-		sizeof(struct bnxt_re_context) - sizeof(struct ibv_context);
-
 	return &dev->vdev;
 }
 

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -141,7 +141,7 @@ struct bnxt_re_dev {
 };
 
 struct bnxt_re_context {
-	struct ibv_context ibvctx;
+	struct verbs_context ibvctx;
 	uint32_t dev_id;
 	uint32_t max_qp;
 	uint32_t max_srq;
@@ -167,7 +167,7 @@ static inline struct bnxt_re_dev *to_bnxt_re_dev(struct ibv_device *ibvdev)
 static inline struct bnxt_re_context *to_bnxt_re_context(
 		struct ibv_context *ibvctx)
 {
-	return container_of(ibvctx, struct bnxt_re_context, ibvctx);
+	return container_of(ibvctx, struct bnxt_re_context, ibvctx.context);
 }
 
 static inline struct bnxt_re_pd *to_bnxt_re_pd(struct ibv_pd *ibvpd)

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -730,7 +730,7 @@ static int bnxt_re_check_qp_limits(struct bnxt_re_context *cntx,
 	struct ibv_device_attr devattr;
 	int ret;
 
-	ret = bnxt_re_query_device(&cntx->ibvctx, &devattr);
+	ret = bnxt_re_query_device(&cntx->ibvctx.context, &devattr);
 	if (ret)
 		return ret;
 	if (attr->cap.max_send_sge > devattr.max_sge)
@@ -865,7 +865,7 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 	struct bnxt_re_qpcap *cap;
 
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvpd->context);
-	struct bnxt_re_dev *dev = to_bnxt_re_dev(cntx->ibvctx.device);
+	struct bnxt_re_dev *dev = to_bnxt_re_dev(cntx->ibvctx.context.device);
 
 	if (bnxt_re_check_qp_limits(cntx, attr))
 		return NULL;

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -75,7 +75,7 @@ static const struct verbs_match_ent hca_table[] = {
 	{},
 };
 
-static struct ibv_context_ops iwch_ctx_ops = {
+static const struct verbs_context_ops iwch_ctx_common_ops = {
 	.query_device = iwch_query_device,
 	.query_port = iwch_query_port,
 	.alloc_pd = iwch_alloc_pd,
@@ -100,6 +100,19 @@ static struct ibv_context_ops iwch_ctx_ops = {
 	.req_notify_cq = iwch_arm_cq,
 };
 
+static const struct verbs_context_ops iwch_ctx_t3a_ops = {
+	.poll_cq = t3a_poll_cq,
+	.post_recv = t3a_post_recv,
+	.post_send = t3a_post_send,
+};
+
+static const struct verbs_context_ops iwch_ctx_t3b_ops = {
+	.async_event = t3b_async_event,
+	.poll_cq = t3b_poll_cq,
+	.post_recv = t3b_post_recv,
+	.post_send = t3b_post_send,
+};
+
 unsigned long iwch_page_size;
 unsigned long iwch_page_shift;
 unsigned long iwch_page_mask;
@@ -120,22 +133,16 @@ static struct verbs_context *iwch_alloc_context(struct ibv_device *ibdev,
 				&resp.ibv_resp, sizeof resp))
 		goto err_free;
 
-	context->ibv_ctx.context.ops = iwch_ctx_ops;
+	verbs_set_ops(&context->ibv_ctx, &iwch_ctx_common_ops);
 
 	switch (rhp->hca_type) {
 	case CHELSIO_T3B:
 		PDBG("%s T3B device\n", __FUNCTION__);
-		context->ibv_ctx.context.ops.async_event = t3b_async_event;
-		context->ibv_ctx.context.ops.post_send = t3b_post_send;
-		context->ibv_ctx.context.ops.post_recv = t3b_post_recv;
-		context->ibv_ctx.context.ops.poll_cq = t3b_poll_cq;
+		verbs_set_ops(&context->ibv_ctx, &iwch_ctx_t3b_ops);
 		break;
 	case CHELSIO_T3A:
 		PDBG("%s T3A device\n", __FUNCTION__);
-		context->ibv_ctx.context.ops.async_event = NULL;
-		context->ibv_ctx.context.ops.post_send = t3a_post_send;
-		context->ibv_ctx.context.ops.post_recv = t3a_post_recv;
-		context->ibv_ctx.context.ops.poll_cq = t3a_poll_cq;
+		verbs_set_ops(&context->ibv_ctx, &iwch_ctx_t3a_ops);
 		break;
 	default:
 		PDBG("%s unknown hca type %d\n", __FUNCTION__, rhp->hca_type);

--- a/providers/cxgb3/iwch.h
+++ b/providers/cxgb3/iwch.h
@@ -71,7 +71,7 @@ static inline int t3a_device(struct iwch_device *dev)
 }
 
 struct iwch_context {
-	struct ibv_context ibv_ctx;
+	struct verbs_context ibv_ctx;
 };
 
 struct iwch_pd {
@@ -111,7 +111,7 @@ static inline struct iwch_device *to_iwch_dev(struct ibv_device *ibdev)
 
 static inline struct iwch_context *to_iwch_ctx(struct ibv_context *ibctx)
 {
-	return to_iwch_xxx(ctx, context);
+	return container_of(ibctx, struct iwch_context, ibv_ctx.context);
 }
 
 static inline struct iwch_pd *to_iwch_pd(struct ibv_pd *ibpd)

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -96,8 +96,8 @@ static struct ibv_context_ops c4iw_ctx_ops = {
 	.req_notify_cq = c4iw_arm_cq,
 };
 
-static struct ibv_context *c4iw_alloc_context(struct ibv_device *ibdev,
-					      int cmd_fd)
+static struct verbs_context *c4iw_alloc_context(struct ibv_device *ibdev,
+						int cmd_fd)
 {
 	struct c4iw_context *context;
 	struct ibv_get_context cmd;
@@ -107,12 +107,9 @@ static struct ibv_context *c4iw_alloc_context(struct ibv_device *ibdev,
 	uint64_t raw_fw_ver;
 	struct ibv_device_attr attr;
 
-	context = malloc(sizeof *context);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
 	if (!context)
 		return NULL;
-
-	memset(context, 0, sizeof *context);
-	context->ibv_ctx.cmd_fd = cmd_fd;
 
 	resp.status_page_size = 0;
 	resp.reserved = 0;
@@ -133,8 +130,7 @@ static struct ibv_context *c4iw_alloc_context(struct ibv_device *ibdev,
 			goto err_free;
 	} 
 
-	context->ibv_ctx.device = ibdev;
-	context->ibv_ctx.ops = c4iw_ctx_ops;
+	context->ibv_ctx.context.ops = c4iw_ctx_ops;
 
 	switch (rhp->chip_version) {
 	case CHELSIO_T6:
@@ -143,11 +139,11 @@ static struct ibv_context *c4iw_alloc_context(struct ibv_device *ibdev,
 		PDBG("%s T5/T4 device\n", __FUNCTION__);
 	case CHELSIO_T4:
 		PDBG("%s T4 device\n", __FUNCTION__);
-		context->ibv_ctx.ops.async_event = c4iw_async_event;
-		context->ibv_ctx.ops.post_send = c4iw_post_send;
-		context->ibv_ctx.ops.post_recv = c4iw_post_receive;
-		context->ibv_ctx.ops.poll_cq = c4iw_poll_cq;
-		context->ibv_ctx.ops.req_notify_cq = c4iw_arm_cq;
+		context->ibv_ctx.context.ops.async_event = c4iw_async_event;
+		context->ibv_ctx.context.ops.post_send = c4iw_post_send;
+		context->ibv_ctx.context.ops.post_recv = c4iw_post_receive;
+		context->ibv_ctx.context.ops.poll_cq = c4iw_poll_cq;
+		context->ibv_ctx.context.ops.req_notify_cq = c4iw_arm_cq;
 		break;
 	default:
 		PDBG("%s unknown hca type %d\n", __FUNCTION__,
@@ -159,8 +155,8 @@ static struct ibv_context *c4iw_alloc_context(struct ibv_device *ibdev,
 	if (!rhp->mmid2ptr) {
 		int ret;
 
-		ret = ibv_cmd_query_device(&context->ibv_ctx, &attr, &raw_fw_ver, &qcmd,
-					   sizeof qcmd);
+		ret = ibv_cmd_query_device(&context->ibv_ctx.context, &attr,
+					   &raw_fw_ver, &qcmd, sizeof(qcmd));
 		if (ret)
 			goto err_unmap;
 		rhp->max_mr = attr.max_mr;
@@ -201,6 +197,7 @@ err_free:
 		free(rhp->cqid2ptr);
 	if (rhp->mmid2ptr)
 		free(rhp->cqid2ptr);
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 	return NULL;
 }
@@ -211,6 +208,8 @@ static void c4iw_free_context(struct ibv_context *ibctx)
 
 	if (context->status_page_size)
 		munmap(context->status_page, context->status_page_size);
+
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 }
 

--- a/providers/cxgb4/libcxgb4.h
+++ b/providers/cxgb4/libcxgb4.h
@@ -80,7 +80,7 @@ static inline int dev_is_t4(struct c4iw_dev *dev)
 }
 
 struct c4iw_context {
-	struct ibv_context ibv_ctx;
+	struct verbs_context ibv_ctx;
 	struct t4_dev_status_page *status_page;
 	int status_page_size;
 };
@@ -129,7 +129,7 @@ static inline struct c4iw_dev *to_c4iw_dev(struct ibv_device *ibdev)
 
 static inline struct c4iw_context *to_c4iw_context(struct ibv_context *ibctx)
 {
-	return to_c4iw_xxx(ctx, context);
+	return container_of(ibctx, struct c4iw_context, ibv_ctx.context);
 }
 
 static inline struct c4iw_pd *to_c4iw_pd(struct ibv_pd *ibpd)

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -123,41 +123,42 @@ static struct ibv_context_ops hfi1_ctx_ops = {
 	.detach_mcast	= ibv_cmd_detach_mcast
 };
 
-static struct ibv_context *hfi1_alloc_context(struct ibv_device *ibdev,
-					       int cmd_fd)
+static struct verbs_context *hfi1_alloc_context(struct ibv_device *ibdev,
+						int cmd_fd)
 {
 	struct hfi1_context	    *context;
 	struct ibv_get_context       cmd;
 	struct ibv_get_context_resp  resp;
 	struct hfi1_device         *dev;
 
-	context = malloc(sizeof *context);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
 	if (!context)
 		return NULL;
-	memset(context, 0, sizeof *context);
-	context->ibv_ctx.cmd_fd = cmd_fd;
+
 	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd,
 				sizeof cmd, &resp, sizeof resp))
 		goto err_free;
 
-	context->ibv_ctx.ops = hfi1_ctx_ops;
+	context->ibv_ctx.context.ops = hfi1_ctx_ops;
 	dev = to_idev(ibdev);
 	if (dev->abi_version == 1) {
-		context->ibv_ctx.ops.create_cq     = hfi1_create_cq_v1;
-		context->ibv_ctx.ops.poll_cq       = ibv_cmd_poll_cq;
-		context->ibv_ctx.ops.resize_cq     = hfi1_resize_cq_v1;
-		context->ibv_ctx.ops.destroy_cq    = hfi1_destroy_cq_v1;
-		context->ibv_ctx.ops.create_srq    = hfi1_create_srq_v1;
-		context->ibv_ctx.ops.destroy_srq   = hfi1_destroy_srq_v1;
-		context->ibv_ctx.ops.modify_srq    = hfi1_modify_srq_v1;
-		context->ibv_ctx.ops.post_srq_recv = ibv_cmd_post_srq_recv;
-		context->ibv_ctx.ops.create_qp     = hfi1_create_qp_v1;
-		context->ibv_ctx.ops.destroy_qp    = hfi1_destroy_qp_v1;
-		context->ibv_ctx.ops.post_recv     = ibv_cmd_post_recv;
+		context->ibv_ctx.context.ops.create_cq = hfi1_create_cq_v1;
+		context->ibv_ctx.context.ops.poll_cq = ibv_cmd_poll_cq;
+		context->ibv_ctx.context.ops.resize_cq = hfi1_resize_cq_v1;
+		context->ibv_ctx.context.ops.destroy_cq = hfi1_destroy_cq_v1;
+		context->ibv_ctx.context.ops.create_srq = hfi1_create_srq_v1;
+		context->ibv_ctx.context.ops.destroy_srq = hfi1_destroy_srq_v1;
+		context->ibv_ctx.context.ops.modify_srq = hfi1_modify_srq_v1;
+		context->ibv_ctx.context.ops.post_srq_recv =
+			ibv_cmd_post_srq_recv;
+		context->ibv_ctx.context.ops.create_qp = hfi1_create_qp_v1;
+		context->ibv_ctx.context.ops.destroy_qp = hfi1_destroy_qp_v1;
+		context->ibv_ctx.context.ops.post_recv = ibv_cmd_post_recv;
 	}
 	return &context->ibv_ctx;
 
 err_free:
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 	return NULL;
 }
@@ -166,6 +167,7 @@ static void hfi1_free_context(struct ibv_context *ibctx)
 {
 	struct hfi1_context *context = to_ictx(ibctx);
 
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 }
 

--- a/providers/hfi1verbs/hfiverbs.h
+++ b/providers/hfi1verbs/hfiverbs.h
@@ -74,7 +74,7 @@ struct hfi1_device {
 };
 
 struct hfi1_context {
-	struct ibv_context	ibv_ctx;
+	struct verbs_context	ibv_ctx;
 };
 
 /*
@@ -158,7 +158,7 @@ struct hfi1_srq {
 
 static inline struct hfi1_context *to_ictx(struct ibv_context *ibctx)
 {
-	return to_ixxx(ctx, context);
+	return container_of(ibctx, struct hfi1_context, ibv_ctx.context);
 }
 
 static inline struct hfi1_device *to_idev(struct ibv_device *ibdev)

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -94,7 +94,7 @@ struct hns_roce_buf {
 };
 
 struct hns_roce_context {
-	struct ibv_context		ibv_ctx;
+	struct verbs_context		ibv_ctx;
 	void				*uar;
 	pthread_spinlock_t		uar_lock;
 
@@ -221,7 +221,7 @@ static inline struct hns_roce_device *to_hr_dev(struct ibv_device *ibv_dev)
 
 static inline struct hns_roce_context *to_hr_ctx(struct ibv_context *ibv_ctx)
 {
-	return container_of(ibv_ctx, struct hns_roce_context, ibv_ctx);
+	return container_of(ibv_ctx, struct hns_roce_context, ibv_ctx.context);
 }
 
 static inline struct hns_roce_pd *to_hr_pd(struct ibv_pd *ibv_pd)

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -208,7 +208,8 @@ static void hns_roce_set_sq_sizes(struct hns_roce_qp *qp,
 
 static int hns_roce_verify_cq(int *cqe, struct hns_roce_context *context)
 {
-	struct hns_roce_device *hr_dev = to_hr_dev(context->ibv_ctx.device);
+	struct hns_roce_device *hr_dev =
+		to_hr_dev(context->ibv_ctx.context.device);
 
 	if (hr_dev->hw_version == HNS_ROCE_HW_VER1)
 		if (*cqe < HNS_ROCE_MIN_CQE_NUM) {
@@ -328,7 +329,8 @@ int hns_roce_u_destroy_cq(struct ibv_cq *cq)
 static int hns_roce_verify_qp(struct ibv_qp_init_attr *attr,
 			      struct hns_roce_context *context)
 {
-	struct hns_roce_device *hr_dev = to_hr_dev(context->ibv_ctx.device);
+	struct hns_roce_device *hr_dev =
+		to_hr_dev(context->ibv_ctx.context.device);
 
 	if (hr_dev->hw_version == HNS_ROCE_HW_VER1) {
 		if (attr->cap.max_send_wr < HNS_ROCE_MIN_WQE_NUM) {

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -91,7 +91,7 @@ static const struct verbs_match_ent hca_table[] = {
 	{}
 };
 
-static struct ibv_context_ops i40iw_uctx_ops = {
+static const struct verbs_context_ops i40iw_uctx_ops = {
 	.query_device	= i40iw_uquery_device,
 	.query_port	= i40iw_uquery_port,
 	.alloc_pd	= i40iw_ualloc_pd,
@@ -104,11 +104,6 @@ static struct ibv_context_ops i40iw_uctx_ops = {
 	.cq_event	= i40iw_cq_event,
 	.resize_cq	= i40iw_uresize_cq,
 	.destroy_cq	= i40iw_udestroy_cq,
-	.create_srq	= NULL,
-	.modify_srq	= NULL,
-	.query_srq	= NULL,
-	.destroy_srq	= NULL,
-	.post_srq_recv	= NULL,
 	.create_qp	= i40iw_ucreate_qp,
 	.query_qp	= i40iw_uquery_qp,
 	.modify_qp	= i40iw_umodify_qp,
@@ -161,7 +156,7 @@ static struct verbs_context *i40iw_ualloc_context(struct ibv_device *ibdev,
 		goto err_free;
 	}
 
-	iwvctx->ibv_ctx.context.ops = i40iw_uctx_ops;
+	verbs_set_ops(&iwvctx->ibv_ctx, &i40iw_uctx_ops);
 	iwvctx->max_pds = resp.max_pds;
 	iwvctx->max_qps = resp.max_qps;
 	iwvctx->wq_size = resp.wq_size;

--- a/providers/i40iw/i40iw_umain.h
+++ b/providers/i40iw/i40iw_umain.h
@@ -83,7 +83,7 @@ struct i40iw_upd {
 };
 
 struct i40iw_uvcontext {
-	struct ibv_context ibv_ctx;
+	struct verbs_context ibv_ctx;
 	struct i40iw_upd *iwupd;
 	uint32_t max_pds;	/* maximum pds allowed for this user process */
 	uint32_t max_qps;	/* maximum qps allowed for this user process */
@@ -137,7 +137,7 @@ static inline struct i40iw_udevice *to_i40iw_udev(struct ibv_device *ibdev)
 
 static inline struct i40iw_uvcontext *to_i40iw_uctx(struct ibv_context *ibctx)
 {
-	return to_i40iw_uxxx(ctx, vcontext);
+	return container_of(ibctx, struct i40iw_uvcontext, ibv_ctx.context);
 }
 
 static inline struct i40iw_upd *to_i40iw_upd(struct ibv_pd *ibpd)

--- a/providers/ipathverbs/ipathverbs.h
+++ b/providers/ipathverbs/ipathverbs.h
@@ -54,7 +54,7 @@ struct ipath_device {
 };
 
 struct ipath_context {
-	struct ibv_context	ibv_ctx;
+	struct verbs_context	ibv_ctx;
 };
 
 /*
@@ -137,7 +137,7 @@ struct ipath_srq {
 
 static inline struct ipath_context *to_ictx(struct ibv_context *ibctx)
 {
-	return to_ixxx(ctx, context);
+	return container_of(ibctx, struct ipath_context, ibv_ctx.context);
 }
 
 static inline struct ipath_device *to_idev(struct ibv_device *ibdev)

--- a/providers/mlx4/dbrec.c
+++ b/providers/mlx4/dbrec.c
@@ -55,7 +55,7 @@ static struct mlx4_db_page *__add_page(struct mlx4_context *context,
 				       enum mlx4_db_type type)
 {
 	struct mlx4_db_page *page;
-	int ps = to_mdev(context->ibv_ctx.device)->page_size;
+	int ps = to_mdev(context->ibv_ctx.context.device)->page_size;
 	int pp;
 	int i;
 
@@ -120,7 +120,7 @@ void mlx4_free_db(struct mlx4_context *context, enum mlx4_db_type type,
 		  __be32 *db)
 {
 	struct mlx4_db_page *page;
-	uintptr_t ps = to_mdev(context->ibv_ctx.device)->page_size;
+	uintptr_t ps = to_mdev(context->ibv_ctx.context.device)->page_size;
 	int i;
 
 	pthread_mutex_lock(&context->db_list_mutex);

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -298,10 +298,6 @@ static struct verbs_device *mlx4_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->abi_version = sysfs_dev->abi_ver;
 
-	dev->verbs_dev.sz = sizeof(*dev);
-	dev->verbs_dev.size_of_context =
-		sizeof(struct mlx4_context) - sizeof(struct ibv_context);
-
 	return &dev->verbs_dev;
 }
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -146,8 +146,8 @@ static int mlx4_map_internal_clock(struct mlx4_device *mdev,
 	return 0;
 }
 
-static int mlx4_init_context(struct verbs_device *v_device,
-				struct ibv_context *ibv_ctx, int cmd_fd)
+static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
+						  int cmd_fd)
 {
 	struct mlx4_context	       *context;
 	struct ibv_get_context		cmd;
@@ -155,21 +155,21 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	int				i;
 	struct mlx4_alloc_ucontext_resp_v3 resp_v3;
 	__u16				bf_reg_size;
-	struct mlx4_device              *dev = to_mdev(&v_device->device);
-	struct verbs_context *verbs_ctx = verbs_get_ctx(ibv_ctx);
+	struct mlx4_device              *dev = to_mdev(ibdev);
+	struct verbs_context		*verbs_ctx;
 	struct ibv_device_attr_ex	dev_attrs;
 
-	/* memory footprint of mlx4_context and verbs_context share
-	* struct ibv_context.
-	*/
-	context = to_mctx(ibv_ctx);
-	ibv_ctx->cmd_fd = cmd_fd;
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	if (!context)
+		return NULL;
+
+	verbs_ctx = &context->ibv_ctx;
 
 	mlx4_read_env();
 	if (dev->abi_version <= MLX4_UVERBS_NO_DEV_CAPS_ABI_VERSION) {
 		if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd),
 					&resp_v3.ibv_resp, sizeof(resp_v3)))
-			return errno;
+			goto failed;
 
 		context->num_qps  = resp_v3.qp_tab_size;
 		bf_reg_size	  = resp_v3.bf_reg_size;
@@ -177,7 +177,7 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	} else  {
 		if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd),
 					&resp.ibv_resp, sizeof(resp)))
-			return errno;
+			goto failed;
 
 		context->num_qps  = resp.qp_tab_size;
 		bf_reg_size	  = resp.bf_reg_size;
@@ -205,7 +205,7 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	context->uar = mmap(NULL, dev->page_size, PROT_WRITE,
 			    MAP_SHARED, cmd_fd, 0);
 	if (context->uar == MAP_FAILED)
-		return errno;
+		goto failed;
 
 	if (bf_reg_size) {
 		context->bf_page = mmap(NULL, dev->page_size,
@@ -226,16 +226,16 @@ static int mlx4_init_context(struct verbs_device *v_device,
 		context->bf_buf_size = 0;
 	}
 
-	ibv_ctx->ops = mlx4_ctx_ops;
+	verbs_ctx->context.ops = mlx4_ctx_ops;
 
 	context->hca_core_clock = NULL;
 	memset(&dev_attrs, 0, sizeof(dev_attrs));
-	if (!mlx4_query_device_ex(ibv_ctx, NULL, &dev_attrs,
+	if (!mlx4_query_device_ex(&verbs_ctx->context, NULL, &dev_attrs,
 				  sizeof(struct ibv_device_attr_ex))) {
 		context->max_qp_wr = dev_attrs.orig_attr.max_qp_wr;
 		context->max_sge = dev_attrs.orig_attr.max_sge;
 		if (context->core_clock.offset_valid)
-			mlx4_map_internal_clock(dev, ibv_ctx);
+			mlx4_map_internal_clock(dev, &verbs_ctx->context);
 	}
 
 	verbs_ctx->close_xrcd = mlx4_close_xrcd;
@@ -256,21 +256,28 @@ static int mlx4_init_context(struct verbs_device *v_device,
 	verbs_ctx->destroy_rwq_ind_table = mlx4_destroy_rwq_ind_table;
 	verbs_ctx->modify_cq = mlx4_modify_cq;
 
-	return 0;
+	return verbs_ctx;
 
+failed:
+	verbs_uninit_context(&context->ibv_ctx);
+	free(context);
+	return NULL;
 }
 
-static void mlx4_uninit_context(struct verbs_device *v_device,
-					struct ibv_context *ibv_ctx)
+static void mlx4_free_context(struct ibv_context *ibv_ctx)
 {
 	struct mlx4_context *context = to_mctx(ibv_ctx);
+	struct mlx4_device *mdev = to_mdev(ibv_ctx->device);
 
-	munmap(context->uar, to_mdev(&v_device->device)->page_size);
+	munmap(context->uar, mdev->page_size);
 	if (context->bf_page)
-		munmap(context->bf_page, to_mdev(&v_device->device)->page_size);
+		munmap(context->bf_page, mdev->page_size);
 	if (context->hca_core_clock)
 		munmap(context->hca_core_clock - context->core_clock.offset,
-		       to_mdev(&v_device->device)->page_size);
+		       mdev->page_size);
+
+	verbs_uninit_context(&context->ibv_ctx);
+	free(context);
 }
 
 static void mlx4_uninit_device(struct verbs_device *verbs_device)
@@ -305,8 +312,8 @@ static const struct verbs_device_ops mlx4_dev_ops = {
 	.match_table = hca_table,
 	.alloc_device = mlx4_device_alloc,
 	.uninit_device = mlx4_uninit_device,
-	.init_context = mlx4_init_context,
-	.uninit_context = mlx4_uninit_context,
+	.alloc_context = mlx4_alloc_context,
+	.free_context = mlx4_free_context,
 };
 PROVIDER_DRIVER(mlx4_dev_ops);
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -167,16 +167,16 @@ static int mlx4_init_context(struct verbs_device *v_device,
 
 	mlx4_read_env();
 	if (dev->abi_version <= MLX4_UVERBS_NO_DEV_CAPS_ABI_VERSION) {
-		if (ibv_cmd_get_context(ibv_ctx, &cmd, sizeof cmd,
-					&resp_v3.ibv_resp, sizeof resp_v3))
+		if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd),
+					&resp_v3.ibv_resp, sizeof(resp_v3)))
 			return errno;
 
 		context->num_qps  = resp_v3.qp_tab_size;
 		bf_reg_size	  = resp_v3.bf_reg_size;
 		context->cqe_size = sizeof (struct mlx4_cqe);
 	} else  {
-		if (ibv_cmd_get_context(ibv_ctx, &cmd, sizeof cmd,
-					&resp.ibv_resp, sizeof resp))
+		if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd),
+					&resp.ibv_resp, sizeof(resp)))
 			return errno;
 
 		context->num_qps  = resp.qp_tab_size;

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -81,7 +81,7 @@ static const struct verbs_match_ent hca_table[] = {
 	{}
 };
 
-static struct ibv_context_ops mlx4_ctx_ops = {
+static const struct verbs_context_ops mlx4_ctx_ops = {
 	.query_device  = mlx4_query_device,
 	.query_port    = mlx4_query_port,
 	.alloc_pd      = mlx4_alloc_pd,
@@ -112,7 +112,25 @@ static struct ibv_context_ops mlx4_ctx_ops = {
 	.create_ah     = mlx4_create_ah,
 	.destroy_ah    = mlx4_destroy_ah,
 	.attach_mcast  = ibv_cmd_attach_mcast,
-	.detach_mcast  = ibv_cmd_detach_mcast
+	.detach_mcast  = ibv_cmd_detach_mcast,
+
+	.close_xrcd = mlx4_close_xrcd,
+	.create_cq_ex = mlx4_create_cq_ex,
+	.create_flow = mlx4_create_flow,
+	.create_qp_ex = mlx4_create_qp_ex,
+	.create_rwq_ind_table = mlx4_create_rwq_ind_table,
+	.create_srq_ex = mlx4_create_srq_ex,
+	.create_wq = mlx4_create_wq,
+	.destroy_flow = mlx4_destroy_flow,
+	.destroy_rwq_ind_table = mlx4_destroy_rwq_ind_table,
+	.destroy_wq = mlx4_destroy_wq,
+	.get_srq_num = verbs_get_srq_num,
+	.modify_cq = mlx4_modify_cq,
+	.modify_wq = mlx4_modify_wq,
+	.open_qp = mlx4_open_qp,
+	.open_xrcd = mlx4_open_xrcd,
+	.query_device_ex = mlx4_query_device_ex,
+	.query_rt_values = mlx4_query_rt_values,
 };
 
 static void mlx4_read_env(void)
@@ -226,7 +244,7 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 		context->bf_buf_size = 0;
 	}
 
-	verbs_ctx->context.ops = mlx4_ctx_ops;
+	verbs_set_ops(verbs_ctx, &mlx4_ctx_ops);
 
 	context->hca_core_clock = NULL;
 	memset(&dev_attrs, 0, sizeof(dev_attrs));
@@ -237,24 +255,6 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 		if (context->core_clock.offset_valid)
 			mlx4_map_internal_clock(dev, &verbs_ctx->context);
 	}
-
-	verbs_ctx->close_xrcd = mlx4_close_xrcd;
-	verbs_ctx->open_xrcd = mlx4_open_xrcd;
-	verbs_ctx->create_srq_ex = mlx4_create_srq_ex;
-	verbs_ctx->get_srq_num = verbs_get_srq_num;
-	verbs_ctx->create_qp_ex = mlx4_create_qp_ex;
-	verbs_ctx->open_qp = mlx4_open_qp;
-	verbs_ctx->ibv_create_flow = mlx4_create_flow;
-	verbs_ctx->ibv_destroy_flow = mlx4_destroy_flow;
-	verbs_ctx->create_cq_ex = mlx4_create_cq_ex;
-	verbs_ctx->query_device_ex = mlx4_query_device_ex;
-	verbs_ctx->query_rt_values = mlx4_query_rt_values;
-	verbs_ctx->create_wq = mlx4_create_wq;
-	verbs_ctx->modify_wq = mlx4_modify_wq;
-	verbs_ctx->destroy_wq = mlx4_destroy_wq;
-	verbs_ctx->create_rwq_ind_table = mlx4_create_rwq_ind_table;
-	verbs_ctx->destroy_rwq_ind_table = mlx4_destroy_rwq_ind_table;
-	verbs_ctx->modify_cq = mlx4_modify_cq;
 
 	return verbs_ctx;
 

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -99,7 +99,7 @@ struct mlx4_device {
 struct mlx4_db_page;
 
 struct mlx4_context {
-	struct ibv_context		ibv_ctx;
+	struct verbs_context		ibv_ctx;
 
 	void			       *uar;
 
@@ -260,7 +260,7 @@ static inline struct mlx4_device *to_mdev(struct ibv_device *ibdev)
 
 static inline struct mlx4_context *to_mctx(struct ibv_context *ibctx)
 {
-	return to_mxxx(ctx, context);
+	return container_of(ibctx, struct mlx4_context, ibv_ctx.context);
 }
 
 static inline struct mlx4_pd *to_mpd(struct ibv_pd *ibpd)

--- a/providers/mlx5/buf.c
+++ b/providers/mlx5/buf.c
@@ -538,7 +538,7 @@ int mlx5_alloc_buf_contig(struct mlx5_context *mctx,
 	int block_size_exp;
 	int max_block_log;
 	int min_block_log;
-	struct ibv_context *context = &mctx->ibv_ctx;
+	struct ibv_context *context = &mctx->ibv_ctx.context;
 	off_t offset;
 
 	mlx5_alloc_get_env_info(&max_block_log,

--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1717,7 +1717,7 @@ int mlx5_alloc_cq_buf(struct mlx5_context *mctx, struct mlx5_cq *cq,
 {
 	struct mlx5_cqe64 *cqe;
 	int i;
-	struct mlx5_device *dev = to_mdev(mctx->ibv_ctx.device);
+	struct mlx5_device *dev = to_mdev(mctx->ibv_ctx.context.device);
 	int ret;
 	enum mlx5_alloc_type type;
 	enum mlx5_alloc_type default_type = MLX5_ALLOC_TYPE_ANON;

--- a/providers/mlx5/dbrec.c
+++ b/providers/mlx5/dbrec.c
@@ -49,7 +49,7 @@ struct mlx5_db_page {
 static struct mlx5_db_page *__add_page(struct mlx5_context *context)
 {
 	struct mlx5_db_page *page;
-	int ps = to_mdev(context->ibv_ctx.device)->page_size;
+	int ps = to_mdev(context->ibv_ctx.context.device)->page_size;
 	int pp;
 	int i;
 	int nlong;
@@ -121,7 +121,7 @@ out:
 void mlx5_free_db(struct mlx5_context *context, __be32 *db)
 {
 	struct mlx5_db_page *page;
-	uintptr_t ps = to_mdev(context->ibv_ctx.device)->page_size;
+	uintptr_t ps = to_mdev(context->ibv_ctx.context.device)->page_size;
 	int i;
 
 	pthread_mutex_lock(&context->db_list_mutex);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -549,7 +549,7 @@ static int mlx5_cmd_get_context(struct mlx5_context *context,
 				struct mlx5_alloc_ucontext_resp *resp,
 				size_t resp_len)
 {
-	struct verbs_context *verbs_ctx = verbs_get_ctx(&context->ibv_ctx);
+	struct verbs_context *verbs_ctx = &context->ibv_ctx;
 
 	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
 				 req_len, &resp->ibv_resp, resp_len))
@@ -856,8 +856,8 @@ static void adjust_uar_info(struct mlx5_device *mdev,
 	context->num_uars_per_page = resp.num_uars_per_page;
 }
 
-static int mlx5_init_context(struct verbs_device *vdev,
-			     struct ibv_context *ctx, int cmd_fd)
+static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
+						int cmd_fd)
 {
 	struct mlx5_context	       *context;
 	struct mlx5_alloc_ucontext	req;
@@ -868,7 +868,7 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	int				low_lat_uuars;
 	int				gross_uuars;
 	int				j;
-	struct mlx5_device	       *mdev;
+	struct mlx5_device	       *mdev = to_mdev(ibdev);
 	struct verbs_context	       *v_ctx;
 	struct ibv_port_attr		port_attr;
 	struct ibv_device_attr_ex	device_attr;
@@ -876,13 +876,13 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	int				bfi;
 	int				num_sys_page_map;
 
-	mdev = to_mdev(&vdev->device);
-	v_ctx = verbs_get_ctx(ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	if (!context)
+		return NULL;
+
+	v_ctx = &context->ibv_ctx;
 	page_size = mdev->page_size;
 	mlx5_single_threaded = single_threaded_app();
-
-	context = to_mctx(ctx);
-	context->ibv_ctx.cmd_fd = cmd_fd;
 
 	open_debug_file(context);
 	set_debug_mask();
@@ -1001,15 +1001,15 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	    sizeof(resp.hca_core_clock_offset) &&
 	    resp.comp_mask & MLX5_IB_ALLOC_UCONTEXT_RESP_MASK_CORE_CLOCK_OFFSET) {
 		context->core_clock.offset = resp.hca_core_clock_offset;
-		mlx5_map_internal_clock(mdev, ctx);
+		mlx5_map_internal_clock(mdev, &v_ctx->context);
 	}
 
-	mlx5_read_env(&vdev->device, context);
+	mlx5_read_env(ibdev, context);
 
 	mlx5_spinlock_init(&context->hugetlb_lock);
 	list_head_init(&context->hugetlb_list);
 
-	context->ibv_ctx.ops = mlx5_ctx_ops;
+	v_ctx->context.ops = mlx5_ctx_ops;
 
 	v_ctx->create_qp_ex = mlx5_create_qp_ex;
 	v_ctx->open_xrcd = mlx5_open_xrcd;
@@ -1030,7 +1030,7 @@ static int mlx5_init_context(struct verbs_device *vdev,
 	v_ctx->modify_cq = mlx5_modify_cq;
 
 	memset(&device_attr, 0, sizeof(device_attr));
-	if (!mlx5_query_device_ex(ctx, NULL, &device_attr,
+	if (!mlx5_query_device_ex(&v_ctx->context, NULL, &device_attr,
 				  sizeof(struct ibv_device_attr_ex))) {
 		context->cached_device_cap_flags =
 			device_attr.orig_attr.device_cap_flags;
@@ -1040,11 +1040,11 @@ static int mlx5_init_context(struct verbs_device *vdev,
 
 	for (j = 0; j < min(MLX5_MAX_PORTS_NUM, context->num_ports); ++j) {
 		memset(&port_attr, 0, sizeof(port_attr));
-		if (!mlx5_query_port(ctx, j + 1, &port_attr))
+		if (!mlx5_query_port(&v_ctx->context, j + 1, &port_attr))
 			context->cached_link_layer[j] = port_attr.link_layer;
 	}
 
-	return 0;
+	return v_ctx;
 
 err_free_bf:
 	free(context->bfs);
@@ -1055,11 +1055,13 @@ err_free:
 			munmap(context->uar[i].reg, page_size);
 	}
 	close_debug_file(context);
-	return errno;
+
+	verbs_uninit_context(&context->ibv_ctx);
+	free(context);
+	return NULL;
 }
 
-static void mlx5_cleanup_context(struct verbs_device *device,
-				 struct ibv_context *ibctx)
+static void mlx5_free_context(struct ibv_context *ibctx)
 {
 	struct mlx5_context *context = to_mctx(ibctx);
 	int page_size = to_mdev(ibctx->device)->page_size;
@@ -1074,6 +1076,9 @@ static void mlx5_cleanup_context(struct verbs_device *device,
 		munmap(context->hca_core_clock - context->core_clock.offset,
 		       page_size);
 	close_debug_file(context);
+
+	verbs_uninit_context(&context->ibv_ctx);
+	free(context);
 }
 
 static void mlx5_uninit_device(struct verbs_device *verbs_device)
@@ -1108,7 +1113,7 @@ static const struct verbs_device_ops mlx5_dev_ops = {
 	.match_table = hca_table,
 	.alloc_device = mlx5_device_alloc,
 	.uninit_device = mlx5_uninit_device,
-	.init_context = mlx5_init_context,
-	.uninit_context = mlx5_cleanup_context,
+	.alloc_context = mlx5_alloc_context,
+	.free_context = mlx5_free_context,
 };
 PROVIDER_DRIVER(mlx5_dev_ops);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -549,7 +549,9 @@ static int mlx5_cmd_get_context(struct mlx5_context *context,
 				struct mlx5_alloc_ucontext_resp *resp,
 				size_t resp_len)
 {
-	if (!ibv_cmd_get_context(&context->ibv_ctx, &req->ibv_req,
+	struct verbs_context *verbs_ctx = verbs_get_ctx(&context->ibv_ctx);
+
+	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
 				 req_len, &resp->ibv_resp, resp_len))
 		return 0;
 
@@ -572,12 +574,12 @@ static int mlx5_cmd_get_context(struct mlx5_context *context,
 	 * to do so. If zero is a valid response, we will add a new
 	 * field that indicates whether the request was handled.
 	 */
-	if (!ibv_cmd_get_context(&context->ibv_ctx, &req->ibv_req,
+	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
 				 offsetof(struct mlx5_alloc_ucontext, lib_caps),
 				 &resp->ibv_resp, resp_len))
 		return 0;
 
-	return ibv_cmd_get_context(&context->ibv_ctx, &req->ibv_req,
+	return ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
 				   offsetof(struct mlx5_alloc_ucontext,
 					    cqe_version),
 				   &resp->ibv_resp, resp_len);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1099,10 +1099,6 @@ static struct verbs_device *mlx5_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 	dev->page_size   = sysconf(_SC_PAGESIZE);
 	dev->driver_abi_ver = sysfs_dev->abi_ver;
 
-	dev->verbs_dev.sz = sizeof(*dev);
-	dev->verbs_dev.size_of_context = sizeof(struct mlx5_context) -
-		sizeof(struct ibv_context);
-
 	return &dev->verbs_dev;
 }
 

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -230,7 +230,7 @@ struct mlx5_uar_info {
 };
 
 struct mlx5_context {
-	struct ibv_context		ibv_ctx;
+	struct verbs_context		ibv_ctx;
 	int				max_num_qps;
 	int				bf_reg_size;
 	int				tot_uuars;
@@ -548,7 +548,7 @@ static inline struct mlx5_device *to_mdev(struct ibv_device *ibdev)
 
 static inline struct mlx5_context *to_mctx(struct ibv_context *ibctx)
 {
-	return to_mxxx(ctx, context);
+	return container_of(ibctx, struct mlx5_context, ibv_ctx.context);
 }
 
 static inline struct mlx5_pd *to_mpd(struct ibv_pd *ibpd)

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -114,18 +114,17 @@ static struct ibv_context_ops mthca_ctx_ops = {
 	.detach_mcast  = ibv_cmd_detach_mcast
 };
 
-static struct ibv_context *mthca_alloc_context(struct ibv_device *ibdev, int cmd_fd)
+static struct verbs_context *mthca_alloc_context(struct ibv_device *ibdev,
+						 int cmd_fd)
 {
 	struct mthca_context            *context;
 	struct ibv_get_context           cmd;
 	struct mthca_alloc_ucontext_resp resp;
 	int                              i;
 
-	context = calloc(1, sizeof *context);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
 	if (!context)
 		return NULL;
-
-	context->ibv_ctx.cmd_fd = cmd_fd;
 
 	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd, sizeof cmd,
 				&resp.ibv_resp, sizeof resp))
@@ -135,13 +134,7 @@ static struct ibv_context *mthca_alloc_context(struct ibv_device *ibdev, int cmd
 	context->qp_table_shift = ffs(context->num_qps) - 1 - MTHCA_QP_TABLE_BITS;
 	context->qp_table_mask  = (1 << context->qp_table_shift) - 1;
 
-	/*
-	 * Need to set ibv_ctx.device because mthca_is_memfree() will
-	 * look at it to figure out the HCA type.
-	 */
-	context->ibv_ctx.device = ibdev;
-
-	if (mthca_is_memfree(&context->ibv_ctx)) {
+	if (mthca_is_memfree(&context->ibv_ctx.context)) {
 		context->db_tab = mthca_alloc_db_tab(resp.uarc_size);
 		if (!context->db_tab)
 			goto err_free;
@@ -159,26 +152,28 @@ static struct ibv_context *mthca_alloc_context(struct ibv_device *ibdev, int cmd
 
 	pthread_spin_init(&context->uar_lock, PTHREAD_PROCESS_PRIVATE);
 
-	context->pd = mthca_alloc_pd(&context->ibv_ctx);
+	context->pd = mthca_alloc_pd(&context->ibv_ctx.context);
 	if (!context->pd)
 		goto err_unmap;
 
-	context->pd->context = &context->ibv_ctx;
+	context->pd->context = &context->ibv_ctx.context;
 
-	context->ibv_ctx.ops = mthca_ctx_ops;
+	context->ibv_ctx.context.ops = mthca_ctx_ops;
 
-	if (mthca_is_memfree(&context->ibv_ctx)) {
-		context->ibv_ctx.ops.req_notify_cq = mthca_arbel_arm_cq;
-		context->ibv_ctx.ops.cq_event      = mthca_arbel_cq_event;
-		context->ibv_ctx.ops.post_send     = mthca_arbel_post_send;
-		context->ibv_ctx.ops.post_recv     = mthca_arbel_post_recv;
-		context->ibv_ctx.ops.post_srq_recv = mthca_arbel_post_srq_recv;
+	if (mthca_is_memfree(&context->ibv_ctx.context)) {
+		context->ibv_ctx.context.ops.req_notify_cq = mthca_arbel_arm_cq;
+		context->ibv_ctx.context.ops.cq_event = mthca_arbel_cq_event;
+		context->ibv_ctx.context.ops.post_send = mthca_arbel_post_send;
+		context->ibv_ctx.context.ops.post_recv = mthca_arbel_post_recv;
+		context->ibv_ctx.context.ops.post_srq_recv =
+			mthca_arbel_post_srq_recv;
 	} else {
-		context->ibv_ctx.ops.req_notify_cq = mthca_tavor_arm_cq;
-		context->ibv_ctx.ops.cq_event      = NULL;
-		context->ibv_ctx.ops.post_send     = mthca_tavor_post_send;
-		context->ibv_ctx.ops.post_recv     = mthca_tavor_post_recv;
-		context->ibv_ctx.ops.post_srq_recv = mthca_tavor_post_srq_recv;
+		context->ibv_ctx.context.ops.req_notify_cq = mthca_tavor_arm_cq;
+		context->ibv_ctx.context.ops.cq_event = NULL;
+		context->ibv_ctx.context.ops.post_send = mthca_tavor_post_send;
+		context->ibv_ctx.context.ops.post_recv = mthca_tavor_post_recv;
+		context->ibv_ctx.context.ops.post_srq_recv =
+			mthca_tavor_post_srq_recv;
 	}
 
 	return &context->ibv_ctx;
@@ -190,6 +185,7 @@ err_db_tab:
 	mthca_free_db_tab(context->db_tab);
 
 err_free:
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 	return NULL;
 }
@@ -201,6 +197,8 @@ static void mthca_free_context(struct ibv_context *ibctx)
 	mthca_free_pd(context->pd);
 	munmap(context->uar, to_mdev(ibctx->device)->page_size);
 	mthca_free_db_tab(context->db_tab);
+
+	verbs_uninit_context(&context->ibv_ctx);
 	free(context);
 }
 

--- a/providers/mthca/mthca.h
+++ b/providers/mthca/mthca.h
@@ -97,7 +97,7 @@ struct mthca_device {
 struct mthca_db_table;
 
 struct mthca_context {
-	struct ibv_context     ibv_ctx;
+	struct verbs_context     ibv_ctx;
 	void                  *uar;
 	pthread_spinlock_t     uar_lock;
 	struct mthca_db_table *db_tab;
@@ -229,7 +229,7 @@ static inline struct mthca_device *to_mdev(struct ibv_device *ibdev)
 
 static inline struct mthca_context *to_mctx(struct ibv_context *ibctx)
 {
-	return to_mxxx(ctx, context);
+	return container_of(ibctx, struct mthca_context, ibv_ctx.context);
 }
 
 static inline struct mthca_pd *to_mpd(struct ibv_pd *ibpd)

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -63,7 +63,7 @@ static const struct verbs_match_ent hca_table[] = {
 	{},
 };
 
-static struct ibv_context_ops nes_uctx_ops = {
+static const struct verbs_context_ops nes_uctx_ops = {
 	.query_device = nes_uquery_device,
 	.query_port = nes_uquery_port,
 	.alloc_pd = nes_ualloc_pd,
@@ -76,11 +76,6 @@ static struct ibv_context_ops nes_uctx_ops = {
 	.cq_event = nes_cq_event,
 	.resize_cq = nes_uresize_cq,
 	.destroy_cq = nes_udestroy_cq,
-	.create_srq = NULL,
-	.modify_srq = NULL,
-	.query_srq = NULL,
-	.destroy_srq = NULL,
-	.post_srq_recv = NULL,
 	.create_qp = nes_ucreate_qp,
 	.query_qp = nes_uquery_qp,
 	.modify_qp = nes_umodify_qp,
@@ -92,6 +87,10 @@ static struct ibv_context_ops nes_uctx_ops = {
 	.attach_mcast = nes_uattach_mcast,
 	.detach_mcast = nes_udetach_mcast,
 	.async_event = nes_async_event
+};
+
+static const struct verbs_context_ops nes_uctx_no_db_ops = {
+	.poll_cq = nes_upoll_cq_no_db_read,
 };
 
 
@@ -134,10 +133,10 @@ static struct verbs_context *nes_ualloc_context(struct ibv_device *ibdev,
 			sscanf(value, "%d", &nes_drv_opt);
 	}
 
+	verbs_set_ops(&nesvctx->ibv_ctx, &nes_uctx_ops);
 	if (nes_drv_opt & NES_DRV_OPT_NO_DB_READ)
-		nes_uctx_ops.poll_cq = nes_upoll_cq_no_db_read;
+		verbs_set_ops(&nesvctx->ibv_ctx, &nes_uctx_no_db_ops);
 
-	nesvctx->ibv_ctx.context.ops = nes_uctx_ops;
 	nesvctx->max_pds = resp.max_pds;
 	nesvctx->max_qps = resp.max_qps;
 	nesvctx->wq_size = resp.wq_size;

--- a/providers/nes/nes_umain.h
+++ b/providers/nes/nes_umain.h
@@ -261,7 +261,7 @@ struct nes_upd {
 };
 
 struct nes_uvcontext {
-	struct ibv_context ibv_ctx;
+	struct verbs_context ibv_ctx;
 	struct nes_upd *nesupd;
 	uint32_t max_pds; /* maximum pds allowed for this user process */
 	uint32_t max_qps; /* maximum qps allowed for this user process */
@@ -331,7 +331,7 @@ static inline struct nes_udevice *to_nes_udev(struct ibv_device *ibdev)
 
 static inline struct nes_uvcontext *to_nes_uctx(struct ibv_context *ibctx)
 {
-	return to_nes_uxxx(ctx, vcontext);
+	return container_of(ibctx, struct nes_uvcontext, ibv_ctx.context);
 }
 
 static inline struct nes_upd *to_nes_upd(struct ibv_pd *ibpd)

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -64,7 +64,7 @@ static const struct verbs_match_ent ucna_table[] = {
 	{}
 };
 
-static struct ibv_context_ops ocrdma_ctx_ops = {
+static const struct verbs_context_ops ocrdma_ctx_ops = {
 	.query_device = ocrdma_query_device,
 	.query_port = ocrdma_query_port,
 	.alloc_pd = ocrdma_alloc_pd,
@@ -121,7 +121,8 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 				&resp.ibv_resp, sizeof(resp)))
 		goto cmd_err;
 
-	ctx->ibv_ctx.context.ops = ocrdma_ctx_ops;
+	verbs_set_ops(&ctx->ibv_ctx, &ocrdma_ctx_ops);
+
 	get_ocrdma_dev(ibdev)->id = resp.dev_id;
 	get_ocrdma_dev(ibdev)->max_inline_data = resp.max_inline_data;
 	get_ocrdma_dev(ibdev)->wqe_size = resp.wqe_size;

--- a/providers/ocrdma/ocrdma_main.h
+++ b/providers/ocrdma/ocrdma_main.h
@@ -68,7 +68,7 @@ struct ocrdma_device {
 };
 
 struct ocrdma_devctx {
-	struct ibv_context ibv_ctx;
+	struct verbs_context ibv_ctx;
 	uint32_t *ah_tbl;
 	uint32_t ah_tbl_len;
 	pthread_mutex_t tbl_lock;
@@ -231,7 +231,7 @@ struct ocrdma_ah {
 
 static inline struct ocrdma_devctx *get_ocrdma_ctx(struct ibv_context *ibctx)
 {
-	return get_ocrdma_xxx(ctx, devctx);
+	return container_of(ibctx, struct ocrdma_devctx, ibv_ctx.context);
 }
 
 static inline struct ocrdma_device *get_ocrdma_dev(struct ibv_device *ibdev)

--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -118,7 +118,7 @@ struct qelr_device {
 };
 
 struct qelr_devctx {
-	struct ibv_context	ibv_ctx;
+	struct verbs_context	ibv_ctx;
 	FILE			*dbg_fp;
 	void			*db_addr;
 	uint64_t		db_pa;
@@ -251,7 +251,7 @@ struct qelr_qp {
 
 static inline struct qelr_devctx *get_qelr_ctx(struct ibv_context *ibctx)
 {
-	return container_of(ibctx, struct qelr_devctx, ibv_ctx);
+	return container_of(ibctx, struct qelr_devctx, ibv_ctx.context);
 }
 
 static inline struct qelr_device *get_qelr_dev(struct ibv_device *ibdev)

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -80,7 +80,7 @@ static const struct verbs_match_ent hca_table[] = {
 	{}
 };
 
-static struct ibv_context_ops qelr_ctx_ops = {
+static const struct verbs_context_ops qelr_ctx_ops = {
 	.query_device = qelr_query_device,
 	.query_port = qelr_query_port,
 	.alloc_pd = qelr_alloc_pd,
@@ -176,8 +176,9 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 				&resp.ibv_resp, sizeof(resp)))
 		goto cmd_err;
 
+	verbs_set_ops(&ctx->ibv_ctx, &qelr_ctx_ops);
+
 	ctx->kernel_page_size = sysconf(_SC_PAGESIZE);
-	ctx->ibv_ctx.context.ops = qelr_ctx_ops;
 	ctx->db_pa = resp.db_pa;
 	ctx->db_size = resp.db_size;
 	ctx->max_send_wr = resp.max_send_wr;

--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -887,7 +887,7 @@ static inline void qelr_init_dpm_info(struct qelr_devctx *cxt,
 	dpm->is_edpm = 0;
 
 	/* Currently dpm is not supported for iWARP */
-	if (IS_IWARP(cxt->ibv_ctx.device))
+	if (IS_IWARP(cxt->ibv_ctx.context.device))
 		return;
 
 	if (qelr_chain_is_full(&qp->sq.chain) &&

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -828,7 +828,7 @@ static int rxe_destroy_ah(struct ibv_ah *ibah)
 	return 0;
 }
 
-static struct ibv_context_ops rxe_ctx_ops = {
+static const struct verbs_context_ops rxe_ctx_ops = {
 	.query_device = rxe_query_device,
 	.query_port = rxe_query_port,
 	.alloc_pd = rxe_alloc_pd,
@@ -838,7 +838,6 @@ static struct ibv_context_ops rxe_ctx_ops = {
 	.create_cq = rxe_create_cq,
 	.poll_cq = rxe_poll_cq,
 	.req_notify_cq = ibv_cmd_req_notify_cq,
-	.cq_event = NULL,
 	.resize_cq = rxe_resize_cq,
 	.destroy_cq = rxe_destroy_cq,
 	.create_srq = rxe_create_srq,
@@ -873,7 +872,7 @@ static struct verbs_context *rxe_alloc_context(struct ibv_device *ibdev,
 				sizeof cmd, &resp, sizeof resp))
 		goto out;
 
-	context->ibv_ctx.context.ops = rxe_ctx_ops;
+	verbs_set_ops(&context->ibv_ctx, &rxe_ctx_ops);
 
 	return &context->ibv_ctx;
 

--- a/providers/rxe/rxe.h
+++ b/providers/rxe/rxe.h
@@ -54,7 +54,7 @@ struct rxe_device {
 };
 
 struct rxe_context {
-	struct ibv_context	ibv_ctx;
+	struct verbs_context	ibv_ctx;
 };
 
 struct rxe_cq {
@@ -98,7 +98,7 @@ struct rxe_srq {
 
 static inline struct rxe_context *to_rctx(struct ibv_context *ibctx)
 {
-	return to_rxxx(ctx, context);
+	return container_of(ibctx, struct rxe_context, ibv_ctx.context);
 }
 
 static inline struct rxe_device *to_rdev(struct ibv_device *ibdev)

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -105,7 +105,7 @@ struct pvrdma_device {
 };
 
 struct pvrdma_context {
-	struct ibv_context		ibv_ctx;
+	struct verbs_context		ibv_ctx;
 	void				*uar;
 	pthread_spinlock_t		uar_lock;
 	int				max_qp_wr;
@@ -201,7 +201,7 @@ static inline struct pvrdma_device *to_vdev(struct ibv_device *ibdev)
 
 static inline struct pvrdma_context *to_vctx(struct ibv_context *ibctx)
 {
-	return container_of(ibctx, struct pvrdma_context, ibv_ctx);
+	return container_of(ibctx, struct pvrdma_context, ibv_ctx.context);
 }
 
 static inline struct pvrdma_pd *to_vpd(struct ibv_pd *ibpd)

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -51,7 +51,7 @@
 #define PCI_VENDOR_ID_VMWARE		0x15AD
 #define PCI_DEVICE_ID_VMWARE_PVRDMA	0x0820
 
-static struct ibv_context_ops pvrdma_ctx_ops = {
+static const struct verbs_context_ops pvrdma_ctx_ops = {
 	.query_device = pvrdma_query_device,
 	.query_port = pvrdma_query_port,
 	.alloc_pd = pvrdma_alloc_pd,
@@ -129,7 +129,8 @@ static int pvrdma_init_context_shared(struct pvrdma_context *context,
 	}
 
 	pthread_spin_init(&context->uar_lock, PTHREAD_PROCESS_PRIVATE);
-	context->ibv_ctx.context.ops = pvrdma_ctx_ops;
+
+	verbs_set_ops(&context->ibv_ctx, &pvrdma_ctx_ops);
 
 	return 0;
 }


### PR DESCRIPTION
This make all the context creation uniform by having every driver create a struct verbs_context using the same startup flow.

Long ago we added a new and flow, which was intended to support a stable provider ABI. Now that the ABI is private we do not need that.

By having every single provider create a verbs_context we can now rely on things like the priv existing and a sane init ordering where the priv can exist even before the first command runs.

Having priv always available is a valuable component to introduce support for the new ioctl kabi.

Finally, the last three patches rework the ops setup to use a struct of function pointers scheme and provides defaults for every function. The defaults return ENOSYS which fixes a bunch of cases where the user could have called a function without driver support and got a crash.