### PR TITLE
Fixes so that code will compile using the musl c library and GCC 6.3.0

### DIFF
--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -34,7 +34,7 @@
 
 #include <config.h>
 
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -1172,6 +1172,7 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
 	return ret;
 }
 
+int __fxstat(int ver, int socket, struct stat *buf);
 int __fxstat(int ver, int socket, struct stat *buf)
 {
 	int fd, ret;
@@ -1180,7 +1181,7 @@ int __fxstat(int ver, int socket, struct stat *buf)
 	if (fd_get(socket, &fd) == fd_rsocket) {
 		ret = real.fxstat(ver, socket, buf);
 		if (!ret)
-			buf->st_mode = (buf->st_mode & ~S_IFMT) | __S_IFSOCK;
+			buf->st_mode = (buf->st_mode & ~S_IFMT) | S_IFSOCK;
 	} else {
 		ret = real.fxstat(ver, fd, buf);
 	}

--- a/providers/cxgb3/cq.c
+++ b/providers/cxgb3/cq.c
@@ -33,7 +33,7 @@
 
 #include <stdio.h>
 #include <pthread.h>
-#include <sys/errno.h>
+#include <errno.h>
 
 #include <infiniband/opcode.h>
 

--- a/providers/cxgb4/cq.c
+++ b/providers/cxgb4/cq.c
@@ -34,7 +34,7 @@
 #include <stdio.h>
 #include <syslog.h>
 #include <pthread.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <infiniband/opcode.h>
 #include <util/compiler.h>
 #include "libcxgb4.h"

--- a/providers/cxgb4/libcxgb4.h
+++ b/providers/cxgb4/libcxgb4.h
@@ -37,7 +37,7 @@
 #include <stddef.h>
 #include <string.h>
 #include <syslog.h>
-#include <sys/errno.h>
+#include <errno.h>
 #include <sys/time.h>
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -34,6 +34,7 @@
 #define _HNS_ROCE_U_H
 
 #include <stddef.h>
+#include <endian.h>
 #include <util/compiler.h>
 
 #include <infiniband/driver.h>

--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -54,7 +54,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <execinfo.h>
 
 #define QELR_SQE_ELEMENT_SIZE	(sizeof(struct rdma_sq_sge))
 #define QELR_RQE_ELEMENT_SIZE	(sizeof(struct rdma_rq_sge))


### PR DESCRIPTION
Changes are mostly to headers to either use the standard location or
to include a missing header that is implicit with glibc.

A small problem with a private constant has also been corrected.

These changes also ensure that all current warnings are fixed. This
is important, as there is not other easy way to fail the build for
genuine missing function definitions.