### PR TITLE
New kabi support for rdma-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,9 @@
 #      Do not generate backwards compatibility symbols in the shared
 #      libraries. This may is necessary if using a dynmic linker that does
 #      not support symbol versions, such as uclibc.
+#  -DIOCTL_MODE=both (default write)
+#      Enable new kABI ioctl() support and support for the legacy write
+#      path. May also be 'ioctl' to disable fallback to write.
 
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project(rdma-core C)
@@ -433,6 +436,18 @@ RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WREDUNDANT_DECLS "-Wredundant-decls")
 # directory. For developer convenience
 if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
   file(WRITE ${CMAKE_BINARY_DIR}/.gitignore "*")
+endif()
+
+if ("${IOCTL_MODE}" STREQUAL "both")
+  set(IOCTL_MODE_NUM 3)
+elseif ("${IOCTL_MODE}" STREQUAL "write")
+  set(IOCTL_MODE_NUM 2)
+elseif ("${IOCTL_MODE}" STREQUAL "ioctl")
+  set(IOCTL_MODE_NUM 1)
+elseif ("${IOCTL_MODE}" STREQUAL "")
+  set(IOCTL_MODE_NUM 2)
+else()
+  message(FATAL_ERROR "-DIOCTL_MODE=${IOCTL_MODE} is not a valid choice")
 endif()
 
 configure_file("${BUILDLIB}/config.h.in" "${BUILD_INCLUDE}/config.h" ESCAPE_QUOTES @ONLY)

--- a/buildlib/config.h.in
+++ b/buildlib/config.h.in
@@ -48,4 +48,15 @@
 # define NRESOLVE_NEIGH 1
 #endif
 
+#if @IOCTL_MODE_NUM@ == 1
+# define VERBS_IOCTL_ONLY 1
+# define VERBS_WRITE_ONLY 0
+#elif  @IOCTL_MODE_NUM@ == 2
+# define VERBS_IOCTL_ONLY 0
+# define VERBS_WRITE_ONLY 1
+#elif  @IOCTL_MODE_NUM@ == 3
+# define VERBS_IOCTL_ONLY 0
+# define VERBS_WRITE_ONLY 0
+#endif
+
 #endif

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -9,7 +9,7 @@ mkdir build-clang build32 build-sparse build-aarch64
 
 # Build with latest clang first
 cd build-clang
-CC=clang-5.0 CFLAGS=-Werror cmake -GNinja ..
+CC=clang-5.0 CFLAGS=-Werror cmake -GNinja .. -DIOCTL_MODE=both
 ninja
 ../buildlib/check-build --src .. --cc clang-5.0
 
@@ -17,19 +17,19 @@ ninja
 cd ../build32
 # travis's trusty is not configured in a way that enables all 32 bit
 # packages. We could fix this with some sudo stuff.. For now turn off libnl
-CC=gcc-7 CFLAGS="-Werror -m32" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0
+CC=gcc-7 CFLAGS="-Werror -m32" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both
 ninja
 
 # aarch64 build to check compilation on ARM 64bit platform
 cd ../build-aarch64
-CC=$HOME/aarch64/bin/aarch64-linux-gnu-gcc CFLAGS="-Werror -Wno-maybe-uninitialized" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0
+CC=$HOME/aarch64/bin/aarch64-linux-gnu-gcc CFLAGS="-Werror -Wno-maybe-uninitialized" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=ioctl
 ninja
 
 # Run sparse on the subdirectories which are sparse clean
 cd ../build-sparse
 mv ../CMakeLists.txt ../CMakeLists-orig.txt
 grep -v "# NO SPARSE" ../CMakeLists-orig.txt > ../CMakeLists.txt
-CC=cgcc CFLAGS="-Werror" cmake -GNinja ..
+CC=cgcc CFLAGS="-Werror" cmake -GNinja .. -DIOCTL_MODE=both
 ninja | grep -v '^\[' | tee out
 # sparse does not fail gcc on messages
 if [ -s out ]; then
@@ -42,7 +42,7 @@ cd ../build-clang
 cp ../util/udma_barrier.h ../util/udma_barrier.h.old
 echo "#error Fail" >> ../util/udma_barrier.h
 rm CMakeCache.txt
