### PR TITLE
Remove uapi structure copies from drivers

### DIFF
--- a/buildlib/make_abi_structs.py
+++ b/buildlib/make_abi_structs.py
@@ -24,8 +24,8 @@ def in_struct(ln,FO,nesting=0):
     """Copy a top level structure over to the #define output, keeping track of
     nested structures."""
     if nesting == 0:
-        if ln == "};":
-            FO.write("}\n\n");
+        if re.match(r"(}.*);",ln):
+            FO.write(ln[:-1] + "\n\n");
             return find_struct;
 
     FO.write(ln + " \\\n");
@@ -33,7 +33,7 @@ def in_struct(ln,FO,nesting=0):
     if ln == "struct {" or ln == "union {":
         return functools.partial(in_struct,nesting=nesting+1);
 
-    if  re.match(r"}.*;",ln):
+    if re.match(r"}.*;",ln):
         return functools.partial(in_struct,nesting=nesting-1);
     return functools.partial(in_struct,nesting=nesting);
 

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -58,6 +58,7 @@ rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h
   rdma/mlx5-abi.h
+  rdma/nes-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
   )

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -56,4 +56,5 @@ endfunction()
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
+  rdma/qedr-abi.h
   )

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -59,6 +59,7 @@ rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h
   rdma/mlx5-abi.h
+  rdma/mthca-abi.h
   rdma/nes-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -55,6 +55,7 @@ endfunction()
 
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
+  rdma/bnxt_re-abi.h
   rdma/cxgb4-abi.h
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -55,6 +55,7 @@ endfunction()
 
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
+  rdma/cxgb4-abi.h
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h
   rdma/mlx5-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -57,4 +57,5 @@ endfunction()
 rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
   rdma/qedr-abi.h
+  rdma/rdma_user_rxe.h
   )

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -63,4 +63,5 @@ rdma_kernel_provider_abi(
   rdma/nes-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
+  rdma/vmw_pvrdma-abi.h
   )

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -57,6 +57,7 @@ endfunction()
 rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h
+  rdma/mlx5-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
   )

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -57,6 +57,7 @@ endfunction()
 rdma_kernel_provider_abi(
   rdma/bnxt_re-abi.h
   rdma/cxgb4-abi.h
+  rdma/i40iw-abi.h
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h
   rdma/mlx5-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -56,6 +56,7 @@ endfunction()
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
   rdma/ib_user_verbs.h
+  rdma/mlx4-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
   )

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -40,6 +40,7 @@
 #define __BNXT_RE_ABI_H__
 
 #include <infiniband/kern-abi.h>
+#include <rdma/bnxt_re-abi.h>
 
 #define BNXT_RE_ABI_VERSION 1
 
@@ -183,19 +184,12 @@ enum bnxt_re_ud_cqe_mask {
 	BNXT_RE_UD_CQE_SRCQPLO_SHIFT	= 0x30
 };
 
-enum bnxt_re_shpg_offt {
-	BNXT_RE_SHPG_BEG_RESV_OFFT	= 0x00,
-	BNXT_RE_SHPG_AVID_OFFT		= 0x10,
-	BNXT_RE_SHPG_AVID_SIZE		= 0x04,
-	BNXT_RE_SHPG_END_RESV_OFFT	= 0xFF0
-};
-
 struct bnxt_re_db_hdr {
 	__le32 indx;
 	__le32 typ_qid; /* typ: 4, qid:20*/
 };
 
