### PR TITLE
Ioctl changes 

### DIFF
--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -3,6 +3,7 @@ publish_internal_headers(rdma
   rdma/cxgb3-abi.h
   rdma/cxgb4-abi.h
   rdma/hns-abi.h
+  rdma/i40iw-abi.h
   rdma/ib_user_cm.h
   rdma/ib_user_ioctl_verbs.h
   rdma/ib_user_mad.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -5,6 +5,7 @@ publish_internal_headers(rdma
   rdma/hns-abi.h
   rdma/i40iw-abi.h
   rdma/ib_user_cm.h
+  rdma/ib_user_ioctl_cmds.h
   rdma/ib_user_ioctl_verbs.h
   rdma/ib_user_mad.h
   rdma/ib_user_sa.h
@@ -18,6 +19,7 @@ publish_internal_headers(rdma
   rdma/rdma_netlink.h
   rdma/rdma_user_cm.h
   rdma/rdma_user_ioctl.h
+  rdma/rdma_user_ioctl_cmds.h
   rdma/rdma_user_rxe.h
   rdma/vmw_pvrdma-abi.h
   )

--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -53,11 +53,16 @@ struct bnxt_re_uctx_resp {
 	__u32 rsvd;
 };
 
+/*
+ * This struct is placed after the ib_uverbs_alloc_pd_resp struct, which is
+ * not 8 byted aligned. To avoid undesired padding in various cases we have to
+ * set this struct to packed.
+ */
 struct bnxt_re_pd_resp {
 	__u32 pdid;
 	__u32 dpi;
 	__u64 dbr;
-};
+} __attribute__((packed, aligned(4)));
 
 struct bnxt_re_cq_req {
 	__u64 cq_va;

--- a/kernel-headers/rdma/cxgb4-abi.h
+++ b/kernel-headers/rdma/cxgb4-abi.h
@@ -79,4 +79,9 @@ struct c4iw_alloc_ucontext_resp {
 	__u32 status_page_size;
 	__u32 reserved; /* explicit padding (optional for i386) */
 };
+
+struct c4iw_alloc_pd_resp {
+	__u32 pdid;
+};
+
 #endif /* CXGB4_ABI_USER_H */

--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -38,6 +38,12 @@
 
 struct hns_roce_ib_create_cq {
 	__u64   buf_addr;
+	__u64	db_addr;
+};
+
+struct hns_roce_ib_create_cq_resp {
+	__u64	cqn; /* Only 32 bits used, 64 for compat */
+	__u64	cap_flags;
 };
 
 struct hns_roce_ib_create_qp {
@@ -49,7 +55,17 @@ struct hns_roce_ib_create_qp {
 	__u8    reserved[5];
 };
 
+struct hns_roce_ib_create_qp_resp {
+	__u64	cap_flags;
+};
+
 struct hns_roce_ib_alloc_ucontext_resp {
 	__u32	qp_tab_size;
+	__u32	reserved;
 };
+
+struct hns_roce_ib_alloc_pd_resp {
+	__u32 pdn;
+};
+
 #endif /* HNS_ABI_USER_H */

--- a/kernel-headers/rdma/i40iw-abi.h
+++ b/kernel-headers/rdma/i40iw-abi.h
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2006 - 2016 Intel Corporation.  All rights reserved.
+ * Copyright (c) 2005 Topspin Communications.  All rights reserved.
+ * Copyright (c) 2005 Cisco Systems.  All rights reserved.
+ * Copyright (c) 2005 Open Grid Computing, Inc. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ */
+
+#ifndef I40IW_ABI_H
+#define I40IW_ABI_H
+
+#include <linux/types.h>
+
+#define I40IW_ABI_VER 5
+
+struct i40iw_alloc_ucontext_req {
+	__u32 reserved32;
+	__u8 userspace_ver;
+	__u8 reserved8[3];
+};
+
+struct i40iw_alloc_ucontext_resp {
+	__u32 max_pds;		/* maximum pds allowed for this user process */
+	__u32 max_qps;		/* maximum qps allowed for this user process */
+	__u32 wq_size;		/* size of the WQs (sq+rq) allocated to the mmaped area */
+	__u8 kernel_ver;
+	__u8 reserved[3];
+};
+
+struct i40iw_alloc_pd_resp {
+	__u32 pd_id;
+	__u8 reserved[4];
+};
+
+struct i40iw_create_cq_req {
+	__u64 user_cq_buffer;
+	__u64 user_shadow_area;
+};
+
+struct i40iw_create_qp_req {
+	__u64 user_wqe_buffers;
+	__u64 user_compl_ctx;
+
+	/* UDA QP PHB */
+	__u64 user_sq_phb;	/* place for VA of the sq phb buff */
+	__u64 user_rq_phb;	/* place for VA of the rq phb buff */
+};
+
+enum i40iw_memreg_type {
+	IW_MEMREG_TYPE_MEM = 0x0000,
+	IW_MEMREG_TYPE_QP = 0x0001,
+	IW_MEMREG_TYPE_CQ = 0x0002,
+};
+
+struct i40iw_mem_reg_req {
+	__u16 reg_type;		/* Memory, QP or CQ */
+	__u16 cq_pages;
+	__u16 rq_pages;
+	__u16 sq_pages;
+};
+
+struct i40iw_create_cq_resp {
+	__u32 cq_id;
+	__u32 cq_size;
+	__u32 mmap_db_index;
+	__u32 reserved;
+};
+
+struct i40iw_create_qp_resp {
+	__u32 qp_id;
+	__u32 actual_sq_size;
+	__u32 actual_rq_size;
+	__u32 i40iw_drv_opt;
+	__u16 push_idx;
+	__u8  lsmm;
+	__u8  rsvd2;
+};
+
+#endif

--- a/kernel-headers/rdma/ib_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/ib_user_ioctl_cmds.h
@@ -1,6 +1,5 @@
-/* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright (c) 2017-2018, Mellanox Technologies inc.  All rights reserved.
+ * Copyright (c) 2018, Mellanox Technologies inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,13 +30,54 @@
  * SOFTWARE.
  */
 
-#ifndef IB_USER_IOCTL_VERBS_H
-#define IB_USER_IOCTL_VERBS_H
+#ifndef IB_USER_IOCTL_CMDS_H
+#define IB_USER_IOCTL_CMDS_H
 
-#include <linux/types.h>
+#define UVERBS_ID_NS_MASK 0xF000
+#define UVERBS_ID_NS_SHIFT 12
 
-#ifndef RDMA_UAPI_PTR
-#define RDMA_UAPI_PTR(_type, _name)	_type __attribute__((aligned(8))) _name
-#endif
+#define UVERBS_UDATA_DRIVER_DATA_NS	1
+#define UVERBS_UDATA_DRIVER_DATA_FLAG	(1UL << UVERBS_ID_NS_SHIFT)
+
+enum uverbs_default_objects {
+	UVERBS_OBJECT_DEVICE, /* No instances of DEVICE are allowed */
+	UVERBS_OBJECT_PD,
+	UVERBS_OBJECT_COMP_CHANNEL,
+	UVERBS_OBJECT_CQ,
+	UVERBS_OBJECT_QP,
+	UVERBS_OBJECT_SRQ,
+	UVERBS_OBJECT_AH,
+	UVERBS_OBJECT_MR,
+	UVERBS_OBJECT_MW,
+	UVERBS_OBJECT_FLOW,
+	UVERBS_OBJECT_XRCD,
+	UVERBS_OBJECT_RWQ_IND_TBL,
+	UVERBS_OBJECT_WQ,
+};
+
+enum {
+	UVERBS_ATTR_UHW_IN = UVERBS_UDATA_DRIVER_DATA_FLAG,
+	UVERBS_ATTR_UHW_OUT,
+};
+
+enum uverbs_attrs_create_cq_cmd_attr_ids {
+	UVERBS_ATTR_CREATE_CQ_HANDLE,
+	UVERBS_ATTR_CREATE_CQ_CQE,
+	UVERBS_ATTR_CREATE_CQ_USER_HANDLE,
+	UVERBS_ATTR_CREATE_CQ_COMP_CHANNEL,
+	UVERBS_ATTR_CREATE_CQ_COMP_VECTOR,
+	UVERBS_ATTR_CREATE_CQ_FLAGS,
+	UVERBS_ATTR_CREATE_CQ_RESP_CQE,
+};
+
+enum uverbs_attrs_destroy_cq_cmd_attr_ids {
+	UVERBS_ATTR_DESTROY_CQ_HANDLE,
+	UVERBS_ATTR_DESTROY_CQ_RESP,
+};
+
+enum uverbs_methods_cq {
+	UVERBS_METHOD_CQ_CREATE,
+	UVERBS_METHOD_CQ_DESTROY,
+};
 
 #endif

--- a/kernel-headers/rdma/mlx4-abi.h
+++ b/kernel-headers/rdma/mlx4-abi.h
@@ -59,6 +59,10 @@ struct mlx4_ib_alloc_ucontext_resp_v3 {
 	__u16	bf_regs_per_page;
 };
 
+enum {
+	MLX4_USER_DEV_CAP_LARGE_CQE	= 1L << 0,
+};
+
 struct mlx4_ib_alloc_ucontext_resp {
 	__u32	dev_caps;
 	__u32	qp_tab_size;
@@ -162,12 +166,25 @@ struct mlx4_ib_rss_caps {
 	__u8 reserved[7];
 };
 
+enum query_device_resp_mask {
+	MLX4_IB_QUERY_DEV_RESP_MASK_CORE_CLOCK_OFFSET = 1UL << 0,
+};
+
+struct mlx4_ib_tso_caps {
+	__u32 max_tso; /* Maximum tso payload size in bytes */
+	/* Corresponding bit will be set if qp type from
+	 * 'enum ib_qp_type' is supported.
+	 */
+	__u32 supported_qpts;
+};
+
 struct mlx4_uverbs_ex_query_device_resp {
 	__u32			comp_mask;
 	__u32			response_length;
 	__u64			hca_core_clock_offset;
 	__u32			max_inl_recv_sz;
 	struct mlx4_ib_rss_caps	rss_caps;
+	struct mlx4_ib_tso_caps tso_caps;
 };
 
 #endif /* MLX4_ABI_USER_H */

--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -163,6 +163,10 @@ struct mlx5_ib_cqe_comp_caps {
 	__u32 supported_format; /* enum mlx5_ib_cqe_comp_res_format */
 };
 
+enum mlx5_ib_packet_pacing_cap_flags {
+	MLX5_IB_PP_SUPPORT_BURST	= 1 << 0,
+};
+
 struct mlx5_packet_pacing_caps {
 	__u32 qp_rate_limit_min;
 	__u32 qp_rate_limit_max; /* In kpbs */
@@ -172,7 +176,8 @@ struct mlx5_packet_pacing_caps {
 	 * supported_qpts |= 1 << IB_QPT_RAW_PACKET
 	 */
 	__u32 supported_qpts;
-	__u32 reserved;
+	__u8  cap_flags; /* enum mlx5_ib_packet_pacing_cap_flags */
+	__u8  reserved[3];
 };
 
 enum mlx5_ib_mpw_caps {
@@ -360,6 +365,18 @@ struct mlx5_ib_create_ah_resp {
 	__u32	response_length;
 	__u8	dmac[ETH_ALEN];
 	__u8	reserved[6];
+};
+
+struct mlx5_ib_burst_info {
+	__u32       max_burst_sz;
+	__u16       typical_pkt_sz;
+	__u16       reserved;
+};
+
+struct mlx5_ib_modify_qp {
+	__u32			   comp_mask;
+	struct mlx5_ib_burst_info  burst_info;
+	__u32			   reserved;
 };
 
 struct mlx5_ib_modify_qp_resp {

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -238,6 +238,14 @@ enum rdma_nldev_command {
 
 	RDMA_NLDEV_CMD_RES_QP_GET, /* can dump */
 
+	RDMA_NLDEV_CMD_RES_CM_ID_GET, /* can dump */
+
+	RDMA_NLDEV_CMD_RES_CQ_GET, /* can dump */
+
+	RDMA_NLDEV_CMD_RES_MR_GET, /* can dump */
+
+	RDMA_NLDEV_CMD_RES_PD_GET, /* can dump */
+
 	RDMA_NLDEV_NUM_OPS
 };
 
@@ -349,6 +357,36 @@ enum rdma_nldev_attr {
 	 * to read /proc/PID/comm file.
 	 */
 	RDMA_NLDEV_ATTR_RES_KERN_NAME,		/* string */
+
+	RDMA_NLDEV_ATTR_RES_CM_ID,		/* nested table */
+	RDMA_NLDEV_ATTR_RES_CM_ID_ENTRY,	/* nested table */
+	/*
+	 * rdma_cm_id port space.
+	 */
+	RDMA_NLDEV_ATTR_RES_PS,			/* u32 */
+	/*
+	 * Source and destination socket addresses
+	 */
+	RDMA_NLDEV_ATTR_RES_SRC_ADDR,		/* __kernel_sockaddr_storage */
+	RDMA_NLDEV_ATTR_RES_DST_ADDR,		/* __kernel_sockaddr_storage */
+
+	RDMA_NLDEV_ATTR_RES_CQ,			/* nested table */
+	RDMA_NLDEV_ATTR_RES_CQ_ENTRY,		/* nested table */
+	RDMA_NLDEV_ATTR_RES_CQE,		/* u32 */
+	RDMA_NLDEV_ATTR_RES_USECNT,		/* u64 */
+	RDMA_NLDEV_ATTR_RES_POLL_CTX,		/* u8 */
+
+	RDMA_NLDEV_ATTR_RES_MR,			/* nested table */
+	RDMA_NLDEV_ATTR_RES_MR_ENTRY,		/* nested table */
+	RDMA_NLDEV_ATTR_RES_RKEY,		/* u32 */
+	RDMA_NLDEV_ATTR_RES_LKEY,		/* u32 */
+	RDMA_NLDEV_ATTR_RES_IOVA,		/* u64 */
+	RDMA_NLDEV_ATTR_RES_MRLEN,		/* u64 */
+
+	RDMA_NLDEV_ATTR_RES_PD,			/* nested table */
+	RDMA_NLDEV_ATTR_RES_PD_ENTRY,		/* nested table */
+	RDMA_NLDEV_ATTR_RES_LOCAL_DMA_LKEY,	/* u32 */
+	RDMA_NLDEV_ATTR_RES_UNSAFE_GLOBAL_RKEY,	/* u32 */
 
 	RDMA_NLDEV_ATTR_MAX
 };

--- a/kernel-headers/rdma/rdma_user_ioctl.h
+++ b/kernel-headers/rdma/rdma_user_ioctl.h
@@ -34,48 +34,12 @@
 #ifndef RDMA_USER_IOCTL_H
 #define RDMA_USER_IOCTL_H
 
-#include <linux/types.h>
-#include <linux/ioctl.h>
 #include <rdma/ib_user_mad.h>
 #include <rdma/hfi/hfi1_ioctl.h>
+#include <rdma/rdma_user_ioctl_cmds.h>
 
-/* Documentation/ioctl/ioctl-number.txt */
-#define RDMA_IOCTL_MAGIC	0x1b
 /* Legacy name, for user space application which already use it */
 #define IB_IOCTL_MAGIC		RDMA_IOCTL_MAGIC
-
-#define RDMA_VERBS_IOCTL \
-	_IOWR(RDMA_IOCTL_MAGIC, 1, struct ib_uverbs_ioctl_hdr)
-
-#define UVERBS_ID_NS_MASK 0xF000
-#define UVERBS_ID_NS_SHIFT 12
-
-enum {
-	/* User input */
-	UVERBS_ATTR_F_MANDATORY = 1U << 0,
-	/*
-	 * Valid output bit should be ignored and considered set in
-	 * mandatory fields. This bit is kernel output.
-	 */
-	UVERBS_ATTR_F_VALID_OUTPUT = 1U << 1,
-};
-
-struct ib_uverbs_attr {
-	__u16 attr_id;		/* command specific type attribute */
-	__u16 len;		/* only for pointers */
-	__u16 flags;		/* combination of UVERBS_ATTR_F_XXXX */
-	__u16 reserved;
-	__aligned_u64 data;	/* ptr to command, inline data or idr/fd */
-};
-
-struct ib_uverbs_ioctl_hdr {
-	__u16 length;
-	__u16 object_id;
-	__u16 method_id;
-	__u16 num_attrs;
-	__aligned_u64 reserved;
-	struct ib_uverbs_attr  attrs[0];
-};
 
 /*
  * General blocks assignments

--- a/kernel-headers/rdma/rdma_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/rdma_user_ioctl_cmds.h
@@ -1,6 +1,5 @@
-/* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright (c) 2017-2018, Mellanox Technologies inc.  All rights reserved.
+ * Copyright (c) 2018, Mellanox Technologies inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -31,13 +30,64 @@
  * SOFTWARE.
  */
 
-#ifndef IB_USER_IOCTL_VERBS_H
-#define IB_USER_IOCTL_VERBS_H
+#ifndef RDMA_USER_IOCTL_CMDS_H
+#define RDMA_USER_IOCTL_CMDS_H
 
 #include <linux/types.h>
+#include <linux/ioctl.h>
 
-#ifndef RDMA_UAPI_PTR
-#define RDMA_UAPI_PTR(_type, _name)	_type __attribute__((aligned(8))) _name
-#endif
+/* Documentation/ioctl/ioctl-number.txt */
+#define RDMA_IOCTL_MAGIC	0x1b
+#define RDMA_VERBS_IOCTL \
+	_IOWR(RDMA_IOCTL_MAGIC, 1, struct ib_uverbs_ioctl_hdr)
+
+enum {
+	/* User input */
+	UVERBS_ATTR_F_MANDATORY = 1U << 0,
+	/*
+	 * Valid output bit should be ignored and considered set in
+	 * mandatory fields. This bit is kernel output.
+	 */
+	UVERBS_ATTR_F_VALID_OUTPUT = 1U << 1,
+};
+
+struct ib_uverbs_attr {
+	__u16 attr_id;		/* command specific type attribute */
+	__u16 len;		/* only for pointers */
+	__u16 flags;		/* combination of UVERBS_ATTR_F_XXXX */
+	__u16 reserved;
+	__aligned_u64 data;	/* ptr to command, inline data or idr/fd */
+};
+
+struct ib_uverbs_ioctl_hdr {
+	__u16 length;
+	__u16 object_id;
+	__u16 method_id;
+	__u16 num_attrs;
+	__aligned_u64 reserved1;
+	__u32 driver_id;
+	__u32 reserved2;
+	struct ib_uverbs_attr  attrs[0];
+};
+
+enum rdma_driver_id {
+	RDMA_DRIVER_UNKNOWN,
+	RDMA_DRIVER_MLX5,
+	RDMA_DRIVER_MLX4,
+	RDMA_DRIVER_CXGB3,
+	RDMA_DRIVER_CXGB4,
+	RDMA_DRIVER_MTHCA,
+	RDMA_DRIVER_BNXT_RE,
+	RDMA_DRIVER_OCRDMA,
+	RDMA_DRIVER_NES,
+	RDMA_DRIVER_I40IW,
+	RDMA_DRIVER_VMW_PVRDMA,
+	RDMA_DRIVER_QEDR,
+	RDMA_DRIVER_HNS,
+	RDMA_DRIVER_USNIC,
+	RDMA_DRIVER_RXE,
+	RDMA_DRIVER_HFI1,
+	RDMA_DRIVER_QIB,
+};
 
 #endif

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -144,4 +144,26 @@ struct rxe_recv_wqe {
 	struct rxe_dma_info	dma;
 };
 
+struct rxe_create_cq_resp {
+	struct mminfo mi;
+};
+
+struct rxe_resize_cq_resp {
+	struct mminfo mi;
+};
+
+struct rxe_create_qp_resp {
+	struct mminfo rq_mi;
+	struct mminfo sq_mi;
+};
+
+struct rxe_create_srq_resp {
+	struct mminfo mi;
+	__u32 srq_num;
+};
+
+struct rxe_modify_srq_cmd {
+	__u64 mmap_info_addr;
+};
+
 #endif /* RDMA_USER_RXE_H */

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -37,25 +37,25 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			      uint32_t flags, struct ibv_cq *cq,
 			      struct ibv_command_buffer *link)
 {
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE, 7, link);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE, 7, link);
 	struct ib_uverbs_attr *handle;
 	uint32_t resp_cqe;
 	int ret;
 
 	cq->context = context;
 
-	handle = fill_attr_out_obj(cmdb, CREATE_CQ_HANDLE);
-	fill_attr_out_ptr(cmdb, CREATE_CQ_RESP_CQE, &resp_cqe);
+	handle = fill_attr_out_obj(cmdb, UVERBS_ATTR_CREATE_CQ_HANDLE);
+	fill_attr_out_ptr(cmdb, UVERBS_ATTR_CREATE_CQ_RESP_CQE, &resp_cqe);
 
-	fill_attr_in_uint32(cmdb, CREATE_CQ_CQE, cqe);
-	fill_attr_in_uint64(cmdb, CREATE_CQ_USER_HANDLE, (uintptr_t)cq);
+	fill_attr_in_uint32(cmdb, UVERBS_ATTR_CREATE_CQ_CQE, cqe);
+	fill_attr_in_uint64(cmdb, UVERBS_ATTR_CREATE_CQ_USER_HANDLE, (uintptr_t)cq);
 	if (channel)
-		fill_attr_in_fd(cmdb, CREATE_CQ_COMP_CHANNEL, channel->fd);
-	fill_attr_in_uint32(cmdb, CREATE_CQ_COMP_VECTOR, comp_vector);
+		fill_attr_in_fd(cmdb, UVERBS_ATTR_CREATE_CQ_COMP_CHANNEL, channel->fd);
+	fill_attr_in_uint32(cmdb, UVERBS_ATTR_CREATE_CQ_COMP_VECTOR, comp_vector);
 
 	if (flags) {
 		fallback_require_ex(cmdb);
-		fill_attr_in_uint32(cmdb, CREATE_CQ_FLAGS, flags);
+		fill_attr_in_uint32(cmdb, UVERBS_ATTR_CREATE_CQ_FLAGS, flags);
 	}
 
 	switch (execute_ioctl_fallback(cq->context, create_cq, cmdb, &ret)) {
@@ -108,7 +108,7 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 		break;
 	}
 
-	cq->handle = read_attr_obj(CREATE_CQ_HANDLE, handle);
+	cq->handle = read_attr_obj(UVERBS_ATTR_CREATE_CQ_HANDLE, handle);
 	cq->cqe = resp_cqe;
 
 	return 0;
@@ -120,7 +120,7 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 		      size_t cmd_size, struct ib_uverbs_create_cq_resp *resp,
 		      size_t resp_size)
 {
-	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE);
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE);
 
 	return ibv_icmd_create_cq(context, cqe, channel, comp_vector, 0, cq,
 				  cmdb);
@@ -134,7 +134,7 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
 			 size_t resp_size)
 {
-	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_CREATE);
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE);
 	uint32_t flags = 0;
 
 	if (!check_comp_mask(cq_attr->comp_mask, IBV_CQ_INIT_ATTR_MASK_FLAGS))
@@ -150,13 +150,13 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 
 int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 {
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_CQ_DESTROY, 2,
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_DESTROY, 2,
 			     NULL);
 	DECLARE_LEGACY_CORE_BUFS(destroy_cq);
 	int ret;
 
-	fill_attr_out_ptr(cmdb, DESTROY_CQ_RESP, &resp);
-	fill_attr_in_obj(cmdb, DESTROY_CQ_HANDLE, cq->handle);
+	fill_attr_out_ptr(cmdb, UVERBS_ATTR_DESTROY_CQ_RESP, &resp);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_CQ_HANDLE, cq->handle);
 
 	switch (execute_ioctl_fallback(cq->context, destroy_cq, cmdb, &ret)) {
 	case TRY_WRITE: {

--- a/libibverbs/cmd_fallback.c
+++ b/libibverbs/cmd_fallback.c
@@ -53,8 +53,8 @@ enum write_fallback _check_legacy(struct ibv_command_buffer *cmdb, int *ret)
 
 	for (cmdb = cmdb->next; cmdb; cmdb = cmdb->next) {
 		for (cur = cmdb->hdr.attrs; cur != cmdb->next_attr; cur++) {
-			if (cur->attr_id != UVERBS_UHW_IN &&
-			    cur->attr_id != UVERBS_UHW_OUT &&
+			if (cur->attr_id != UVERBS_ATTR_UHW_IN &&
+			    cur->attr_id != UVERBS_ATTR_UHW_OUT &&
 			    cur->flags & UVERBS_ATTR_F_MANDATORY)
 				goto not_supp;
 		}
@@ -133,7 +133,7 @@ void *_write_get_req(struct ibv_command_buffer *link, void *onstack,
 	if (link->uhw_in_idx != _UHW_NO_INDEX) {
 		struct ib_uverbs_attr *uhw = &link->hdr.attrs[link->uhw_in_idx];
 
-		assert(uhw->attr_id == UVERBS_UHW_IN);
+		assert(uhw->attr_id == UVERBS_ATTR_UHW_IN);
 		assert(link->uhw_in_headroom_dwords * 4 >= size);
 		hdr = (void *)((uintptr_t)uhw->data - size);
 		hdr->in_words = __check_divide(size + uhw->len, 4);
@@ -154,7 +154,7 @@ void *_write_get_req_ex(struct ibv_command_buffer *link, void *onstack,
 	if (link->uhw_in_idx != _UHW_NO_INDEX) {
 		struct ib_uverbs_attr *uhw = &link->hdr.attrs[link->uhw_in_idx];
 
-		assert(uhw->attr_id == UVERBS_UHW_IN);
+		assert(uhw->attr_id == UVERBS_ATTR_UHW_IN);
 		assert(link->uhw_in_headroom_dwords * 4 >= full_size);
 		hdr = (void *)((uintptr_t)uhw->data - full_size);
 		hdr->hdr.in_words = __check_divide(size, 8);
@@ -178,7 +178,7 @@ void *_write_get_resp(struct ibv_command_buffer *link,
 		struct ib_uverbs_attr *uhw =
 			&link->hdr.attrs[link->uhw_out_idx];
 
-		assert(uhw->attr_id == UVERBS_UHW_OUT);
+		assert(uhw->attr_id == UVERBS_ATTR_UHW_OUT);
 		assert(link->uhw_out_headroom_dwords * 4 >= resp_size);
 		resp_start = (void *)((uintptr_t)uhw->data - resp_size);
 		hdr->out_words = __check_divide(resp_size + uhw->len, 4);
@@ -200,7 +200,7 @@ void *_write_get_resp_ex(struct ibv_command_buffer *link,
 		struct ib_uverbs_attr *uhw =
 			&link->hdr.attrs[link->uhw_out_idx];
 
-		assert(uhw->attr_id == UVERBS_UHW_OUT);
+		assert(uhw->attr_id == UVERBS_ATTR_UHW_OUT);
 		assert(link->uhw_out_headroom_dwords * 4 >= resp_size);
 		resp_start = (void *)((uintptr_t)uhw->data - resp_size);
 		hdr->hdr.out_words = __check_divide(resp_size, 8);

--- a/libibverbs/cmd_ioctl.c
+++ b/libibverbs/cmd_ioctl.c
@@ -35,6 +35,7 @@
 #include "ibverbs.h"
 
 #include <sys/ioctl.h>
+#include <infiniband/driver.h>
 
 #include <rdma/ib_user_ioctl_cmds.h>
 
@@ -125,12 +126,14 @@ static void finalize_attrs(struct ibv_command_buffer *cmd)
 
 int execute_ioctl(struct ibv_context *context, struct ibv_command_buffer *cmd)
 {
+	struct verbs_context *vctx = verbs_get_ctx(context);
+
 	prepare_attrs(cmd);
 	cmd->hdr.length = sizeof(cmd->hdr) +
 		sizeof(cmd->hdr.attrs[0]) * cmd->hdr.num_attrs;
 	cmd->hdr.reserved1 = 0;
 	cmd->hdr.reserved2 = 0;
-	cmd->hdr.driver_id = 0;
+	cmd->hdr.driver_id = vctx->priv->driver_id;
 
 	if (ioctl(context->cmd_fd, RDMA_VERBS_IOCTL, &cmd->hdr))
 		return errno;

--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -37,8 +37,7 @@
 
 #include <stdint.h>
 #include <assert.h>
-#include <rdma/rdma_user_ioctl.h>
-#include <rdma/ib_user_ioctl_verbs.h>
+#include <rdma/rdma_user_ioctl_cmds.h>
 #include <infiniband/verbs.h>
 
 static inline uint64_t ioctl_ptr_to_u64(const void *ptr)

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -36,6 +36,7 @@
 #include <infiniband/cmd_ioctl.h>
 #include <infiniband/driver.h>
 #include <rdma/ib_user_verbs.h>
+#include <rdma/ib_user_ioctl_cmds.h>
 
 #include <stdbool.h>
 

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -186,7 +186,8 @@ __lib_ibv_create_cq_ex(struct ibv_context *context,
  * failure path of this function.
  */
 int verbs_init_context(struct verbs_context *context_ex,
-		       struct ibv_device *device, int cmd_fd)
+		       struct ibv_device *device, int cmd_fd,
+		       uint32_t driver_id)
 {
 	struct ibv_context *context = &context_ex->context;
 
@@ -224,6 +225,7 @@ int verbs_init_context(struct verbs_context *context_ex,
 		return -1;
 	}
 
+	context_ex->priv->driver_id = driver_id;
 	verbs_set_ops(context_ex, &verbs_dummy_ops);
 
 	return 0;
@@ -236,7 +238,8 @@ int verbs_init_context(struct verbs_context *context_ex,
  */
 void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,
 				    size_t alloc_size,
-				    struct verbs_context *context_offset)
+				    struct verbs_context *context_offset,
+				    uint32_t driver_id)
 {
 	void *drv_context;
 	struct verbs_context *context;
@@ -250,7 +253,7 @@ void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,
 
 	context = drv_context + (uintptr_t)context_offset;
 
-	if (verbs_init_context(context, device, cmd_fd))
+	if (verbs_init_context(context, device, cmd_fd, driver_id))
 		goto err_free;
 
 	return drv_context;

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -41,6 +41,7 @@
 #include <ccan/list.h>
 #include <config.h>
 #include <stdbool.h>
+#include <rdma/rdma_user_ioctl_cmds.h>
 
 struct verbs_device;
 
@@ -300,15 +301,18 @@ void verbs_register_driver(const struct verbs_device_ops *ops);
 
 void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,
 				    size_t alloc_size,
-				    struct verbs_context *context_offset);
+				    struct verbs_context *context_offset,
+				    uint32_t driver_id);
 
-#define verbs_init_and_alloc_context(ibdev, cmd_fd, drv_ctx_ptr, ctx_memb)     \
+#define verbs_init_and_alloc_context(ibdev, cmd_fd, drv_ctx_ptr, ctx_memb,     \
+				     driver_id)				       \
 	((typeof(drv_ctx_ptr))_verbs_init_and_alloc_context(                   \
 		ibdev, cmd_fd, sizeof(*drv_ctx_ptr),                           \
-		&((typeof(drv_ctx_ptr))NULL)->ctx_memb))
+		&((typeof(drv_ctx_ptr))NULL)->ctx_memb, (driver_id)))
 
 int verbs_init_context(struct verbs_context *context_ex,
-		       struct ibv_device *device, int cmd_fd);
+		       struct ibv_device *device, int cmd_fd,
+		       uint32_t driver_id);
 void verbs_uninit_context(struct verbs_context *context);
 void verbs_set_ops(struct verbs_context *vctx,
 		   const struct verbs_context_ops *ops);

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -62,6 +62,7 @@ struct verbs_ex_private {
 					  struct ibv_cq_init_attr_ex *init_attr);
 
 	uint64_t unsupported_ioctls;
+	uint32_t driver_id;
 };
 
 #define IBV_INIT_CMD(cmd, size, opcode)					\

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -117,7 +117,8 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(vdev);
 	struct bnxt_re_context *cntx;
 
-	cntx = verbs_init_and_alloc_context(vdev, cmd_fd, cntx, ibvctx);
+	cntx = verbs_init_and_alloc_context(vdev, cmd_fd, cntx, ibvctx,
+					    RDMA_DRIVER_BNXT_RE);
 	if (!cntx)
 		return NULL;
 

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -125,7 +125,8 @@ static struct verbs_context *iwch_alloc_context(struct ibv_device *ibdev,
 	struct iwch_alloc_ucontext_resp resp;
 	struct iwch_device *rhp = to_iwch_dev(ibdev);
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_CXGB3);
 	if (!context)
 		return NULL;
 

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -115,7 +115,8 @@ static struct verbs_context *c4iw_alloc_context(struct ibv_device *ibdev,
 	uint64_t raw_fw_ver;
 	struct ibv_device_attr attr;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_CXGB4);
 	if (!context)
 		return NULL;
 

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -144,7 +144,8 @@ static struct verbs_context *hfi1_alloc_context(struct ibv_device *ibdev,
 	struct ib_uverbs_get_context_resp  resp;
 	struct hfi1_device         *dev;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_HFI1);
 	if (!context)
 		return NULL;
 

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -71,7 +71,8 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	struct hns_roce_alloc_ucontext_resp resp;
 	struct hns_roce_device *hr_dev = to_hr_dev(ibdev);
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_HNS);
 	if (!context)
 		return NULL;
 

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -134,7 +134,8 @@ static struct verbs_context *i40iw_ualloc_context(struct ibv_device *ibdev,
 	struct i40iw_get_context cmd;
 	struct i40iw_ualloc_ucontext_resp resp;
 
-	iwvctx = verbs_init_and_alloc_context(ibdev, cmd_fd, iwvctx, ibv_ctx);
+	iwvctx = verbs_init_and_alloc_context(ibdev, cmd_fd, iwvctx, ibv_ctx,
+					      RDMA_DRIVER_I40IW);
 	if (!iwvctx)
 		return NULL;
 

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -143,7 +143,8 @@ static struct verbs_context *ipath_alloc_context(struct ibv_device *ibdev,
 	struct ib_uverbs_get_context_resp  resp;
 	struct ipath_device         *dev;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_QIB);
 	if (!context)
 		return NULL;
 

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -177,7 +177,8 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 	struct verbs_context		*verbs_ctx;
 	struct ibv_device_attr_ex	dev_attrs;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_MLX4);
 	if (!context)
 		return NULL;
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -974,7 +974,8 @@ static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
 	int				bfi;
 	int				num_sys_page_map;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_MLX5);
 	if (!context)
 		return NULL;
 

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -137,7 +137,8 @@ static struct verbs_context *mthca_alloc_context(struct ibv_device *ibdev,
 	struct mthca_alloc_ucontext_resp resp;
 	int                              i;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_MTHCA);
 	if (!context)
 		return NULL;
 

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -109,7 +109,8 @@ static struct verbs_context *nes_ualloc_context(struct ibv_device *ibdev,
 
 	page_size = sysconf(_SC_PAGESIZE);
 
-	nesvctx = verbs_init_and_alloc_context(ibdev, cmd_fd, nesvctx, ibv_ctx);
+	nesvctx = verbs_init_and_alloc_context(ibdev, cmd_fd, nesvctx, ibv_ctx,
+					       RDMA_DRIVER_NES);
 	if (!nesvctx)
 		return NULL;
 

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -112,7 +112,8 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 	struct ocrdma_get_context cmd;
 	struct ocrdma_alloc_ucontext_resp resp;
 
-	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx);
+	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
+					   RDMA_DRIVER_OCRDMA);
 	if (!ctx)
 		return NULL;
 

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -162,7 +162,8 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 	struct qelr_get_context cmd;
 	struct qelr_alloc_ucontext_resp resp;
 
-	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx);
+	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
+					   RDMA_DRIVER_QEDR);
 	if (!ctx)
 		return NULL;
 