-CC=clang-5.0 CFLAGS=-Werror cmake -GNinja ..
+CC=clang-5.0 CFLAGS=-Werror cmake -GNinja .. -DIOCTL_MODE=both
 ninja
 cp ../util/udma_barrier.h.old ../util/udma_barrier.h
 

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -9,6 +9,7 @@ publish_headers(infiniband
 
 publish_internal_headers(infiniband
   cmd_ioctl.h
+  cmd_write.h
   driver.h
   kern-abi.h
   marshall.h
@@ -27,6 +28,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
   1 1.1.${PACKAGE_VERSION}
   cmd.c
+  cmd_fallback.c
   cmd_ioctl.c
   compat-1_0.c
   device.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -28,6 +28,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
   1 1.1.${PACKAGE_VERSION}
   cmd.c
+  cmd_cq.c
   cmd_fallback.c
   cmd_ioctl.c
   compat-1_0.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -8,6 +8,7 @@ publish_headers(infiniband
   )
 
 publish_internal_headers(infiniband
+  cmd_ioctl.h
   driver.h
   kern-abi.h
   marshall.h
@@ -26,6 +27,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
   1 1.1.${PACKAGE_VERSION}
   cmd.c
+  cmd_ioctl.c
   compat-1_0.c
   device.c
   dummy_ops.c

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infiniband/cmd_write.h>
+
+static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
+			      struct ibv_comp_channel *channel, int comp_vector,
+			      uint32_t flags, struct ibv_cq *cq,
+			      struct ibv_command_buffer *link)
+{
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE, 7, link);
+	struct ib_uverbs_attr *handle;
+	uint32_t resp_cqe;
+	int ret;
+
+	cq->context = context;
+
+	handle = fill_attr_out_obj(cmdb, CREATE_CQ_HANDLE);
+	fill_attr_out_ptr(cmdb, CREATE_CQ_RESP_CQE, &resp_cqe);
+
+	fill_attr_in_uint32(cmdb, CREATE_CQ_CQE, cqe);
+	fill_attr_in_uint64(cmdb, CREATE_CQ_USER_HANDLE, (uintptr_t)cq);
+	if (channel)
+		fill_attr_in_fd(cmdb, CREATE_CQ_COMP_CHANNEL, channel->fd);
+	fill_attr_in_uint32(cmdb, CREATE_CQ_COMP_VECTOR, comp_vector);
+
+	if (flags) {
+		fallback_require_ex(cmdb);
+		fill_attr_in_uint32(cmdb, CREATE_CQ_FLAGS, flags);
+	}
+
+	switch (execute_ioctl_fallback(cq->context, create_cq, cmdb, &ret)) {
+	case TRY_WRITE: {
+		DECLARE_LEGACY_UHW_BUFS(link, create_cq);
+
+		*req = (struct ib_uverbs_create_cq){
+			.user_handle = (uintptr_t)cq,
+			.cqe = cqe,
+			.comp_vector = comp_vector,
+			.comp_channel = channel ? channel->fd : -1,
+		};
+
+		ret = execute_write_bufs(IB_USER_VERBS_CMD_CREATE_CQ,
+					 cq->context, req, resp);
+		if (ret)
+			return ret;
+
+		cq->handle = resp->cq_handle;
+		cq->cqe = resp->cqe;
+
+		return 0;
+	}
+	case TRY_WRITE_EX: {
+		DECLARE_LEGACY_UHW_BUFS_EX(link, create_cq);
+
+		*req = (struct ib_uverbs_ex_create_cq){
+			.user_handle = (uintptr_t)cq,
+			.cqe = cqe,
+			.comp_vector = comp_vector,
+			.comp_channel = channel ? channel->fd : -1,
+			.flags = flags,
+		};
+
+		ret = execute_write_bufs_ex(IB_USER_VERBS_EX_CMD_CREATE_CQ,
+					    cq->context, req, resp);
+		if (ret)
+			return ret;
+
+		cq->handle = resp->base.cq_handle;
+		cq->cqe = resp->base.cqe;
+
+		return 0;
+	}
+
+	case ERROR:
+		return ret;
+
+	case SUCCESS:
+		break;
+	}
+
+	cq->handle = read_attr_obj(CREATE_CQ_HANDLE, handle);
+	cq->cqe = resp_cqe;
+
+	return 0;
+}
+
+int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
+		      struct ibv_comp_channel *channel, int comp_vector,
+		      struct ibv_cq *cq, struct ibv_create_cq *cmd,
+		      size_t cmd_size, struct ib_uverbs_create_cq_resp *resp,
+		      size_t resp_size)
+{
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE);
+
+	return ibv_icmd_create_cq(context, cqe, channel, comp_vector, 0, cq,
+				  cmdb);
+}
+
+int ibv_cmd_create_cq_ex(struct ibv_context *context,
+			 struct ibv_cq_init_attr_ex *cq_attr,
+			 struct ibv_cq_ex *cq,
+			 struct ibv_create_cq_ex *cmd,
+			 size_t cmd_size,
+			 struct ib_uverbs_ex_create_cq_resp *resp,
+			 size_t resp_size)
+{
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE);
+	uint32_t flags = 0;
+
+	if (!check_comp_mask(cq_attr->comp_mask, IBV_CQ_INIT_ATTR_MASK_FLAGS))
+		return EOPNOTSUPP;
+
+	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)
+		flags |= IBV_CREATE_CQ_EX_KERNEL_FLAG_COMPLETION_TIMESTAMP;
+
+	return ibv_icmd_create_cq(context, cq_attr->cqe, cq_attr->channel,
+				  cq_attr->comp_vector, flags,
+				  ibv_cq_ex_to_cq(cq), cmdb);
+}
+
+int ibv_cmd_destroy_cq(struct ibv_cq *cq)
+{
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_DESTROY, 2,
+			     NULL);
+	DECLARE_LEGACY_CORE_BUFS(destroy_cq);
+	int ret;
+
+	fill_attr_out_ptr(cmdb, DESTROY_CQ_RESP, &resp);
+	fill_attr_in_obj(cmdb, DESTROY_CQ_HANDLE, cq->handle);
+
+	switch (execute_ioctl_fallback(cq->context, destroy_cq, cmdb, &ret)) {
+	case TRY_WRITE: {
+		*req = (struct ib_uverbs_destroy_cq){
+			.cq_handle = cq->handle,
+		};
+
+		ret = execute_write(IB_USER_VERBS_CMD_DESTROY_CQ, cq->context,
+				    req, &resp);
+		break;
+	}
+
+	default:
+		break;
+	}
+
+	if (ret)
+		return ret;
+
+	pthread_mutex_lock(&cq->mutex);
+	while (cq->comp_events_completed != resp.comp_events_reported ||
+	       cq->async_events_completed != resp.async_events_reported)
+		pthread_cond_wait(&cq->cond, &cq->mutex);
+	pthread_mutex_unlock(&cq->mutex);
+
+	return 0;
+}