-struct bnxt_re_cntx_resp {
+struct ubnxt_re_cntx_resp {
 	struct ib_uverbs_get_context_resp resp;
 	__u32 dev_id;
 	__u32 max_qp; /* To allocate qp-table */
@@ -205,24 +199,24 @@ struct bnxt_re_cntx_resp {
 	__u32 rsvd;
 };
 
-struct bnxt_re_pd_resp {
+struct ubnxt_re_pd_resp {
 	struct ib_uverbs_alloc_pd_resp resp;
 	__u32 pdid;
 	__u32 dpi;
 	__u64 dbr;
 };
 
-struct bnxt_re_mr_resp {
+struct ubnxt_re_mr_resp {
 	struct ib_uverbs_reg_mr_resp resp;
 };
 
-struct bnxt_re_cq_req {
+struct ubnxt_re_cq_req {
 	struct ibv_create_cq cmd;
 	__u64 cq_va;
 	__u64 cq_handle;
 };
 
-struct bnxt_re_cq_resp {
+struct ubnxt_re_cq_resp {
 	struct ib_uverbs_create_cq_resp resp;
 	__u32 cqid;
 	__u32 tail;
@@ -263,14 +257,14 @@ struct bnxt_re_term_cqe {
 	__le64 rsvd1;
 };
 
-struct bnxt_re_qp_req {
+struct ubnxt_re_qp_req {
 	struct ibv_create_qp cmd;
 	__u64 qpsva;
 	__u64 qprva;
 	__u64 qp_handle;
 };
 
-struct bnxt_re_qp_resp {
+struct ubnxt_re_qp_resp {
 	struct ib_uverbs_create_qp_resp resp;
 	__u32 qpid;
 	__u32 rsvd;

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -41,10 +41,22 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/bnxt_re-abi.h>
+#include <kernel-abi/bnxt_re-abi.h>
 
 #define BNXT_RE_ABI_VERSION 1
 
 #define BNXT_RE_FULL_FLAG_DELTA        0x80
+
+DECLARE_DRV_CMD(ubnxt_re_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, bnxt_re_pd_resp);
+DECLARE_DRV_CMD(ubnxt_re_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		bnxt_re_cq_req, bnxt_re_cq_resp);
+DECLARE_DRV_CMD(ubnxt_re_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		bnxt_re_qp_req, bnxt_re_qp_resp);
+DECLARE_DRV_CMD(ubnxt_re_cntx, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, bnxt_re_uctx_resp);
+DECLARE_DRV_CMD(ubnxt_re_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, empty);
 
 enum bnxt_re_wr_opcode {
 	BNXT_RE_WR_OPCD_SEND		= 0x00,
@@ -189,41 +201,6 @@ struct bnxt_re_db_hdr {
 	__le32 typ_qid; /* typ: 4, qid:20*/
 };
 
-struct ubnxt_re_cntx_resp {
-	struct ib_uverbs_get_context_resp resp;
-	__u32 dev_id;
-	__u32 max_qp; /* To allocate qp-table */
-	__u32 pg_size;
-	__u32 cqe_size;
-	__u32 max_cqd;
-	__u32 rsvd;
-};
-
-struct ubnxt_re_pd_resp {
-	struct ib_uverbs_alloc_pd_resp resp;
-	__u32 pdid;
-	__u32 dpi;
-	__u64 dbr;
-};
-
-struct ubnxt_re_mr_resp {
-	struct ib_uverbs_reg_mr_resp resp;
-};
-
-struct ubnxt_re_cq_req {
-	struct ibv_create_cq cmd;
-	__u64 cq_va;
-	__u64 cq_handle;
-};
-
-struct ubnxt_re_cq_resp {
-	struct ib_uverbs_create_cq_resp resp;
-	__u32 cqid;
-	__u32 tail;
-	__u32 phase;
-	__u32 rsvd;
-};
-
 struct bnxt_re_bcqe {
 	__le32 flg_st_typ_ph;
 	__le32 qphi_rwrid;
@@ -255,19 +232,6 @@ struct bnxt_re_term_cqe {
 	__le32 rq_sq_cidx;
 	__le32 rsvd;
 	__le64 rsvd1;
-};
-
-struct ubnxt_re_qp_req {
-	struct ibv_create_qp cmd;
-	__u64 qpsva;
-	__u64 qprva;
-	__u64 qp_handle;
-};
-
-struct ubnxt_re_qp_resp {
-	struct ib_uverbs_create_qp_resp resp;
-	__u32 qpid;
-	__u32 rsvd;
 };
 
 struct bnxt_re_bsqe {

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -124,13 +124,13 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 
 	memset(&resp, 0, sizeof(resp));
 	if (ibv_cmd_get_context(&cntx->ibvctx, &cmd, sizeof(cmd),
-				&resp.resp, sizeof(resp)))
+				&resp.ibv_resp, sizeof(resp)))
 		goto failed;
 
 	cntx->dev_id = resp.dev_id;
 	cntx->max_qp = resp.max_qp;
 	dev->pg_size = resp.pg_size;
-	dev->cqe_size = resp.cqe_size;
+	dev->cqe_size = resp.cqe_sz;
 	dev->max_cq_depth = resp.max_cqd;
 	pthread_spin_init(&cntx->fqlock, PTHREAD_PROCESS_PRIVATE);
 	/* mmap shared page. */

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -113,7 +113,7 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 						   int cmd_fd)
 {
 	struct ibv_get_context cmd;
-	struct bnxt_re_cntx_resp resp;
+	struct ubnxt_re_cntx_resp resp;
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(vdev);
 	struct bnxt_re_context *cntx;
 

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -81,7 +81,7 @@ int bnxt_re_query_port(struct ibv_context *ibvctx, uint8_t port,
 struct ibv_pd *bnxt_re_alloc_pd(struct ibv_context *ibvctx)
 {
 	struct ibv_alloc_pd cmd;
-	struct bnxt_re_pd_resp resp;
+	struct ubnxt_re_pd_resp resp;
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
 	struct bnxt_re_pd *pd;
@@ -137,7 +137,7 @@ struct ibv_mr *bnxt_re_reg_mr(struct ibv_pd *ibvpd, void *sva, size_t len,
 {
 	struct bnxt_re_mr *mr;
 	struct ibv_reg_mr cmd;
-	struct bnxt_re_mr_resp resp;
+	struct ubnxt_re_mr_resp resp;
 
 	mr = calloc(1, sizeof(*mr));
 	if (!mr)
@@ -169,8 +169,8 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 				 struct ibv_comp_channel *channel, int vec)
 {
 	struct bnxt_re_cq *cq;
-	struct bnxt_re_cq_req cmd;
-	struct bnxt_re_cq_resp resp;
+	struct ubnxt_re_cq_req cmd;
+	struct ubnxt_re_cq_resp resp;
 
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
@@ -873,8 +873,8 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 				 struct ibv_qp_init_attr *attr)
 {
 	struct bnxt_re_qp *qp;
-	struct bnxt_re_qp_req req;
-	struct bnxt_re_qp_resp resp;
+	struct ubnxt_re_qp_req req;
+	struct ubnxt_re_qp_resp resp;
 	struct bnxt_re_qpcap *cap;
 
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvpd->context);
@@ -1422,7 +1422,7 @@ struct ibv_ah *bnxt_re_create_ah(struct ibv_pd *ibvpd, struct ibv_ah_attr *attr)
 		goto failed;
 	}
 	/* read AV ID now. */
-	ah->avid = *(uint32_t *)(uctx->shpg + BNXT_RE_SHPG_AVID_OFFT);
+	ah->avid = *(uint32_t *)(uctx->shpg + BNXT_RE_AVID_OFFT);
 	pthread_mutex_unlock(&uctx->shlock);
 
 	return &ah->ibvah;

--- a/providers/cxgb4/cxgb4-abi.h
+++ b/providers/cxgb4/cxgb4-abi.h
@@ -34,20 +34,21 @@
 
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
+#include <rdma/cxgb4-abi.h>
 
-struct c4iw_alloc_ucontext_resp {
+struct uc4iw_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp ibv_resp;
 	__u64 status_page_key;
 	__u32 status_page_size;
 	__u32 reserved;
 };
 
-struct c4iw_alloc_pd_resp {
+struct uc4iw_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp ibv_resp;
 	uint32_t pdid;
 };
 
-struct c4iw_create_cq_resp {
+struct uc4iw_create_cq_resp {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	__u64 key;
 	__u64 gts_key;
@@ -58,11 +59,7 @@ struct c4iw_create_cq_resp {
 	__u32 reserved;
 };
 
-enum {
-	C4IW_QPF_ONCHIP = (1<<0),
-};
-
-struct c4iw_create_qp_resp_v0 {
+struct uc4iw_create_qp_resp_v0 {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	__u64 sq_key;
 	__u64 rq_key;
@@ -77,7 +74,7 @@ struct c4iw_create_qp_resp_v0 {
 	__u32 qid_mask;
 };
 
-struct c4iw_create_qp_resp {
+struct uc4iw_create_qp_resp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	__u64 ma_sync_key;
 	__u64 sq_key;

--- a/providers/cxgb4/cxgb4-abi.h
+++ b/providers/cxgb4/cxgb4-abi.h
@@ -35,59 +35,35 @@
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
 #include <rdma/cxgb4-abi.h>
+#include <kernel-abi/cxgb4-abi.h>
 
-struct uc4iw_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-	__u64 status_page_key;
-	__u32 status_page_size;
-	__u32 reserved;
-};
+/* compat for ABI version 0 */
+#define _c4iw_create_qp_resp_v0                                                \
+	{                                                                      \
+		__u64 sq_key;                                                  \
+		__u64 rq_key;                                                  \
+		__u64 sq_db_gts_key;                                           \
+		__u64 rq_db_gts_key;                                           \
+		__u64 sq_memsize;                                              \
+		__u64 rq_memsize;                                              \
+		__u32 sqid;                                                    \
+		__u32 rqid;                                                    \
+		__u32 sq_size;                                                 \
+		__u32 rq_size;                                                 \
+		__u32 qid_mask;                                                \
+	};
+struct c4iw_create_qp_resp_v0 _c4iw_create_qp_resp_v0;
+#define _STRUCT_c4iw_create_qp_resp_v0 struct _c4iw_create_qp_resp_v0
 
-struct uc4iw_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	uint32_t pdid;
-};
+DECLARE_DRV_CMD(uc4iw_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, c4iw_alloc_pd_resp);
+DECLARE_DRV_CMD(uc4iw_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		empty, c4iw_create_cq_resp);
+DECLARE_DRV_CMD(uc4iw_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		empty, c4iw_create_qp_resp);
+DECLARE_DRV_CMD(uc4iw_create_qp_v0, IB_USER_VERBS_CMD_CREATE_QP,
+		empty, c4iw_create_qp_resp_v0);
+DECLARE_DRV_CMD(uc4iw_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, c4iw_alloc_ucontext_resp);
 
-struct uc4iw_create_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	__u64 key;
-	__u64 gts_key;
-	__u64 memsize;
-	__u32 cqid;
-	__u32 size;
-	__u32 qid_mask;
-	__u32 reserved;
-};
-
-struct uc4iw_create_qp_resp_v0 {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	__u64 sq_key;
-	__u64 rq_key;
-	__u64 sq_db_gts_key;
-	__u64 rq_db_gts_key;
-	__u64 sq_memsize;
-	__u64 rq_memsize;
-	__u32 sqid;
-	__u32 rqid;
-	__u32 sq_size;
-	__u32 rq_size;
-	__u32 qid_mask;
-};
-
-struct uc4iw_create_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	__u64 ma_sync_key;
-	__u64 sq_key;
-	__u64 rq_key;
-	__u64 sq_db_gts_key;
-	__u64 rq_db_gts_key;
-	__u64 sq_memsize;
-	__u64 rq_memsize;
-	__u32 sqid;
-	__u32 rqid;
-	__u32 sq_size;
-	__u32 rq_size;
-	__u32 qid_mask;
-	__u32 flags;
-};
 #endif				/* IWCH_ABI_H */

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -109,7 +109,7 @@ static struct verbs_context *c4iw_alloc_context(struct ibv_device *ibdev,
 {
 	struct c4iw_context *context;
 	struct ibv_get_context cmd;
-	struct c4iw_alloc_ucontext_resp resp;
+	struct uc4iw_alloc_ucontext_resp resp;
 	struct c4iw_dev *rhp = to_c4iw_dev(ibdev);
 	struct ibv_query_device qcmd;
 	uint64_t raw_fw_ver;

--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -79,7 +79,7 @@ int c4iw_query_port(struct ibv_context *context, uint8_t port,
 struct ibv_pd *c4iw_alloc_pd(struct ibv_context *context)
 {
 	struct ibv_alloc_pd cmd;
-	struct c4iw_alloc_pd_resp resp;
+	struct uc4iw_alloc_pd_resp resp;
 	struct c4iw_pd *pd;
 
 	pd = malloc(sizeof *pd);
@@ -168,7 +168,7 @@ int c4iw_dereg_mr(struct ibv_mr *mr)
 struct ibv_cq *c4iw_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_comp_channel *channel, int comp_vector)
 {
-	struct c4iw_create_cq_resp resp;
+	struct uc4iw_create_cq_resp resp;
 	struct c4iw_cq *chp;
 	struct c4iw_dev *dev = to_c4iw_dev(context->device);
 	int ret;
@@ -303,7 +303,7 @@ static struct ibv_qp *create_qp_v0(struct ibv_pd *pd,
 				   struct ibv_qp_init_attr *attr)
 {
 	struct ibv_create_qp cmd;
-	struct c4iw_create_qp_resp_v0 resp;
+	struct uc4iw_create_qp_resp_v0 resp;
 	struct c4iw_qp *qhp;
 	struct c4iw_dev *dev = to_c4iw_dev(pd->context->device);
 	int ret;
@@ -406,7 +406,7 @@ static struct ibv_qp *create_qp(struct ibv_pd *pd,
 				struct ibv_qp_init_attr *attr)
 {
 	struct ibv_create_qp cmd;
-	struct c4iw_create_qp_resp resp;
+	struct uc4iw_create_qp_resp resp;
 	struct c4iw_qp *qhp;
 	struct c4iw_dev *dev = to_c4iw_dev(pd->context->device);
 	struct c4iw_context *ctx = to_c4iw_context(pd->context);

--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -303,7 +303,7 @@ static struct ibv_qp *create_qp_v0(struct ibv_pd *pd,
 				   struct ibv_qp_init_attr *attr)
 {
 	struct ibv_create_qp cmd;
-	struct uc4iw_create_qp_resp_v0 resp;
+	struct uc4iw_create_qp_v0_resp resp;
 	struct c4iw_qp *qhp;
 	struct c4iw_dev *dev = to_c4iw_dev(pd->context->device);
 	int ret;

--- a/providers/i40iw/i40iw-abi.h
+++ b/providers/i40iw/i40iw-abi.h
@@ -32,10 +32,11 @@
 *
 *******************************************************************************/
 
-#ifndef I40IW_ABI_H
-#define I40IW_ABI_H
+#ifndef PROVIDER_I40IW_ABI_H
+#define PROVIDER_I40IW_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/i40iw-abi.h>
 
 #define I40IW_ABI_VER 5
 
@@ -72,12 +73,6 @@ struct i40iw_ucreate_cq_resp {
 	__u32 cq_size;
 	__u32 mmap_db_index;
 	__u32 reserved;
-};
-
-enum i40iw_umemreg_type {
-	I40IW_UMEMREG_TYPE_MEM = 0x0000,
-	I40IW_UMEMREG_TYPE_QP = 0x0001,
-	I40IW_UMEMREG_TYPE_CQ = 0x0002
 };
 
 struct i40iw_ureg_mr {

--- a/providers/i40iw/i40iw-abi.h
+++ b/providers/i40iw/i40iw-abi.h
@@ -37,67 +37,19 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/i40iw-abi.h>
+#include <kernel-abi/i40iw-abi.h>
 
 #define I40IW_ABI_VER 5
 
-struct i40iw_get_context {
-	struct ibv_get_context cmd;
-	__u32 reserved32;
-	__u8 userspace_ver;
-	__u8 reserved8[3];
-};
-
-struct i40iw_ualloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-	__u32 max_pds;		/* maximum pds allowed for this user process */
-	__u32 max_qps;		/* maximum qps allowed for this user process */
-	__u32 wq_size;		/* defines the size of the WQs (sq+rq) allocated to the mmaped area */
-	__u8 kernel_ver;
-	__u8 reserved[3];
-};
-
-struct i40iw_ualloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	__u32 pd_id;
-	__u8 reserved[4];
-};
-
-struct i40iw_ucreate_cq {
-	struct ibv_create_cq ibv_cmd;
-	__u64 user_cq_buffer;
-};
-
-struct i40iw_ucreate_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	__u32 cq_id;
-	__u32 cq_size;
-	__u32 mmap_db_index;
-	__u32 reserved;
-};
-
-struct i40iw_ureg_mr {
-	struct ibv_reg_mr ibv_cmd;
-	__u16 reg_type;
-	__u16 cq_pages;
-	__u16 rq_pages;
-	__u16 sq_pages;
-};
-
-struct i40iw_ucreate_qp {
-	struct ibv_create_qp ibv_cmd;
-	__u64 user_wqe_buffers;
-	__u64 user_compl_ctx;
-};
-
-struct i40iw_ucreate_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	__u32 qp_id;
-	__u32 actual_sq_size;
-	__u32 actual_rq_size;
-	__u32 i40iw_drv_opt;
-	__u16 push_idx;
-	__u8  rsvd1;
-	__u8  rsvd2;
-};
+DECLARE_DRV_CMD(i40iw_ualloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, i40iw_alloc_pd_resp);
+DECLARE_DRV_CMD(i40iw_ucreate_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		i40iw_create_cq_req, i40iw_create_cq_resp);
+DECLARE_DRV_CMD(i40iw_ucreate_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		i40iw_create_qp_req, i40iw_create_qp_resp);
+DECLARE_DRV_CMD(i40iw_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		i40iw_alloc_ucontext_req, i40iw_alloc_ucontext_resp);
+DECLARE_DRV_CMD(i40iw_ureg_mr, IB_USER_VERBS_CMD_REG_MR,
+		i40iw_mem_reg_req, empty);
 
 #endif /* I40IW_ABI_H */

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -132,7 +132,7 @@ static struct verbs_context *i40iw_ualloc_context(struct ibv_device *ibdev,
 	struct ibv_pd *ibv_pd;
 	struct i40iw_uvcontext *iwvctx;
 	struct i40iw_get_context cmd;
-	struct i40iw_ualloc_ucontext_resp resp;
+	struct i40iw_get_context_resp resp;
 
 	iwvctx = verbs_init_and_alloc_context(ibdev, cmd_fd, iwvctx, ibv_ctx,
 					      RDMA_DRIVER_I40IW);

--- a/providers/i40iw/i40iw_uverbs.c
+++ b/providers/i40iw/i40iw_uverbs.c
@@ -159,7 +159,7 @@ struct ibv_mr *i40iw_ureg_mr(struct ibv_pd *pd, void *addr, size_t length, int a
 	if (!mr)
 		return NULL;
 
-	cmd.reg_type = I40IW_UMEMREG_TYPE_MEM;
+	cmd.reg_type = IW_MEMREG_TYPE_MEM;
 
 	if (ibv_cmd_reg_mr(pd, addr, length, (uintptr_t)addr,
 			   access, mr, &cmd.ibv_cmd, sizeof(cmd),
@@ -254,7 +254,7 @@ struct ibv_cq *i40iw_ucreate_cq(struct ibv_context *context, int cqe,
 
 	memset(info.cq_base, 0, totalsize);
 	info.shadow_area = (u64 *)((u8 *)info.cq_base + (cq_pages << 12));
-	reg_mr_cmd.reg_type = I40IW_UMEMREG_TYPE_CQ;
+	reg_mr_cmd.reg_type = IW_MEMREG_TYPE_CQ;
 
 	reg_mr_cmd.cq_pages = cq_pages;
 
@@ -526,7 +526,7 @@ static int i40iw_vmapped_qp(struct i40iw_uqp *iwuqp, struct ibv_pd *pd,
 	info->rq = &info->sq[sqsize / I40IW_QP_WQE_MIN_SIZE];
 	info->shadow_area = info->rq[rqsize / I40IW_QP_WQE_MIN_SIZE].elem;
 
-	reg_mr_cmd.reg_type = I40IW_UMEMREG_TYPE_QP;
+	reg_mr_cmd.reg_type = IW_MEMREG_TYPE_QP;
 	reg_mr_cmd.sq_pages = sq_pages;
 	reg_mr_cmd.rq_pages = rq_pages;
 

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -34,25 +34,18 @@
 #define MLX4_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/mlx4-abi.h>
 
 #define MLX4_UVERBS_MIN_ABI_VERSION	2
 #define MLX4_UVERBS_MAX_ABI_VERSION	4
 
 #define MLX4_UVERBS_NO_DEV_CAPS_ABI_VERSION	3
 
-enum {
-	MLX4_USER_DEV_CAP_64B_CQE	= 1L << 0
-};
-
 struct mlx4_alloc_ucontext_resp_v3 {
 	struct ib_uverbs_get_context_resp	ibv_resp;
 	__u32				qp_tab_size;
 	__u16				bf_reg_size;
 	__u16				bf_regs_per_page;
-};
-
-enum mlx4_query_dev_ex_resp_mask {
-	MLX4_QUERY_DEV_RESP_MASK_CORE_CLOCK_OFFSET = 1UL << 0,
 };
 
 struct mlx4_alloc_ucontext_resp {
@@ -99,20 +92,6 @@ struct mlx4_resize_cq {
 	__u64				buf_addr;
 };
 
-struct mlx4_rss_caps {
-	__u64 rx_hash_fields_mask; /* enum ibv_rx_hash_fields */
-	__u8 rx_hash_function; /* enum ibv_rx_hash_function_flags */
-	__u8 reserved[7];
-};
-
-struct mlx4_ib_tso_caps {
-	__u32 max_tso; /* Maximum tso payload size in bytes */
-	/* Corresponding bit will be set if qp type from
-	 * 'enum ib_qp_type' is supported.
-	 */
-	__u32 supported_qpts;
-};
-
 struct mlx4_query_device_ex_resp {
 	struct ib_uverbs_ex_query_device_resp ibv_resp;
 	__u32				comp_mask;
@@ -121,7 +100,7 @@ struct mlx4_query_device_ex_resp {
 	__u32				max_inl_recv_sz;
 	/* Explicitly align the response to u64 */
 	__u32				reserved;
-	struct mlx4_rss_caps            rss_caps; /* vendor data channel */
+	struct mlx4_ib_rss_caps            rss_caps; /* vendor data channel */
 	struct mlx4_ib_tso_caps		tso_caps;
 };
 
@@ -158,49 +137,23 @@ struct mlx4_create_qp {
 	__u32				inl_recv_sz;
 };
 
-struct mlx4_create_qp_drv_ex_rss {
-	__u64		hash_fields_mask; /* enum ibv_rx_hash_fields */
-	__u8		hash_function; /* enum ibv_rx_hash_function_flags */
-	__u8		reserved[7];
-	__u8		hash_key[40];
-	__u32		comp_mask;
-	__u32		reserved1;
-};
-
 struct mlx4_create_qp_ex_rss {
 	struct ibv_create_qp_ex		 ibv_cmd;
-	struct mlx4_create_qp_drv_ex_rss drv_ex;
-};
-
-struct mlx4_create_qp_drv_ex {
-	__u64		buf_addr;
-	__u64		db_addr;
-	__u8		log_sq_bb_count;
-	__u8		log_sq_stride;
-	__u8		sq_no_prefetch;	/* was reserved in ABI 2 */
-	__u8		reserved[5];
+	struct mlx4_ib_create_qp_rss drv_ex;
 };
 
 struct mlx4_create_qp_ex {
 	struct ibv_create_qp_ex		ibv_cmd;
-	struct mlx4_create_qp_drv_ex	drv_ex;
+	struct mlx4_ib_create_qp	drv_ex;
 };
 
 struct mlx4_create_qp_resp_ex {
 	struct ib_uverbs_ex_create_qp_resp	ibv_resp;
 };
 
-struct mlx4_drv_create_wq {
-	__u64		buf_addr;
-	__u64		db_addr;
-	__u8		log_range_size;
-	__u8		reserved[3];
-	__u32		comp_mask;
-};
-
 struct mlx4_create_wq {
 	struct ibv_create_wq		ibv_cmd;
-	struct mlx4_drv_create_wq	drv;
+	struct mlx4_ib_create_wq	drv;
 };
 
 struct mlx4_modify_wq {

--- a/providers/mlx4/mlx4-abi.h
+++ b/providers/mlx4/mlx4-abi.h
@@ -35,131 +35,40 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/mlx4-abi.h>
+#include <kernel-abi/mlx4-abi.h>
 
 #define MLX4_UVERBS_MIN_ABI_VERSION	2
 #define MLX4_UVERBS_MAX_ABI_VERSION	4
 
 #define MLX4_UVERBS_NO_DEV_CAPS_ABI_VERSION	3
 
-struct mlx4_alloc_ucontext_resp_v3 {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				qp_tab_size;
-	__u16				bf_reg_size;
-	__u16				bf_regs_per_page;
-};
-
-struct mlx4_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				dev_caps;
-	__u32				qp_tab_size;
-	__u16				bf_reg_size;
-	__u16				bf_regs_per_page;
-	__u32				cqe_size;
-};
-
-struct mlx4_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	__u32				pdn;
-	__u32				reserved;
-};
-
-struct mlx4_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct mlx4_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	__u32				cqn;
-	__u32				reserved;
-};
-
-struct mlx4_create_cq_ex {
-	struct ibv_create_cq_ex		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct mlx4_create_cq_resp_ex {
-	struct ib_uverbs_ex_create_cq_resp	ibv_resp;
-	__u32				cqn;
-	__u32				reserved;
-};
-
-struct mlx4_resize_cq {
-	struct ibv_resize_cq		ibv_cmd;
-	__u64				buf_addr;
-};
-
-struct mlx4_query_device_ex_resp {
-	struct ib_uverbs_ex_query_device_resp ibv_resp;
-	__u32				comp_mask;
-	__u32				response_length;
-	__u64				hca_core_clock_offset;
-	__u32				max_inl_recv_sz;
-	/* Explicitly align the response to u64 */
-	__u32				reserved;
-	struct mlx4_ib_rss_caps            rss_caps; /* vendor data channel */
-	struct mlx4_ib_tso_caps		tso_caps;
-};
-
-struct mlx4_query_device_ex {
-	struct ibv_query_device_ex	ibv_cmd;
-};
-
-struct mlx4_create_srq {
-	struct ibv_create_srq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct mlx4_create_xsrq {
-	struct ibv_create_xsrq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct mlx4_create_srq_resp {
-	struct ib_uverbs_create_srq_resp	ibv_resp;
-	__u32				srqn;
-	__u32				reserved;
-};
-
-struct mlx4_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u8				log_sq_bb_count;
-	__u8				log_sq_stride;
-	__u8				sq_no_prefetch;	/* was reserved in ABI 2 */
-	__u8				reserved;
-	__u32				inl_recv_sz;
-};
-
-struct mlx4_create_qp_ex_rss {
-	struct ibv_create_qp_ex		 ibv_cmd;
-	struct mlx4_ib_create_qp_rss drv_ex;
-};
-
-struct mlx4_create_qp_ex {
-	struct ibv_create_qp_ex		ibv_cmd;
-	struct mlx4_ib_create_qp	drv_ex;
-};
-
-struct mlx4_create_qp_resp_ex {
-	struct ib_uverbs_ex_create_qp_resp	ibv_resp;
-};
-
-struct mlx4_create_wq {
-	struct ibv_create_wq		ibv_cmd;
-	struct mlx4_ib_create_wq	drv;
-};
-
-struct mlx4_modify_wq {
-	struct ibv_modify_wq	ibv_cmd;
-	__u32			comp_mask;
-	__u32			reserved;
-};
+DECLARE_DRV_CMD(mlx4_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, mlx4_ib_alloc_pd_resp);
+DECLARE_DRV_CMD(mlx4_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		mlx4_ib_create_cq, mlx4_ib_create_cq_resp);
+DECLARE_DRV_CMD(mlx4_create_cq_ex, IB_USER_VERBS_EX_CMD_CREATE_CQ,
+		mlx4_ib_create_cq, mlx4_ib_create_cq_resp);
+DECLARE_DRV_CMD(mlx4_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		mlx4_ib_create_qp, empty);
+DECLARE_DRV_CMD(mlx4_create_qp_ex, IB_USER_VERBS_EX_CMD_CREATE_QP,
+		mlx4_ib_create_qp, empty);
+DECLARE_DRV_CMD(mlx4_create_qp_ex_rss, IB_USER_VERBS_EX_CMD_CREATE_QP,
+		mlx4_ib_create_qp_rss, empty);
+DECLARE_DRV_CMD(mlx4_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		mlx4_ib_create_srq, mlx4_ib_create_srq_resp);
+DECLARE_DRV_CMD(mlx4_create_wq, IB_USER_VERBS_EX_CMD_CREATE_WQ,
+		mlx4_ib_create_wq, empty);
+DECLARE_DRV_CMD(mlx4_create_xsrq, IB_USER_VERBS_CMD_CREATE_XSRQ,
+		mlx4_ib_create_srq, mlx4_ib_create_srq_resp);
+DECLARE_DRV_CMD(mlx4_alloc_ucontext_v3, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, mlx4_ib_alloc_ucontext_resp_v3);
+DECLARE_DRV_CMD(mlx4_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, mlx4_ib_alloc_ucontext_resp);
+DECLARE_DRV_CMD(mlx4_modify_wq, IB_USER_VERBS_EX_CMD_MODIFY_WQ,
+		mlx4_ib_modify_wq, empty);
+DECLARE_DRV_CMD(mlx4_query_device_ex, IB_USER_VERBS_EX_CMD_QUERY_DEVICE,
+		empty, mlx4_uverbs_ex_query_device_resp);
+DECLARE_DRV_CMD(mlx4_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		mlx4_ib_resize_cq, empty);
 
 #endif /* MLX4_ABI_H */

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -171,7 +171,7 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 	struct ibv_get_context		cmd;
 	struct mlx4_alloc_ucontext_resp resp;
 	int				i;
-	struct mlx4_alloc_ucontext_resp_v3 resp_v3;
+	struct mlx4_alloc_ucontext_v3_resp resp_v3;
 	__u16				bf_reg_size;
 	struct mlx4_device              *dev = to_mdev(ibdev);
 	struct verbs_context		*verbs_ctx;

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -200,7 +200,7 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 
 		context->num_qps  = resp.qp_tab_size;
 		bf_reg_size	  = resp.bf_reg_size;
-		if (resp.dev_caps & MLX4_USER_DEV_CAP_64B_CQE)
+		if (resp.dev_caps & MLX4_USER_DEV_CAP_LARGE_CQE)
 			context->cqe_size = resp.cqe_size;
 		else
 			context->cqe_size = sizeof (struct mlx4_cqe);

--- a/providers/mlx4/srq.c
+++ b/providers/mlx4/srq.c
@@ -234,7 +234,7 @@ struct ibv_srq *mlx4_create_xrc_srq(struct ibv_context *context,
 				    struct ibv_srq_init_attr_ex *attr_ex)
 {
 	struct mlx4_create_xsrq cmd;
-	struct mlx4_create_srq_resp resp;
+	struct mlx4_create_xsrq_resp resp;
 	struct mlx4_srq *srq;
 	int ret;
 

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -92,7 +92,7 @@ int mlx4_query_device_ex(struct ibv_context *context,
 	attr->tso_caps.max_tso = resp.tso_caps.max_tso;
 	attr->tso_caps.supported_qpts = resp.tso_caps.supported_qpts;
 
-	if (resp.comp_mask & MLX4_QUERY_DEV_RESP_MASK_CORE_CLOCK_OFFSET) {
+	if (resp.comp_mask & MLX4_IB_QUERY_DEV_RESP_MASK_CORE_CLOCK_OFFSET) {
 		mctx->core_clock.offset = resp.hca_core_clock_offset;
 		mctx->core_clock.offset_valid = 1;
 	}
@@ -767,17 +767,17 @@ static int mlx4_cmd_create_qp_ex_rss(struct ibv_context *context,
 	int ret;
 
 	if (attr->rx_hash_conf.rx_hash_key_len !=
-	    sizeof(cmd_ex.drv_ex.hash_key)) {
+	    sizeof(cmd_ex.drv_ex.rx_hash_key)) {
 		errno = ENOTSUP;
 		return errno;
 	}
 
-	cmd_ex.drv_ex.hash_fields_mask =
+	cmd_ex.drv_ex.rx_hash_fields_mask =
 		attr->rx_hash_conf.rx_hash_fields_mask;
-	cmd_ex.drv_ex.hash_function =
+	cmd_ex.drv_ex.rx_hash_function =
 		attr->rx_hash_conf.rx_hash_function;
-	memcpy(cmd_ex.drv_ex.hash_key, attr->rx_hash_conf.rx_hash_key,
-	       sizeof(cmd_ex.drv_ex.hash_key));
+	memcpy(cmd_ex.drv_ex.rx_hash_key, attr->rx_hash_conf.rx_hash_key,
+	       sizeof(cmd_ex.drv_ex.rx_hash_key));
 
 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
 				    sizeof(qp->verbs_qp), attr,

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -225,23 +225,18 @@ struct mlx5_query_device_ex {
 	struct ibv_query_device_ex	ibv_cmd;
 };
 
-struct mlx5_striding_rq_caps {
-	struct mlx5dv_striding_rq_caps	caps;
-	__u32				reserved;
-};
-
 struct mlx5_query_device_ex_resp {
 	struct ib_uverbs_ex_query_device_resp ibv_resp;
 	__u32				comp_mask;
 	__u32				response_length;
-	struct ibv_tso_caps		tso_caps;
+	struct mlx5_ib_tso_caps		tso_caps;
 	struct mlx5_ib_rss_caps            rss_caps; /* vendor data channel */
-	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
+	struct mlx5_ib_cqe_comp_caps	cqe_comp_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	__u32				support_multi_pkt_send_wqe;
 	__u32				flags; /* Use enum mlx5_query_dev_resp_flags */
-	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
-	struct mlx5_striding_rq_caps	striding_rq_caps;
+	struct mlx5_ib_sw_parsing_caps	sw_parsing_caps;
+	struct mlx5_ib_striding_rq_caps	striding_rq_caps;
 	__u32				tunnel_offloads_caps;
 	__u32				reserved;
 };

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -35,23 +35,11 @@
 
 #include <infiniband/kern-abi.h>
 #include <infiniband/verbs.h>
+#include <rdma/mlx5-abi.h>
 #include "mlx5dv.h"
 
 #define MLX5_UVERBS_MIN_ABI_VERSION	1
 #define MLX5_UVERBS_MAX_ABI_VERSION	1
-
-enum {
-	MLX5_QP_FLAG_SIGNATURE		= 1 << 0,
-	MLX5_QP_FLAG_SCATTER_CQE	= 1 << 1,
-	MLX5_QP_FLAG_TUNNEL_OFFLOADS	= 1 << 2,
-	MLX5_QP_FLAG_BFREG_INDEX	= 1 << 3,
-	MLX5_QP_FLAG_TYPE_DCT		= 1 << 4,
-	MLX5_QP_FLAG_TYPE_DCI		= 1 << 5,
-};
-
-enum {
-	MLX5_RWQ_FLAG_SIGNATURE		= 1 << 0,
-};
 
 enum {
 	MLX5_NUM_NON_FP_BFREGS_PER_UAR	= 2,
@@ -60,10 +48,6 @@ enum {
 	MLX5_MAX_BFREGS			= MLX5_MAX_UARS * MLX5_NUM_NON_FP_BFREGS_PER_UAR,
 	MLX5_DEF_TOT_UUARS		= 8 * MLX5_NUM_NON_FP_BFREGS_PER_UAR,
 	MLX5_MED_BFREGS_TSHOLD		= 12,
-};
-
-enum mlx5_lib_caps {
-	MLX5_LIB_CAP_4K_UAR		= 1 << 0,
 };
 
 struct mlx5_alloc_ucontext {
@@ -77,31 +61,6 @@ struct mlx5_alloc_ucontext {
 	__u16				reserved1;
 	__u32				reserved2;
 	__u64				lib_caps;
-};
-
-enum mlx5_ib_alloc_ucontext_resp_mask {
-	MLX5_IB_ALLOC_UCONTEXT_RESP_MASK_CORE_CLOCK_OFFSET = 1UL << 0,
-};
-
-/* Bit indexes for the mlx5_alloc_ucontext_resp.clock_info_versions bitmap */
-enum {
-	MLX5_IB_CLOCK_INFO_V1	= 0,
-};
-
-enum {
-	MLX5_IB_CLOCK_INFO_KERNEL_UPDATING = 1,
-};
-
-struct mlx5_ib_clock_info {
-	__u32 sig;
-	__u32 resv;
-	__u64 nsec;
-	__u64 last_cycles;
-	__u64 frac;
-	__u32 mult;
-	__u32 shift;
-	__u64 mask;
-	__u64 overflow_period;
 };
 
 struct mlx5_alloc_ucontext_resp {
@@ -140,10 +99,6 @@ struct mlx5_create_ah_resp {
 struct mlx5_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp	ibv_resp;
 	__u32				pdn;
-};
-
-enum mlx5_create_cq_flags {
-	MLX5_CREATE_CQ_FLAGS_CQE_128B_PAD	= 1 << 0,
 };
 
 struct mlx5_create_cq {
@@ -246,10 +201,6 @@ struct mlx5_create_qp_resp {
 	__u32				uuar_index;
 };
 
-enum mlx5_create_wq_comp_mask {
-	MLX5_IB_CREATE_WQ_STRIDING_RQ =		1 << 0,
-};
-
 struct mlx5_drv_create_wq {
 	__u64		buf_addr;
 	__u64		db_addr;
@@ -304,35 +255,10 @@ struct mlx5_query_device_ex {
 	struct ibv_query_device_ex	ibv_cmd;
 };
 
-struct mlx5_reserved_tso_caps {
-	__u64 reserved;
-};
-
 struct mlx5_rss_caps {
 	__u64 rx_hash_fields_mask; /* enum ibv_rx_hash_fields */
 	__u8 rx_hash_function; /* enum ibv_rx_hash_function_flags */
 	__u8 reserved[7];
-};
-
-enum mlx5_ib_packet_pacing_cap_flags {
-	MLX5_IB_PP_SUPPORT_BURST	= 1 << 0,
-};
-
-struct mlx5_packet_pacing_caps {
-	struct ibv_packet_pacing_caps caps;
-	__u8   cap_flags; /* enum mlx5_ib_packet_pacing_cap_flags */
-	__u8   reserved[3];
-};
-
-enum mlx5_mpw_caps {
-	MLX5_MPW_OBSOLETE	= 1 << 0, /* Obsoleted, don't use */
-	MLX5_ALLOW_MPW		= 1 << 1,
-	MLX5_SUPPORT_EMPW	= 1 << 2,
-};
-
-enum mlx5_query_dev_resp_flags {
-	MLX5_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP	= 1 << 0,
-	MLX5_QUERY_DEV_RESP_FLAGS_CQE_128B_PAD	= 1 << 1,
 };
 
 struct mlx5_striding_rq_caps {
@@ -362,13 +288,7 @@ struct mlx5_modify_qp_resp_ex {
 	__u32  dctn;
 };
 
-struct mlx5_ib_burst_info {
-	__u32	max_burst_sz;
-	__u16	typical_pkt_sz;
-	__u16	reserved;
-};
-
-struct mlx5_ib_modify_qp {
+struct mlx5_modify_qp {
 	struct ibv_modify_qp_ex		ibv_cmd;
 	__u32				comp_mask;
 	struct mlx5_ib_burst_info	burst_info;

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -36,6 +36,7 @@
 #include <infiniband/kern-abi.h>
 #include <infiniband/verbs.h>
 #include <rdma/mlx5-abi.h>
+#include <kernel-abi/mlx5-abi.h>
 #include "mlx5dv.h"
 
 #define MLX5_UVERBS_MIN_ABI_VERSION	1
@@ -50,202 +51,38 @@ enum {
 	MLX5_MED_BFREGS_TSHOLD		= 12,
 };
 
-struct mlx5_alloc_ucontext {
-	struct ibv_get_context		ibv_req;
-	__u32				total_num_uuars;
-	__u32				num_low_latency_uuars;
-	__u32				flags;
-	__u32				comp_mask;
-	__u8				cqe_version;
-	__u8				reserved0;
-	__u16				reserved1;
-	__u32				reserved2;
-	__u64				lib_caps;
-};
-
-struct mlx5_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				qp_tab_size;
-	__u32				bf_reg_size;
-	__u32				tot_uuars;
-	__u32				cache_line_size;
-	__u16				max_sq_desc_sz;
-	__u16				max_rq_desc_sz;
-	__u32				max_send_wqebb;
-	__u32				max_recv_wr;
-	__u32				max_srq_recv_wr;
-	__u16				num_ports;
-	__u16				reserved1;
-	__u32				comp_mask;
-	__u32				response_length;
-	__u8				cqe_version;
-	__u8				cmds_supp_uhw;
-	__u8				reserved2;
-	__u8				clock_info_versions;
-	__u64				hca_core_clock_offset;
-	__u32				log_uar_size;
-	__u32				num_uars_per_page;
-	__u32				num_dyn_bfregs;
-	__u32				reserved3;
-};
-
-struct mlx5_create_ah_resp {
-	struct ib_uverbs_create_ah_resp	ibv_resp;
-	__u32				response_length;
-	__u8				dmac[ETHERNET_LL_SIZE];
-	__u8				reserved[6];
-};
-
-struct mlx5_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	__u32				pdn;
-};
-
-struct mlx5_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u32				cqe_size;
-	__u8                            cqe_comp_en;
-	__u8                            cqe_comp_res_format;
-	__u16                           flags; /* Use enum mlx5_create_cq_flags */
-};
-
-struct mlx5_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	__u32				cqn;
-};
-
-struct mlx5_create_srq {
-	struct ibv_create_srq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u32				flags;
-};
-
-struct mlx5_create_srq_resp {
-	struct ib_uverbs_create_srq_resp	ibv_resp;
-	__u32				srqn;
-	__u32				reserved;
-};
-
-struct mlx5_create_srq_ex {
-	struct ibv_create_xsrq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u32				flags;
-	__u32				reserved;
-	__u32                           uidx;
-	__u32                           reserved1;
-};
-
-struct mlx5_create_qp_ex {
-	struct ibv_create_qp_ex	ibv_cmd;
-	struct mlx5_ib_create_qp drv_ex;
-};
-
-struct mlx5_create_qp_ex_rss {
-	struct ibv_create_qp_ex	ibv_cmd;
-	__u64 rx_hash_fields_mask; /* enum ibv_rx_hash_fields */
-	__u8 rx_hash_function; /* enum ibv_rx_hash_function_flags */
-	__u8 rx_key_len;
-	__u8 reserved[6];
-	__u8 rx_hash_key[128];
-	__u32   comp_mask;
-	__u32   create_flags;
-};
-
-struct mlx5_create_qp_resp_ex {
-	struct ib_uverbs_ex_create_qp_resp	ibv_resp;
-	__u32				uuar_index;
-	__u32				reserved;
-};
-
-struct mlx5_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u32				sq_wqe_count;
-	__u32				rq_wqe_count;
-	__u32				rq_wqe_shift;
-	__u32				flags;
-	__u32                           uidx;
-	__u32                           bfreg_index;
-	union {
-		/* SQ buffer address - used for Raw Packet QP */
-		__u64			sq_buf_addr;
-		/* DC access key - used to create a DCT QP */
-		__u64			access_key;
-	};
-};
-
-struct mlx5_create_qp_resp {
-	struct ib_uverbs_create_qp_resp	ibv_resp;
-	__u32				uuar_index;
-};
-
-struct mlx5_create_wq {
-	struct ibv_create_wq	ibv_cmd;
-	struct mlx5_ib_create_wq	drv;
-};
-
-struct mlx5_create_wq_resp {
-	struct ib_uverbs_ex_create_wq_resp	ibv_resp;
-	__u32			response_length;
-	__u32			reserved;
-};
-
-struct mlx5_modify_wq {
-	struct ibv_modify_wq	ibv_cmd;
-	__u32			comp_mask;
-	__u32			reserved;
-};
-
-struct mlx5_create_rwq_ind_table_resp {
-	struct ib_uverbs_ex_create_rwq_ind_table_resp ibv_resp;
-};
-
-struct mlx5_destroy_rwq_ind_table {
-	struct ibv_destroy_rwq_ind_table ibv_cmd;
-};
-
-struct mlx5_resize_cq {
-	struct ibv_resize_cq		ibv_cmd;
-	__u64				buf_addr;
-	__u16				cqe_size;
-	__u16				reserved0;
-	__u32				reserved1;
-};
-
-struct mlx5_resize_cq_resp {
-	struct ib_uverbs_resize_cq_resp	ibv_resp;
-};
-
-struct mlx5_query_device_ex {
-	struct ibv_query_device_ex	ibv_cmd;
-};
-
-struct mlx5_query_device_ex_resp {
-	struct ib_uverbs_ex_query_device_resp ibv_resp;
-	__u32				comp_mask;
-	__u32				response_length;
-	struct mlx5_ib_tso_caps		tso_caps;
-	struct mlx5_ib_rss_caps            rss_caps; /* vendor data channel */
-	struct mlx5_ib_cqe_comp_caps	cqe_comp_caps;
-	struct mlx5_packet_pacing_caps	packet_pacing_caps;
-	__u32				support_multi_pkt_send_wqe;
-	__u32				flags; /* Use enum mlx5_query_dev_resp_flags */
-	struct mlx5_ib_sw_parsing_caps	sw_parsing_caps;
-	struct mlx5_ib_striding_rq_caps	striding_rq_caps;
-	__u32				tunnel_offloads_caps;
-	__u32				reserved;
-};
-
-struct mlx5_modify_qp_resp_ex {
-	struct ib_uverbs_ex_modify_qp_resp base;
-	__u32  response_length;
-	__u32  dctn;
-};
+DECLARE_DRV_CMD(mlx5_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		mlx5_ib_alloc_ucontext_req_v2, mlx5_ib_alloc_ucontext_resp);
+DECLARE_DRV_CMD(mlx5_create_ah, IB_USER_VERBS_CMD_CREATE_AH,
+		empty, mlx5_ib_create_ah_resp);
+DECLARE_DRV_CMD(mlx5_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, mlx5_ib_alloc_pd_resp);
+DECLARE_DRV_CMD(mlx5_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		mlx5_ib_create_cq, mlx5_ib_create_cq_resp);
+DECLARE_DRV_CMD(mlx5_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		mlx5_ib_create_srq, mlx5_ib_create_srq_resp);
+DECLARE_DRV_CMD(mlx5_create_srq_ex, IB_USER_VERBS_CMD_CREATE_XSRQ,
+		mlx5_ib_create_srq, mlx5_ib_create_srq_resp);
+DECLARE_DRV_CMD(mlx5_create_qp_ex, IB_USER_VERBS_EX_CMD_CREATE_QP,
+		mlx5_ib_create_qp, mlx5_ib_create_qp_resp);
+DECLARE_DRV_CMD(mlx5_create_qp_ex_rss, IB_USER_VERBS_EX_CMD_CREATE_QP,
+		mlx5_ib_create_qp_rss, mlx5_ib_create_qp_resp);
+DECLARE_DRV_CMD(mlx5_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		mlx5_ib_create_qp, mlx5_ib_create_qp_resp);
+DECLARE_DRV_CMD(mlx5_create_wq, IB_USER_VERBS_EX_CMD_CREATE_WQ,
+		mlx5_ib_create_wq, mlx5_ib_create_wq_resp);
+DECLARE_DRV_CMD(mlx5_modify_wq, IB_USER_VERBS_EX_CMD_MODIFY_WQ,
+		mlx5_ib_modify_wq, empty);
+DECLARE_DRV_CMD(mlx5_create_rwq_ind_table, IB_USER_VERBS_EX_CMD_CREATE_RWQ_IND_TBL,
+		empty, empty);
+DECLARE_DRV_CMD(mlx5_destroy_rwq_ind_table, IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL,
+		empty, empty);
+DECLARE_DRV_CMD(mlx5_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		mlx5_ib_resize_cq, empty);
+DECLARE_DRV_CMD(mlx5_query_device_ex, IB_USER_VERBS_EX_CMD_QUERY_DEVICE,
+		empty, mlx5_ib_query_device_resp);
+DECLARE_DRV_CMD(mlx5_modify_qp_ex, IB_USER_VERBS_EX_CMD_MODIFY_QP,
+		empty, mlx5_ib_modify_qp_resp);
 
 struct mlx5_modify_qp {
 	struct ibv_modify_qp_ex		ibv_cmd;

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -139,26 +139,9 @@ struct mlx5_create_srq_ex {
 	__u32                           reserved1;
 };
 
-struct mlx5_create_qp_drv_ex {
-	__u64			buf_addr;
-	__u64			db_addr;
-	__u32			sq_wqe_count;
-	__u32			rq_wqe_count;
-	__u32			rq_wqe_shift;
-	__u32			flags;
-	__u32			uidx;
-	__u32			reserved;
-	union {
-		/* SQ buffer address - used for Raw Packet QP */
-		__u64			sq_buf_addr;
-		/* DC access key - used to create a DCT QP */
-		__u64			access_key;
-	};
-};
-
 struct mlx5_create_qp_ex {
 	struct ibv_create_qp_ex	ibv_cmd;
-	struct mlx5_create_qp_drv_ex drv_ex;
+	struct mlx5_ib_create_qp drv_ex;
 };
 
 struct mlx5_create_qp_ex_rss {
@@ -201,22 +184,9 @@ struct mlx5_create_qp_resp {
 	__u32				uuar_index;
 };
 
-struct mlx5_drv_create_wq {
-	__u64		buf_addr;
-	__u64		db_addr;
-	__u32		rq_wqe_count;
-	__u32		rq_wqe_shift;
-	__u32		user_index;
-	__u32		flags;
-	__u32		comp_mask;
-	__u32		single_stride_log_num_of_bytes;
-	__u32		single_wqe_log_num_of_strides;
-	__u32		two_byte_shift_en;
-};
-
 struct mlx5_create_wq {
 	struct ibv_create_wq	ibv_cmd;
-	struct mlx5_drv_create_wq	drv;
+	struct mlx5_ib_create_wq	drv;
 };
 
 struct mlx5_create_wq_resp {
@@ -255,12 +225,6 @@ struct mlx5_query_device_ex {
 	struct ibv_query_device_ex	ibv_cmd;
 };
 
-struct mlx5_rss_caps {
-	__u64 rx_hash_fields_mask; /* enum ibv_rx_hash_fields */
-	__u8 rx_hash_function; /* enum ibv_rx_hash_function_flags */
-	__u8 reserved[7];
-};
-
 struct mlx5_striding_rq_caps {
 	struct mlx5dv_striding_rq_caps	caps;
 	__u32				reserved;
@@ -271,7 +235,7 @@ struct mlx5_query_device_ex_resp {
 	__u32				comp_mask;
 	__u32				response_length;
 	struct ibv_tso_caps		tso_caps;
-	struct mlx5_rss_caps            rss_caps; /* vendor data channel */
+	struct mlx5_ib_rss_caps            rss_caps; /* vendor data channel */
 	struct mlx5dv_cqe_comp_caps	cqe_comp_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	__u32				support_multi_pkt_send_wqe;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -577,7 +577,7 @@ static int mlx5_cmd_get_context(struct mlx5_context *context,
 {
 	struct verbs_context *verbs_ctx = &context->ibv_ctx;
 
-	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
+	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_cmd,
 				 req_len, &resp->ibv_resp, resp_len))
 		return 0;
 
@@ -600,14 +600,14 @@ static int mlx5_cmd_get_context(struct mlx5_context *context,
 	 * to do so. If zero is a valid response, we will add a new
 	 * field that indicates whether the request was handled.
 	 */
-	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
+	if (!ibv_cmd_get_context(verbs_ctx, &req->ibv_cmd,
 				 offsetof(struct mlx5_alloc_ucontext, lib_caps),
 				 &resp->ibv_resp, resp_len))
 		return 0;
 
-	return ibv_cmd_get_context(verbs_ctx, &req->ibv_req,
+	return ibv_cmd_get_context(verbs_ctx, &req->ibv_cmd,
 				   offsetof(struct mlx5_alloc_ucontext,
-					    cqe_version),
+					    max_cqe_version),
 				   &resp->ibv_resp, resp_len);
 }
 
@@ -1010,9 +1010,9 @@ static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
 	memset(&req, 0, sizeof(req));
 	memset(&resp, 0, sizeof(resp));
 
-	req.total_num_uuars = tot_uuars;
-	req.num_low_latency_uuars = low_lat_uuars;
-	req.cqe_version = MLX5_CQE_VERSION_V1;
+	req.total_num_bfregs = tot_uuars;
+	req.num_low_latency_bfregs = low_lat_uuars;
+	req.max_cqe_version = MLX5_CQE_VERSION_V1;
 	req.lib_caps |= MLX5_LIB_CAP_4K_UAR;
 
 	if (mlx5_cmd_get_context(context, &req, sizeof(req), &resp,
@@ -1021,7 +1021,7 @@ static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
 
 	context->max_num_qps		= resp.qp_tab_size;
 	context->bf_reg_size		= resp.bf_reg_size;
-	context->tot_uuars		= resp.tot_uuars;
+	context->tot_uuars		= resp.tot_bfregs;
 	context->low_lat_uuars		= low_lat_uuars;
 	context->cache_line_size	= resp.cache_line_size;
 	context->max_sq_desc_sz = resp.max_sq_desc_sz;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -917,7 +917,7 @@ int mlx5dv_get_clock_info(struct ibv_context *ctx_in,
 	if (!ci)
 		return EINVAL;
 
-	sig = (atomic_uint32_t *)&ci->sig;
+	sig = (atomic_uint32_t *)&ci->sign;
 
 	do {
 		retry = 10;
@@ -930,7 +930,7 @@ repeat:
 			return EBUSY;
 		}
 		clock_info->nsec   = ci->nsec;
-		clock_info->last_cycles = ci->last_cycles;
+		clock_info->last_cycles = ci->cycles;
 		clock_info->frac   = ci->frac;
 		clock_info->mult   = ci->mult;
 		clock_info->shift  = ci->shift;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -149,7 +149,6 @@ enum {
 };
 
 enum {
-	MLX5_SRQ_FLAG_SIGNATURE		= (1 << 0),
 	MLX5_SRQ_FLAG_TM_SW_CNT		= (1 << 6),
 	MLX5_SRQ_FLAG_TM_CQE_REQ	= (1 << 7),
 };
@@ -184,11 +183,6 @@ enum mlx5_rsc_type {
 	MLX5_RSC_TYPE_SRQ,
 	MLX5_RSC_TYPE_RWQ,
 	MLX5_RSC_TYPE_INVAL,
-};
-
-enum {
-	MLX5_USER_CMDS_SUPP_UHW_QUERY_DEVICE = 1 << 0,
-	MLX5_USER_CMDS_SUPP_UHW_CREATE_AH    = 1 << 1,
 };
 
 enum mlx5_vendor_cap_flags {

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2617,7 +2617,8 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	if (err)
 		return err;
 
-	attr->tso_caps = resp.tso_caps;
+	attr->tso_caps.max_tso = resp.tso_caps.max_tso;
+	attr->tso_caps.supported_qpts = resp.tso_caps.supported_qpts;
 	attr->rss_caps.rx_hash_fields_mask = resp.rss_caps.rx_hash_fields_mask;
 	attr->rss_caps.rx_hash_function = resp.rss_caps.rx_hash_function;
 	attr->packet_pacing_caps.qp_rate_limit_min =
@@ -2633,9 +2634,22 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	if (resp.support_multi_pkt_send_wqe & MLX5_IB_SUPPORT_EMPW)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_ENHANCED_MPW;
 
-	mctx->cqe_comp_caps = resp.cqe_comp_caps;
-	mctx->sw_parsing_caps = resp.sw_parsing_caps;
-	mctx->striding_rq_caps = resp.striding_rq_caps.caps;
+	mctx->cqe_comp_caps.max_num = resp.cqe_comp_caps.max_num;
+	mctx->cqe_comp_caps.supported_format = resp.cqe_comp_caps.supported_format;
+	mctx->sw_parsing_caps.sw_parsing_offloads =
+		resp.sw_parsing_caps.sw_parsing_offloads;
+	mctx->sw_parsing_caps.supported_qpts =
+		resp.sw_parsing_caps.supported_qpts;
+	mctx->striding_rq_caps.min_single_stride_log_num_of_bytes =
+		resp.striding_rq_caps.min_single_stride_log_num_of_bytes;
+	mctx->striding_rq_caps.max_single_stride_log_num_of_bytes =
+		resp.striding_rq_caps.max_single_stride_log_num_of_bytes;
+	mctx->striding_rq_caps.min_single_wqe_log_num_of_strides =
+		resp.striding_rq_caps.min_single_wqe_log_num_of_strides;
+	mctx->striding_rq_caps.max_single_wqe_log_num_of_strides =
+		resp.striding_rq_caps.max_single_wqe_log_num_of_strides;
+	mctx->striding_rq_caps.supported_qpts =
+		resp.striding_rq_caps.supported_qpts;
 	mctx->tunnel_offloads_caps = resp.tunnel_offloads_caps;
 	mctx->packet_pacing_caps = resp.packet_pacing_caps;
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -685,7 +685,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 					goto err_db;
 				}
 
-				cmd.flags |= MLX5_CREATE_CQ_FLAGS_CQE_128B_PAD;
+				cmd.flags |= MLX5_IB_CREATE_CQ_FLAGS_CQE_128B_PAD;
 			}
 		}
 	}
@@ -2133,7 +2133,7 @@ int mlx5_modify_qp_rate_limit(struct ibv_qp *qp,
 {
 	struct ibv_qp_attr qp_attr = {};
 	struct ib_uverbs_ex_modify_qp_resp resp = {};
-	struct mlx5_ib_modify_qp cmd = {};
+	struct mlx5_modify_qp cmd = {};
 	struct mlx5_context *mctx = to_mctx(qp->context);
 	int ret;
 
@@ -2620,12 +2620,17 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	attr->tso_caps = resp.tso_caps;
 	attr->rss_caps.rx_hash_fields_mask = resp.rss_caps.rx_hash_fields_mask;
 	attr->rss_caps.rx_hash_function = resp.rss_caps.rx_hash_function;
-	attr->packet_pacing_caps = resp.packet_pacing_caps.caps;
+	attr->packet_pacing_caps.qp_rate_limit_min =
+		resp.packet_pacing_caps.qp_rate_limit_min;
+	attr->packet_pacing_caps.qp_rate_limit_max =
+		resp.packet_pacing_caps.qp_rate_limit_max;
+	attr->packet_pacing_caps.supported_qpts =
+		resp.packet_pacing_caps.supported_qpts;
 
-	if (resp.support_multi_pkt_send_wqe & MLX5_ALLOW_MPW)
+	if (resp.support_multi_pkt_send_wqe & MLX5_IB_ALLOW_MPW)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_MPW_ALLOWED;
 
-	if (resp.support_multi_pkt_send_wqe & MLX5_SUPPORT_EMPW)
+	if (resp.support_multi_pkt_send_wqe & MLX5_IB_SUPPORT_EMPW)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_ENHANCED_MPW;
 
 	mctx->cqe_comp_caps = resp.cqe_comp_caps;
@@ -2634,10 +2639,10 @@ int mlx5_query_device_ex(struct ibv_context *context,
 	mctx->tunnel_offloads_caps = resp.tunnel_offloads_caps;
 	mctx->packet_pacing_caps = resp.packet_pacing_caps;
 
-	if (resp.flags & MLX5_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP)
+	if (resp.flags & MLX5_IB_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_CQE_128B_COMP;
 
-	if (resp.flags & MLX5_QUERY_DEV_RESP_FLAGS_CQE_128B_PAD)
+	if (resp.flags & MLX5_IB_QUERY_DEV_RESP_FLAGS_CQE_128B_PAD)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_CQE_128B_PAD;
 
 	major     = (raw_fw_ver >> 32) & 0xffff;
@@ -2726,7 +2731,7 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 
 	rwq->wq_sig = rwq_sig_enabled(context);
 	if (rwq->wq_sig)
-		cmd.drv.flags = MLX5_RWQ_FLAG_SIGNATURE;
+		cmd.drv.flags = MLX5_WQ_FLAG_SIGNATURE;
 
 	ret = mlx5_calc_rwq_size(ctx, rwq, attr, mlx5wq_attr);
 	if (ret < 0) {

--- a/providers/mthca/mthca-abi.h
+++ b/providers/mthca/mthca-abi.h
@@ -36,68 +36,21 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/mthca-abi.h>
+#include <kernel-abi/mthca-abi.h>
 
-struct umthca_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				qp_tab_size;
-	__u32				uarc_size;
-};
-
-struct umthca_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	__u32				pdn;
-	__u32				reserved;
-};
-
-struct umthca_reg_mr {
-	struct ibv_reg_mr		ibv_cmd;
-	__u32				mr_attrs;
-	__u32				reserved;
-};
-
-struct umthca_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	__u32				lkey;
-	__u32				pdn;
-	__u64				arm_db_page;
-	__u64				set_db_page;
-	__u32				arm_db_index;
-	__u32				set_db_index;
-};
-
-struct umthca_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	__u32				cqn;
-	__u32				reserved;
-};
-
-struct umthca_resize_cq {
-	struct ibv_resize_cq		ibv_cmd;
-	__u32				lkey;
-	__u32				reserved;
-};
-
-struct umthca_create_srq {
-	struct ibv_create_srq		ibv_cmd;
-	__u32				lkey;
-	__u32				db_index;
-	__u64				db_page;
-};
-
-struct umthca_create_srq_resp {
-	struct ib_uverbs_create_srq_resp	ibv_resp;
-	__u32				srqn;
-	__u32				reserved;
-};
-
-struct umthca_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	__u32				lkey;
-	__u32				reserved;
-	__u64				sq_db_page;
-	__u64				rq_db_page;
-	__u32				sq_db_index;
-	__u32				rq_db_index;
-};
+DECLARE_DRV_CMD(umthca_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, mthca_alloc_pd_resp);
+DECLARE_DRV_CMD(umthca_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		mthca_create_cq, mthca_create_cq_resp);
+DECLARE_DRV_CMD(umthca_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		mthca_create_qp, empty);
+DECLARE_DRV_CMD(umthca_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		mthca_create_srq, mthca_create_srq_resp);
+DECLARE_DRV_CMD(umthca_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, mthca_alloc_ucontext_resp);
+DECLARE_DRV_CMD(umthca_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		mthca_reg_mr, empty);
+DECLARE_DRV_CMD(umthca_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		mthca_resize_cq, empty);
 
 #endif /* MTHCA_ABI_H */

--- a/providers/mthca/mthca-abi.h
+++ b/providers/mthca/mthca-abi.h
@@ -35,33 +35,27 @@
 #define MTHCA_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/mthca-abi.h>
 
-#define MTHCA_UVERBS_ABI_VERSION	1
-
-struct mthca_alloc_ucontext_resp {
+struct umthca_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp	ibv_resp;
 	__u32				qp_tab_size;
 	__u32				uarc_size;
 };
 
-struct mthca_alloc_pd_resp {
+struct umthca_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp	ibv_resp;
 	__u32				pdn;
 	__u32				reserved;
 };
 
-struct mthca_reg_mr {
+struct umthca_reg_mr {
 	struct ibv_reg_mr		ibv_cmd;
-/*
- * Mark the memory region with a DMA attribute that causes
- * in-flight DMA to be flushed when the region is written to:
- */
-#define MTHCA_MR_DMASYNC	0x1
 	__u32				mr_attrs;
 	__u32				reserved;
 };
 
-struct mthca_create_cq {
+struct umthca_create_cq {
 	struct ibv_create_cq		ibv_cmd;
 	__u32				lkey;
 	__u32				pdn;
@@ -71,32 +65,32 @@ struct mthca_create_cq {
 	__u32				set_db_index;
 };
 
-struct mthca_create_cq_resp {
+struct umthca_create_cq_resp {
 	struct ib_uverbs_create_cq_resp	ibv_resp;
 	__u32				cqn;
 	__u32				reserved;
 };
 
-struct mthca_resize_cq {
+struct umthca_resize_cq {
 	struct ibv_resize_cq		ibv_cmd;
 	__u32				lkey;
 	__u32				reserved;
 };
 
-struct mthca_create_srq {
+struct umthca_create_srq {
 	struct ibv_create_srq		ibv_cmd;
 	__u32				lkey;
 	__u32				db_index;
 	__u64				db_page;
 };
 
-struct mthca_create_srq_resp {
+struct umthca_create_srq_resp {
 	struct ib_uverbs_create_srq_resp	ibv_resp;
 	__u32				srqn;
 	__u32				reserved;
 };
 
-struct mthca_create_qp {
+struct umthca_create_qp {
 	struct ibv_create_qp		ibv_cmd;
 	__u32				lkey;
 	__u32				reserved;

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -134,7 +134,7 @@ static struct verbs_context *mthca_alloc_context(struct ibv_device *ibdev,
 {
 	struct mthca_context            *context;
 	struct ibv_get_context           cmd;
-	struct mthca_alloc_ucontext_resp resp;
+	struct umthca_alloc_ucontext_resp resp;
 	int                              i;
 
 	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,

--- a/providers/mthca/verbs.c
+++ b/providers/mthca/verbs.c
@@ -74,7 +74,7 @@ int mthca_query_port(struct ibv_context *context, uint8_t port,
 struct ibv_pd *mthca_alloc_pd(struct ibv_context *context)
 {
 	struct ibv_alloc_pd        cmd;
-	struct mthca_alloc_pd_resp resp;
+	struct umthca_alloc_pd_resp resp;
 	struct mthca_pd           *pd;
 
 	pd = malloc(sizeof *pd);
@@ -118,7 +118,7 @@ static struct ibv_mr *__mthca_reg_mr(struct ibv_pd *pd, void *addr,
 				     int dma_sync)
 {
 	struct ibv_mr *mr;
-	struct mthca_reg_mr cmd;
+	struct umthca_reg_mr cmd;
 	struct ib_uverbs_reg_mr_resp resp;
 	int ret;
 
@@ -177,8 +177,8 @@ struct ibv_cq *mthca_create_cq(struct ibv_context *context, int cqe,
 			       struct ibv_comp_channel *channel,
 			       int comp_vector)
 {
-	struct mthca_create_cq      cmd;
-	struct mthca_create_cq_resp resp;
+	struct umthca_create_cq      cmd;
+	struct umthca_create_cq_resp resp;
 	struct mthca_cq      	   *cq;
 	int                  	    ret;
 
@@ -272,7 +272,7 @@ err:
 int mthca_resize_cq(struct ibv_cq *ibcq, int cqe)
 {
 	struct mthca_cq *cq = to_mcq(ibcq);
-	struct mthca_resize_cq cmd;
+	struct umthca_resize_cq cmd;
 	struct ibv_mr *mr;
 	struct mthca_buf buf;
 	struct ib_uverbs_resize_cq_resp resp;
@@ -375,8 +375,8 @@ static int align_queue_size(struct ibv_context *context, int size, int spare)
 struct ibv_srq *mthca_create_srq(struct ibv_pd *pd,
 				 struct ibv_srq_init_attr *attr)
 {
-	struct mthca_create_srq      cmd;
-	struct mthca_create_srq_resp resp;
+	struct umthca_create_srq      cmd;
+	struct umthca_create_srq_resp resp;
 	struct mthca_srq            *srq;
 	int                          ret;
 
@@ -489,7 +489,7 @@ int mthca_destroy_srq(struct ibv_srq *srq)
 
 struct ibv_qp *mthca_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
 {
-	struct mthca_create_qp    cmd;
+	struct umthca_create_qp    cmd;
 	struct ib_uverbs_create_qp_resp resp;
 	struct mthca_qp          *qp;
 	int                       ret;

--- a/providers/nes/nes-abi.h
+++ b/providers/nes/nes-abi.h
@@ -36,66 +36,17 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/nes-abi.h>
+#include <kernel-abi/nes-abi.h>
 
-struct nes_get_context {
-	struct ibv_get_context cmd;
-	__u32 reserved32;
-	__u8 userspace_ver;
-	__u8 reserved8[3];
-};
-
-
-struct nes_ualloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-	__u32 max_pds; 	/* maximum pds allowed for this user process */
-	__u32 max_qps; 	/* maximum qps allowed for this user process */
-	__u32 wq_size; 	/* defines the size of the WQs (sq+rq) allocated to the mmaped area */
-	__u8 virtwq;
-	__u8 kernel_ver;
-	__u8 reserved[2];
-};
-
-struct nes_ualloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	__u32 pd_id;
-	__u32 db_index;
-};
-
-struct nes_ucreate_cq {
-	struct ibv_create_cq ibv_cmd;
-	__u64 user_cq_buffer;
-	__u32 mcrqf;
-	__u8 reserved[4];
-};
-
-struct nes_ucreate_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	__u32 cq_id;
-	__u32 cq_size;
-	__u32 mmap_db_index;
-	__u32 reserved;
-};
-
-struct nes_ureg_mr {
-	struct ibv_reg_mr ibv_cmd;
-	__u32 reg_type;	/* indicates if id is memory, QP or CQ */
-	__u32 reserved;
-};
-
-struct nes_ucreate_qp {
-	struct ibv_create_qp ibv_cmd;
-	__u64	user_sq_buffer;
-	__u64   user_qp_buffer;
-};
-
-struct nes_ucreate_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	__u32 qp_id;
-	__u32 actual_sq_size;
-	__u32 actual_rq_size;
-	__u32 mmap_sq_db_index;
-	__u32 mmap_rq_db_index;
-	__u32 nes_drv_opt;
-};
+DECLARE_DRV_CMD(nes_ualloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, nes_alloc_pd_resp);
+DECLARE_DRV_CMD(nes_ucreate_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		nes_create_cq_req, nes_create_cq_resp);
+DECLARE_DRV_CMD(nes_ucreate_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		nes_create_qp_req, nes_create_qp_resp);
+DECLARE_DRV_CMD(nes_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		nes_alloc_ucontext_req, nes_alloc_ucontext_resp);
+DECLARE_DRV_CMD(nes_ureg_mr, IB_USER_VERBS_CMD_REG_MR,
+		nes_mem_reg_req, empty);
 
 #endif			/* nes_ABI_H */

--- a/providers/nes/nes-abi.h
+++ b/providers/nes/nes-abi.h
@@ -35,9 +35,7 @@
 #define nes_ABI_H
 
 #include <infiniband/kern-abi.h>
-
-#define NES_ABI_USERSPACE_VER 2
-#define NES_ABI_KERNEL_VER 2
+#include <rdma/nes-abi.h>
 
 struct nes_get_context {
 	struct ibv_get_context cmd;
@@ -78,12 +76,6 @@ struct nes_ucreate_cq_resp {
 	__u32 reserved;
 };
 
-enum nes_umemreg_type {
-	NES_UMEMREG_TYPE_MEM = 0x0000,
-	NES_UMEMREG_TYPE_QP = 0x0001,
-	NES_UMEMREG_TYPE_CQ = 0x0002,
-};
-
 struct nes_ureg_mr {
 	struct ibv_reg_mr ibv_cmd;
 	__u32 reg_type;	/* indicates if id is memory, QP or CQ */
@@ -104,13 +96,6 @@ struct nes_ucreate_qp_resp {
 	__u32 mmap_sq_db_index;
 	__u32 mmap_rq_db_index;
 	__u32 nes_drv_opt;
-};
-
-struct nes_cqe {
-	__u32 header;
-	__u32 len;
-	__u32 wrid_hi_stag;
-	__u32 wrid_low_msn;
 };
 
 #endif			/* nes_ABI_H */

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -103,7 +103,7 @@ static struct verbs_context *nes_ualloc_context(struct ibv_device *ibdev,
 	struct ibv_pd *ibv_pd;
 	struct nes_uvcontext *nesvctx;
 	struct nes_get_context cmd;
-	struct nes_ualloc_ucontext_resp resp;
+	struct nes_get_context_resp resp;
 	char value[16];
 	uint32_t nes_drv_opt = 0;
 

--- a/providers/nes/nes_uverbs.c
+++ b/providers/nes/nes_uverbs.c
@@ -127,7 +127,7 @@ struct ibv_pd *nes_ualloc_pd(struct ibv_context *context)
 		return NULL;
 	}
 	nesupd->pd_id = resp.pd_id;
-	nesupd->db_index = resp.db_index;
+	nesupd->db_index = resp.mmap_db_index;
 
 	nesupd->udoorbell = mmap(NULL, page_size, PROT_WRITE | PROT_READ, MAP_SHARED,
 			context->cmd_fd, nesupd->db_index * page_size);
@@ -967,7 +967,7 @@ static int nes_vmapped_qp(struct nes_uqp *nesuqp, struct ibv_pd *pd, struct ibv_
         }
 	// So now the memory has been registered..
 	memset (&cmd, 0, sizeof(cmd) );
-	cmd.user_sq_buffer = (__u64) ((uintptr_t) nesuqp->sq_vbase);
+	cmd.user_wqe_buffers = (__u64) ((uintptr_t) nesuqp->sq_vbase);
 	cmd.user_qp_buffer = (__u64) ((uintptr_t) nesuqp);
 	ret = ibv_cmd_create_qp(pd, &nesuqp->ibv_qp, attr, &cmd.ibv_cmd, sizeof cmd,
 				&resp->ibv_resp, sizeof (struct nes_ucreate_qp_resp) );

--- a/providers/nes/nes_uverbs.c
+++ b/providers/nes/nes_uverbs.c
@@ -176,7 +176,7 @@ struct ibv_mr *nes_ureg_mr(struct ibv_pd *pd, void *addr,
 	if (!mr)
 		return NULL;
 
-	cmd.reg_type = NES_UMEMREG_TYPE_MEM;
+	cmd.reg_type = IWNES_MEMREG_TYPE_MEM;
 	if (ibv_cmd_reg_mr(pd, addr, length, (uintptr_t) addr,
 			access, mr, &cmd.ibv_cmd, sizeof cmd,
 			&resp, sizeof resp)) {
@@ -239,7 +239,7 @@ struct ibv_cq *nes_ucreate_cq(struct ibv_context *context, int cqe,
 		goto err;
 
 	/* Register the memory for the CQ */
-	reg_mr_cmd.reg_type = NES_UMEMREG_TYPE_CQ;
+	reg_mr_cmd.reg_type = IWNES_MEMREG_TYPE_CQ;
 
 	ret = ibv_cmd_reg_mr(&nesvctx->nesupd->ibv_pd, (void *)nesucq->cqes,
 			(nesucq->size*sizeof(struct nes_hw_cqe)),
@@ -951,7 +951,7 @@ static int nes_vmapped_qp(struct nes_uqp *nesuqp, struct ibv_pd *pd, struct ibv_
 	nesuqp->rq_vbase = (struct nes_hw_qp_wqe *) (((char *) nesuqp->sq_vbase) +
 			   (nesuqp->sq_size * sizeof(struct nes_hw_qp_wqe)));
 
-	reg_mr_cmd.reg_type = NES_UMEMREG_TYPE_QP;
+	reg_mr_cmd.reg_type = IWNES_MEMREG_TYPE_QP;
 
 	//fprintf(stderr, PFX "qp_rq_vbase = %p qp_sq_vbase=%p reg_mr = %p\n",
 	//		nesuqp->rq_vbase, nesuqp->sq_vbase, &nesuqp->mr);

--- a/providers/qedr/qelr_abi.h
+++ b/providers/qedr/qelr_abi.h
@@ -34,87 +34,20 @@
 #define __QELR_ABI_H__
 
 #include <infiniband/kern-abi.h>
+#include <rdma/qedr-abi.h>
+#include <kernel-abi/qedr-abi.h>
 
 #define QELR_ABI_VERSION			(8)
 
-struct qelr_get_context {
-	struct ibv_get_context cmd;		/* must be first */
-};
-
-struct qelr_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;	/* must be first */
-	__u64 db_pa;
-	__u32 db_size;
-
-	__u32 max_send_wr;
-	__u32 max_recv_wr;
-	__u32 max_srq_wr;
-	__u32 sges_per_send_wr;
-	__u32 sges_per_recv_wr;
-	__u32 sges_per_srq_wr;
-	__u32 max_cqes;
-};
-
-struct qelr_alloc_pd_req {
-	struct ibv_alloc_pd cmd;		/* must be first */
-};
-
-struct qelr_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;	/* must be first */
-	__u32 pd_id;
-};
-
-struct qelr_create_cq_req {
-	struct ibv_create_cq ibv_cmd;		/* must be first */
-
-	__u64 addr;	/* user space virtual address of CQ buffer */
-	__u64 len;	/* size of CQ buffer */
-};
-
-struct qelr_create_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;	/* must be first */
-	__u32 db_offset;
-	__u16 icid;
-};
-
-struct qelr_reg_mr {
-	struct ibv_reg_mr ibv_cmd;		/* must be first */
-};
-
-struct qelr_reg_mr_resp {
-	struct ib_uverbs_reg_mr_resp ibv_resp;	/* must be first */
-};
-
-struct qelr_create_qp_req {
-	struct ibv_create_qp ibv_qp;	/* must be first */
-
-	__u32 qp_handle_hi;
-	__u32 qp_handle_lo;
-
-	/* SQ */
-	__u64 sq_addr;	/* user space virtual address of SQ buffer */
-	__u64 sq_len;		/* length of SQ buffer */
-
-	/* RQ */
-	__u64 rq_addr;	/* user space virtual address of RQ buffer */
-	__u64 rq_len;		/* length of RQ buffer */
-};
-
-struct qelr_create_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;	/* must be first */
-
-	__u32 qp_id;
-	__u32 atomic_supported;
-
-	/* SQ */
-	__u32 sq_db_offset;
-	__u16 sq_icid;
-
-	/* RQ */
-	__u32 rq_db_offset;
-	__u16 rq_icid;
-
-	__u32 rq_db2_offset;
-};
+DECLARE_DRV_CMD(qelr_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, qedr_alloc_pd_uresp);
+DECLARE_DRV_CMD(qelr_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		qedr_create_cq_ureq, qedr_create_cq_uresp);
+DECLARE_DRV_CMD(qelr_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		qedr_create_qp_ureq, qedr_create_qp_uresp);
+DECLARE_DRV_CMD(qelr_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, qedr_alloc_ucontext_resp);
+DECLARE_DRV_CMD(qelr_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, empty);
 
 #endif /* __QELR_ABI_H__ */

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -160,7 +160,7 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 {
 	struct qelr_devctx *ctx;
 	struct qelr_get_context cmd;
-	struct qelr_alloc_ucontext_resp resp;
+	struct qelr_get_context_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_QEDR);
@@ -172,8 +172,7 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 	qelr_open_debug_file(ctx);
 	qelr_set_debug_mask();
 
-	if (ibv_cmd_get_context(&ctx->ibv_ctx,
-				(struct ibv_get_context *)&cmd, sizeof(cmd),
+	if (ibv_cmd_get_context(&ctx->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto cmd_err;
 

--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -114,7 +114,7 @@ int qelr_query_port(struct ibv_context *context, uint8_t port,
 
 struct ibv_pd *qelr_alloc_pd(struct ibv_context *context)
 {
-	struct qelr_alloc_pd_req cmd;
+	struct qelr_alloc_pd cmd;
 	struct qelr_alloc_pd_resp resp;
 	struct qelr_pd *pd;
 	struct qelr_devctx *cxt = get_qelr_ctx(context);
@@ -126,7 +126,7 @@ struct ibv_pd *qelr_alloc_pd(struct ibv_context *context)
 	bzero(pd, sizeof(*pd));
 	memset(&cmd, 0, sizeof(cmd));
 
-	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.cmd, sizeof(cmd),
+	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.ibv_cmd, sizeof(cmd),
 			     &resp.ibv_resp, sizeof(resp))) {
 		free(pd);
 		return NULL;
@@ -226,7 +226,7 @@ struct ibv_cq *qelr_create_cq(struct ibv_context *context, int cqe,
 {
 	struct qelr_devctx *cxt = get_qelr_ctx(context);
 	struct qelr_create_cq_resp resp;
-	struct qelr_create_cq_req cmd;
+	struct qelr_create_cq cmd;
 	struct qelr_cq *cq;
 	int chain_size;
 	int rc;
@@ -492,7 +492,7 @@ static inline void qelr_print_qp_init_attr(
 
 static inline void
 qelr_create_qp_configure_sq_req(struct qelr_qp *qp,
-				struct qelr_create_qp_req *req)
+				struct qelr_create_qp *req)
 {
 	req->sq_addr = (uintptr_t)qp->sq.chain.first_addr;
 	req->sq_len = qp->sq.chain.size;
@@ -500,7 +500,7 @@ qelr_create_qp_configure_sq_req(struct qelr_qp *qp,
 
 static inline void
 qelr_create_qp_configure_rq_req(struct qelr_qp *qp,
-				struct qelr_create_qp_req *req)
+				struct qelr_create_qp *req)
 {
 	req->rq_addr = (uintptr_t)qp->rq.chain.first_addr;
 	req->rq_len = qp->rq.chain.size;
@@ -508,7 +508,7 @@ qelr_create_qp_configure_rq_req(struct qelr_qp *qp,
 
 static inline void
 qelr_create_qp_configure_req(struct qelr_qp *qp,
-			     struct qelr_create_qp_req *req)
+			     struct qelr_create_qp *req)
 {
 	memset(req, 0, sizeof(*req));
 	req->qp_handle_hi = U64_HI(qp);
@@ -522,7 +522,7 @@ struct ibv_qp *qelr_create_qp(struct ibv_pd *pd,
 {
 	struct qelr_devctx *cxt = get_qelr_ctx(pd->context);
 	struct qelr_create_qp_resp resp;
-	struct qelr_create_qp_req req;
+	struct qelr_create_qp req;
 	struct qelr_qp *qp;
 	int rc;
 
@@ -538,8 +538,8 @@ struct ibv_qp *qelr_create_qp(struct ibv_pd *pd,
 
 	qelr_create_qp_configure_req(qp, &req);
 
-	rc = ibv_cmd_create_qp(pd, &qp->ibv_qp, attrs, &req.ibv_qp, sizeof(req),
-			       &resp.ibv_resp, sizeof(resp));
+	rc = ibv_cmd_create_qp(pd, &qp->ibv_qp, attrs, &req.ibv_cmd,
+			       sizeof(req), &resp.ibv_resp, sizeof(resp));
 	if (rc) {
 		DP_ERR(cxt->dbg_fp,
 		       "create qp: failed on ibv_cmd_create_qp with %d\n", rc);

--- a/providers/rxe/rxe-abi.h
+++ b/providers/rxe/rxe-abi.h
@@ -36,38 +36,18 @@
 #define RXE_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/rdma_user_rxe.h>
+#include <kernel-abi/rdma_user_rxe.h>
 
-struct mmap_info {
-	__u64 offset;
-	__u32 size;
-	__u32 pad;
-};
-
-struct urxe_create_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	struct mmap_info mi;
-};
-
-struct urxe_resize_cq_resp {
-	struct ib_uverbs_resize_cq_resp ibv_resp;
-	struct mmap_info mi;
-};
-
-struct urxe_create_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	struct mmap_info rq_mi;
-	struct mmap_info sq_mi;
-};
-
-struct urxe_create_srq_resp {
-	struct ib_uverbs_create_srq_resp ibv_resp;
-	struct mmap_info mi;
-	__u32 srq_num;
-};
-
-struct urxe_modify_srq_cmd {
-	struct ibv_modify_srq ibv_cmd;
-	__u64 mmap_info_addr;
-};
+DECLARE_DRV_CMD(urxe_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		empty, rxe_create_cq_resp);
+DECLARE_DRV_CMD(urxe_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		empty, rxe_create_qp_resp);
+DECLARE_DRV_CMD(urxe_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		empty, rxe_create_srq_resp);
+DECLARE_DRV_CMD(urxe_modify_srq, IB_USER_VERBS_CMD_MODIFY_SRQ,
+		rxe_modify_srq_cmd, empty);
+DECLARE_DRV_CMD(urxe_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		empty, rxe_resize_cq_resp);
 
 #endif /* RXE_ABI_H */

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -308,9 +308,9 @@ static int rxe_modify_srq(struct ibv_srq *ibsrq,
 		   struct ibv_srq_attr *attr, int attr_mask)
 {
 	struct rxe_srq *srq = to_rsrq(ibsrq);
-	struct urxe_modify_srq_cmd cmd;
+	struct urxe_modify_srq cmd;
 	int rc = 0;
-	struct mmap_info mi;
+	struct mminfo mi;
 
 	mi.offset = 0;
 	mi.size = 0;

--- a/providers/rxe/rxe.h
+++ b/providers/rxe/rxe.h
@@ -59,7 +59,7 @@ struct rxe_context {
 
 struct rxe_cq {
 	struct ibv_cq		ibv_cq;
-	struct mmap_info	mmap_info;
+	struct mminfo		mmap_info;
 	struct rxe_queue		*queue;
 	pthread_spinlock_t	lock;
 };
@@ -78,9 +78,9 @@ struct rxe_wq {
 
 struct rxe_qp {
 	struct ibv_qp		ibv_qp;
-	struct mmap_info	rq_mmap_info;
+	struct mminfo		rq_mmap_info;
 	struct rxe_wq		rq;
-	struct mmap_info	sq_mmap_info;
+	struct mminfo		sq_mmap_info;
 	struct rxe_wq		sq;
 	unsigned int		ssn;
 };
@@ -89,7 +89,7 @@ struct rxe_qp {
 
 struct rxe_srq {
 	struct ibv_srq		ibv_srq;
-	struct mmap_info	mmap_info;
+	struct mminfo		mmap_info;
 	struct rxe_wq		rq;
 	uint32_t		srq_num;
 };

--- a/providers/vmw_pvrdma/cq.c
+++ b/providers/vmw_pvrdma/cq.c
@@ -239,15 +239,15 @@ struct ibv_cq *pvrdma_create_cq(struct ibv_context *context, int cqe,
 
 	cq->ring_state = cq->buf.buf;
 
-	cmd.udata.buf_addr = (uintptr_t) cq->buf.buf;
-	cmd.udata.buf_size = cq->buf.length;
+	cmd.buf_addr = (uintptr_t) cq->buf.buf;
+	cmd.buf_size = cq->buf.length;
 	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
 				&cq->ibv_cq, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp));
 	if (ret)
 		goto err_buf;
 
-	cq->cqn = resp.udata.cqn;
+	cq->cqn = resp.cqn;
 	cq->cqe_cnt = cq->ibv_cq.cqe;
 
 	return &cq->ibv_cq;

--- a/providers/vmw_pvrdma/pvrdma-abi.h
+++ b/providers/vmw_pvrdma/pvrdma-abi.h
@@ -48,40 +48,17 @@
 
 #include <infiniband/kern-abi.h>
 #include <rdma/vmw_pvrdma-abi.h>
+#include <kernel-abi/vmw_pvrdma-abi.h>
 
-struct user_pvrdma_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp		ibv_resp;
-	struct pvrdma_alloc_ucontext_resp	udata;
-};
-
-struct user_pvrdma_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	struct pvrdma_alloc_pd_resp	udata;
-};
-
-struct user_pvrdma_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	struct pvrdma_create_cq		udata;
-};
-
-struct user_pvrdma_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	struct pvrdma_create_cq_resp	udata;
-};
-
-struct user_pvrdma_create_srq {
-	struct ibv_create_srq		ibv_cmd;
-	struct pvrdma_create_srq	udata;
-};
-
-struct user_pvrdma_create_srq_resp {
-	struct ib_uverbs_create_srq_resp	ibv_resp;
-	struct pvrdma_create_srq_resp	udata;
-};
-
-struct user_pvrdma_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	struct pvrdma_create_qp		udata;
-};
+DECLARE_DRV_CMD(user_pvrdma_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, pvrdma_alloc_pd_resp);
+DECLARE_DRV_CMD(user_pvrdma_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		pvrdma_create_cq, pvrdma_create_cq_resp);
+DECLARE_DRV_CMD(user_pvrdma_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		pvrdma_create_qp, empty);
+DECLARE_DRV_CMD(user_pvrdma_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		pvrdma_create_srq, pvrdma_create_srq_resp);
+DECLARE_DRV_CMD(user_pvrdma_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, pvrdma_alloc_ucontext_resp);
 
 #endif /* __PVRDMA_ABI_FIX_H__ */

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -58,7 +58,7 @@
 #include <ccan/minmax.h>
 #include <util/compiler.h>
 
-#include "pvrdma-abi-fix.h"
+#include "pvrdma-abi.h"
 #include "pvrdma_ring.h"
 
 #define PFX "pvrdma: "

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -116,7 +116,7 @@ static int pvrdma_init_context_shared(struct pvrdma_context *context,
 				&resp.ibv_resp, sizeof(resp)))
 		return errno;
 
-	context->qp_tbl = calloc(resp.udata.qp_tab_size & 0xFFFF,
+	context->qp_tbl = calloc(resp.qp_tab_size & 0xFFFF,
 				 sizeof(struct pvrdma_qp *));
 	if (!context->qp_tbl)
 		return -ENOMEM;

--- a/providers/vmw_pvrdma/qp.c
+++ b/providers/vmw_pvrdma/qp.c
@@ -137,8 +137,8 @@ struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
 	pvrdma_init_srq_queue(srq);
 
 	memset(&cmd, 0, sizeof(cmd));
-	cmd.udata.buf_addr = (uintptr_t) srq->buf.buf;
-	cmd.udata.buf_size = srq->buf.length;
+	cmd.buf_addr = (uintptr_t) srq->buf.buf;
+	cmd.buf_size = srq->buf.length;
 
 	ret = ibv_cmd_create_srq(pd, &srq->ibv_srq, attr,
 				 &cmd.ibv_cmd, sizeof(cmd),
@@ -147,7 +147,7 @@ struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
 	if (ret)
 		goto err_free;
 
-	srq->srqn = resp.udata.srqn;
+	srq->srqn = resp.srqn;
 
 	return &srq->ibv_srq;
 
@@ -276,11 +276,11 @@ struct ibv_qp *pvrdma_create_qp(struct ibv_pd *pd,
 	pvrdma_init_qp_queue(qp);
 
 	memset(&cmd, 0, sizeof(cmd));
-	cmd.udata.sbuf_addr = (uintptr_t)qp->sbuf.buf;
-	cmd.udata.sbuf_size = qp->sbuf.length;
-	cmd.udata.rbuf_addr = (uintptr_t)qp->rbuf.buf;
-	cmd.udata.rbuf_size = qp->rbuf.length;
-	cmd.udata.qp_addr = (uintptr_t) qp;
+	cmd.sbuf_addr = (uintptr_t)qp->sbuf.buf;
+	cmd.sbuf_size = qp->sbuf.length;
+	cmd.rbuf_addr = (uintptr_t)qp->rbuf.buf;
+	cmd.rbuf_size = qp->rbuf.length;
+	cmd.qp_addr = (uintptr_t) qp;
 
 	ret = ibv_cmd_create_qp(pd, &qp->ibv_qp, attr,
 				&cmd.ibv_cmd, sizeof(cmd),

--- a/providers/vmw_pvrdma/verbs.c
+++ b/providers/vmw_pvrdma/verbs.c
@@ -93,7 +93,7 @@ struct ibv_pd *pvrdma_alloc_pd(struct ibv_context *context)
 		return NULL;
 	}
 
-	pd->pdn = resp.udata.pdn;
+	pd->pdn = resp.pdn;
 
 	return &pd->ibv_pd;
 }


### PR DESCRIPTION
This converts most of the drivers to have largely empty -abi.h headers that contain only simple mechanical declarations, such as:

```c
DECLARE_DRV_CMD(mlx5_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
		mlx5_ib_alloc_ucontext_req_v2, mlx5_ib_alloc_ucontext_resp);
```

Similar to the new DECLARE_CMD macro, this automatically constructs a driver request and response structure using the kernel uapi headers:

```c
struct mlx5_alloc_ucontext {
     struct ibv_get_context ibv_cmd;
     union {
          _STRUCT_mlx5_ib_alloc_ucontext_req_v2; // Inlined version of below
          struct mlx5_ib_alloc_ucontext_req_v2 drv_payload;
     };
};

struct mlx5_alloc_ucontext_resp {
    struct ib_uverbs_get_context ibv_resp;
    union {
        _STRUCT_mlx5_ib_alloc_ucontext_resp; // Inlined version of below
        struct mlx5_ib_alloc_ucontext_resp drv_payload;
    };
};
```

As with kern-abi.h, a codegen script is used to produce the _STRUCT_* macros from the real kernel ABI headers.

Everything is tied together with the enum tag to minimize typing and avoid errors, the macros match the correct core structs via the tag to the driver structs. This is preparation for a future bulk change to push the new ioctl API down into the drivers.

The macro also contains static_assertions that ensure padding isn't being added when the structs are concatenated, which detected several bugs.

Patches for the remaining drivers are still pending on the kernel changes.

This work supports the 32/64 compat by forcing the userspace to use the same memory layouts as the kernel after the kernel layouts have been validated to be good.