### PR TITLE
Mlx4 TSO

### DIFF
--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -105,6 +105,14 @@ struct mlx4_rss_caps {
 	__u8 reserved[7];
 };
 
+struct mlx4_ib_tso_caps {
+	__u32 max_tso; /* Maximum tso payload size in bytes */
+	/* Corresponding bit will be set if qp type from
+	 * 'enum ib_qp_type' is supported.
+	 */
+	__u32 supported_qpts;
+};
+
 struct mlx4_query_device_ex_resp {
 	struct ib_uverbs_ex_query_device_resp ibv_resp;
 	__u32				comp_mask;
@@ -114,6 +122,7 @@ struct mlx4_query_device_ex_resp {
 	/* Explicitly align the response to u64 */
 	__u32				reserved;
 	struct mlx4_rss_caps            rss_caps; /* vendor data channel */
+	struct mlx4_ib_tso_caps		tso_caps;
 };
 
 struct mlx4_query_device_ex {

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -111,6 +111,8 @@ struct mlx4_query_device_ex_resp {
 	__u32				response_length;
 	__u64				hca_core_clock_offset;
 	__u32				max_inl_recv_sz;
+	/* Explicitly align the response to u64 */
+	__u32				reserved;
 	struct mlx4_rss_caps            rss_caps; /* vendor data channel */
 };
 

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -399,7 +399,7 @@ int mlx4_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 int mlx4_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
 			  struct ibv_recv_wr **bad_wr);
 void mlx4_calc_sq_wqe_size(struct ibv_qp_cap *cap, enum ibv_qp_type type,
-			   struct mlx4_qp *qp);
+			   struct mlx4_qp *qp, struct ibv_qp_init_attr_ex *attr);
 int mlx4_alloc_qp_buf(struct ibv_context *context, uint32_t max_recv_sge,
 		       enum ibv_qp_type type, struct mlx4_qp *qp,
 		       struct mlx4dv_qp_init_attr *mlx4qp_attr);

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -393,6 +393,11 @@ struct mlx4_wqe_raddr_seg {
 	__be32			reserved;
 };
 
+struct mlx4_wqe_lso_seg {
+	__be32			mss_hdr_size;
+	__be32			header[0];
+};
+
 struct mlx4_wqe_atomic_seg {
 	__be64			swap_add;
 	__be64			compare;

--- a/providers/mlx4/qp.c
+++ b/providers/mlx4/qp.c
@@ -619,7 +619,7 @@ static int num_inline_segs(int data, enum ibv_qp_type type)
 }
 
 void mlx4_calc_sq_wqe_size(struct ibv_qp_cap *cap, enum ibv_qp_type type,
-			   struct mlx4_qp *qp)
+			   struct mlx4_qp *qp, struct ibv_qp_init_attr_ex *attr)
 {
 	int size;
 	int max_sq_sge;
@@ -666,6 +666,9 @@ void mlx4_calc_sq_wqe_size(struct ibv_qp_cap *cap, enum ibv_qp_type type,
 		size = sizeof (struct mlx4_wqe_bind_seg);
 
 	size += sizeof (struct mlx4_wqe_ctrl_seg);
+
+	if (attr->comp_mask & IBV_QP_INIT_ATTR_MAX_TSO_HEADER)
+		size += align(sizeof (struct mlx4_wqe_lso_seg) + attr->max_tso_header, 16);
 
 	for (qp->sq.wqe_shift = 6; 1 << qp->sq.wqe_shift < size;
 	     qp->sq.wqe_shift++)


### PR DESCRIPTION
This patch set implements the TSO related stuff in the mlx4 provider.
The matching kernel part was sent into for-next few days ago.