--- a/libibverbs/cmd_fallback.c
+++ b/libibverbs/cmd_fallback.c
@@ -1,0 +1,263 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infiniband/cmd_ioctl.h>
+#include <infiniband/cmd_write.h>
+#include "ibverbs.h"
+
+#include <util/compiler.h>
+#include <ccan/build_assert.h>
+
+#include <unistd.h>
+
+/*
+ * Check if the command buffer provided by the driver includes anything that
+ * is not compatible with the legacy interface. If so, then
+ * _execute_ioctl_fallback indicates it handled the call and sets the error
+ * code
+ */
+enum write_fallback _check_legacy(struct ibv_command_buffer *cmdb, int *ret)
+{
+	struct ib_uverbs_attr *cur;
+	bool fallback_require_ex = cmdb->fallback_require_ex;
+	bool fallback_ioctl_only = cmdb->fallback_ioctl_only;
+
+	for (cmdb = cmdb->next; cmdb; cmdb = cmdb->next) {
+		for (cur = cmdb->hdr.attrs; cur != cmdb->next_attr; cur++) {
+			if (cur->attr_id != UVERBS_UHW_IN &&
+			    cur->attr_id != UVERBS_UHW_OUT &&
+			    cur->flags & UVERBS_ATTR_F_MANDATORY)
+				goto not_supp;
+		}
+		fallback_require_ex |= cmdb->fallback_require_ex;
+		fallback_ioctl_only |= cmdb->fallback_ioctl_only;
+	}
+
+	if (fallback_ioctl_only)
+		return ERROR;
+
+	if (fallback_require_ex)
+		return TRY_WRITE_EX;
+	return TRY_WRITE;
+
+not_supp:
+	errno = EOPNOTSUPP;
+	*ret = EOPNOTSUPP;
+	return ERROR;
+}
+
+/*
+ * Used to support callers that have a fallback to the old write ABI
+ * interface.
+ */
+enum write_fallback _execute_ioctl_fallback(struct ibv_context *ctx,
+					    unsigned int cmd_bit,
+					    struct ibv_command_buffer *cmdb,
+					    int *ret)
+{
+	uint64_t cmd_val = 1ULL << cmd_bit;
+
+	BUILD_ASSERT(sizeof(struct verbs_context_ops) / sizeof(void *) < 64);
+
+	struct verbs_ex_private *priv =
+		container_of(ctx, struct verbs_context, context)->priv;
+
+	if (priv->unsupported_ioctls & cmd_val)
+		return _check_legacy(cmdb, ret);
+
+	*ret = execute_ioctl(ctx, cmdb);
+
+	if (likely(*ret == 0))
+		return SUCCESS;
+
+	if (*ret == ENOTTY) {
+		/* ENOTTY means the ioctl framework is entirely absent */
+		priv->unsupported_ioctls = UINT64_MAX;
+		return _check_legacy(cmdb, ret);
+	}
+
+	if (*ret == EPROTONOSUPPORT) {
+		/*
+		 * EPROTONOSUPPORT means we have the ioctl framework but this
+		 * specific method is not supported
+		 */
+		priv->unsupported_ioctls |= cmd_val;
+		return _check_legacy(cmdb, ret);
+	}
+
+	return ERROR;
+}
+
+/*
+ * Within the command implementation we get a pointer to the request and
+ * response buffers for the legacy interface. This pointer is either allocated
+ * on the stack (if the driver didn't provide a UHW) or arranged to be
+ * directly before the UHW memory (see _write_set_uhw)
+ */
+void *_write_get_req(struct ibv_command_buffer *link, void *onstack,
+		     size_t size)
+{
+	struct ib_uverbs_cmd_hdr *hdr;
+
+	size += sizeof(*hdr);
+
+	if (link->uhw_in_idx != _UHW_NO_INDEX) {
+		struct ib_uverbs_attr *uhw = &link->hdr.attrs[link->uhw_in_idx];
+
+		assert(uhw->attr_id == UVERBS_UHW_IN);
+		assert(link->uhw_in_headroom_dwords * 4 >= size);
+		hdr = (void *)((uintptr_t)uhw->data - size);
+		hdr->in_words = __check_divide(size + uhw->len, 4);
+	} else {
+		hdr = onstack;
+		hdr->in_words = __check_divide(size, 4);
+	}
+
+	return hdr + 1;
+}
+
+void *_write_get_req_ex(struct ibv_command_buffer *link, void *onstack,
+			size_t size)
+{
+	struct _ib_ex_hdr *hdr;
+	size_t full_size = size + sizeof(*hdr);
+
+	if (link->uhw_in_idx != _UHW_NO_INDEX) {
+		struct ib_uverbs_attr *uhw = &link->hdr.attrs[link->uhw_in_idx];
+
+		assert(uhw->attr_id == UVERBS_UHW_IN);
+		assert(link->uhw_in_headroom_dwords * 4 >= full_size);
+		hdr = (void *)((uintptr_t)uhw->data - full_size);
+		hdr->hdr.in_words = __check_divide(size, 8);
+		hdr->ex_hdr.provider_in_words = __check_divide(uhw->len, 8);
+	} else {
+		hdr = onstack;
+		hdr->hdr.in_words = __check_divide(size, 8);
+		hdr->ex_hdr.provider_in_words = 0;
+	}
+
+	return hdr + 1;
+}
+
+void *_write_get_resp(struct ibv_command_buffer *link,
+		      struct ib_uverbs_cmd_hdr *hdr, void *onstack,
+		      size_t resp_size)
+{
+	void *resp_start;
+
+	if (link->uhw_out_idx != _UHW_NO_INDEX) {
+		struct ib_uverbs_attr *uhw =
+			&link->hdr.attrs[link->uhw_out_idx];
+
+		assert(uhw->attr_id == UVERBS_UHW_OUT);
+		assert(link->uhw_out_headroom_dwords * 4 >= resp_size);
+		resp_start = (void *)((uintptr_t)uhw->data - resp_size);
+		hdr->out_words = __check_divide(resp_size + uhw->len, 4);
+	} else {
+		resp_start = onstack;
+		hdr->out_words = __check_divide(resp_size, 4);
+	}
+
+	return resp_start;
+}
+
+void *_write_get_resp_ex(struct ibv_command_buffer *link,
+			 struct _ib_ex_hdr *hdr, void *onstack,
+			 size_t resp_size)
+{
+	void *resp_start;
+
+	if (link->uhw_out_idx != _UHW_NO_INDEX) {
+		struct ib_uverbs_attr *uhw =
+			&link->hdr.attrs[link->uhw_out_idx];
+
+		assert(uhw->attr_id == UVERBS_UHW_OUT);
+		assert(link->uhw_out_headroom_dwords * 4 >= resp_size);
+		resp_start = (void *)((uintptr_t)uhw->data - resp_size);
+		hdr->hdr.out_words = __check_divide(resp_size, 8);
+		hdr->ex_hdr.provider_out_words = __check_divide(uhw->len, 8);
+	} else {
+		resp_start = onstack;
+		hdr->hdr.out_words = __check_divide(resp_size, 8);
+		hdr->ex_hdr.provider_out_words = 0;
+	}
+
+	return resp_start;
+}
+
+int _execute_write_raw(unsigned int cmdnum, struct ibv_context *ctx,
+		       struct ib_uverbs_cmd_hdr *hdr, void *resp)
+{
+	hdr->command = cmdnum;
+
+	/*
+	 * Users assumes the stack buffer is zeroed before passing to the
+	 * kernel for writing.
+	 */
+	memset(resp, 0, hdr->out_words * 4);
+
+	if (write(ctx->cmd_fd, hdr, hdr->in_words * 4) != hdr->in_words * 4)
+		return errno;
+
+	VALGRIND_MAKE_MEM_DEFINED(resp, hdr->out_words * 4);
+
+	return 0;
+}
+
+int _execute_write_raw_ex(uint32_t cmdnum, struct ibv_context *ctx,
+			  struct _ib_ex_hdr *hdr, void *resp)
+{
+	size_t write_bytes =
+		sizeof(*hdr) +
+		(hdr->hdr.in_words + hdr->ex_hdr.provider_in_words) * 8;
+	size_t resp_bytes =
+		(hdr->hdr.out_words + hdr->ex_hdr.provider_out_words) * 8;
+
+	hdr->hdr.command = (IB_USER_VERBS_CMD_FLAG_EXTENDED
+			    << IB_USER_VERBS_CMD_FLAGS_SHIFT) |
+			   cmdnum;
+	hdr->ex_hdr.cmd_hdr_reserved = 0;
+	hdr->ex_hdr.response =  ioctl_ptr_to_u64(resp);
+
+	/*
+	 * Users assumes the stack buffer is zeroed before passing to the
+	 * kernel for writing.
+	 */
+	memset(resp, 0, resp_bytes);
+
+	if (write(ctx->cmd_fd, hdr, write_bytes) != write_bytes)
+		return errno;
+
+	VALGRIND_MAKE_MEM_DEFINED(resp, resp_bytes);
+
+	return 0;
+}

