### PR TITLE
Update RXE to use the latest kernel headers with the ABI change

### DIFF
--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -57,6 +57,7 @@ endfunction()
 rdma_kernel_provider_abi(
   rdma/bnxt_re-abi.h
   rdma/cxgb4-abi.h
+  rdma/hns-abi.h
   rdma/i40iw-abi.h
   rdma/ib_user_verbs.h
   rdma/mlx4-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -56,6 +56,7 @@ endfunction()
 # Transform the kernel ABIs used by the providers
 rdma_kernel_provider_abi(
   rdma/bnxt_re-abi.h
+  rdma/cxgb3-abi.h
   rdma/cxgb4-abi.h
   rdma/hns-abi.h
   rdma/i40iw-abi.h

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -64,6 +64,7 @@ rdma_kernel_provider_abi(
   rdma/mlx5-abi.h
   rdma/mthca-abi.h
   rdma/nes-abi.h
+  rdma/ocrdma-abi.h
   rdma/qedr-abi.h
   rdma/rdma_user_rxe.h
   rdma/vmw_pvrdma-abi.h

--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -65,8 +65,8 @@ struct bnxt_re_pd_resp {
 } __attribute__((packed, aligned(4)));
 
 struct bnxt_re_cq_req {
-	__u64 cq_va;
-	__u64 cq_handle;
+	__aligned_u64 cq_va;
+	__aligned_u64 cq_handle;
 };
 
 struct bnxt_re_cq_resp {
@@ -77,9 +77,9 @@ struct bnxt_re_cq_resp {
 };
 
 struct bnxt_re_qp_req {
-	__u64 qpsva;
-	__u64 qprva;
-	__u64 qp_handle;
+	__aligned_u64 qpsva;
+	__aligned_u64 qprva;
+	__aligned_u64 qp_handle;
 };
 
 struct bnxt_re_qp_resp {
@@ -88,8 +88,8 @@ struct bnxt_re_qp_resp {
 };
 
 struct bnxt_re_srq_req {
-	__u64 srqva;
-	__u64 srq_handle;
+	__aligned_u64 srqva;
+	__aligned_u64 srq_handle;
 };
 
 struct bnxt_re_srq_resp {

--- a/kernel-headers/rdma/cxgb3-abi.h
+++ b/kernel-headers/rdma/cxgb3-abi.h
@@ -41,21 +41,21 @@
  * Make sure that all structs defined in this file remain laid out so
  * that they pack the same way on 32-bit and 64-bit architectures (to
  * avoid incompatibility between 32-bit userspace and 64-bit kernels).
- * In particular do not use pointer types -- pass pointers in __u64
+ * In particular do not use pointer types -- pass pointers in __aligned_u64
  * instead.
  */
 struct iwch_create_cq_req {
-	__u64 user_rptr_addr;
+	__aligned_u64 user_rptr_addr;
 };
 
 struct iwch_create_cq_resp_v0 {
-	__u64 key;
+	__aligned_u64 key;
 	__u32 cqid;
 	__u32 size_log2;
 };
 
 struct iwch_create_cq_resp {
-	__u64 key;
+	__aligned_u64 key;
 	__u32 cqid;
 	__u32 size_log2;
 	__u32 memsize;
@@ -63,8 +63,8 @@ struct iwch_create_cq_resp {
 };
 
 struct iwch_create_qp_resp {
-	__u64 key;
-	__u64 db_key;
+	__aligned_u64 key;
+	__aligned_u64 db_key;
 	__u32 qpid;
 	__u32 size_log2;
 	__u32 sq_size_log2;

--- a/kernel-headers/rdma/cxgb3-abi.h
+++ b/kernel-headers/rdma/cxgb3-abi.h
@@ -74,4 +74,9 @@ struct iwch_create_qp_resp {
 struct iwch_reg_user_mr_resp {
 	__u32 pbl_addr;
 };
+
+struct iwch_alloc_pd_resp {
+	__u32 pdid;
+};
+
 #endif /* CXGB3_ABI_USER_H */

--- a/kernel-headers/rdma/cxgb4-abi.h
+++ b/kernel-headers/rdma/cxgb4-abi.h
@@ -41,13 +41,13 @@
  * Make sure that all structs defined in this file remain laid out so
  * that they pack the same way on 32-bit and 64-bit architectures (to
  * avoid incompatibility between 32-bit userspace and 64-bit kernels).
- * In particular do not use pointer types -- pass pointers in __u64
+ * In particular do not use pointer types -- pass pointers in __aligned_u64
  * instead.
  */
 struct c4iw_create_cq_resp {
-	__u64 key;
-	__u64 gts_key;
-	__u64 memsize;
+	__aligned_u64 key;
+	__aligned_u64 gts_key;
+	__aligned_u64 memsize;
 	__u32 cqid;
 	__u32 size;
 	__u32 qid_mask;
@@ -59,13 +59,13 @@ enum {
 };
 
 struct c4iw_create_qp_resp {
-	__u64 ma_sync_key;
-	__u64 sq_key;
-	__u64 rq_key;
-	__u64 sq_db_gts_key;
-	__u64 rq_db_gts_key;
-	__u64 sq_memsize;
-	__u64 rq_memsize;
+	__aligned_u64 ma_sync_key;
+	__aligned_u64 sq_key;
+	__aligned_u64 rq_key;
+	__aligned_u64 sq_db_gts_key;
+	__aligned_u64 rq_db_gts_key;
+	__aligned_u64 sq_memsize;
+	__aligned_u64 rq_memsize;
 	__u32 sqid;
 	__u32 rqid;
 	__u32 sq_size;
@@ -75,7 +75,7 @@ struct c4iw_create_qp_resp {
 };
 
 struct c4iw_alloc_ucontext_resp {
-	__u64 status_page_key;
+	__aligned_u64 status_page_key;
 	__u32 status_page_size;
 	__u32 reserved; /* explicit padding (optional for i386) */
 };

--- a/kernel-headers/rdma/hfi/hfi1_ioctl.h
+++ b/kernel-headers/rdma/hfi/hfi1_ioctl.h
@@ -79,7 +79,7 @@ struct hfi1_user_info {
 };
 
 struct hfi1_ctxt_info {
-	__u64 runtime_flags;    /* chip/drv runtime flags (HFI1_CAP_*) */
+	__aligned_u64 runtime_flags;    /* chip/drv runtime flags (HFI1_CAP_*) */
 	__u32 rcvegr_size;      /* size of each eager buffer */
 	__u16 num_active;       /* number of active units */
 	__u16 unit;             /* unit (chip) assigned to caller */
@@ -98,9 +98,9 @@ struct hfi1_ctxt_info {
 
 struct hfi1_tid_info {
 	/* virtual address of first page in transfer */
-	__u64 vaddr;
+	__aligned_u64 vaddr;
 	/* pointer to tid array. this array is big enough */
-	__u64 tidlist;
+	__aligned_u64 tidlist;
 	/* number of tids programmed by this request */
 	__u32 tidcnt;
 	/* length of transfer buffer programmed by this request */
@@ -131,23 +131,23 @@ struct hfi1_base_info {
 	 */
 	__u32 bthqp;
 	/* PIO credit return address, */
-	__u64 sc_credits_addr;
+	__aligned_u64 sc_credits_addr;
 	/*
 	 * Base address of write-only pio buffers for this process.
 	 * Each buffer has sendpio_credits*64 bytes.
 	 */
-	__u64 pio_bufbase_sop;
+	__aligned_u64 pio_bufbase_sop;
 	/*
 	 * Base address of write-only pio buffers for this process.
 	 * Each buffer has sendpio_credits*64 bytes.
 	 */
-	__u64 pio_bufbase;
+	__aligned_u64 pio_bufbase;
 	/* address where receive buffer queue is mapped into */
-	__u64 rcvhdr_bufbase;
+	__aligned_u64 rcvhdr_bufbase;
 	/* base address of Eager receive buffers. */
-	__u64 rcvegr_bufbase;
+	__aligned_u64 rcvegr_bufbase;
 	/* base address of SDMA completion ring */
-	__u64 sdma_comp_bufbase;
+	__aligned_u64 sdma_comp_bufbase;
 	/*
 	 * User register base for init code, not to be used directly by
 	 * protocol or applications.  Always maps real chip register space.
@@ -155,20 +155,20 @@ struct hfi1_base_info {
 	 * ur_rcvhdrhead, ur_rcvhdrtail, ur_rcvegrhead, ur_rcvegrtail,
 	 * ur_rcvtidflow
 	 */
-	__u64 user_regbase;
+	__aligned_u64 user_regbase;
 	/* notification events */
-	__u64 events_bufbase;
+	__aligned_u64 events_bufbase;
 	/* status page */
-	__u64 status_bufbase;
+	__aligned_u64 status_bufbase;
 	/* rcvhdrtail update */
-	__u64 rcvhdrtail_base;
+	__aligned_u64 rcvhdrtail_base;
 	/*
 	 * shared memory pages for subctxts if ctxt is shared; these cover
 	 * all the processes in the group sharing a single context.
 	 * all have enough space for the num_subcontexts value on this job.
 	 */
-	__u64 subctxt_uregbase;
-	__u64 subctxt_rcvegrbuf;
-	__u64 subctxt_rcvhdrbuf;
+	__aligned_u64 subctxt_uregbase;
+	__aligned_u64 subctxt_rcvegrbuf;
+	__aligned_u64 subctxt_rcvhdrbuf;
 };
 #endif /* _LINIUX__HFI1_IOCTL_H */

--- a/kernel-headers/rdma/hfi/hfi1_user.h
+++ b/kernel-headers/rdma/hfi/hfi1_user.h
@@ -177,8 +177,8 @@ struct hfi1_sdma_comp_entry {
  * Device status and notifications from driver to user-space.
  */
 struct hfi1_status {
-	__u64 dev;      /* device/hw status bits */
-	__u64 port;     /* port state and status bits */
+	__aligned_u64 dev;      /* device/hw status bits */
+	__aligned_u64 port;     /* port state and status bits */
 	char freezemsg[0];
 };
 

--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -37,18 +37,18 @@
 #include <linux/types.h>
 
 struct hns_roce_ib_create_cq {
-	__u64   buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 };
 
 struct hns_roce_ib_create_cq_resp {
-	__u64	cqn; /* Only 32 bits used, 64 for compat */
-	__u64	cap_flags;
+	__aligned_u64 cqn; /* Only 32 bits used, 64 for compat */
+	__aligned_u64 cap_flags;
 };
 
 struct hns_roce_ib_create_qp {
-	__u64	buf_addr;
-	__u64   db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u8    log_sq_bb_count;
 	__u8    log_sq_stride;
 	__u8    sq_no_prefetch;
@@ -56,7 +56,7 @@ struct hns_roce_ib_create_qp {
 };
 
 struct hns_roce_ib_create_qp_resp {
-	__u64	cap_flags;
+	__aligned_u64 cap_flags;
 };
 
 struct hns_roce_ib_alloc_ucontext_resp {

--- a/kernel-headers/rdma/i40iw-abi.h
+++ b/kernel-headers/rdma/i40iw-abi.h
@@ -61,17 +61,17 @@ struct i40iw_alloc_pd_resp {
 };
 
 struct i40iw_create_cq_req {
-	__u64 user_cq_buffer;
-	__u64 user_shadow_area;
+	__aligned_u64 user_cq_buffer;
+	__aligned_u64 user_shadow_area;
 };
 
 struct i40iw_create_qp_req {
-	__u64 user_wqe_buffers;
-	__u64 user_compl_ctx;
+	__aligned_u64 user_wqe_buffers;
+	__aligned_u64 user_compl_ctx;
 
 	/* UDA QP PHB */
-	__u64 user_sq_phb;	/* place for VA of the sq phb buff */
-	__u64 user_rq_phb;	/* place for VA of the rq phb buff */
+	__aligned_u64 user_sq_phb;	/* place for VA of the sq phb buff */
+	__aligned_u64 user_rq_phb;	/* place for VA of the rq phb buff */
 };
 
 enum i40iw_memreg_type {

--- a/kernel-headers/rdma/ib_user_cm.h
+++ b/kernel-headers/rdma/ib_user_cm.h
@@ -73,8 +73,8 @@ struct ib_ucm_cmd_hdr {
 };
 
 struct ib_ucm_create_id {
-	__u64 uid;
-	__u64 response;
+	__aligned_u64 uid;
+	__aligned_u64 response;
 };
 
 struct ib_ucm_create_id_resp {
@@ -82,7 +82,7 @@ struct ib_ucm_create_id_resp {
 };
 
 struct ib_ucm_destroy_id {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 reserved;
 };
@@ -92,7 +92,7 @@ struct ib_ucm_destroy_id_resp {
 };
 
 struct ib_ucm_attr_id {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 reserved;
 };
@@ -105,7 +105,7 @@ struct ib_ucm_attr_id_resp {
 };
 
 struct ib_ucm_init_qp_attr {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 qp_state;
 };
@@ -123,7 +123,7 @@ struct ib_ucm_notify {
 };
 
 struct ib_ucm_private_data {
-	__u64 data;
+	__aligned_u64 data;
 	__u32 id;
 	__u8  len;
 	__u8  reserved[3];
@@ -135,9 +135,9 @@ struct ib_ucm_req {
 	__u32 qp_type;
 	__u32 psn;
 	__be64 sid;
-	__u64 data;
-	__u64 primary_path;
-	__u64 alternate_path;
+	__aligned_u64 data;
+	__aligned_u64 primary_path;
+	__aligned_u64 alternate_path;
 	__u8  len;
 	__u8  peer_to_peer;
 	__u8  responder_resources;
@@ -153,8 +153,8 @@ struct ib_ucm_req {
 };
 
 struct ib_ucm_rep {
-	__u64 uid;
-	__u64 data;
+	__aligned_u64 uid;
+	__aligned_u64 data;
 	__u32 id;
 	__u32 qpn;
 	__u32 psn;
@@ -172,15 +172,15 @@ struct ib_ucm_rep {
 struct ib_ucm_info {
 	__u32 id;
 	__u32 status;
-	__u64 info;
-	__u64 data;
+	__aligned_u64 info;
+	__aligned_u64 data;
 	__u8  info_len;
 	__u8  data_len;
 	__u8  reserved[6];
 };
 
 struct ib_ucm_mra {
-	__u64 data;
+	__aligned_u64 data;
 	__u32 id;
 	__u8  len;
 	__u8  timeout;
@@ -188,8 +188,8 @@ struct ib_ucm_mra {
 };
 
 struct ib_ucm_lap {
-	__u64 path;
-	__u64 data;
+	__aligned_u64 path;
+	__aligned_u64 data;
 	__u32 id;
 	__u8  len;
 	__u8  reserved[3];
@@ -199,8 +199,8 @@ struct ib_ucm_sidr_req {
 	__u32 id;
 	__u32 timeout;
 	__be64 sid;
-	__u64 data;
-	__u64 path;
+	__aligned_u64 data;
+	__aligned_u64 path;
 	__u16 reserved_pkey;
 	__u8  len;
 	__u8  max_cm_retries;
@@ -212,8 +212,8 @@ struct ib_ucm_sidr_rep {
 	__u32 qpn;
 	__u32 qkey;
 	__u32 status;
-	__u64 info;
-	__u64 data;
+	__aligned_u64 info;
+	__aligned_u64 data;
 	__u8  info_len;
 	__u8  data_len;
 	__u8  reserved[6];
@@ -222,9 +222,9 @@ struct ib_ucm_sidr_rep {
  * event notification ABI structures.
  */
 struct ib_ucm_event_get {
-	__u64 response;
-	__u64 data;
-	__u64 info;
+	__aligned_u64 response;
+	__aligned_u64 data;
+	__aligned_u64 info;
 	__u8  data_len;
 	__u8  info_len;
 	__u8  reserved[6];
@@ -303,7 +303,7 @@ struct ib_ucm_sidr_rep_event_resp {
 #define IB_UCM_PRES_ALTERNATE 0x08
 
 struct ib_ucm_event_resp {
-	__u64 uid;
+	__aligned_u64 uid;
 	__u32 id;
 	__u32 event;
 	__u32 present;

--- a/kernel-headers/rdma/ib_user_ioctl_verbs.h
+++ b/kernel-headers/rdma/ib_user_ioctl_verbs.h
@@ -37,7 +37,7 @@
 #include <linux/types.h>
 
 #ifndef RDMA_UAPI_PTR
-#define RDMA_UAPI_PTR(_type, _name)	_type __attribute__((aligned(8))) _name
+#define RDMA_UAPI_PTR(_type, _name)	__aligned_u64 _name
 #endif
 
 #endif

--- a/kernel-headers/rdma/ib_user_mad.h
+++ b/kernel-headers/rdma/ib_user_mad.h
@@ -143,7 +143,7 @@ struct ib_user_mad_hdr {
  */
 struct ib_user_mad {
 	struct ib_user_mad_hdr hdr;
-	__u64	data[0];
+	__aligned_u64	data[0];
 };
 
 /*
@@ -225,7 +225,7 @@ struct ib_user_mad_reg_req2 {
 	__u8	mgmt_class_version;
 	__u16   res;
 	__u32   flags;
-	__u64   method_mask[2];
+	__aligned_u64 method_mask[2];
 	__u32   oui;
 	__u8	rmpp_version;
 	__u8	reserved[3];

--- a/kernel-headers/rdma/ib_user_verbs.h
+++ b/kernel-headers/rdma/ib_user_verbs.h
@@ -117,13 +117,13 @@ enum {
  */
 
 struct ib_uverbs_async_event_desc {
-	__u64 element;
+	__aligned_u64 element;
 	__u32 event_type;	/* enum ib_event_type */
 	__u32 reserved;
 };
 
 struct ib_uverbs_comp_event_desc {
-	__u64 cq_handle;
+	__aligned_u64 cq_handle;
 };
 
 struct ib_uverbs_cq_moderation_caps {
@@ -150,15 +150,15 @@ struct ib_uverbs_cmd_hdr {
 };
 
 struct ib_uverbs_ex_cmd_hdr {
-	__u64 response;
+	__aligned_u64 response;
 	__u16 provider_in_words;
 	__u16 provider_out_words;
 	__u32 cmd_hdr_reserved;
 };
 
 struct ib_uverbs_get_context {
-	__u64 response;
-	__u64 driver_data[0];
+	__aligned_u64 response;
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_get_context_resp {
@@ -167,16 +167,16 @@ struct ib_uverbs_get_context_resp {
 };
 
 struct ib_uverbs_query_device {
-	__u64 response;
-	__u64 driver_data[0];
+	__aligned_u64 response;
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_query_device_resp {
-	__u64 fw_ver;
+	__aligned_u64 fw_ver;
 	__be64 node_guid;
 	__be64 sys_image_guid;
-	__u64 max_mr_size;
-	__u64 page_size_cap;
+	__aligned_u64 max_mr_size;
+	__aligned_u64 page_size_cap;
 	__u32 vendor_id;
 	__u32 vendor_part_id;
 	__u32 hw_ver;
@@ -221,7 +221,7 @@ struct ib_uverbs_ex_query_device {
 };
 
 struct ib_uverbs_odp_caps {
-	__u64 general_caps;
+	__aligned_u64 general_caps;
 	struct {
 		__u32 rc_odp_caps;
 		__u32 uc_odp_caps;
@@ -260,9 +260,9 @@ struct ib_uverbs_ex_query_device_resp {
 	__u32 comp_mask;
 	__u32 response_length;
 	struct ib_uverbs_odp_caps odp_caps;
-	__u64 timestamp_mask;
-	__u64 hca_core_clock; /* in KHZ */
-	__u64 device_cap_flags_ex;
+	__aligned_u64 timestamp_mask;
+	__aligned_u64 hca_core_clock; /* in KHZ */
+	__aligned_u64 device_cap_flags_ex;
 	struct ib_uverbs_rss_caps rss_caps;
 	__u32  max_wq_type_rq;
 	__u32 raw_packet_caps;
@@ -271,10 +271,10 @@ struct ib_uverbs_ex_query_device_resp {
 };
 
 struct ib_uverbs_query_port {
-	__u64 response;
+	__aligned_u64 response;
 	__u8  port_num;
 	__u8  reserved[7];
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_query_port_resp {
@@ -302,8 +302,8 @@ struct ib_uverbs_query_port_resp {
 };
 
 struct ib_uverbs_alloc_pd {
-	__u64 response;
-	__u64 driver_data[0];
+	__aligned_u64 response;
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_alloc_pd_resp {
@@ -315,10 +315,10 @@ struct ib_uverbs_dealloc_pd {
 };
 
 struct ib_uverbs_open_xrcd {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 fd;
 	__u32 oflags;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_open_xrcd_resp {
@@ -330,13 +330,13 @@ struct ib_uverbs_close_xrcd {
 };
 
 struct ib_uverbs_reg_mr {
-	__u64 response;
-	__u64 start;
-	__u64 length;
-	__u64 hca_va;
+	__aligned_u64 response;
+	__aligned_u64 start;
+	__aligned_u64 length;
+	__aligned_u64 hca_va;
 	__u32 pd_handle;
 	__u32 access_flags;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_reg_mr_resp {
@@ -346,12 +346,12 @@ struct ib_uverbs_reg_mr_resp {
 };
 
 struct ib_uverbs_rereg_mr {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 mr_handle;
 	__u32 flags;
-	__u64 start;
-	__u64 length;
-	__u64 hca_va;
+	__aligned_u64 start;
+	__aligned_u64 length;
+	__aligned_u64 hca_va;
 	__u32 pd_handle;
 	__u32 access_flags;
 };
@@ -366,7 +366,7 @@ struct ib_uverbs_dereg_mr {
 };
 
 struct ib_uverbs_alloc_mw {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 pd_handle;
 	__u8  mw_type;
 	__u8  reserved[3];
@@ -382,7 +382,7 @@ struct ib_uverbs_dealloc_mw {
 };
 
 struct ib_uverbs_create_comp_channel {
-	__u64 response;
+	__aligned_u64 response;
 };
 
 struct ib_uverbs_create_comp_channel_resp {
@@ -390,13 +390,13 @@ struct ib_uverbs_create_comp_channel_resp {
 };
 
 struct ib_uverbs_create_cq {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 cqe;
 	__u32 comp_vector;
 	__s32 comp_channel;
 	__u32 reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 enum ib_uverbs_ex_create_cq_flags {
@@ -405,7 +405,7 @@ enum ib_uverbs_ex_create_cq_flags {
 };
 
 struct ib_uverbs_ex_create_cq {
-	__u64 user_handle;
+	__aligned_u64 user_handle;
 	__u32 cqe;
 	__u32 comp_vector;
 	__s32 comp_channel;
@@ -426,26 +426,26 @@ struct ib_uverbs_ex_create_cq_resp {
 };
 
 struct ib_uverbs_resize_cq {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 cq_handle;
 	__u32 cqe;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_resize_cq_resp {
 	__u32 cqe;
 	__u32 reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_poll_cq {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 cq_handle;
 	__u32 ne;
 };
 
 struct ib_uverbs_wc {
-	__u64 wr_id;
+	__aligned_u64 wr_id;
 	__u32 status;
 	__u32 opcode;
 	__u32 vendor_err;
@@ -477,7 +477,7 @@ struct ib_uverbs_req_notify_cq {
 };
 
 struct ib_uverbs_destroy_cq {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 cq_handle;
 	__u32 reserved;
 };
@@ -546,8 +546,8 @@ struct ib_uverbs_qp_attr {
 };
 
 struct ib_uverbs_create_qp {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 send_cq_handle;
 	__u32 recv_cq_handle;
@@ -561,7 +561,7 @@ struct ib_uverbs_create_qp {
 	__u8  qp_type;
 	__u8  is_srq;
 	__u8  reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 enum ib_uverbs_create_qp_mask {
@@ -587,7 +587,7 @@ enum {
 };
 
 struct ib_uverbs_ex_create_qp {
-	__u64 user_handle;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 send_cq_handle;
 	__u32 recv_cq_handle;
@@ -608,13 +608,13 @@ struct ib_uverbs_ex_create_qp {
 };
 
 struct ib_uverbs_open_qp {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 qpn;
 	__u8  qp_type;
 	__u8  reserved[7];
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 /* also used for open response */
@@ -655,10 +655,10 @@ struct ib_uverbs_qp_dest {
 };
 
 struct ib_uverbs_query_qp {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 qp_handle;
 	__u32 attr_mask;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_query_qp_resp {
@@ -692,7 +692,7 @@ struct ib_uverbs_query_qp_resp {
 	__u8  alt_timeout;
 	__u8  sq_sig_all;
 	__u8  reserved[5];
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_modify_qp {
@@ -722,7 +722,7 @@ struct ib_uverbs_modify_qp {
 	__u8  alt_port_num;
 	__u8  alt_timeout;
 	__u8  reserved[2];
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_ex_modify_qp {
@@ -740,7 +740,7 @@ struct ib_uverbs_ex_modify_qp_resp {
 };
 
 struct ib_uverbs_destroy_qp {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 qp_handle;
 	__u32 reserved;
 };
@@ -756,13 +756,13 @@ struct ib_uverbs_destroy_qp_resp {
  * document the ABI.
  */
 struct ib_uverbs_sge {
-	__u64 addr;
+	__aligned_u64 addr;
 	__u32 length;
 	__u32 lkey;
 };
 
 struct ib_uverbs_send_wr {
-	__u64 wr_id;
+	__aligned_u64 wr_id;
 	__u32 num_sge;
 	__u32 opcode;
 	__u32 send_flags;
@@ -772,14 +772,14 @@ struct ib_uverbs_send_wr {
 	} ex;
 	union {
 		struct {
-			__u64 remote_addr;
+			__aligned_u64 remote_addr;
 			__u32 rkey;
 			__u32 reserved;
 		} rdma;
 		struct {
-			__u64 remote_addr;
-			__u64 compare_add;
-			__u64 swap;
+			__aligned_u64 remote_addr;
+			__aligned_u64 compare_add;
+			__aligned_u64 swap;
 			__u32 rkey;
 			__u32 reserved;
 		} atomic;
@@ -793,7 +793,7 @@ struct ib_uverbs_send_wr {
 };
 
 struct ib_uverbs_post_send {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 qp_handle;
 	__u32 wr_count;
 	__u32 sge_count;
@@ -806,13 +806,13 @@ struct ib_uverbs_post_send_resp {
 };
 
 struct ib_uverbs_recv_wr {
-	__u64 wr_id;
+	__aligned_u64 wr_id;
 	__u32 num_sge;
 	__u32 reserved;
 };
 
 struct ib_uverbs_post_recv {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 qp_handle;
 	__u32 wr_count;
 	__u32 sge_count;
@@ -825,7 +825,7 @@ struct ib_uverbs_post_recv_resp {
 };
 
 struct ib_uverbs_post_srq_recv {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 srq_handle;
 	__u32 wr_count;
 	__u32 sge_count;
@@ -838,8 +838,8 @@ struct ib_uverbs_post_srq_recv_resp {
 };
 
 struct ib_uverbs_create_ah {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 reserved;
 	struct ib_uverbs_ah_attr attr;
@@ -858,7 +858,7 @@ struct ib_uverbs_attach_mcast {
 	__u32 qp_handle;
 	__u16 mlid;
 	__u16 reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_detach_mcast {
@@ -866,7 +866,7 @@ struct ib_uverbs_detach_mcast {
 	__u32 qp_handle;
 	__u16 mlid;
 	__u16 reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_flow_spec_hdr {
@@ -874,7 +874,7 @@ struct ib_uverbs_flow_spec_hdr {
 	__u16 size;
 	__u16 reserved;
 	/* followed by flow_spec */
-	__u64 flow_spec_data[0];
+	__aligned_u64 flow_spec_data[0];
 };
 
 struct ib_uverbs_flow_eth_filter {
@@ -1033,18 +1033,18 @@ struct ib_uverbs_destroy_flow  {
 };
 
 struct ib_uverbs_create_srq {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 max_wr;
 	__u32 max_sge;
 	__u32 srq_limit;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_create_xsrq {
-	__u64 response;
-	__u64 user_handle;
+	__aligned_u64 response;
+	__aligned_u64 user_handle;
 	__u32 srq_type;
 	__u32 pd_handle;
 	__u32 max_wr;
@@ -1053,7 +1053,7 @@ struct ib_uverbs_create_xsrq {
 	__u32 max_num_tags;
 	__u32 xrcd_handle;
 	__u32 cq_handle;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_create_srq_resp {
@@ -1068,14 +1068,14 @@ struct ib_uverbs_modify_srq {
 	__u32 attr_mask;
 	__u32 max_wr;
 	__u32 srq_limit;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_query_srq {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 srq_handle;
 	__u32 reserved;
-	__u64 driver_data[0];
+	__aligned_u64 driver_data[0];
 };
 
 struct ib_uverbs_query_srq_resp {
@@ -1086,7 +1086,7 @@ struct ib_uverbs_query_srq_resp {
 };
 
 struct ib_uverbs_destroy_srq {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 srq_handle;
 	__u32 reserved;
 };
@@ -1098,7 +1098,7 @@ struct ib_uverbs_destroy_srq_resp {
 struct ib_uverbs_ex_create_wq  {
 	__u32 comp_mask;
 	__u32 wq_type;
-	__u64 user_handle;
+	__aligned_u64 user_handle;
 	__u32 pd_handle;
 	__u32 cq_handle;
 	__u32 max_wr;

--- a/kernel-headers/rdma/mlx4-abi.h
+++ b/kernel-headers/rdma/mlx4-abi.h
@@ -183,6 +183,7 @@ struct mlx4_uverbs_ex_query_device_resp {
 	__u32			response_length;
 	__u64			hca_core_clock_offset;
 	__u32			max_inl_recv_sz;
+	__u32			reserved;
 	struct mlx4_ib_rss_caps	rss_caps;
 	struct mlx4_ib_tso_caps tso_caps;
 };

--- a/kernel-headers/rdma/mlx4-abi.h
+++ b/kernel-headers/rdma/mlx4-abi.h
@@ -77,8 +77,8 @@ struct mlx4_ib_alloc_pd_resp {
 };
 
 struct mlx4_ib_create_cq {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 };
 
 struct mlx4_ib_create_cq_resp {
@@ -87,12 +87,12 @@ struct mlx4_ib_create_cq_resp {
 };
 
 struct mlx4_ib_resize_cq {
-	__u64	buf_addr;
+	__aligned_u64 buf_addr;
 };
 
 struct mlx4_ib_create_srq {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 };
 
 struct mlx4_ib_create_srq_resp {
@@ -101,7 +101,7 @@ struct mlx4_ib_create_srq_resp {
 };
 
 struct mlx4_ib_create_qp_rss {
-	__u64   rx_hash_fields_mask; /* Use  enum mlx4_ib_rx_hash_fields */
+	__aligned_u64 rx_hash_fields_mask; /* Use  enum mlx4_ib_rx_hash_fields */
 	__u8    rx_hash_function; /* Use enum mlx4_ib_rx_hash_function_flags */
 	__u8    reserved[7];
 	__u8    rx_hash_key[40];
@@ -110,8 +110,8 @@ struct mlx4_ib_create_qp_rss {
 };
 
 struct mlx4_ib_create_qp {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u8	log_sq_bb_count;
 	__u8	log_sq_stride;
 	__u8	sq_no_prefetch;
@@ -120,8 +120,8 @@ struct mlx4_ib_create_qp {
 };
 
 struct mlx4_ib_create_wq {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u8	log_range_size;
 	__u8	reserved[3];
 	__u32   comp_mask;
@@ -161,7 +161,7 @@ enum mlx4_ib_rx_hash_fields {
 };
 
 struct mlx4_ib_rss_caps {
-	__u64 rx_hash_fields_mask; /* enum mlx4_ib_rx_hash_fields */
+	__aligned_u64 rx_hash_fields_mask; /* enum mlx4_ib_rx_hash_fields */
 	__u8 rx_hash_function; /* enum mlx4_ib_rx_hash_function_flags */
 	__u8 reserved[7];
 };
@@ -181,7 +181,7 @@ struct mlx4_ib_tso_caps {
 struct mlx4_uverbs_ex_query_device_resp {
 	__u32			comp_mask;
 	__u32			response_length;
-	__u64			hca_core_clock_offset;
+	__aligned_u64		hca_core_clock_offset;
 	__u32			max_inl_recv_sz;
 	__u32			reserved;
 	struct mlx4_ib_rss_caps	rss_caps;

--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -84,7 +84,7 @@ struct mlx5_ib_alloc_ucontext_req_v2 {
 	__u8	reserved0;
 	__u16	reserved1;
 	__u32	reserved2;
-	__u64	lib_caps;
+	__aligned_u64 lib_caps;
 };
 
 enum mlx5_ib_alloc_ucontext_resp_mask {
@@ -125,7 +125,7 @@ struct mlx5_ib_alloc_ucontext_resp {
 	__u8	cmds_supp_uhw;
 	__u8	eth_min_inline;
 	__u8	clock_info_versions;
-	__u64	hca_core_clock_offset;
+	__aligned_u64 hca_core_clock_offset;
 	__u32	log_uar_size;
 	__u32	num_uars_per_page;
 	__u32	num_dyn_bfregs;
@@ -147,7 +147,7 @@ struct mlx5_ib_tso_caps {
 };
 
 struct mlx5_ib_rss_caps {
-	__u64 rx_hash_fields_mask; /* enum mlx5_rx_hash_fields */
+	__aligned_u64 rx_hash_fields_mask; /* enum mlx5_rx_hash_fields */
 	__u8 rx_hash_function; /* enum mlx5_rx_hash_function_flags */
 	__u8 reserved[7];
 };
@@ -248,8 +248,8 @@ enum mlx5_ib_create_cq_flags {
 };
 
 struct mlx5_ib_create_cq {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u32	cqe_size;
 	__u8    cqe_comp_en;
 	__u8    cqe_comp_res_format;
@@ -262,15 +262,15 @@ struct mlx5_ib_create_cq_resp {
 };
 
 struct mlx5_ib_resize_cq {
-	__u64	buf_addr;
+	__aligned_u64 buf_addr;
 	__u16	cqe_size;
 	__u16	reserved0;
 	__u32	reserved1;
 };
 
 struct mlx5_ib_create_srq {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u32	flags;
 	__u32	reserved0; /* explicit padding (optional on i386) */
 	__u32	uidx;
@@ -283,8 +283,8 @@ struct mlx5_ib_create_srq_resp {
 };
 
 struct mlx5_ib_create_qp {
-	__u64	buf_addr;
-	__u64	db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u32	sq_wqe_count;
 	__u32	rq_wqe_count;
 	__u32	rq_wqe_shift;
@@ -292,8 +292,8 @@ struct mlx5_ib_create_qp {
 	__u32	uidx;
 	__u32	bfreg_index;
 	union {
-		__u64	sq_buf_addr;
-		__u64	access_key;
+		__aligned_u64 sq_buf_addr;
+		__aligned_u64 access_key;
 	};
 };
 
@@ -324,7 +324,7 @@ enum mlx5_rx_hash_fields {
 };
 
 struct mlx5_ib_create_qp_rss {
-	__u64 rx_hash_fields_mask; /* enum mlx5_rx_hash_fields */
+	__aligned_u64 rx_hash_fields_mask; /* enum mlx5_rx_hash_fields */
 	__u8 rx_hash_function; /* enum mlx5_rx_hash_function_flags */
 	__u8 rx_key_len; /* valid only for Toeplitz */
 	__u8 reserved[6];
@@ -349,8 +349,8 @@ enum mlx5_ib_create_wq_mask {
 };
 
 struct mlx5_ib_create_wq {
-	__u64   buf_addr;
-	__u64   db_addr;
+	__aligned_u64 buf_addr;
+	__aligned_u64 db_addr;
 	__u32   rq_wqe_count;
 	__u32   rq_wqe_shift;
 	__u32   user_index;
@@ -402,13 +402,13 @@ struct mlx5_ib_modify_wq {
 struct mlx5_ib_clock_info {
 	__u32 sign;
 	__u32 resv;
-	__u64 nsec;
-	__u64 cycles;
-	__u64 frac;
+	__aligned_u64 nsec;
+	__aligned_u64 cycles;
+	__aligned_u64 frac;
 	__u32 mult;
 	__u32 shift;
-	__u64 mask;
-	__u64 overflow_period;
+	__aligned_u64 mask;
+	__aligned_u64 overflow_period;
 };
 
 enum mlx5_ib_mmap_cmd {

--- a/kernel-headers/rdma/mthca-abi.h
+++ b/kernel-headers/rdma/mthca-abi.h
@@ -74,8 +74,8 @@ struct mthca_reg_mr {
 struct mthca_create_cq {
 	__u32 lkey;
 	__u32 pdn;
-	__u64 arm_db_page;
-	__u64 set_db_page;
+	__aligned_u64 arm_db_page;
+	__aligned_u64 set_db_page;
 	__u32 arm_db_index;
 	__u32 set_db_index;
 };
@@ -93,7 +93,7 @@ struct mthca_resize_cq {
 struct mthca_create_srq {
 	__u32 lkey;
 	__u32 db_index;
-	__u64 db_page;
+	__aligned_u64 db_page;
 };
 
 struct mthca_create_srq_resp {
@@ -104,8 +104,8 @@ struct mthca_create_srq_resp {
 struct mthca_create_qp {
 	__u32 lkey;
 	__u32 reserved;
-	__u64 sq_db_page;
-	__u64 rq_db_page;
+	__aligned_u64 sq_db_page;
+	__aligned_u64 rq_db_page;
 	__u32 sq_db_index;
 	__u32 rq_db_index;
 };

--- a/kernel-headers/rdma/nes-abi.h
+++ b/kernel-headers/rdma/nes-abi.h
@@ -72,14 +72,14 @@ struct nes_alloc_pd_resp {
 };
 
 struct nes_create_cq_req {
-	__u64 user_cq_buffer;
+	__aligned_u64 user_cq_buffer;
 	__u32 mcrqf;
 	__u8 reserved[4];
 };
 
 struct nes_create_qp_req {
-	__u64 user_wqe_buffers;
-	__u64 user_qp_buffer;
+	__aligned_u64 user_wqe_buffers;
+	__aligned_u64 user_qp_buffer;
 };
 
 enum iwnes_memreg_type {

--- a/kernel-headers/rdma/ocrdma-abi.h
+++ b/kernel-headers/rdma/ocrdma-abi.h
@@ -55,13 +55,13 @@ struct ocrdma_alloc_ucontext_resp {
 	__u32 wqe_size;
 	__u32 max_inline_data;
 	__u32 dpp_wqe_size;
-	__u64 ah_tbl_page;
+	__aligned_u64 ah_tbl_page;
 	__u32 ah_tbl_len;
 	__u32 rqe_size;
 	__u8 fw_ver[32];
 	/* for future use/new features in progress */
-	__u64 rsvd1;
-	__u64 rsvd2;
+	__aligned_u64 rsvd1;
+	__aligned_u64 rsvd2;
 };
 
 struct ocrdma_alloc_pd_ureq {
@@ -87,13 +87,13 @@ struct ocrdma_create_cq_uresp {
 	__u32 page_size;
 	__u32 num_pages;
 	__u32 max_hw_cqe;
-	__u64 page_addr[MAX_CQ_PAGES];
-	__u64 db_page_addr;
+	__aligned_u64 page_addr[MAX_CQ_PAGES];
+	__aligned_u64 db_page_addr;
 	__u32 db_page_size;
 	__u32 phase_change;
 	/* for future use/new features in progress */
-	__u64 rsvd1;
-	__u64 rsvd2;
+	__aligned_u64 rsvd1;
+	__aligned_u64 rsvd2;
 };
 
 #define MAX_QP_PAGES 8
@@ -115,9 +115,9 @@ struct ocrdma_create_qp_uresp {
 	__u32 rq_page_size;
 	__u32 num_sq_pages;
 	__u32 num_rq_pages;
-	__u64 sq_page_addr[MAX_QP_PAGES];
-	__u64 rq_page_addr[MAX_QP_PAGES];
-	__u64 db_page_addr;
+	__aligned_u64 sq_page_addr[MAX_QP_PAGES];
+	__aligned_u64 rq_page_addr[MAX_QP_PAGES];
+	__aligned_u64 db_page_addr;
 	__u32 db_page_size;
 	__u32 dpp_credit;
 	__u32 dpp_offset;
@@ -126,7 +126,7 @@ struct ocrdma_create_qp_uresp {
 	__u32 db_sq_offset;
 	__u32 db_rq_offset;
 	__u32 db_shift;
-	__u64 rsvd[11];
+	__aligned_u64 rsvd[11];
 };
 
 struct ocrdma_create_srq_uresp {
@@ -137,16 +137,16 @@ struct ocrdma_create_srq_uresp {
 	__u32 rq_page_size;
 	__u32 num_rq_pages;
 
-	__u64 rq_page_addr[MAX_QP_PAGES];
-	__u64 db_page_addr;
+	__aligned_u64 rq_page_addr[MAX_QP_PAGES];
+	__aligned_u64 db_page_addr;
 
 	__u32 db_page_size;
 	__u32 num_rqe_allocated;
 	__u32 db_rq_offset;
 	__u32 db_shift;
 
-	__u64 rsvd2;
-	__u64 rsvd3;
+	__aligned_u64 rsvd2;
+	__aligned_u64 rsvd3;
 };
 
 #endif	/* OCRDMA_ABI_USER_H */

--- a/kernel-headers/rdma/ocrdma-abi.h
+++ b/kernel-headers/rdma/ocrdma-abi.h
@@ -65,7 +65,7 @@ struct ocrdma_alloc_ucontext_resp {
 };
 
 struct ocrdma_alloc_pd_ureq {
-	__u64 rsvd1;
+	__u32 rsvd[2];
 };
 
 struct ocrdma_alloc_pd_uresp {
@@ -73,7 +73,7 @@ struct ocrdma_alloc_pd_uresp {
 	__u32 dpp_enabled;
 	__u32 dpp_page_addr_hi;
 	__u32 dpp_page_addr_lo;
-	__u64 rsvd1;
+	__u32 rsvd[2];
 };
 
 struct ocrdma_create_cq_ureq {

--- a/kernel-headers/rdma/qedr-abi.h
+++ b/kernel-headers/rdma/qedr-abi.h
@@ -53,6 +53,7 @@ struct qedr_alloc_ucontext_resp {
 	__u8 dpm_enabled;
 	__u8 wids_enabled;
 	__u16 wid_count;
+	__u32 reserved;
 };
 
 struct qedr_alloc_pd_ureq {
@@ -61,6 +62,7 @@ struct qedr_alloc_pd_ureq {
 
 struct qedr_alloc_pd_uresp {
 	__u32 pd_id;
+	__u32 reserved;
 };
 
 struct qedr_create_cq_ureq {
@@ -71,6 +73,7 @@ struct qedr_create_cq_ureq {
 struct qedr_create_cq_uresp {
 	__u32 db_offset;
 	__u16 icid;
+	__u16 reserved;
 };
 
 struct qedr_create_qp_ureq {
@@ -105,6 +108,7 @@ struct qedr_create_qp_uresp {
 	__u16 rq_icid;
 
 	__u32 rq_db2_offset;
+	__u32 reserved;
 };
 
 #endif /* __QEDR_USER_H__ */

--- a/kernel-headers/rdma/qedr-abi.h
+++ b/kernel-headers/rdma/qedr-abi.h
@@ -40,7 +40,7 @@
 /* user kernel communication data structures. */
 
 struct qedr_alloc_ucontext_resp {
-	__u64 db_pa;
+	__aligned_u64 db_pa;
 	__u32 db_size;
 
 	__u32 max_send_wr;
@@ -57,7 +57,7 @@ struct qedr_alloc_ucontext_resp {
 };
 
 struct qedr_alloc_pd_ureq {
-	__u64 rsvd1;
+	__aligned_u64 rsvd1;
 };
 
 struct qedr_alloc_pd_uresp {
@@ -66,8 +66,8 @@ struct qedr_alloc_pd_uresp {
 };
 
 struct qedr_create_cq_ureq {
-	__u64 addr;
-	__u64 len;
+	__aligned_u64 addr;
+	__aligned_u64 len;
 };
 
 struct qedr_create_cq_uresp {
@@ -82,17 +82,17 @@ struct qedr_create_qp_ureq {
 
 	/* SQ */
 	/* user space virtual address of SQ buffer */
-	__u64 sq_addr;
+	__aligned_u64 sq_addr;
 
 	/* length of SQ buffer */
-	__u64 sq_len;
+	__aligned_u64 sq_len;
 
 	/* RQ */
 	/* user space virtual address of RQ buffer */
-	__u64 rq_addr;
+	__aligned_u64 rq_addr;
 
 	/* length of RQ buffer */
-	__u64 rq_len;
+	__aligned_u64 rq_len;
 };
 
 struct qedr_create_qp_uresp {

--- a/kernel-headers/rdma/rdma_user_cm.h
+++ b/kernel-headers/rdma/rdma_user_cm.h
@@ -270,10 +270,15 @@ struct rdma_ucm_event_resp {
 	__u32 id;
 	__u32 event;
 	__u32 status;
+	/*
+	 * NOTE: This union is not aligned to 8 bytes so none of the union
+	 * members may contain a u64 or anything with higher alignment than 4.
+	 */
 	union {
 		struct rdma_ucm_conn_param conn;
 		struct rdma_ucm_ud_param   ud;
 	} param;
+	__u32 reserved;
 };
 
 /* Option levels */

--- a/kernel-headers/rdma/rdma_user_cm.h
+++ b/kernel-headers/rdma/rdma_user_cm.h
@@ -80,8 +80,8 @@ struct rdma_ucm_cmd_hdr {
 };
 
 struct rdma_ucm_create_id {
-	__u64 uid;
-	__u64 response;
+	__aligned_u64 uid;
+	__aligned_u64 response;
 	__u16 ps;
 	__u8  qp_type;
 	__u8  reserved[5];
@@ -92,7 +92,7 @@ struct rdma_ucm_create_id_resp {
 };
 
 struct rdma_ucm_destroy_id {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 reserved;
 };
@@ -102,7 +102,7 @@ struct rdma_ucm_destroy_id_resp {
 };
 
 struct rdma_ucm_bind_ip {
-	__u64 response;
+	__aligned_u64 response;
 	struct sockaddr_in6 addr;
 	__u32 id;
 };
@@ -143,13 +143,13 @@ enum {
 };
 
 struct rdma_ucm_query {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 option;
 };
 
 struct rdma_ucm_query_route_resp {
-	__u64 node_guid;
+	__aligned_u64 node_guid;
 	struct ib_user_path_rec ib_route[2];
 	struct sockaddr_in6 src_addr;
 	struct sockaddr_in6 dst_addr;
@@ -159,7 +159,7 @@ struct rdma_ucm_query_route_resp {
 };
 
 struct rdma_ucm_query_addr_resp {
-	__u64 node_guid;
+	__aligned_u64 node_guid;
 	__u8  port_num;
 	__u8  reserved;
 	__u16 pkey;
@@ -210,7 +210,7 @@ struct rdma_ucm_listen {
 };
 
 struct rdma_ucm_accept {
-	__u64 uid;
+	__aligned_u64 uid;
 	struct rdma_ucm_conn_param conn_param;
 	__u32 id;
 	__u32 reserved;
@@ -228,7 +228,7 @@ struct rdma_ucm_disconnect {
 };
 
 struct rdma_ucm_init_qp_attr {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 qp_state;
 };
@@ -239,8 +239,8 @@ struct rdma_ucm_notify {
 };
 
 struct rdma_ucm_join_ip_mcast {
-	__u64 response;		/* rdma_ucm_create_id_resp */
-	__u64 uid;
+	__aligned_u64 response;		/* rdma_ucm_create_id_resp */
+	__aligned_u64 uid;
 	struct sockaddr_in6 addr;
 	__u32 id;
 };
@@ -253,8 +253,8 @@ enum {
 };
 
 struct rdma_ucm_join_mcast {
-	__u64 response;		/* rdma_ucma_create_id_resp */
-	__u64 uid;
+	__aligned_u64 response;		/* rdma_ucma_create_id_resp */
+	__aligned_u64 uid;
 	__u32 id;
 	__u16 addr_size;
 	__u16 join_flags;
@@ -262,11 +262,11 @@ struct rdma_ucm_join_mcast {
 };
 
 struct rdma_ucm_get_event {
-	__u64 response;
+	__aligned_u64 response;
 };
 
 struct rdma_ucm_event_resp {
-	__u64 uid;
+	__aligned_u64 uid;
 	__u32 id;
 	__u32 event;
 	__u32 status;
@@ -296,7 +296,7 @@ enum {
 };
 
 struct rdma_ucm_set_option {
-	__u64 optval;
+	__aligned_u64 optval;
 	__u32 id;
 	__u32 level;
 	__u32 optname;
@@ -304,7 +304,7 @@ struct rdma_ucm_set_option {
 };
 
 struct rdma_ucm_migrate_id {
-	__u64 response;
+	__aligned_u64 response;
 	__u32 id;
 	__u32 fd;
 };

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -78,12 +78,14 @@ struct rxe_send_wr {
 		struct {
 			__u64	remote_addr;
 			__u32	rkey;
+			__u32	reserved;
 		} rdma;
 		struct {
 			__u64	remote_addr;
 			__u64	compare_add;
 			__u64	swap;
 			__u32	rkey;
+			__u32	reserved;
 		} atomic;
 		struct {
 			__u32	remote_qpn;

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -58,6 +58,8 @@ struct rxe_global_route {
 struct rxe_av {
 	__u8			port_num;
 	__u8			network_type;
+	__u16			reserved1;
+	__u32			reserved2;
 	struct rxe_global_route	grh;
 	union {
 		struct sockaddr_in	_sockaddr_in;
@@ -66,7 +68,7 @@ struct rxe_av {
 };
 
 struct rxe_send_wr {
-	__u64			wr_id;
+	__aligned_u64		wr_id;
 	__u32			num_sge;
 	__u32			opcode;
 	__u32			send_flags;
@@ -76,14 +78,14 @@ struct rxe_send_wr {
 	} ex;
 	union {
 		struct {
-			__u64	remote_addr;
+			__aligned_u64 remote_addr;
 			__u32	rkey;
 			__u32	reserved;
 		} rdma;
 		struct {
-			__u64	remote_addr;
-			__u64	compare_add;
-			__u64	swap;
+			__aligned_u64 remote_addr;
+			__aligned_u64 compare_add;
+			__aligned_u64 swap;
 			__u32	rkey;
 			__u32	reserved;
 		} atomic;
@@ -92,22 +94,26 @@ struct rxe_send_wr {
 			__u32	remote_qkey;
 			__u16	pkey_index;
 		} ud;
+		/* reg is only used by the kernel and is not part of the uapi */
 		struct {
-			struct ib_mr *mr;
+			union {
+				struct ib_mr *mr;
+				__aligned_u64 reserved;
+			};
 			__u32        key;
-			int          access;
+			__u32        access;
 		} reg;
 	} wr;
 };
 
 struct rxe_sge {
-	__u64	addr;
+	__aligned_u64 addr;
 	__u32	length;
 	__u32	lkey;
 };
 
 struct mminfo {
-	__u64			offset;
+	__aligned_u64  		offset;
 	__u32			size;
 	__u32			pad;
 };
@@ -118,6 +124,7 @@ struct rxe_dma_info {
 	__u32			cur_sge;
 	__u32			num_sge;
 	__u32			sge_offset;
+	__u32			reserved;
 	union {
 		__u8		inline_data[0];
 		struct rxe_sge	sge[0];
@@ -129,7 +136,7 @@ struct rxe_send_wqe {
 	struct rxe_av		av;
 	__u32			status;
 	__u32			state;
-	__u64			iova;
+	__aligned_u64		iova;
 	__u32			mask;
 	__u32			first_psn;
 	__u32			last_psn;
@@ -140,7 +147,7 @@ struct rxe_send_wqe {
 };
 
 struct rxe_recv_wqe {
-	__u64			wr_id;
+	__aligned_u64		wr_id;
 	__u32			num_sge;
 	__u32			padding;
 	struct rxe_dma_info	dma;
@@ -162,10 +169,11 @@ struct rxe_create_qp_resp {
 struct rxe_create_srq_resp {
 	struct mminfo mi;
 	__u32 srq_num;
+	__u32 reserved;
 };
 
 struct rxe_modify_srq_cmd {
-	__u64 mmap_info_addr;
+	__aligned_u64 mmap_info_addr;
 };
 
 #endif /* RDMA_USER_RXE_H */

--- a/kernel-headers/rdma/vmw_pvrdma-abi.h
+++ b/kernel-headers/rdma/vmw_pvrdma-abi.h
@@ -143,7 +143,7 @@ struct pvrdma_alloc_pd_resp {
 };
 
 struct pvrdma_create_cq {
-	__u64 buf_addr;
+	__aligned_u64 buf_addr;
 	__u32 buf_size;
 	__u32 reserved;
 };
@@ -154,13 +154,13 @@ struct pvrdma_create_cq_resp {
 };
 
 struct pvrdma_resize_cq {
-	__u64 buf_addr;
+	__aligned_u64 buf_addr;
 	__u32 buf_size;
 	__u32 reserved;
 };
 
 struct pvrdma_create_srq {
-	__u64 buf_addr;
+	__aligned_u64 buf_addr;
 	__u32 buf_size;
 	__u32 reserved;
 };
@@ -171,25 +171,25 @@ struct pvrdma_create_srq_resp {
 };
 
 struct pvrdma_create_qp {
-	__u64 rbuf_addr;
-	__u64 sbuf_addr;
+	__aligned_u64 rbuf_addr;
+	__aligned_u64 sbuf_addr;
 	__u32 rbuf_size;
 	__u32 sbuf_size;
-	__u64 qp_addr;
+	__aligned_u64 qp_addr;
 };
 
 /* PVRDMA masked atomic compare and swap */
 struct pvrdma_ex_cmp_swap {
-	__u64 swap_val;
-	__u64 compare_val;
-	__u64 swap_mask;
-	__u64 compare_mask;
+	__aligned_u64 swap_val;
+	__aligned_u64 compare_val;
+	__aligned_u64 swap_mask;
+	__aligned_u64 compare_mask;
 };
 
 /* PVRDMA masked atomic fetch and add */
 struct pvrdma_ex_fetch_add {
-	__u64 add_val;
-	__u64 field_boundary;
+	__aligned_u64 add_val;
+	__aligned_u64 field_boundary;
 };
 
 /* PVRDMA address vector. */
@@ -207,14 +207,14 @@ struct pvrdma_av {
 
 /* PVRDMA scatter/gather entry */
 struct pvrdma_sge {
-	__u64   addr;
+	__aligned_u64 addr;
 	__u32   length;
 	__u32   lkey;
 };
 
 /* PVRDMA receive queue work request */
 struct pvrdma_rq_wqe_hdr {
-	__u64 wr_id;		/* wr id */
+	__aligned_u64 wr_id;		/* wr id */
 	__u32 num_sge;		/* size of s/g array */
 	__u32 total_len;	/* reserved */
 };
@@ -222,7 +222,7 @@ struct pvrdma_rq_wqe_hdr {
 
 /* PVRDMA send queue work request */
 struct pvrdma_sq_wqe_hdr {
-	__u64 wr_id;		/* wr id */
+	__aligned_u64 wr_id;		/* wr id */
 	__u32 num_sge;		/* size of s/g array */
 	__u32 total_len;	/* reserved */
 	__u32 opcode;		/* operation type */
@@ -234,19 +234,19 @@ struct pvrdma_sq_wqe_hdr {
 	__u32 reserved;
 	union {
 		struct {
-			__u64 remote_addr;
+			__aligned_u64 remote_addr;
 			__u32 rkey;
 			__u8 reserved[4];
 		} rdma;
 		struct {
-			__u64 remote_addr;
-			__u64 compare_add;
-			__u64 swap;
+			__aligned_u64 remote_addr;
+			__aligned_u64 compare_add;
+			__aligned_u64 swap;
 			__u32 rkey;
 			__u32 reserved;
 		} atomic;
 		struct {
-			__u64 remote_addr;
+			__aligned_u64 remote_addr;
 			__u32 log_arg_sz;
 			__u32 rkey;
 			union {
@@ -255,8 +255,8 @@ struct pvrdma_sq_wqe_hdr {
 			} wr_data;
 		} masked_atomics;
 		struct {
-			__u64 iova_start;
-			__u64 pl_pdir_dma;
+			__aligned_u64 iova_start;
+			__aligned_u64 pl_pdir_dma;
 			__u32 page_shift;
 			__u32 page_list_len;
 			__u32 length;
@@ -275,8 +275,8 @@ struct pvrdma_sq_wqe_hdr {
 
 /* Completion queue element. */
 struct pvrdma_cqe {
-	__u64 wr_id;
-	__u64 qp;
+	__aligned_u64 wr_id;
+	__aligned_u64 qp;
 	__u32 opcode;
 	__u32 status;
 	__u32 byte_len;

--- a/kernel-headers/rdma/vmw_pvrdma-abi.h
+++ b/kernel-headers/rdma/vmw_pvrdma-abi.h
@@ -262,6 +262,7 @@ struct pvrdma_sq_wqe_hdr {
 			__u32 length;
 			__u32 access_flags;
 			__u32 rkey;
+			__u32 reserved;
 		} fast_reg;
 		struct {
 			__u32 remote_qpn;

--- a/providers/cxgb3/iwch-abi.h
+++ b/providers/cxgb3/iwch-abi.h
@@ -34,34 +34,35 @@
 
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
+#include <rdma/cxgb3-abi.h>
 
-struct iwch_alloc_ucontext_resp {
+struct uiwch_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp ibv_resp;
 };
 
-struct iwch_alloc_pd_resp {
+struct uiwch_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp ibv_resp;
 	uint32_t pdid;
 };
 
-struct iwch_create_cq {
+struct uiwch_create_cq {
 	struct ibv_create_cq ibv_cmd;
 	uint64_t user_rptr_addr;
 };
 
-struct iwch_reg_mr_resp {
+struct uiwch_reg_mr_resp {
 	struct ib_uverbs_reg_mr_resp ibv_resp;
 	uint32_t pbl_addr;
 };
 
-struct iwch_create_cq_resp_v0 {
+struct uiwch_create_cq_resp_v0 {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint64_t physaddr;
 	uint32_t cqid;
 	uint32_t size_log2;
 };
 
-struct iwch_create_cq_resp_v1 {
+struct uiwch_create_cq_resp_v1 {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint64_t physaddr;
 	uint32_t cqid;
@@ -70,11 +71,11 @@ struct iwch_create_cq_resp_v1 {
 	uint32_t reserved; /* for proper alignment */
 };
 
-struct iwch_create_qp {
+struct uiwch_create_qp {
 	struct ibv_create_qp ibv_cmd;
 };
 
-struct iwch_create_qp_resp {
+struct uiwch_create_qp_resp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	uint64_t physaddr;
 	uint64_t doorbell;

--- a/providers/cxgb3/iwch-abi.h
+++ b/providers/cxgb3/iwch-abi.h
@@ -35,53 +35,17 @@
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
 #include <rdma/cxgb3-abi.h>
+#include <kernel-abi/cxgb3-abi.h>
 
-struct uiwch_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-};
+DECLARE_DRV_CMD(uiwch_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, iwch_alloc_pd_resp);
+DECLARE_DRV_CMD(uiwch_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		iwch_create_cq_req, iwch_create_cq_resp);
+DECLARE_DRV_CMD(uiwch_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		empty, iwch_create_qp_resp);
+DECLARE_DRV_CMD(uiwch_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, empty);
+DECLARE_DRV_CMD(uiwch_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, iwch_reg_user_mr_resp);
 
-struct uiwch_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	uint32_t pdid;
-};
-
-struct uiwch_create_cq {
-	struct ibv_create_cq ibv_cmd;
-	uint64_t user_rptr_addr;
-};
-
-struct uiwch_reg_mr_resp {
-	struct ib_uverbs_reg_mr_resp ibv_resp;
-	uint32_t pbl_addr;
-};
-
-struct uiwch_create_cq_resp_v0 {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint64_t physaddr;
-	uint32_t cqid;
-	uint32_t size_log2;
-};
-
-struct uiwch_create_cq_resp_v1 {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint64_t physaddr;
-	uint32_t cqid;
-	uint32_t size_log2;
-	uint32_t memsize;
-	uint32_t reserved; /* for proper alignment */
-};
-
-struct uiwch_create_qp {
-	struct ibv_create_qp ibv_cmd;
-};
-
-struct uiwch_create_qp_resp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	uint64_t physaddr;
-	uint64_t doorbell;
-	uint32_t qpid;
-	uint32_t size_log2;
-	uint32_t sq_size_log2;
-	uint32_t rq_size_log2;
-};
 #endif				/* IWCH_ABI_H */

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -122,7 +122,7 @@ static struct verbs_context *iwch_alloc_context(struct ibv_device *ibdev,
 {
 	struct iwch_context *context;
 	struct ibv_get_context cmd;
-	struct iwch_alloc_ucontext_resp resp;
+	struct uiwch_alloc_ucontext_resp resp;
 	struct iwch_device *rhp = to_iwch_dev(ibdev);
 
 	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,

--- a/providers/cxgb3/verbs.c
+++ b/providers/cxgb3/verbs.c
@@ -75,7 +75,7 @@ int iwch_query_port(struct ibv_context *context, uint8_t port,
 struct ibv_pd *iwch_alloc_pd(struct ibv_context *context)
 {
 	struct ibv_alloc_pd cmd;
-	struct iwch_alloc_pd_resp resp;
+	struct uiwch_alloc_pd_resp resp;
 	struct iwch_pd *pd;
 
 	pd = malloc(sizeof *pd);
@@ -109,7 +109,7 @@ static struct ibv_mr *__iwch_reg_mr(struct ibv_pd *pd, void *addr,
 {
 	struct iwch_mr *mhp;
 	struct ibv_reg_mr cmd;
-	struct iwch_reg_mr_resp resp;
+	struct uiwch_reg_mr_resp resp;
 	struct iwch_device *dev = to_iwch_dev(pd->context->device);
 
 	mhp = malloc(sizeof *mhp);
@@ -168,8 +168,8 @@ int iwch_dereg_mr(struct ibv_mr *mr)
 struct ibv_cq *iwch_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_comp_channel *channel, int comp_vector)
 {
-	struct iwch_create_cq cmd;
-	struct iwch_create_cq_resp_v1 resp;
+	struct uiwch_create_cq cmd;
+	struct uiwch_create_cq_resp_v1 resp;
 	struct iwch_cq *chp;
 	struct iwch_device *dev = to_iwch_dev(context->device);
 	int ret;
@@ -288,8 +288,8 @@ int iwch_post_srq_recv(struct ibv_srq *ibsrq, struct ibv_recv_wr *wr,
 
 struct ibv_qp *iwch_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
 {
-	struct iwch_create_qp cmd;
-	struct iwch_create_qp_resp resp;
+	struct uiwch_create_qp cmd;
+	struct uiwch_create_qp_resp resp;
 	struct iwch_qp *qhp;
 	struct iwch_device *dev = to_iwch_dev(pd->context->device);
 	int ret;

--- a/providers/hns/hns_roce_u_abi.h
+++ b/providers/hns/hns_roce_u_abi.h
@@ -34,43 +34,16 @@
 #define _HNS_ROCE_U_ABI_H
 
 #include <infiniband/kern-abi.h>
+#include <rdma/hns-abi.h>
+#include <kernel-abi/hns-abi.h>
 
-struct hns_roce_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp	ibv_resp;
-	__u32				qp_tab_size;
-	__u32				reserved;
-};
+DECLARE_DRV_CMD(hns_roce_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		empty, hns_roce_ib_alloc_pd_resp);
+DECLARE_DRV_CMD(hns_roce_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		hns_roce_ib_create_cq, hns_roce_ib_create_cq_resp);
+DECLARE_DRV_CMD(hns_roce_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		hns_roce_ib_create_qp, hns_roce_ib_create_qp_resp);
+DECLARE_DRV_CMD(hns_roce_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, hns_roce_ib_alloc_ucontext_resp);
 
-struct hns_roce_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp	ibv_resp;
-	__u32				pdn;
-	__u32				reserved;
-};
-
-struct hns_roce_create_cq {
-	struct ibv_create_cq		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-};
-
-struct hns_roce_create_cq_resp {
-	struct ib_uverbs_create_cq_resp	ibv_resp;
-	__u64				cqn; /* Only 32 bits used, 64 for compat */
-	__u64				cap_flags;
-};
-
-struct hns_roce_create_qp {
-	struct ibv_create_qp		ibv_cmd;
-	__u64				buf_addr;
-	__u64				db_addr;
-	__u8				log_sq_bb_count;
-	__u8				log_sq_stride;
-	__u8				sq_no_prefetch;
-	__u8				reserved[5];
-};
-
-struct hns_roce_create_qp_resp {
-	struct ib_uverbs_create_qp_resp	base;
-	__u64				cap_flags;
-};
 #endif /* _HNS_ROCE_U_ABI_H */

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -605,7 +605,7 @@ struct ibv_qp *hns_roce_u_create_qp(struct ibv_pd *pd,
 	pthread_mutex_lock(&to_hr_ctx(pd->context)->qp_table_mutex);
 
 	ret = ibv_cmd_create_qp(pd, &qp->ibv_qp, attr, &cmd.ibv_cmd,
-				sizeof(cmd), &resp.base, sizeof(resp));
+				sizeof(cmd), &resp.ibv_resp, sizeof(resp));
 	if (ret) {
 		fprintf(stderr, "ibv_cmd_create_qp failed!\n");
 		goto err_rq_db;

--- a/providers/ocrdma/ocrdma_abi.h
+++ b/providers/ocrdma/ocrdma_abi.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
+#include <rdma/ocrdma-abi.h>
 
 #define OCRDMA_ABI_VERSION	2
 
@@ -61,11 +62,11 @@ enum {
 /* solicited bit */
 #define OCRDMA_DB_CQ_SOLICIT_SHIFT		(31)	/* bit 31 */
 
-struct ocrdma_get_context {
+struct uocrdma_get_context {
 	struct ibv_get_context cmd;
 };
 
-struct ocrdma_alloc_ucontext_resp {
+struct uocrdma_alloc_ucontext_resp {
 	struct ib_uverbs_get_context_resp ibv_resp;
 	uint32_t dev_id;
 	uint32_t wqe_size;
@@ -79,12 +80,12 @@ struct ocrdma_alloc_ucontext_resp {
 	uint64_t rsvd2;
 };
 
-struct ocrdma_alloc_pd_req {
+struct uocrdma_alloc_pd_req {
 	struct ibv_alloc_pd cmd;
 	uint64_t rsvd;
 };
 
-struct ocrdma_alloc_pd_resp {
+struct uocrdma_alloc_pd_resp {
 	struct ib_uverbs_alloc_pd_resp ibv_resp;
 	uint32_t id;
 	uint32_t dpp_enabled;
@@ -93,14 +94,13 @@ struct ocrdma_alloc_pd_resp {
 	uint64_t rsvd;
 };
 
-struct ocrdma_create_cq_req {
+struct uocrdma_create_cq_req {
 	struct ibv_create_cq ibv_cmd;
 	uint32_t dpp_cq;
 	uint32_t rsvd;
 };
 
-#define MAX_CQ_PAGES 8
-struct ocrdma_create_cq_resp {
+struct uocrdma_create_cq_resp {
 	struct ib_uverbs_create_cq_resp ibv_resp;
 	uint32_t cq_id;
 	uint32_t size;
@@ -114,15 +114,15 @@ struct ocrdma_create_cq_resp {
 	uint64_t rsvd2;
 };
 
-struct ocrdma_reg_mr {
+struct uocrdma_reg_mr {
 	struct ibv_reg_mr ibv_cmd;
 };
 
-struct ocrdma_reg_mr_resp {
+struct uocrdma_reg_mr_resp {
 	struct ib_uverbs_reg_mr_resp ibv_resp;
 };
 
-struct ocrdma_create_qp_cmd {
+struct uocrdma_create_qp_cmd {
 	struct ibv_create_qp ibv_cmd;
 	uint8_t enable_dpp_cq;
 	uint8_t rsvd;
@@ -130,10 +130,7 @@ struct ocrdma_create_qp_cmd {
 	uint32_t rsvd1;		/* pad */
 };
 
-#define MAX_QP_PAGES 8
-#define MAX_UD_HDR_PAGES 8
-
-struct ocrdma_create_qp_uresp {
+struct uocrdma_create_qp_uresp {
 	struct ib_uverbs_create_qp_resp ibv_resp;
 	uint16_t qp_id;
 	uint16_t sq_dbid;
@@ -157,11 +154,11 @@ struct ocrdma_create_qp_uresp {
 	uint64_t rsvd[11]; /* 8*8 + 4*4 + 8 */
 };
 
-struct ocrdma_create_srq_cmd {
+struct uocrdma_create_srq_cmd {
 	struct ibv_create_srq ibv_cmd;
 };
 
-struct ocrdma_create_srq_resp {
+struct uocrdma_create_srq_resp {
 	struct ib_uverbs_create_srq_resp ibv_resp;
 	uint16_t rq_dbid;
 	uint16_t resv0;

--- a/providers/ocrdma/ocrdma_abi.h
+++ b/providers/ocrdma/ocrdma_abi.h
@@ -38,8 +38,22 @@
 #include <stdint.h>
 #include <infiniband/kern-abi.h>
 #include <rdma/ocrdma-abi.h>
+#include <kernel-abi/ocrdma-abi.h>
 
 #define OCRDMA_ABI_VERSION	2
+
+DECLARE_DRV_CMD(uocrdma_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		empty, ocrdma_alloc_ucontext_resp);
+DECLARE_DRV_CMD(uocrdma_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
+		ocrdma_alloc_pd_ureq, ocrdma_alloc_pd_uresp);
+DECLARE_DRV_CMD(uocrdma_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
+		ocrdma_create_cq_ureq, ocrdma_create_cq_uresp);
+DECLARE_DRV_CMD(uocrdma_reg_mr, IB_USER_VERBS_CMD_REG_MR,
+		empty, empty);
+DECLARE_DRV_CMD(uocrdma_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		ocrdma_create_qp_ureq, ocrdma_create_qp_uresp);
+DECLARE_DRV_CMD(uocrdma_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
+		empty, ocrdma_create_srq_uresp);
 
 #define Bit(_b) (1 << (_b))
 
@@ -61,122 +75,6 @@ enum {
 
 /* solicited bit */
 #define OCRDMA_DB_CQ_SOLICIT_SHIFT		(31)	/* bit 31 */
-
-struct uocrdma_get_context {
-	struct ibv_get_context cmd;
-};
-
-struct uocrdma_alloc_ucontext_resp {
-	struct ib_uverbs_get_context_resp ibv_resp;
-	uint32_t dev_id;
-	uint32_t wqe_size;
-	uint32_t max_inline_data;
-	uint32_t dpp_wqe_size;
-	uint64_t ah_tbl_page;
-	uint32_t ah_tbl_len;
-	uint32_t rqe_size;
-	uint8_t fw_ver[32];
-	uint64_t rsvd1;
-	uint64_t rsvd2;
-};
-
-struct uocrdma_alloc_pd_req {
-	struct ibv_alloc_pd cmd;
-	uint64_t rsvd;
-};
-
-struct uocrdma_alloc_pd_resp {
-	struct ib_uverbs_alloc_pd_resp ibv_resp;
-	uint32_t id;
-	uint32_t dpp_enabled;
-	uint32_t dpp_page_addr_hi;
-	uint32_t dpp_page_addr_lo;
-	uint64_t rsvd;
-};
-
-struct uocrdma_create_cq_req {
-	struct ibv_create_cq ibv_cmd;
-	uint32_t dpp_cq;
-	uint32_t rsvd;
-};
-
-struct uocrdma_create_cq_resp {
-	struct ib_uverbs_create_cq_resp ibv_resp;
-	uint32_t cq_id;
-	uint32_t size;
-	uint32_t num_pages;
-	uint32_t max_hw_cqe;
-	uint64_t page_addr[MAX_CQ_PAGES];
-	uint64_t db_page_addr;
-	uint32_t db_page_size;
-	uint32_t phase_change;
-	uint64_t rsvd1;
-	uint64_t rsvd2;
-};
-
-struct uocrdma_reg_mr {
-	struct ibv_reg_mr ibv_cmd;
-};
-
-struct uocrdma_reg_mr_resp {
-	struct ib_uverbs_reg_mr_resp ibv_resp;
-};
-
-struct uocrdma_create_qp_cmd {
-	struct ibv_create_qp ibv_cmd;
-	uint8_t enable_dpp_cq;
-	uint8_t rsvd;
-	uint16_t dpp_cq_id;
-	uint32_t rsvd1;		/* pad */
-};
-
-struct uocrdma_create_qp_uresp {
-	struct ib_uverbs_create_qp_resp ibv_resp;
-	uint16_t qp_id;
-	uint16_t sq_dbid;
-	uint16_t rq_dbid;
-	uint16_t resv0;		/* pad */
-	uint32_t sq_page_size;
-	uint32_t rq_page_size;
-	uint32_t num_sq_pages;
-	uint32_t num_rq_pages;
-	uint64_t sq_page_addr[MAX_QP_PAGES];
-	uint64_t rq_page_addr[MAX_QP_PAGES];
-	uint64_t db_page_addr;
-	uint32_t db_page_size;
-	uint32_t dpp_credit;
-	uint32_t dpp_offset;
-	uint32_t num_wqe_allocated;
-	uint32_t num_rqe_allocated;
-	uint32_t db_sq_offset;
-	uint32_t db_rq_offset;
-	uint32_t db_shift;
-	uint64_t rsvd[11]; /* 8*8 + 4*4 + 8 */
-};
-
-struct uocrdma_create_srq_cmd {
-	struct ibv_create_srq ibv_cmd;
-};
-
-struct uocrdma_create_srq_resp {
-	struct ib_uverbs_create_srq_resp ibv_resp;
-	uint16_t rq_dbid;
-	uint16_t resv0;
-	uint32_t resv1;
-
-	uint32_t rq_page_size;
-	uint32_t num_rq_pages;
-
-	uint64_t rq_page_addr[MAX_QP_PAGES];
-	uint64_t db_page_addr;
-
-	uint32_t db_page_size;
-	uint32_t num_rqe_allocated;
-	uint32_t db_rq_offset;
-	uint32_t db_shift;
-	uint64_t rsvd2;
-	uint64_t rsvd3;
-};
 
 enum OCRDMA_CQE_STATUS {
 	OCRDMA_CQE_SUCCESS 		= 0,

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -109,8 +109,8 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 						  int cmd_fd)
 {
 	struct ocrdma_devctx *ctx;
-	struct ocrdma_get_context cmd;
-	struct ocrdma_alloc_ucontext_resp resp;
+	struct uocrdma_get_context cmd;
+	struct uocrdma_alloc_ucontext_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_OCRDMA);

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -110,7 +110,7 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 {
 	struct ocrdma_devctx *ctx;
 	struct uocrdma_get_context cmd;
-	struct uocrdma_alloc_ucontext_resp resp;
+	struct uocrdma_get_context_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_OCRDMA);

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -133,7 +133,7 @@ static void ocrdma_free_ah_tbl_id(struct ocrdma_devctx *ctx, int idx)
  */
 struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 {
-	struct uocrdma_alloc_pd_req cmd;
+	struct uocrdma_alloc_pd cmd;
 	struct uocrdma_alloc_pd_resp resp;
 	struct ocrdma_pd *pd;
 	uint64_t map_address = 0;
@@ -144,8 +144,8 @@ struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 	bzero(pd, sizeof *pd);
 	memset(&cmd, 0, sizeof(cmd));
 
-	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.cmd, sizeof cmd,
-			     &resp.ibv_resp, sizeof resp)) {
+	if (ibv_cmd_alloc_pd(context, &pd->ibv_pd, &cmd.ibv_cmd, sizeof(cmd),
+			     &resp.ibv_resp, sizeof(resp))) {
 		free(pd);
 		return NULL;
 	}
@@ -230,7 +230,7 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 					      int comp_vector, int dpp_cq)
 {
 	int status;
-	struct uocrdma_create_cq_req cmd;
+	struct uocrdma_create_cq cmd;
 	struct uocrdma_create_cq_resp resp;
 	struct ocrdma_cq *cq;
 	struct ocrdma_device *dev = get_ocrdma_dev(context->device);
@@ -252,10 +252,10 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 	cq->dev = dev;
 	cq->cq_id = resp.cq_id;
 	cq->cq_dbid = resp.cq_id;
-	cq->cq_mem_size = resp.size;
+	cq->cq_mem_size = resp.page_size;
 	cq->max_hw_cqe = resp.max_hw_cqe;
 	cq->phase_change = resp.phase_change;
-	cq->va = mmap(NULL, resp.size, PROT_READ | PROT_WRITE,
+	cq->va = mmap(NULL, resp.page_size, PROT_READ | PROT_WRITE,
 		      MAP_SHARED, context->cmd_fd, resp.page_addr[0]);
 	if (cq->va == MAP_FAILED)
 		goto cq_err2;
@@ -354,7 +354,7 @@ struct ibv_srq *ocrdma_create_srq(struct ibv_pd *pd,
 {
 	int status = 0;
 	struct ocrdma_srq *srq;
-	struct uocrdma_create_srq_cmd cmd;
+	struct uocrdma_create_srq cmd;
 	struct uocrdma_create_srq_resp resp;
 	void *map_addr;
 
@@ -464,8 +464,8 @@ struct ibv_qp *ocrdma_create_qp(struct ibv_pd *pd,
 				struct ibv_qp_init_attr *attrs)
 {
 	int status = 0;
-	struct uocrdma_create_qp_cmd cmd;
-	struct uocrdma_create_qp_uresp resp;
+	struct uocrdma_create_qp cmd;
+	struct uocrdma_create_qp_resp resp;
 	struct ocrdma_qp *qp;
 	void *map_addr;
 #ifdef DPP_CQ_SUPPORT

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -133,8 +133,8 @@ static void ocrdma_free_ah_tbl_id(struct ocrdma_devctx *ctx, int idx)
  */
 struct ibv_pd *ocrdma_alloc_pd(struct ibv_context *context)
 {
-	struct ocrdma_alloc_pd_req cmd;
-	struct ocrdma_alloc_pd_resp resp;
+	struct uocrdma_alloc_pd_req cmd;
+	struct uocrdma_alloc_pd_resp resp;
 	struct ocrdma_pd *pd;
 	uint64_t map_address = 0;
 
@@ -191,7 +191,7 @@ struct ibv_mr *ocrdma_reg_mr(struct ibv_pd *pd, void *addr,
 {
 	struct ocrdma_mr *mr;
 	struct ibv_reg_mr cmd;
-	struct ocrdma_reg_mr_resp resp;
+	struct uocrdma_reg_mr_resp resp;
 	uint64_t hca_va = (uintptr_t) addr;
 
 	mr = malloc(sizeof *mr);
@@ -230,8 +230,8 @@ static struct ibv_cq *ocrdma_create_cq_common(struct ibv_context *context,
 					      int comp_vector, int dpp_cq)
 {
 	int status;
-	struct ocrdma_create_cq_req cmd;
-	struct ocrdma_create_cq_resp resp;
+	struct uocrdma_create_cq_req cmd;
+	struct uocrdma_create_cq_resp resp;
 	struct ocrdma_cq *cq;
 	struct ocrdma_device *dev = get_ocrdma_dev(context->device);
 	void *map_addr;
@@ -354,8 +354,8 @@ struct ibv_srq *ocrdma_create_srq(struct ibv_pd *pd,
 {
 	int status = 0;
 	struct ocrdma_srq *srq;
-	struct ocrdma_create_srq_cmd cmd;
-	struct ocrdma_create_srq_resp resp;
+	struct uocrdma_create_srq_cmd cmd;
+	struct uocrdma_create_srq_resp resp;
 	void *map_addr;
 
 	srq = calloc(1, sizeof *srq);
@@ -464,8 +464,8 @@ struct ibv_qp *ocrdma_create_qp(struct ibv_pd *pd,
 				struct ibv_qp_init_attr *attrs)
 {
 	int status = 0;
-	struct ocrdma_create_qp_cmd cmd;
-	struct ocrdma_create_qp_uresp resp;
+	struct uocrdma_create_qp_cmd cmd;
+	struct uocrdma_create_qp_uresp resp;
 	struct ocrdma_qp *qp;
 	void *map_addr;
 #ifdef DPP_CQ_SUPPORT

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -910,8 +910,13 @@ static struct verbs_device *rxe_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 
 static const struct verbs_device_ops rxe_dev_ops = {
 	.name = "rxe",
-	.match_min_abi_version = 0,
-	.match_max_abi_version = INT_MAX,
+	/*
+	 * For 64 bit machines ABI version 1 and 2 are the same. Otherwise 32
+	 * bit machines require ABI version 2 which guarentees the user and
+	 * kernel use the same ABI.
+	 */
+	.match_min_abi_version = sizeof(void *) == 8?1:2,
+	.match_max_abi_version = 2,
 	.match_table = hca_table,
 	.alloc_device = rxe_device_alloc,
 	.uninit_device = rxe_uninit_device,


### PR DESCRIPTION
This syncs the rxe headers with the accepted kernel patches and provides the rxe patch to enforce ABI version on 32 bit.

Only the last two patches here are in this series, but the series is based on #315 