--- a/providers/rxe/rxe-abi.h
+++ b/providers/rxe/rxe-abi.h
@@ -43,29 +43,29 @@ struct mmap_info {
 	__u32 pad;
 };
 
-struct rxe_create_cq_resp {
+struct urxe_create_cq_resp {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	struct mmap_info mi;
 };
 
-struct rxe_resize_cq_resp {
+struct urxe_resize_cq_resp {
 	struct ib_uverbs_resize_cq_resp ibv_resp;
 	struct mmap_info mi;
 };
 
-struct rxe_create_qp_resp {
+struct urxe_create_qp_resp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	struct mmap_info rq_mi;
 	struct mmap_info sq_mi;
 };
 
-struct rxe_create_srq_resp {
+struct urxe_create_srq_resp {
 	struct ib_uverbs_create_srq_resp ibv_resp;
 	struct mmap_info mi;
 	__u32 srq_num;
 };
 
-struct rxe_modify_srq_cmd {
+struct urxe_modify_srq_cmd {
 	struct ibv_modify_srq ibv_cmd;
 	__u64 mmap_info_addr;
 };

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -862,7 +862,8 @@ static struct verbs_context *rxe_alloc_context(struct ibv_device *ibdev,
 	struct ibv_get_context cmd;
 	struct ib_uverbs_get_context_resp resp;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_RXE);
 	if (!context)
 		return NULL;
 

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -162,7 +162,7 @@ static struct ibv_cq *rxe_create_cq(struct ibv_context *context, int cqe,
 				    int comp_vector)
 {
 	struct rxe_cq *cq;
-	struct rxe_create_cq_resp resp;
+	struct urxe_create_cq_resp resp;
 	int ret;
 
 	cq = malloc(sizeof *cq);
@@ -196,7 +196,7 @@ static int rxe_resize_cq(struct ibv_cq *ibcq, int cqe)
 {
 	struct rxe_cq *cq = to_rcq(ibcq);
 	struct ibv_resize_cq cmd;
-	struct rxe_resize_cq_resp resp;
+	struct urxe_resize_cq_resp resp;
 	int ret;
 
 	pthread_spin_lock(&cq->lock);
@@ -273,7 +273,7 @@ static struct ibv_srq *rxe_create_srq(struct ibv_pd *pd,
 {
 	struct rxe_srq *srq;
 	struct ibv_create_srq cmd;
-	struct rxe_create_srq_resp resp;
+	struct urxe_create_srq_resp resp;
 	int ret;
 
 	srq = malloc(sizeof *srq);
@@ -308,7 +308,7 @@ static int rxe_modify_srq(struct ibv_srq *ibsrq,
 		   struct ibv_srq_attr *attr, int attr_mask)
 {
 	struct rxe_srq *srq = to_rsrq(ibsrq);
-	struct rxe_modify_srq_cmd cmd;
+	struct urxe_modify_srq_cmd cmd;
 	int rc = 0;
 	struct mmap_info mi;
 
@@ -439,7 +439,7 @@ static struct ibv_qp *rxe_create_qp(struct ibv_pd *pd,
 				    struct ibv_qp_init_attr *attr)
 {
 	struct ibv_create_qp cmd;
-	struct rxe_create_qp_resp resp;
+	struct urxe_create_qp_resp resp;
 	struct rxe_qp *qp;
 	int ret;
 

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -147,7 +147,8 @@ static struct verbs_context *pvrdma_alloc_context(struct ibv_device *ibdev,
 {
 	struct pvrdma_context *context;
 
-	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx);
+	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
+					       RDMA_DRIVER_VMW_PVRDMA);
 	if (!context)
 		return NULL;
 


### PR DESCRIPTION
This series aligns the user space area with the kernel around the last ioctl changes, it includes:
- Move to new headers and make naming consistent.
- Add driver id to ioctl() infrastructure.