--- a/libibverbs/cmd_ioctl.c
+++ b/libibverbs/cmd_ioctl.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infiniband/cmd_ioctl.h>
+
+#include <sys/ioctl.h>
+#include <valgrind/memcheck.h>
+
+/* Number of attrs in this and all the link'd buffers */
+unsigned int __ioctl_final_num_attrs(unsigned int num_attrs,
+				     struct ibv_command_buffer *link)
+{
+	for (; link; link = link->next)
+		num_attrs += link->next_attr - link->hdr.attrs;
+
+	return num_attrs;
+}
+
+/* Linearize the link'd buffers into this one */
+static void prepare_attrs(struct ibv_command_buffer *cmd)
+{
+	struct ib_uverbs_attr *end = cmd->next_attr;
+	struct ibv_command_buffer *link;
+
+	for (link = cmd->next; link; link = link->next) {
+		struct ib_uverbs_attr *cur;
+
+		assert(cmd->hdr.object_id == link->hdr.object_id);
+		assert(cmd->hdr.method_id == link->hdr.method_id);
+
+		for (cur = link->hdr.attrs; cur != link->next_attr; cur++)
+			*end++ = *cur;
+
+		assert(end <= cmd->last_attr);
+	}
+
+	cmd->hdr.num_attrs = end - cmd->hdr.attrs;
+}
+
+static void finalize_attr(struct ib_uverbs_attr *attr)
+{
+	/* Only matches UVERBS_ATTR_TYPE_PTR_OUT */
+	if (attr->flags & UVERBS_ATTR_F_VALID_OUTPUT && attr->len)
+		VALGRIND_MAKE_MEM_DEFINED((void *)(uintptr_t)attr->data,
+					  attr->len);
+}
+
+/*
+ * Copy the link'd attrs back to their source and make all output buffers safe
+ * for VALGRIND
+ */
+static void finalize_attrs(struct ibv_command_buffer *cmd)
+{
+	struct ibv_command_buffer *link;
+	struct ib_uverbs_attr *end;
+
+	for (end = cmd->hdr.attrs; end != cmd->last_attr; end++)
+		finalize_attr(end);
+
+	for (link = cmd->next; link; link = link->next) {
+		struct ib_uverbs_attr *cur;
+
+		for (cur = link->hdr.attrs; cur != link->next_attr; cur++) {
+			finalize_attr(end);
+			*cur = *end++;
+		}
+	}
+}
+
+int execute_ioctl(struct ibv_context *context, struct ibv_command_buffer *cmd)
+{
+	prepare_attrs(cmd);
+	cmd->hdr.length = sizeof(cmd->hdr) +
+		sizeof(cmd->hdr.attrs[0]) * cmd->hdr.num_attrs;
+	cmd->hdr.reserved = 0;
+
+	if (ioctl(context->cmd_fd, RDMA_VERBS_IOCTL, &cmd->hdr))
+		return errno;
+
+	finalize_attrs(cmd);
+
+	return 0;
+}

