### PR TITLE
libqedr: fix wc wr_id initialization on failure cases

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -1771,6 +1771,7 @@ static void __process_resp_one(struct qelr_qp *qp, struct qelr_cq *cq,
 	uint8_t flags;
 
 	wc->opcode = IBV_WC_RECV;
+	wc->wr_id = wr_id;
 	wc->wc_flags = 0;
 
 	switch (resp->status) {
@@ -1815,7 +1816,6 @@ static void __process_resp_one(struct qelr_qp *qp, struct qelr_cq *cq,
 			break;
 		}
 
-		wc->wr_id = wr_id;
 		break;
 	default:
 		wc->status = IBV_WC_GENERAL_ERR;


### PR DESCRIPTION
Assign to a wc it's relevant wr_id in each completion status
(not only in success)

Signed-off-by: Yuval Bason <Yuval.Bason@cavium.com>
Signed-off-by: Michal Kalderon <Michal.Kalderon@cavium.com>