### PR TITLE
mlx4: Enable WQ creation with IBV_WQ_FLAGS_SCATTER_FCS

### DIFF
--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -1422,7 +1422,13 @@ struct ibv_wq *mlx4_create_wq(struct ibv_context *context,
 		}
 	}
 
-	if (attr->comp_mask) {
+	if (!check_comp_mask(attr->comp_mask, IBV_WQ_INIT_ATTR_FLAGS)) {
+		errno = ENOTSUP;
+		return NULL;
+	}
+
+	if ((attr->comp_mask & IBV_WQ_INIT_ATTR_FLAGS) &&
+	    (attr->create_flags & ~IBV_WQ_FLAGS_SCATTER_FCS)) {
 		errno = ENOTSUP;
 		return NULL;
 	}


### PR DESCRIPTION
Enable WQ creation with the IBV_WQ_FLAGS_SCATTER_FCS flag.

Prior to using this option an application should check whether the
IBV_RAW_PACKET_CAP_SCATTER_FCS capability is set on the device's
raw_packet_caps.

The matching kernel patch for mlx4 that reports the required capability was already merged into rdma-next.