--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __INFINIBAND_VERBS_IOCTL_H
+#define __INFINIBAND_VERBS_IOCTL_H
+
+#include <stdint.h>
+#include <assert.h>
+#include <rdma/rdma_user_ioctl.h>
+#include <rdma/ib_user_ioctl_verbs.h>
+#include <infiniband/verbs.h>
+
+static inline uint64_t ioctl_ptr_to_u64(const void *ptr)
+{
+	if (sizeof(ptr) == sizeof(uint64_t))
+		return (uintptr_t)ptr;
+
+	/*
+	 * Some CPU architectures require sign extension when converting from
+	 * a 32 bit to 64 bit pointer.  This should match the kernel
+	 * implementation of compat_ptr() for the architecture.
+	 */
+#if defined(__tilegx__)
+	return (int64_t)(intptr_t)ptr;
+#else
+	return (uintptr_t)ptr;
+#endif
+}
+
+/*
+ * The command buffer is organized as a linked list of blocks of attributes.
+ * Each stack frame allocates its block and then calls up toward to core code
+ * which will do the ioctl. The frame that does the ioctl calls the special
+ * FINAL variant which will allocate enough space to linearize the attribute
+ * buffer for the kernel.
+ *
+ * The current range of attributes to fill is next_attr -> last_attr.
+ */
+struct ibv_command_buffer {
+	struct ibv_command_buffer *next;
+	struct ib_uverbs_attr *next_attr;
+	struct ib_uverbs_attr *last_attr;
+	struct ib_uverbs_ioctl_hdr hdr;
+};
+
+/*
+ * Constructing an array of ibv_command_buffer is a reasonable way to expand
+ * the VLA in hdr.attrs on the stack and also allocate some internal state in
+ * a single contiguous stack memory region. It will over-allocate the region in
+ * some cases, but this approach allows the number of elements to be dynamic,
+ * and not fixed as a compile time constant.
+ */
+#define _IOCTL_NUM_CMDB(_num_attrs)                                            \
+	((sizeof(struct ibv_command_buffer) +                                  \
+	  sizeof(struct ib_uverbs_attr) * (_num_attrs) +                       \
+	  sizeof(struct ibv_command_buffer) - 1) /                             \
+	 sizeof(struct ibv_command_buffer))
+
+unsigned int __ioctl_final_num_attrs(unsigned int num_attrs,
+				     struct ibv_command_buffer *link);
+
+/* If the user doesn't provide a link then don't create a VLA */
+#define _ioctl_final_num_attrs(_num_attrs, _link)                              \
+	((__builtin_constant_p(!(_link)) && !(_link))                          \
+		 ? (_num_attrs)                                                \
+		 : __ioctl_final_num_attrs(_num_attrs, _link))
+
+#define _COMMAND_BUFFER_INIT(_hdr, _object_id, _method_id, _num_attrs, _link)  \
+	((struct ibv_command_buffer){                                          \
+		.hdr =                                                         \
+			{                                                      \
+				.object_id = (_object_id),                     \
+				.method_id = (_method_id),                     \
+			},                                                     \
+		.next = _link,                                                 \
+		.next_attr = (_hdr).attrs,                                     \
+		.last_attr = (_hdr).attrs + _num_attrs})
+
+/*
+ * C99 does not permit an initializer for VLAs, so this function does the init
+ * instead. It is called in the wonky way so that DELCARE_COMMAND_BUFFER can
+ * still be a 'variable', and we so we don't require C11 mode.
+ */
+static inline int _ioctl_init_cmdb(struct ibv_command_buffer *cmd,
+				   uint16_t object_id, uint16_t method_id,
+				   size_t num_attrs,
+				   struct ibv_command_buffer *link)
+{
+	*cmd = _COMMAND_BUFFER_INIT(cmd->hdr, object_id, method_id, num_attrs,
+				    link);
+	return 0;
+}
+
+/*
+ * Construct an IOCTL command buffer on the stack with enough space for
+ * _num_attrs elements. _num_attrs does not have to be a compile time constant.
+ * _link is a previous COMMAND_BUFFER in the call chain.
+ */
+#ifndef __CHECKER__
+#define DECLARE_COMMAND_BUFFER_LINK(_name, _object_id, _method_id, _num_attrs, \
+				    _link)                                     \
+	const unsigned int __##_name##total =                                  \
+		_ioctl_final_num_attrs(_num_attrs, _link);                     \
+	struct ibv_command_buffer _name[_IOCTL_NUM_CMDB(__##_name##total)];    \
+	int __attribute__((unused)) __##_name##dummy = _ioctl_init_cmdb(       \
+		_name, _object_id, _method_id, __##_name##total, _link)
+#else
+/*
+ * sparse enforces kernel rules which forbids VLAs. Make the VLA into a static
+ * array when running sparse. Don't actually run the sparse compile result.
+ */
+#define DECLARE_COMMAND_BUFFER_LINK(_name, _object_id, _method_id, _num_attrs, \
+				    _link)                                     \
+	struct ibv_command_buffer _name[10];                                   \
+	int __attribute__((unused)) __##_name##dummy =                         \
+		_ioctl_init_cmdb(_name, _object_id, _method_id, 10, _link)
+#endif
+
+#define DECLARE_COMMAND_BUFFER(_name, _object_id, _method_id, _num_attrs)      \
+	DECLARE_COMMAND_BUFFER_LINK(_name, _object_id, _method_id, _num_attrs, \
+				    NULL)
+
+int execute_ioctl(struct ibv_context *context, struct ibv_command_buffer *cmd);
+
+static inline struct ib_uverbs_attr *
+_ioctl_next_attr(struct ibv_command_buffer *cmd, uint16_t attr_id)
+{
+	struct ib_uverbs_attr *attr;
+
+	assert(cmd->next_attr < cmd->last_attr);
+	attr = cmd->next_attr++;
+
+	*attr = (struct ib_uverbs_attr){
+		.attr_id = attr_id,
+		/*
+		 * All attributes default to mandatory. Wrapper the fill_*
+		 * call in attr_optional() to make it optional.
+		 */
+		.flags = UVERBS_ATTR_F_MANDATORY,
+	};
+
+	return attr;
+}
+
+/* Make the attribute optional. */
+static inline struct ib_uverbs_attr *attr_optional(struct ib_uverbs_attr *attr)
+{
+	attr->flags &= ~UVERBS_ATTR_F_MANDATORY;
+	return attr;
+}
+
+/* Send attributes of kernel type UVERBS_ATTR_TYPE_IDR */
+static inline struct ib_uverbs_attr *
+fill_attr_in_obj(struct ibv_command_buffer *cmd, uint16_t attr_id, uint32_t idr)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	/* UVERBS_ATTR_TYPE_IDR uses a 64 bit value for the idr # */
+	attr->data = idr;
+	return attr;
+}
+
+static inline struct ib_uverbs_attr *
+fill_attr_out_obj(struct ibv_command_buffer *cmd, uint16_t attr_id)
+{
+	return fill_attr_in_obj(cmd, attr_id, 0);
+}
+
+static inline uint32_t read_attr_obj(uint16_t attr_id,
+				     struct ib_uverbs_attr *attr)
+{
+	assert(attr->attr_id == attr_id);
+	return attr->data;
+}
+
+/* Send attributes of kernel type UVERBS_ATTR_TYPE_PTR_IN */
+static inline struct ib_uverbs_attr *
+fill_attr_in(struct ibv_command_buffer *cmd, uint16_t attr_id, const void *data,
+	     size_t len)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	assert(len <= UINT16_MAX);
+
+	attr->len = len;
+	if (len <= sizeof(uint64_t))
+		memcpy(&attr->data, data, len);
+	else
+		attr->data = ioctl_ptr_to_u64(data);
+
+	return attr;
+}
+
+#define fill_attr_in_ptr(cmd, attr_id, ptr)                                    \
+	fill_attr_in(cmd, attr_id, ptr, sizeof(*ptr))
+
+/* Send attributes of various inline kernel types */
+
+static inline struct ib_uverbs_attr *
+fill_attr_in_uint64(struct ibv_command_buffer *cmd, uint16_t attr_id,
+		    uint64_t data)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	attr->len = sizeof(data);
+	attr->data = data;
+
+	return attr;
+}
+
+static inline struct ib_uverbs_attr *
+fill_attr_in_uint32(struct ibv_command_buffer *cmd, uint16_t attr_id,
+		    uint32_t data)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	attr->len = sizeof(data);
+	memcpy(&attr->data, &data, sizeof(data));
+
+	return attr;
+}
+
+static inline struct ib_uverbs_attr *
+fill_attr_in_fd(struct ibv_command_buffer *cmd, uint16_t attr_id, int fd)
+{
+	struct ib_uverbs_attr *attr;
+
+	if (fd == -1)
+		return NULL;
+
+	attr = _ioctl_next_attr(cmd, attr_id);
+	/* UVERBS_ATTR_TYPE_FD uses a 64 bit value for the idr # */
+	attr->data = fd;
+	return attr;
+}
+
+static inline struct ib_uverbs_attr *
+fill_attr_out_fd(struct ibv_command_buffer *cmd, uint16_t attr_id, int fd)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	attr->data = 0;
+	return attr;
+}
+
+static inline int read_attr_fd(uint16_t attr_id, struct ib_uverbs_attr *attr)
+{
+	assert(attr->attr_id == attr_id);
+	/* The kernel cannot fail to create a FD here, it never returns -1 */
+	return attr->data;
+}
+
+/* Send attributes of kernel type UVERBS_ATTR_TYPE_PTR_OUT */
+static inline struct ib_uverbs_attr *
+fill_attr_out(struct ibv_command_buffer *cmd, uint16_t attr_id, void *data,
+	      size_t len)
+{
+	struct ib_uverbs_attr *attr = _ioctl_next_attr(cmd, attr_id);
+
+	assert(len <= UINT16_MAX);
+	attr->len = len;
+	attr->data = ioctl_ptr_to_u64(data);
+
+	return attr;
+}
+
+#define fill_attr_out_ptr(cmd, attr_id, ptr)                                 \
+	fill_attr_out(cmd, attr_id, ptr, sizeof(*(ptr)))
+
+#endif

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -1,0 +1,311 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __INFINIBAND_VERBS_WRITE_H
+#define __INFINIBAND_VERBS_WRITE_H
+
+#include <infiniband/cmd_ioctl.h>
+#include <infiniband/driver.h>
+#include <rdma/ib_user_verbs.h>
+
+#include <stdbool.h>
+
+static inline struct ib_uverbs_cmd_hdr *get_req_hdr(void *req)
+{
+	return ((struct ib_uverbs_cmd_hdr *)req) - 1;
+}
+
+struct _ib_ex_hdr {
+	struct ib_uverbs_cmd_hdr hdr;
+	struct ib_uverbs_ex_cmd_hdr ex_hdr;
+};
+
+static inline struct _ib_ex_hdr *get_req_hdr_ex(void *req)
+{
+	return ((struct _ib_ex_hdr *)req) - 1;
+}
+
+/*
+ * When using these new interfaces the kernel UAPI structs 'ib_uverbs_*' are
+ * used, not the structs from kern-abi.h. The only difference between the two
+ * is the inclusion of the header in the kern-abi.h struct. This macro creates
+ * memory on the stack that includes both the header and the struct.
+ */
+#define DECLARE_LEGACY_REQ_BUF_CORE(_name, _pattern)                           \
+	struct {                                                               \
+		struct ib_uverbs_cmd_hdr hdr;                                  \
+		struct ib_uverbs_##_pattern core_payload;                      \
+	} _name
+
+#define DECLARE_LEGACY_REQ_BUF_CORE_EX(_name, _pattern)                        \
+	struct {                                                               \
+		struct ib_uverbs_cmd_hdr hdr;                                  \
+		struct ib_uverbs_ex_cmd_hdr ex_hdr;                            \
+		struct ib_uverbs_ex_##_pattern core_payload;                   \
+	} _name
+
+void *_write_get_req(struct ibv_command_buffer *link, void *onstack,
+		     size_t size);
+void *_write_get_req_ex(struct ibv_command_buffer *link, void *onstack,
+			size_t size);
+void *_write_get_resp(struct ibv_command_buffer *link,
+		      struct ib_uverbs_cmd_hdr *hdr, void *onstack,
+		      size_t resp_size);
+void *_write_get_resp_ex(struct ibv_command_buffer *link,
+			 struct _ib_ex_hdr *hdr, void *onstack,
+			 size_t resp_size);
+
+#define DECLARE_LEGACY_REQ_BUF(_name, _link, _pattern)                         \
+	DECLARE_LEGACY_REQ_BUF_CORE(__##_name##_onstack, _pattern);            \
+	struct ib_uverbs_##_pattern *_name =                                   \
+		_write_get_req(_link, &__##_name##_onstack, sizeof(*_name))
+
+#define DECLARE_LEGACY_REQ_BUF_EX(_name, _link, _pattern)                      \
+	DECLARE_LEGACY_REQ_BUF_CORE_EX(__##_name##_onstack, _pattern);         \
+	struct ib_uverbs_ex_##_pattern *_name =                                \
+		_write_get_req_ex(_link, &__##_name##_onstack, sizeof(*_name))
+
+#define DECLARE_LEGACY_RESP_BUF(_name, _link, _req, _pattern)                  \
+	struct ib_uverbs_##_pattern##_resp __##_name##_onstack,                \
+		*_name = _write_get_resp(_link, get_req_hdr(_req),             \
+					 &__##_name##_onstack, sizeof(*_name))
+
+#define DECLARE_LEGACY_RESP_BUF_EX(_name, _link, _req, _pattern)               \
+	struct ib_uverbs_ex_##_pattern##_resp __##_name##_onstack,             \
+		*_name = _write_get_resp_ex(_link, get_req_hdr_ex(_req),       \
+					    &__##_name##_onstack,              \
+					    sizeof(*_name))
+
+/*
+ * This macro creates 'req' and 'resp' pointers in the local stack frame that
+ * point to the core code write command structures patterned off _pattern.
+ *
+ * This should be done before calling execute_write_bufs
+ */
+#define DECLARE_LEGACY_UHW_BUFS(_link, _pattern)                               \
+	DECLARE_LEGACY_REQ_BUF(req, _link, _pattern);                          \
+	DECLARE_LEGACY_RESP_BUF(resp, _link, req, _pattern)
+
+#define DECLARE_LEGACY_UHW_BUFS_EX(_link, _pattern)                            \
+	DECLARE_LEGACY_REQ_BUF_EX(req, _link, _pattern);                       \
+	DECLARE_LEGACY_RESP_BUF_EX(resp, _link, req, _pattern)
+
+/*
+ * This macro is used to implement the compatibility command call wrappers.
+ * Compatibility calls do not accept a command_buffer, and cannot use the new
+ * attribute id mechanism. They accept the legacy kern-abi.h structs that have
+ * the embedded header.
+ */
+void _write_set_uhw(struct ibv_command_buffer *cmdb, const void *req,
+		    size_t core_req_size, size_t req_size, void *resp,
+		    size_t core_resp_size, size_t resp_size);
+#define DECLARE_CMD_BUFFER_COMPAT(_name, _object_id, _method_id)               \
+	DECLARE_COMMAND_BUFFER(_name, _object_id, _method_id, 2);              \
+	_write_set_uhw(_name, cmd, sizeof(*cmd), cmd_size, resp,               \
+		       sizeof(*resp), resp_size)
+
+/*
+ * The fallback scheme keeps track of which ioctls succeed in a per-context
+ * bitmap. If ENOTTY or EPROTONOSUPPORT is seen then the ioctl is never
+ * retried.
+ *
+ * cmd_name should be the name of the function op from verbs_context_ops
+ * that is being implemented.
+ */
+#define _CMD_BIT(cmd_name)                                                     \
+	(offsetof(struct verbs_context_ops, cmd_name) / sizeof(void *))
+
+enum write_fallback { TRY_WRITE, TRY_WRITE_EX, ERROR, SUCCESS };
+
+/*
+ * This bitmask indicate the required behavior of execute_ioctl_fallback when
+ * the ioctl is not supported. It is a priority list where the highest set bit
+ * takes precedence. This approach simplifies the typical required control
+ * flow of the user.
+ */
+static inline void fallback_require_ex(struct ibv_command_buffer *cmdb)
+{
+	cmdb->fallback_require_ex = 1;
+}
+
+static inline void fallback_require_ioctl(struct ibv_command_buffer *cmdb)
+{
+	cmdb->fallback_ioctl_only = 1;
+}
+
+enum write_fallback _check_legacy(struct ibv_command_buffer *cmdb, int *ret);
+
+enum write_fallback _execute_ioctl_fallback(struct ibv_context *ctx,
+					    unsigned int cmd_bit,
+					    struct ibv_command_buffer *cmdb,
+					    int *ret);
+
+#define execute_ioctl_fallback(ctx, cmd_name, cmdb, ret)                       \
+	_execute_ioctl_fallback(ctx, _CMD_BIT(cmd_name), cmdb, ret)
+
+/* These helpers replace the raw write() and IBV_INIT_CMD macros */
+int _execute_write_raw(unsigned int cmdnum, struct ibv_context *ctx,
+		       struct ib_uverbs_cmd_hdr *req, void *resp);
+
+/* For users of DECLARE_LEGACY_UHW_BUFS */
+#define execute_write_bufs(cmdnum, ctx, req, resp)                             \
+	({                                                                     \
+		(req)->response = ioctl_ptr_to_u64(resp);                      \
+		_execute_write_raw(cmdnum, ctx, get_req_hdr(req), resp);       \
+	})
+
+int _execute_write_raw_ex(uint32_t cmdnum, struct ibv_context *ctx,
+			  struct _ib_ex_hdr *req, void *resp);
+
+/* For users of DECLARE_LEGACY_UHW_BUFS_EX */
+#define execute_write_bufs_ex(cmdnum, ctx, req, resp)                          \
+	_execute_write_raw_ex(cmdnum, ctx, get_req_hdr_ex(req), resp)
+
+static inline int _execute_write(uint32_t cmdnum, struct ibv_context *ctx,
+				 void *req, size_t req_len, void *resp,
+				 size_t resp_len)
+{
+	struct ib_uverbs_cmd_hdr *hdr = get_req_hdr(req);
+
+	hdr->in_words = req_len / 4;
+	hdr->out_words = resp_len / 4;
+	return _execute_write_raw(cmdnum, ctx, hdr, resp);
+}
+
+/* For users with no possible UHW bufs. */
+#define DECLARE_LEGACY_CORE_BUFS(_pattern)                                     \
+	DECLARE_LEGACY_REQ_BUF_CORE(__req_onstack, _pattern);                  \
+	struct ib_uverbs_##_pattern *const req = &__req_onstack.core_payload;  \
+	struct ib_uverbs_##_pattern##_resp resp
+
+/*
+ * For users with no UHW bufs. To be used in conjunction with
+ * DECLARE_LEGACY_CORE_BUFS. req points to the core payload (with headroom for
+ * the header).
+ */
+#define execute_write(cmdnum, ctx, req, resp)                                  \
+	({                                                                     \
+		(req)->response = ioctl_ptr_to_u64(resp);                      \
+		_execute_write(cmdnum, ctx, req, sizeof(*req), resp,           \
+			       sizeof(*resp));                                 \
+	})
+
+/*
+ * These two macros are used only with execute_ioctl_fallback - they allow the
+ * IOCTL code to be elided by the compiler when disabled.
+ */
+#define DECLARE_FBCMD_BUFFER DECLARE_COMMAND_BUFFER_LINK
+
+/*
+ * Munge the macros above to remove certain paths during compilation based on
+ * the cmake flag.
+ */
+#if VERBS_IOCTL_ONLY
+static inline enum write_fallback
+_execute_ioctl_only(struct ibv_context *context, struct ibv_command_buffer *cmd,
+		    int *ret)
+{
+	*ret = execute_ioctl(context, cmd);
+	if (*ret)
+		return ERROR;
+
+	return SUCCESS;
+}
+
+#undef execute_ioctl_fallback
+#define execute_ioctl_fallback(ctx, cmd_name, cmdb, ret)                       \
+	_execute_ioctl_only(ctx, cmdb, ret)
+
+#undef execute_write_bufs
+static inline int execute_write_bufs(uint32_t cmdnum,
+				     struct ibv_context *ctx, void *req,
+				     void *resp)
+{
+	return ENOSYS;
+}
+
+#undef execute_write_bufs_ex
+static inline int execute_write_bufs_ex(uint32_t cmdnum,
+					struct ibv_context *ctx, void *req,
+					void *resp)
+{
+	return ENOSYS;
+}
+
+#undef execute_write
+static inline int execute_write(uint32_t cmdnum,
+				struct ibv_context *ctx, void *req,
+				void *resp)
+{
+	return ENOSYS;
+}
+
+#endif
+
+#if VERBS_WRITE_ONLY
+static inline enum write_fallback
+_execute_write_only(struct ibv_context *context, struct ibv_command_buffer *cmd,
+		    int *ret)
+{
+	/*
+	 * write only still has the command buffer, and the command buffer
+	 * carries the fallback guidance that we need to inspect. This is
+	 * written in this odd way so the compiler knows that SUCCESS is not a
+	 * possible return and optimizes accordingly.
+	 */
+	switch (_check_legacy(cmd, ret)) {
+	case TRY_WRITE:
+		return TRY_WRITE;
+	case TRY_WRITE_EX:
+		return TRY_WRITE_EX;
+	default:
+		return ERROR;
+	}
+}
+
+#undef execute_ioctl_fallback
+#define execute_ioctl_fallback(ctx, cmd_name, cmdb, ret)                       \
+	_execute_write_only(ctx, cmdb, ret)
+
+#undef DECLARE_FBCMD_BUFFER
+#define DECLARE_FBCMD_BUFFER(_name, _object_id, _method_id, _num_attrs, _link) \
+	struct ibv_command_buffer _name[1] = {                                 \
+		{                                                              \
+			.next = _link,                                         \
+			.uhw_in_idx = _UHW_NO_INDEX,                           \
+			.uhw_out_idx = _UHW_NO_INDEX,                          \
+		},                                                             \
+	}
+
+#endif
+
+#endif

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -217,7 +217,7 @@ int verbs_init_context(struct verbs_context *context_ex,
 	context_ex->ABI_placeholder2 =
 		(void (*)(void))context_ex->ibv_destroy_flow;
 
-	context_ex->priv = calloc(1, sizeof(context_ex->priv));
+	context_ex->priv = calloc(1, sizeof(*context_ex->priv));
 	if (!context_ex->priv) {
 		errno = ENOMEM;
 		close(cmd_fd);

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -373,10 +373,8 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ibv_cq_init_attr_ex *cq_attr,
 			 struct ibv_cq_ex *cq,
 			 struct ibv_create_cq_ex *cmd,
-			 size_t cmd_core_size,
 			 size_t cmd_size,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
-			 size_t resp_core_size,
 			 size_t resp_size);
 int ibv_cmd_poll_cq(struct ibv_cq *cq, int ne, struct ibv_wc *wc);
 int ibv_cmd_req_notify_cq(struct ibv_cq *cq, int solicited_only);

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -60,6 +60,8 @@ void ibverbs_device_hold(struct ibv_device *dev);
 struct verbs_ex_private {
 	struct ibv_cq_ex *(*create_cq_ex)(struct ibv_context *context,
 					  struct ibv_cq_init_attr_ex *init_attr);
+
+	uint64_t unsupported_ioctls;
 };
 
 #define IBV_INIT_CMD(cmd, size, opcode)					\

--- a/libibverbs/kern-abi.h
+++ b/libibverbs/kern-abi.h
@@ -170,12 +170,7 @@ struct ibv_create_comp_channel {
 
 struct ibv_create_cq {
 	struct ib_uverbs_cmd_hdr hdr;
-	__u64 response;
-	__u64 user_handle;
-	__u32 cqe;
-	__u32 comp_vector;
-	__s32 comp_channel;
-	__u32 reserved;
+	struct ib_uverbs_create_cq core_payload;
 };
 
 enum ibv_create_cq_ex_kernel_flags {
@@ -184,13 +179,7 @@ enum ibv_create_cq_ex_kernel_flags {
 
 struct ibv_create_cq_ex {
 	struct ex_hdr	hdr;
-	__u64		user_handle;
-	__u32		cqe;
-	__u32		comp_vector;
-	__s32		comp_channel;
-	__u32		comp_mask;
-	__u32		flags;
-	__u32		reserved;
+	struct ib_uverbs_ex_create_cq core_payload;
 };
 
 struct ibv_poll_cq {
@@ -215,9 +204,7 @@ struct ibv_resize_cq {
 
 struct ibv_destroy_cq {
 	struct ib_uverbs_cmd_hdr hdr;
-	__u64 response;
-	__u32 cq_handle;
-	__u32 reserved;
+	struct ib_uverbs_destroy_cq core_payload;
 };
 
 #define IBV_CREATE_QP_COMMON	\

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -113,6 +113,7 @@ IBVERBS_1.1 {
 IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 	global:
 		/* These historical symbols are now private to libibverbs */
+		__ioctl_final_num_attrs;
 		_verbs_init_and_alloc_context;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1608,12 +1608,10 @@ struct ibv_context {
 
 enum ibv_cq_init_attr_mask {
 	IBV_CQ_INIT_ATTR_MASK_FLAGS	= 1 << 0,
-	IBV_CQ_INIT_ATTR_MASK_RESERVED	= 1 << 1
 };
 
 enum ibv_create_cq_attr_flags {
 	IBV_CREATE_CQ_ATTR_SINGLE_THREADED = 1 << 0,
-	IBV_CREATE_CQ_ATTR_RESERVED = 1 << 1,
 };
 
 struct ibv_cq_init_attr_ex {

--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -168,7 +168,6 @@ int c4iw_dereg_mr(struct ibv_mr *mr)
 struct ibv_cq *c4iw_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_comp_channel *channel, int comp_vector)
 {
-	struct ibv_create_cq cmd;
 	struct c4iw_create_cq_resp resp;
 	struct c4iw_cq *chp;
 	struct c4iw_dev *dev = to_c4iw_dev(context->device);
@@ -181,7 +180,7 @@ struct ibv_cq *c4iw_create_cq(struct ibv_context *context, int cqe,
 
 	resp.reserved = 0;
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				&chp->ibv_cq, &cmd, sizeof cmd,
+				&chp->ibv_cq, NULL, 0,
 				&resp.ibv_resp, sizeof resp);
 	if (ret)
 		goto err1;

--- a/providers/hfi1verbs/verbs.c
+++ b/providers/hfi1verbs/verbs.c
@@ -169,7 +169,6 @@ struct ibv_cq *hfi1_create_cq(struct ibv_context *context, int cqe,
 			       int comp_vector)
 {
 	struct hfi1_cq		   *cq;
-	struct ibv_create_cq	    cmd;
 	struct hfi1_create_cq_resp resp;
 	int			    ret;
 	size_t			    size;
@@ -180,7 +179,7 @@ struct ibv_cq *hfi1_create_cq(struct ibv_context *context, int cqe,
 		return NULL;
 
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				&cq->ibv_cq, &cmd, sizeof cmd,
+				&cq->ibv_cq, NULL, 0,
 				&resp.ibv_resp, sizeof resp);
 	if (ret) {
 		free(cq);
@@ -205,8 +204,6 @@ struct ibv_cq *hfi1_create_cq_v1(struct ibv_context *context, int cqe,
 				  int comp_vector)
 {
 	struct ibv_cq		   *cq;
-	struct ibv_create_cq	    cmd;
-	struct ib_uverbs_create_cq_resp   resp;
 	int			    ret;
 
 	cq = malloc(sizeof *cq);
@@ -214,7 +211,7 @@ struct ibv_cq *hfi1_create_cq_v1(struct ibv_context *context, int cqe,
 		return NULL;
 
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				cq, &cmd, sizeof cmd, &resp, sizeof resp);
+				cq, NULL, 0, NULL, 0);
 	if (ret) {
 		free(cq);
 		return NULL;

--- a/providers/ipathverbs/verbs.c
+++ b/providers/ipathverbs/verbs.c
@@ -148,7 +148,6 @@ struct ibv_cq *ipath_create_cq(struct ibv_context *context, int cqe,
 			       int comp_vector)
 {
 	struct ipath_cq		   *cq;
-	struct ibv_create_cq	    cmd;
 	struct ipath_create_cq_resp resp;
 	int			    ret;
 	size_t			    size;
@@ -158,7 +157,7 @@ struct ibv_cq *ipath_create_cq(struct ibv_context *context, int cqe,
 		return NULL;
 
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				&cq->ibv_cq, &cmd, sizeof cmd,
+				&cq->ibv_cq, NULL, 0,
 				&resp.ibv_resp, sizeof resp);
 	if (ret) {
 		free(cq);
@@ -183,8 +182,6 @@ struct ibv_cq *ipath_create_cq_v1(struct ibv_context *context, int cqe,
 				  int comp_vector)
 {
 	struct ibv_cq		   *cq;
-	struct ibv_create_cq	    cmd;
-	struct ib_uverbs_create_cq_resp   resp;
 	int			    ret;
 
 	cq = malloc(sizeof *cq);
@@ -192,7 +189,7 @@ struct ibv_cq *ipath_create_cq_v1(struct ibv_context *context, int cqe,
 		return NULL;
 
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				cq, &cmd, sizeof cmd, &resp, sizeof resp);
+				cq, NULL, 0, NULL, 0);
 	if (ret) {
 		free(cq);
 		return NULL;

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -574,7 +574,8 @@ struct ibv_cq_ex *mlx4_create_cq_ex(struct ibv_context *context,
 						.comp_mask = cq_attr->comp_mask,
 						.flags = cq_attr->flags};
 
-	if (!check_comp_mask(cq_attr_c.comp_mask, IBV_CQ_INIT_ATTR_MASK_RESERVED - 1)) {
+	if (!check_comp_mask(cq_attr_c.comp_mask,
+			     IBV_CQ_INIT_ATTR_MASK_FLAGS)) {
 		errno = EINVAL;
 		return NULL;
 	}

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -413,8 +413,8 @@ static int mlx4_cmd_create_cq(struct ibv_context *context,
 			      struct ibv_cq_init_attr_ex *cq_attr,
 			      struct mlx4_cq *cq)
 {
-	struct mlx4_create_cq      cmd = {};
-	struct mlx4_create_cq_resp resp = {};
+	struct mlx4_create_cq      cmd;
+	struct mlx4_create_cq_resp resp;
 	int ret;
 
 	cmd.buf_addr = (uintptr_t) cq->buf.buf;
@@ -436,8 +436,8 @@ static int mlx4_cmd_create_cq_ex(struct ibv_context *context,
 				 struct ibv_cq_init_attr_ex *cq_attr,
 				 struct mlx4_cq *cq)
 {
-	struct mlx4_create_cq_ex      cmd = {};
-	struct mlx4_create_cq_resp_ex resp = {};
+	struct mlx4_create_cq_ex      cmd;
+	struct mlx4_create_cq_resp_ex resp;
 	int ret;
 
 	cmd.buf_addr = (uintptr_t) cq->buf.buf;
@@ -445,10 +445,8 @@ static int mlx4_cmd_create_cq_ex(struct ibv_context *context,
 
 	ret = ibv_cmd_create_cq_ex(context, cq_attr,
 				   &cq->ibv_cq, &cmd.ibv_cmd,
-				   sizeof(cmd.ibv_cmd),
 				   sizeof(cmd),
 				   &resp.ibv_resp,
-				   sizeof(resp.ibv_resp),
 				   sizeof(resp));
 	if (!ret)
 		cq->cqn = resp.cqn;

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -162,7 +162,6 @@ static struct ibv_cq *rxe_create_cq(struct ibv_context *context, int cqe,
 				    int comp_vector)
 {
 	struct rxe_cq *cq;
-	struct ibv_create_cq cmd;
 	struct rxe_create_cq_resp resp;
 	int ret;
 
@@ -172,7 +171,7 @@ static struct ibv_cq *rxe_create_cq(struct ibv_context *context, int cqe,
 	}
 
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				&cq->ibv_cq, &cmd, sizeof cmd,
+				&cq->ibv_cq, NULL, 0,
 				&resp.ibv_resp, sizeof resp);
 	if (ret) {
 		free(cq);


### PR DESCRIPTION
This series implements the new kabi for RDMA core, using all the functions currently implemented in the kernel as an example. It relies on all the latest kernel patches to work correctly.

It implements create_cq, create_cq_ex and destroy_cq using the new kabi.

The library continues to support the write interface, and a compile time switch is provided to select which kernel APIs will be supported. By default today only write is used.