### PR TITLE
Packet pacing

### DIFF
--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -233,6 +233,8 @@ struct verbs_context_ops {
 	int (*modify_cq)(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
 	int (*modify_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 			 int attr_mask);
+	int (*modify_qp_rate_limit)(struct ibv_qp *qp,
+				    struct ibv_qp_rate_limit_attr *attr);
 	int (*modify_srq)(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
 			  int srq_attr_mask);
 	int (*modify_wq)(struct ibv_wq *wq, struct ibv_wq_attr *wq_attr);

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -233,6 +233,12 @@ static int modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr, int attr_mask)
 	return ENOSYS;
 }
 
+static int modify_qp_rate_limit(struct ibv_qp *qp,
+				struct ibv_qp_rate_limit_attr *attr)
+{
+	return ENOSYS;
+}
+
 static int modify_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
 		      int srq_attr_mask)
 {
@@ -393,6 +399,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	get_srq_num,
 	modify_cq,
 	modify_qp,
+	modify_qp_rate_limit,
 	modify_srq,
 	modify_wq,
 	open_qp,
@@ -470,6 +477,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_OP(vctx, get_srq_num);
 	SET_OP(vctx, modify_cq);
 	SET_OP(ctx, modify_qp);
+	SET_OP(vctx, modify_qp_rate_limit);
 	SET_OP(ctx, modify_srq);
 	SET_OP(vctx, modify_wq);
 	SET_OP(vctx, open_qp);

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -31,6 +31,7 @@ rdma_man_pages(
   ibv_get_srq_num.3
   ibv_inc_rkey.3
   ibv_modify_qp.3
+  ibv_modify_qp_rate_limit.3
   ibv_modify_srq.3
   ibv_modify_wq.3
   ibv_open_device.3

--- a/libibverbs/man/ibv_modify_qp_rate_limit.3
+++ b/libibverbs/man/ibv_modify_qp_rate_limit.3
@@ -1,0 +1,67 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH IBV_MODIFY_QP_RATE_LIMIT 3 2018-01-09 libibverbs "Libibverbs Programmer's Manual"
+.SH "NAME"
+ibv_modify_qp_rate_limit \- modify the send rate limits attributes of a queue pair (QP)
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/verbs.h>
+.sp
+.BI "int ibv_modify_qp_rate_limit(struct ibv_qp " "*qp" ", struct ibv_qp_rate_limit_attr " "*attr");
+.fi
+.SH "DESCRIPTION"
+.B ibv_modify_qp_rate_limit()
+modifies the send rate limiting packet pacing attributes of QP
+.I qp
+with the attributes in
+.I attr\fR.
+The argument \fIattr\fR is an ibv_qp_rate_limit_attr struct, as defined in <infiniband/verbs.h>.
+.PP
+The
+.I rate_limit
+defines the MAX send rate this QP will send as long as the link in not blocked and there are work requestes in send queue.
+.PP
+Finer control for shaping the rate limit of a QP is achieved by defining the
+.I max_burst_sz\fR,
+single burst max bytes size and the
+.I typical_pkt_sz\fR,
+typical packet bytes size. These allow the device to adjust the inter-burst gap delay required to correctly shape the scheduling of sends to the wire in order to reach for requested application requirements.
+.PP
+Setting a value of 0 for
+.I max_burst_sz
+or
+.I typical_pkt_sz
+will use the devices defaults.
+.I typical_pkt_sz
+will default to the port's MTU value.
+.PP
+.nf
+struct ibv_qp_rate_limit_attr {
+.in +8
+uint32_t        rate_limit;     /* kbps */
+uint32_t        max_burst_sz;   /* bytes */
+uint16_t        typical_pkt_sz; /* bytes */
+.in -8
+};
+.fi
+.PP
+.SH "RETURN VALUE"
+.B ibv_modify_qp_rate_limit()
+returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+.SH "ERRORS"
+.SS EINVAL
+Invalid arguments.
+.SS ENOSYS
+Function is not implemented for this device.
+.PP
+.SH "SEE ALSO"
+.BR ibv_create_qp (3),
+.BR ibv_destroy_qp (3),
+.BR ibv_modify_qp (3),
+.BR ibv_query_qp (3)
+.SH "AUTHORS"
+.TP
+Alex Rosenbaum <alexr@mellanox.com>
+.TP
+Bodong Wang <bodong@mellanox.com>

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -314,9 +314,14 @@ struct mlx5_rss_caps {
 	__u8 reserved[7];
 };
 
+enum mlx5_ib_packet_pacing_cap_flags {
+	MLX5_IB_PP_SUPPORT_BURST	= 1 << 0,
+};
+
 struct mlx5_packet_pacing_caps {
 	struct ibv_packet_pacing_caps caps;
-	__u32  reserved;
+	__u8   cap_flags; /* enum mlx5_ib_packet_pacing_cap_flags */
+	__u8   reserved[3];
 };
 
 enum mlx5_mpw_caps {
@@ -355,6 +360,19 @@ struct mlx5_modify_qp_resp_ex {
 	struct ib_uverbs_ex_modify_qp_resp base;
 	__u32  response_length;
 	__u32  dctn;
+};
+
+struct mlx5_ib_burst_info {
+	__u32	max_burst_sz;
+	__u16	typical_pkt_sz;
+	__u16	reserved;
+};
+
+struct mlx5_ib_modify_qp {
+	struct ibv_modify_qp_ex		ibv_cmd;
+	__u32				comp_mask;
+	struct mlx5_ib_burst_info	burst_info;
+	__u32				reserved;
 };
 
 #endif /* MLX5_ABI_H */

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -129,6 +129,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.destroy_wq = mlx5_destroy_wq,
 	.get_srq_num = mlx5_get_srq_num,
 	.modify_cq = mlx5_modify_cq,
+	.modify_qp_rate_limit = mlx5_modify_qp_rate_limit,
 	.modify_wq = mlx5_modify_wq,
 	.open_xrcd = mlx5_open_xrcd,
 	.post_srq_ops = mlx5_post_srq_ops,

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -298,6 +298,7 @@ struct mlx5_context {
 	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps	striding_rq_caps;
 	uint32_t			tunnel_offloads_caps;
+	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
 	uint32_t			*count_dyn_bfregs;
@@ -751,6 +752,8 @@ int mlx5_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		  struct ibv_qp_init_attr *init_attr);
 int mlx5_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		   int attr_mask);
+int mlx5_modify_qp_rate_limit(struct ibv_qp *qp,
+			      struct ibv_qp_rate_limit_attr *attr);
 int mlx5_destroy_qp(struct ibv_qp *qp);
 void mlx5_init_qp_indices(struct mlx5_qp *qp);
 void mlx5_init_rwq_indices(struct mlx5_rwq *rwq);


### PR DESCRIPTION
This series extends verbs packet pacing QP rate limiting with burst info to allow user space application finer grain control of the QP send rate.

The matching kernel part was lastly sent into rdma-next.