### PR TITLE
vmw_pvrdma: Fix SRQN returned to library

### DIFF
--- a/providers/vmw_pvrdma/qp.c
+++ b/providers/vmw_pvrdma/qp.c
@@ -108,7 +108,7 @@ struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
 {
 	struct pvrdma_device *dev = to_vdev(pd->context->device);
 	struct user_pvrdma_create_srq cmd;
-	struct ib_uverbs_create_srq_resp resp;
+	struct user_pvrdma_create_srq_resp resp;
 	struct pvrdma_srq *srq;
 	int ret;
 
@@ -142,12 +142,12 @@ struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
 
 	ret = ibv_cmd_create_srq(pd, &srq->ibv_srq, attr,
 				 &cmd.ibv_cmd, sizeof(cmd),
-				 &resp, sizeof(resp));
+				 &resp.ibv_resp, sizeof(resp));
 
 	if (ret)
 		goto err_free;
 
-	srq->srqn = resp.srqn;
+	srq->srqn = resp.udata.srqn;
 
 	return &srq->ibv_srq;
 


### PR DESCRIPTION
Use the correct SQN reported by the driver.

Fixes: 4c8ed14eb6b7 ("vmw_pvrdma: Add SRQ support")
Reviewed-by: Adit Ranadive <aditr@vmware.com>
Reviewed-by: Bryan Tan <bryantan@vmware.com>
Signed-off-by: Aditya Sarwade <asarwade@vmware.com>
Cc: stable@linux-rdma.org