### PR TITLE
Convert remaining providers to use DECLARE_DRV_CMD

### DIFF
--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -57,6 +57,7 @@ endfunction()
 rdma_kernel_provider_abi(
   rdma/bnxt_re-abi.h
   rdma/cxgb4-abi.h
+  rdma/hns-abi.h
   rdma/i40iw-abi.h
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -56,6 +56,7 @@ endfunction()
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
   rdma/bnxt_re-abi.h
+  rdma/cxgb3-abi.h
   rdma/cxgb4-abi.h
   rdma/hns-abi.h
   rdma/i40iw-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -64,6 +64,7 @@ rdma_kernel_provider_abi(
   rdma/mlx5-abi.h
   rdma/mthca-abi.h
   rdma/nes-abi.h
+  rdma/ocrdma-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
   rdma/vmw_pvrdma-abi.h

--- a/kernel-headers/rdma/cxgb3-abi.h
+++ b/kernel-headers/rdma/cxgb3-abi.h
@@ -74,4 +74,9 @@ struct iwch_create_qp_resp {
 struct iwch_reg_user_mr_resp {
 	__u32 pbl_addr;
 };
+
+struct iwch_alloc_pd_resp {
+	__u32 pdid;
+};
+
 #endif /* CXGB3_ABI_USER_H */

--- a/kernel-headers/rdma/mlx4-abi.h
+++ b/kernel-headers/rdma/mlx4-abi.h
@@ -183,6 +183,7 @@ struct mlx4_uverbs_ex_query_device_resp {
 	__u32			response_length;
 	__u64			hca_core_clock_offset;
 	__u32			max_inl_recv_sz;
+	__u32			reserved;
 	struct mlx4_ib_rss_caps	rss_caps;
 	struct mlx4_ib_tso_caps tso_caps;
 };

--- a/kernel-headers/rdma/ocrdma-abi.h
+++ b/kernel-headers/rdma/ocrdma-abi.h
@@ -65,7 +65,7 @@ struct ocrdma_alloc_ucontext_resp {
 };
 
 struct ocrdma_alloc_pd_ureq {
-	__u64 rsvd1;
+	__u32 rsvd[2];
 };
 
 struct ocrdma_alloc_pd_uresp {
@@ -73,7 +73,7 @@ struct ocrdma_alloc_pd_uresp {
 	__u32 dpp_enabled;
 	__u32 dpp_page_addr_hi;
 	__u32 dpp_page_addr_lo;
-	__u64 rsvd1;
+	__u32 rsvd[2];
 };
 
 struct ocrdma_create_cq_ureq {

--- a/kernel-headers/rdma/qedr-abi.h
+++ b/kernel-headers/rdma/qedr-abi.h
@@ -53,6 +53,7 @@ struct qedr_alloc_ucontext_resp {
 	__u8 dpm_enabled;
 	__u8 wids_enabled;
 	__u16 wid_count;
+	__u32 reserved;
 };
 
 struct qedr_alloc_pd_ureq {
@@ -61,6 +62,7 @@ struct qedr_alloc_pd_ureq {
 
 struct qedr_alloc_pd_uresp {
 	__u32 pd_id;
+	__u32 reserved;
 };
 
 struct qedr_create_cq_ureq {
@@ -71,6 +73,7 @@ struct qedr_create_cq_ureq {
 struct qedr_create_cq_uresp {
 	__u32 db_offset;
 	__u16 icid;
+	__u16 reserved;
 };
 
 struct qedr_create_qp_ureq {
@@ -105,6 +108,7 @@ struct qedr_create_qp_uresp {
 	__u16 rq_icid;
 
 	__u32 rq_db2_offset;
+	__u32 reserved;
 };
 
 #endif /* __QEDR_USER_H__ */

--- a/kernel-headers/rdma/rdma_user_cm.h
+++ b/kernel-headers/rdma/rdma_user_cm.h
@@ -270,10 +270,15 @@ struct rdma_ucm_event_resp {
 	__u32 id;
 	__u32 event;
 	__u32 status;
+	/*
+	 * NOTE: This union is not aligned to 8 bytes so none of the union
+	 * members may contain a u64 or anything with higher alignment than 4.
+	 */
 	union {
 		struct rdma_ucm_conn_param conn;
 		struct rdma_ucm_ud_param   ud;
 	} param;
+	__u32 reserved;
 };
 
 /* Option levels */

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -78,12 +78,14 @@ struct rxe_send_wr {
 		struct {
 			__u64	remote_addr;
 			__u32	rkey;
+			__u32	reserved;
 		} rdma;
 		struct {
 			__u64	remote_addr;
 			__u64	compare_add;
 			__u64	swap;
 			__u32	rkey;
+			__u32	reserved;
 		} atomic;
 		struct {
 			__u32	remote_qpn;

--- a/kernel-headers/rdma/vmw_pvrdma-abi.h
+++ b/kernel-headers/rdma/vmw_pvrdma-abi.h
@@ -262,6 +262,7 @@ struct pvrdma_sq_wqe_hdr {
 			__u32 length;
 			__u32 access_flags;
 			__u32 rkey;
+			__u32 reserved;
 		} fast_reg;
 		struct {
 			__u32 remote_qpn;

--- a/providers/cxgb3/iwch-abi.h
+++ b/providers/cxgb3/iwch-abi.h
@@ -34,34 +34,35 @@
 
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
+#include <rdma/cxgb3-abi.h>
 
-struct iwch_alloc_ucontext_resp {
+struct uiwch_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp ibv_resp;
 };
 
-struct iwch_alloc_pd_resp {
+struct uiwch_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp ibv_resp;
 	uint32_t pdid;
 };
 
-struct iwch_create_cq {
+struct uiwch_create_cq {
 	struct ibv_create_cq ibv_cmd;
 	uint64_t user_rptr_addr;
 };
 
-struct iwch_reg_mr_resp {
+struct uiwch_reg_mr_resp {
 	struct ib_uverbs_reg_mr_resp ibv_resp;
 	uint32_t pbl_addr;
 };
 
-struct iwch_create_cq_resp_v0 {
+struct uiwch_create_cq_resp_v0 {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint64_t physaddr;
 	uint32_t cqid;
 	uint32_t size_log2;
 };
 
-struct iwch_create_cq_resp_v1 {
+struct uiwch_create_cq_resp_v1 {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint64_t physaddr;
 	uint32_t cqid;
@@ -70,11 +71,11 @@ struct iwch_create_cq_resp_v1 {
 	uint32_t reserved; /* for proper alignment */
 };
 
-struct iwch_create_qp {
+struct uiwch_create_qp {
 	struct ibv_create_qp ibv_cmd;
 };
 
-struct iwch_create_qp_resp {
+struct uiwch_create_qp_resp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	uint64_t physaddr;
 	uint64_t doorbell;

--- a/providers/cxgb3/iwch-abi.h
+++ b/providers/cxgb3/iwch-abi.h
@@ -35,53 +35,17 @@
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
 #include <rdma/cxgb3-abi.h>
+#include <kernel-abi/cxgb3-abi.h>
 
-struct uiwch_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-};
+DECLARE_DRV_CMD(uiwch_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, iwch_alloc_pd_resp);
+DECLARE_DRV_CMD(uiwch_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		iwch_create_cq_req, iwch_create_cq_resp);
+DECLARE_DRV_CMD(uiwch_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		empty, iwch_create_qp_resp);
+DECLARE_DRV_CMD(uiwch_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, empty);
+DECLARE_DRV_CMD(uiwch_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, iwch_reg_user_mr_resp);
 
-struct uiwch_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	uint32_t pdid;
-};
-
-struct uiwch_create_cq {
-	struct ibv_create_cq ibv_cmd;
-	uint64_t user_rptr_addr;
-};
-
-struct uiwch_reg_mr_resp {
-	struct ib_uverbs_reg_mr_resp ibv_resp;
-	uint32_t pbl_addr;
-};
-
-struct uiwch_create_cq_resp_v0 {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint64_t physaddr;
-	uint32_t cqid;
-	uint32_t size_log2;
-};
-
-struct uiwch_create_cq_resp_v1 {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint64_t physaddr;
-	uint32_t cqid;
-	uint32_t size_log2;
-	uint32_t memsize;
-	uint32_t reserved; /* for proper alignment */
-};
-
-struct uiwch_create_qp {
-	struct ibv_create_qp ibv_cmd;
-};
-
-struct uiwch_create_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	uint64_t physaddr;
-	uint64_t doorbell;
-	uint32_t qpid;
-	uint32_t size_log2;
-	uint32_t sq_size_log2;
-	uint32_t rq_size_log2;
-};
 #endif				/* IWCH_ABI_H */

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -122,7 +122,7 @@ static struct verbs_context *iwch_alloc_context(struct ibv_device *ibdev,
 {
 	struct iwch_context *context;
 	struct ibv_get_context cmd;
-	struct iwch_alloc_ucontext_resp resp;
+	struct uiwch_alloc_ucontext_resp resp;
 	struct iwch_device *rhp = to_iwch_dev(ibdev);
 
 	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,

--- a/providers/cxgb3/verbs.c
+++ b/providers/cxgb3/verbs.c
@@ -75,7 +75,7 @@ int iwch_query_port(struct ibv_context *context, uint8_t port,
 struct ibv_pd *iwch_alloc_pd(struct ibv_context *context)
 {
 	struct ibv_alloc_pd cmd;
-	struct iwch_alloc_pd_resp resp;
+	struct uiwch_alloc_pd_resp resp;
 	struct iwch_pd *pd;
 
 	pd = malloc(sizeof *pd);
@@ -109,7 +109,7 @@ static struct ibv_mr *__iwch_reg_mr(struct ibv_pd *pd, void *addr,
 {
 	struct iwch_mr *mhp;
 	struct ibv_reg_mr cmd;
-	struct iwch_reg_mr_resp resp;
+	struct uiwch_reg_mr_resp resp;
 	struct iwch_device *dev = to_iwch_dev(pd->context->device);
 
 	mhp = malloc(sizeof *mhp);
@@ -168,8 +168,8 @@ int iwch_dereg_mr(struct ibv_mr *mr)
 struct ibv_cq *iwch_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_comp_channel *channel, int comp_vector)
 {
-	struct iwch_create_cq cmd;
-	struct iwch_create_cq_resp_v1 resp;
+	struct uiwch_create_cq cmd;
+	struct uiwch_create_cq_resp_v1 resp;
 	struct iwch_cq *chp;
 	struct iwch_device *dev = to_iwch_dev(context->device);
 	int ret;
@@ -288,8 +288,8 @@ int iwch_post_srq_recv(struct ibv_srq *ibsrq, struct ibv_recv_wr *wr,
 
 struct ibv_qp *iwch_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
 {
-	struct iwch_create_qp cmd;
-	struct iwch_create_qp_resp resp;
+	struct uiwch_create_qp cmd;
+	struct uiwch_create_qp_resp resp;
 	struct iwch_qp *qhp;
 	struct iwch_device *dev = to_iwch_dev(pd->context->device);
 	int ret;

--- a/providers/hns/hns_roce_u_abi.h
+++ b/providers/hns/hns_roce_u_abi.h
@@ -34,43 +34,16 @@
 #define _HNS_ROCE_U_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/hns-abi.h>
+#include <kernel-abi/hns-abi.h>
 
-struct hns_roce_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				qp_tab_size;
-	__u32				reserved;
-};
+DECLARE_DRV_CMD(hns_roce_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, hns_roce_ib_alloc_pd_resp);
+DECLARE_DRV_CMD(hns_roce_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		hns_roce_ib_create_cq, hns_roce_ib_create_cq_resp);
+DECLARE_DRV_CMD(hns_roce_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		hns_roce_ib_create_qp, hns_roce_ib_create_qp_resp);
+DECLARE_DRV_CMD(hns_roce_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, hns_roce_ib_alloc_ucontext_resp);
 
-struct hns_roce_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	__u32				pdn;
-	__u32				reserved;
-};
-
-struct hns_roce_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct hns_roce_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	__u64				cqn; /* Only 32 bits used, 64 for compat */
-	__u64				cap_flags;
-};
-
-struct hns_roce_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u8				log_sq_bb_count;
-	__u8				log_sq_stride;
-	__u8				sq_no_prefetch;
-	__u8				reserved[5];
-};
-
-struct hns_roce_create_qp_resp {
-	struct ib_uverbs_create_qp_resp	base;
-	__u64				cap_flags;
-};
 #endif /* _HNS_ROCE_U_ABI_H */

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -605,7 +605,7 @@ struct ibv_qp *hns_roce_u_create_qp(struct ibv_pd *pd,
 	pthread_mutex_lock(&to_hr_ctx(pd->context)->qp_table_mutex);
 
 	ret = ibv_cmd_create_qp(pd, &qp->ibv_qp, attr, &cmd.ibv_cmd,
-				sizeof(cmd), &resp.base, sizeof(resp));
+				sizeof(cmd), &resp.ibv_resp, sizeof(resp));
 	if (ret) {
 		fprintf(stderr, "ibv_cmd_create_qp failed!\n");
 		goto err_rq_db;

--- a/providers/ocrdma/ocrdma_abi.h
+++ b/providers/ocrdma/ocrdma_abi.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
+#include <rdma/ocrdma-abi.h>
 
 #define OCRDMA_ABI_VERSION	2
 
@@ -61,11 +62,11 @@ enum {
 /* solicited bit */
 #define OCRDMA_DB_CQ_SOLICIT_SHIFT		(31)	/* bit 31 */
 
-struct ocrdma_get_context {
+struct uocrdma_get_context {
 	struct ibv_get_context cmd;
 };
 
-struct ocrdma_alloc_ucontext_resp {
+struct uocrdma_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp ibv_resp;
 	uint32_t dev_id;
 	uint32_t wqe_size;
@@ -79,12 +80,12 @@ struct ocrdma_alloc_ucontext_resp {
 	uint64_t rsvd2;
 };
 
-struct ocrdma_alloc_pd_req {
+struct uocrdma_alloc_pd_req {
 	struct ibv_alloc_pd cmd;
 	uint64_t rsvd;
 };
 
-struct ocrdma_alloc_pd_resp {
+struct uocrdma_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp ibv_resp;
 	uint32_t id;
 	uint32_t dpp_enabled;
@@ -93,14 +94,13 @@ struct ocrdma_alloc_pd_resp {
 	uint64_t rsvd;
 };
 
-struct ocrdma_create_cq_req {
+struct uocrdma_create_cq_req {
 	struct ibv_create_cq ibv_cmd;
 	uint32_t dpp_cq;
 	uint32_t rsvd;
 };
 
-#define MAX_CQ_PAGES 8
-struct ocrdma_create_cq_resp {
+struct uocrdma_create_cq_resp {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint32_t cq_id;
 	uint32_t size;
@@ -114,15 +114,15 @@ struct ocrdma_create_cq_resp {
 	uint64_t rsvd2;
 };
 
-struct ocrdma_reg_mr {
+struct uocrdma_reg_mr {
 	struct ibv_reg_mr ibv_cmd;
 };
 
-struct ocrdma_reg_mr_resp {
+struct uocrdma_reg_mr_resp {
 	struct ib_uverbs_reg_mr_resp ibv_resp;
 };
 
-struct ocrdma_create_qp_cmd {
+struct uocrdma_create_qp_cmd {
 	struct ibv_create_qp ibv_cmd;
 	uint8_t enable_dpp_cq;
 	uint8_t rsvd;
@@ -130,10 +130,7 @@ struct ocrdma_create_qp_cmd {
 	uint32_t rsvd1;		/* pad */
 };
 
-#define MAX_QP_PAGES 8
-#define MAX_UD_HDR_PAGES 8
-
-struct ocrdma_create_qp_uresp {
+struct uocrdma_create_qp_uresp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	uint16_t qp_id;
 	uint16_t sq_dbid;
@@ -157,11 +154,11 @@ struct ocrdma_create_qp_uresp {
 	uint64_t rsvd[11]; /* 8*8 + 4*4 + 8 */
 };
 
-struct ocrdma_create_srq_cmd {
+struct uocrdma_create_srq_cmd {
 	struct ibv_create_srq ibv_cmd;
 };
 
-struct ocrdma_create_srq_resp {
+struct uocrdma_create_srq_resp {
 	struct ib_uverbs_create_srq_resp ibv_resp;
 	uint16_t rq_dbid;
 	uint16_t resv0;

--- a/providers/ocrdma/ocrdma_abi.h
+++ b/providers/ocrdma/ocrdma_abi.h
@@ -38,8 +38,22 @@
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
 #include <rdma/ocrdma-abi.h>
+#include <kernel-abi/ocrdma-abi.h>
 
 #define OCRDMA_ABI_VERSION	2
+
+DECLARE_DRV_CMD(uocrdma_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, ocrdma_alloc_ucontext_resp);
+DECLARE_DRV_CMD(uocrdma_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		ocrdma_alloc_pd_ureq, ocrdma_alloc_pd_uresp);
+DECLARE_DRV_CMD(uocrdma_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		ocrdma_create_cq_ureq, ocrdma_create_cq_uresp);
+DECLARE_DRV_CMD(uocrdma_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, empty);
+DECLARE_DRV_CMD(uocrdma_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		ocrdma_create_qp_ureq, ocrdma_create_qp_uresp);
+DECLARE_DRV_CMD(uocrdma_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		empty, ocrdma_create_srq_uresp);
 
 #define Bit(_b) (1 << (_b))
 
@@ -61,122 +75,6 @@ enum {
 
 /* solicited bit */
 #define OCRDMA_DB_CQ_SOLICIT_SHIFT		(31)	/* bit 31 */
-
-struct uocrdma_get_context {
-	struct ibv_get_context cmd;
-};
-
-struct uocrdma_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-	uint32_t dev_id;
-	uint32_t wqe_size;
-	uint32_t max_inline_data;
-	uint32_t dpp_wqe_size;
-	uint64_t ah_tbl_page;
-	uint32_t ah_tbl_len;
-	uint32_t rqe_size;
-	uint8_t fw_ver[32];
-	uint64_t rsvd1;
-	uint64_t rsvd2;
-};
-
-struct uocrdma_alloc_pd_req {
-	struct ibv_alloc_pd cmd;
-	uint64_t rsvd;
-};
-
-struct uocrdma_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	uint32_t id;
-	uint32_t dpp_enabled;
-	uint32_t dpp_page_addr_hi;
-	uint32_t dpp_page_addr_lo;
-	uint64_t rsvd;
-};
-
-struct uocrdma_create_cq_req {
-	struct ibv_create_cq ibv_cmd;
-	uint32_t dpp_cq;
-	uint32_t rsvd;
-};
-
-struct uocrdma_create_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint32_t cq_id;
-	uint32_t size;
-	uint32_t num_pages;
-	uint32_t max_hw_cqe;
-	uint64_t page_addr[MAX_CQ_PAGES];
-	uint64_t db_page_addr;
-	uint32_t db_page_size;
-	uint32_t phase_change;
-	uint64_t rsvd1;
-	uint64_t rsvd2;
-};
-
-struct uocrdma_reg_mr {
-	struct ibv_reg_mr ibv_cmd;
-};
-
-struct uocrdma_reg_mr_resp {
-	struct ib_uverbs_reg_mr_resp ibv_resp;
-};
-
-struct uocrdma_create_qp_cmd {
-	struct ibv_create_qp ibv_cmd;
-	uint8_t enable_dpp_cq;
-	uint8_t rsvd;
-	uint16_t dpp_cq_id;
-	uint32_t rsvd1;		/* pad */
-};
-
-struct uocrdma_create_qp_uresp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	uint16_t qp_id;
-	uint16_t sq_dbid;
-	uint16_t rq_dbid;
-	uint16_t resv0;		/* pad */
-	uint32_t sq_page_size;
-	uint32_t rq_page_size;
-	uint32_t num_sq_pages;
-	uint32_t num_rq_pages;
-	uint64_t sq_page_addr[MAX_QP_PAGES];
-	uint64_t rq_page_addr[MAX_QP_PAGES];
-	uint64_t db_page_addr;
-	uint32_t db_page_size;
-	uint32_t dpp_credit;
-	uint32_t dpp_offset;
-	uint32_t num_wqe_allocated;
-	uint32_t num_rqe_allocated;
-	uint32_t db_sq_offset;
-	uint32_t db_rq_offset;
-	uint32_t db_shift;
-	uint64_t rsvd[11]; /* 8*8 + 4*4 + 8 */
-};
-
-struct uocrdma_create_srq_cmd {
-	struct ibv_create_srq ibv_cmd;
-};
-
-struct uocrdma_create_srq_resp {
-	struct ib_uverbs_create_srq_resp ibv_resp;
-	uint16_t rq_dbid;
-	uint16_t resv0;
-	uint32_t resv1;
-
-	uint32_t rq_page_size;
-	uint32_t num_rq_pages;
-
-	uint64_t rq_page_addr[MAX_QP_PAGES];
-	uint64_t db_page_addr;
-
-	uint32_t db_page_size;
-	uint32_t num_rqe_allocated;
-	uint32_t db_rq_offset;
-	uint32_t db_shift;
-	uint64_t rsvd2;
-	uint64_t rsvd3;
-};
 
 enum OCRDMA_CQE_STATUS {
 	OCRDMA_CQE_SUCCESS 		= 0,

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -109,8 +109,8 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 						  int cmd_fd)
 {
 	struct ocrdma_devctx *ctx;
-	struct ocrdma_get_context cmd;
-	struct ocrdma_alloc_ucontext_resp resp;
+	struct uocrdma_get_context cmd;
+	struct uocrdma_alloc_ucontext_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_OCRDMA);

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -110,7 +110,7 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 {
 	struct ocrdma_devctx *ctx;
 	struct uocrdma_get_context cmd;
-	struct uocrdma_alloc_ucontext_resp resp;
+	struct uocrdma_get_context_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_OCRDMA);

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -133,7 +133,7 @@ static void ocrdma_free_ah_tbl_id(struct ocrdma_devctx *ctx, int idx)
  */
 struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 {
-	struct uocrdma_alloc_pd_req cmd;
+	struct uocrdma_alloc_pd cmd;
 	struct uocrdma_alloc_pd_resp resp;
 	struct ocrdma_pd *pd;
 	uint64_t map_address = 0;
@@ -144,8 +144,8 @@ struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 	bzero(pd, sizeof *pd);
 	memset(&cmd, 0, sizeof(cmd));
 
-	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.cmd, sizeof cmd,
-			     &resp.ibv_resp, sizeof resp)) {
+	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.ibv_cmd, sizeof(cmd),
+			     &resp.ibv_resp, sizeof(resp))) {
 		free(pd);
 		return NULL;
 	}
@@ -230,7 +230,7 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 					      int comp_vector, int dpp_cq)
 {
 	int status;
-	struct uocrdma_create_cq_req cmd;
+	struct uocrdma_create_cq cmd;
 	struct uocrdma_create_cq_resp resp;
 	struct ocrdma_cq *cq;
 	struct ocrdma_device *dev = get_ocrdma_dev(context->device);
@@ -252,10 +252,10 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 	cq->dev = dev;
 	cq->cq_id = resp.cq_id;
 	cq->cq_dbid = resp.cq_id;
-	cq->cq_mem_size = resp.size;
+	cq->cq_mem_size = resp.page_size;
 	cq->max_hw_cqe = resp.max_hw_cqe;
 	cq->phase_change = resp.phase_change;
-	cq->va = mmap(NULL, resp.size, PROT_READ | PROT_WRITE,
+	cq->va = mmap(NULL, resp.page_size, PROT_READ | PROT_WRITE,
 		      MAP_SHARED, context->cmd_fd, resp.page_addr[0]);
 	if (cq->va == MAP_FAILED)
 		goto cq_err2;
@@ -354,7 +354,7 @@ struct ibv_srq *ocrdma_create_srq(struct ibv_pd *pd,
 {
 	int status = 0;
 	struct ocrdma_srq *srq;
-	struct uocrdma_create_srq_cmd cmd;
+	struct uocrdma_create_srq cmd;
 	struct uocrdma_create_srq_resp resp;
 	void *map_addr;
 
@@ -464,8 +464,8 @@ struct ibv_qp *ocrdma_create_qp(struct ibv_pd *pd,
 				struct ibv_qp_init_attr *attrs)
 {
 	int status = 0;
-	struct uocrdma_create_qp_cmd cmd;
-	struct uocrdma_create_qp_uresp resp;
+	struct uocrdma_create_qp cmd;
+	struct uocrdma_create_qp_resp resp;
 	struct ocrdma_qp *qp;
 	void *map_addr;
 #ifdef DPP_CQ_SUPPORT

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -133,8 +133,8 @@ static void ocrdma_free_ah_tbl_id(struct ocrdma_devctx *ctx, int idx)
  */
 struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 {
-	struct ocrdma_alloc_pd_req cmd;
-	struct ocrdma_alloc_pd_resp resp;
+	struct uocrdma_alloc_pd_req cmd;
+	struct uocrdma_alloc_pd_resp resp;
 	struct ocrdma_pd *pd;
 	uint64_t map_address = 0;
 
@@ -191,7 +191,7 @@ struct ibv_mr *ocrdma_reg_mr(struct ibv_pd *pd, void *addr,
 {
 	struct ocrdma_mr *mr;
 	struct ibv_reg_mr cmd;
-	struct ocrdma_reg_mr_resp resp;
+	struct uocrdma_reg_mr_resp resp;
 	uint64_t hca_va = (uintptr_t) addr;
 
 	mr = malloc(sizeof *mr);
@@ -230,8 +230,8 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 					      int comp_vector, int dpp_cq)
 {
 	int status;
-	struct ocrdma_create_cq_req cmd;
-	struct ocrdma_create_cq_resp resp;
+	struct uocrdma_create_cq_req cmd;
+	struct uocrdma_create_cq_resp resp;
 	struct ocrdma_cq *cq;
 	struct ocrdma_device *dev = get_ocrdma_dev(context->device);
 	void *map_addr;
@@ -354,8 +354,8 @@ struct ibv_srq *ocrdma_create_srq(struct ibv_pd *pd,
 {
 	int status = 0;
 	struct ocrdma_srq *srq;
-	struct ocrdma_create_srq_cmd cmd;
-	struct ocrdma_create_srq_resp resp;
+	struct uocrdma_create_srq_cmd cmd;
+	struct uocrdma_create_srq_resp resp;
 	void *map_addr;
 
 	srq = calloc(1, sizeof *srq);
@@ -464,8 +464,8 @@ struct ibv_qp *ocrdma_create_qp(struct ibv_pd *pd,
 				struct ibv_qp_init_attr *attrs)
 {
 	int status = 0;
-	struct ocrdma_create_qp_cmd cmd;
-	struct ocrdma_create_qp_uresp resp;
+	struct uocrdma_create_qp_cmd cmd;
+	struct uocrdma_create_qp_uresp resp;
 	struct ocrdma_qp *qp;
 	void *map_addr;
 #ifdef DPP_CQ_SUPPORT


### PR DESCRIPTION
Now that the kernel patches have landed this does the rest of the providers except for hfi1 and ipath, as rdmavt does not use ABI structs at all.