### PR TITLE
Device memory support 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,6 +276,26 @@ CHECK_C_SOURCE_COMPILES("
 RDMA_DoFixup("${HAVE_GLIBC_UAPI_COMPAT}" "linux/in.h")
 RDMA_DoFixup("${HAVE_GLIBC_UAPI_COMPAT}" "linux/in6.h")
 
+# Check if off_t is 64 bits, eg large file support is enabled
+CHECK_C_SOURCE_COMPILES("
+#include <sys/types.h>
+ #define BUILD_ASSERT_OR_ZERO(cond) (sizeof(char [1 - 2*!(cond)]) - 1)
+ int main(int argc,const char *argv[]) { return BUILD_ASSERT_OR_ZERO(sizeof(off_t) >= 8); }"
+  HAVE_LARGE_FILES)
+
+if (NOT HAVE_LARGE_FILES)
+  CHECK_C_SOURCE_COMPILES("
+#define _FILE_OFFSET_BITS 64
+#include <sys/types.h>
+ #define BUILD_ASSERT_OR_ZERO(cond) (sizeof(char [1 - 2*!(cond)]) - 1)
+ int main(int argc,const char *argv[]) { return BUILD_ASSERT_OR_ZERO(sizeof(off_t) >= 8); }"
+    HAVE_LARGE_FILES2)
+  if (NOT HAVE_LARGE_FILES2)
+    message(FATAL_ERROR "Could not enable large file support")
+  endif()
+  add_definitions("-D_FILE_OFFSET_BITS=64")
+endif()
+
 # Provide a shim if C11 stdatomic.h is not supported.
 if (NOT HAVE_SPARSE)
   CHECK_INCLUDE_FILE("stdatomic.h" HAVE_STDATOMIC)

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -13,6 +13,7 @@ publish_internal_headers(rdma
   rdma/mlx4-abi.h
   rdma/mlx5-abi.h
   rdma/mlx5_user_ioctl_cmds.h
+  rdma/mlx5_user_ioctl_verbs.h
   rdma/mthca-abi.h
   rdma/nes-abi.h
   rdma/ocrdma-abi.h

--- a/kernel-headers/rdma/ib_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/ib_user_ioctl_cmds.h
@@ -54,6 +54,7 @@ enum uverbs_default_objects {
 	UVERBS_OBJECT_RWQ_IND_TBL,
 	UVERBS_OBJECT_WQ,
 	UVERBS_OBJECT_FLOW_ACTION,
+	UVERBS_OBJECT_DM,
 };
 
 enum {
@@ -98,6 +99,36 @@ enum uverbs_methods_actions_flow_action_ops {
 	UVERBS_METHOD_FLOW_ACTION_ESP_CREATE,
 	UVERBS_METHOD_FLOW_ACTION_DESTROY,
 	UVERBS_METHOD_FLOW_ACTION_ESP_MODIFY,
+};
+
+enum uverbs_attrs_alloc_dm_cmd_attr_ids {
+	UVERBS_ATTR_ALLOC_DM_HANDLE,
+	UVERBS_ATTR_ALLOC_DM_LENGTH,
+	UVERBS_ATTR_ALLOC_DM_ALIGNMENT,
+};
+
+enum uverbs_attrs_free_dm_cmd_attr_ids {
+	UVERBS_ATTR_FREE_DM_HANDLE,
+};
+
+enum uverbs_methods_dm {
+	UVERBS_METHOD_DM_ALLOC,
+	UVERBS_METHOD_DM_FREE,
+};
+
+enum uverbs_attrs_reg_dm_mr_cmd_attr_ids {
+	UVERBS_ATTR_REG_DM_MR_HANDLE,
+	UVERBS_ATTR_REG_DM_MR_OFFSET,
+	UVERBS_ATTR_REG_DM_MR_LENGTH,
+	UVERBS_ATTR_REG_DM_MR_PD_HANDLE,
+	UVERBS_ATTR_REG_DM_MR_ACCESS_FLAGS,
+	UVERBS_ATTR_REG_DM_MR_DM_HANDLE,
+	UVERBS_ATTR_REG_DM_MR_RESP_LKEY,
+	UVERBS_ATTR_REG_DM_MR_RESP_RKEY,
+};
+
+enum uverbs_methods_mr {
+	UVERBS_METHOD_DM_MR_REG,
 };
 
 #endif

--- a/kernel-headers/rdma/ib_user_verbs.h
+++ b/kernel-headers/rdma/ib_user_verbs.h
@@ -268,6 +268,7 @@ struct ib_uverbs_ex_query_device_resp {
 	__u32 raw_packet_caps;
 	struct ib_uverbs_tm_caps tm_caps;
 	struct ib_uverbs_cq_moderation_caps cq_moderation_caps;
+	__aligned_u64 max_dm_size;
 };
 
 struct ib_uverbs_query_port {

--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -107,6 +107,14 @@ enum mlx5_user_inline_mode {
 	MLX5_USER_INLINE_MODE_TCP_UDP,
 };
 
+enum {
+	MLX5_USER_ALLOC_UCONTEXT_FLOW_ACTION_FLAGS_ESP_AES_GCM = 1 << 0,
+	MLX5_USER_ALLOC_UCONTEXT_FLOW_ACTION_FLAGS_ESP_AES_GCM_REQ_METADATA = 1 << 1,
+	MLX5_USER_ALLOC_UCONTEXT_FLOW_ACTION_FLAGS_ESP_AES_GCM_SPI_STEERING = 1 << 2,
+	MLX5_USER_ALLOC_UCONTEXT_FLOW_ACTION_FLAGS_ESP_AES_GCM_FULL_OFFLOAD = 1 << 3,
+	MLX5_USER_ALLOC_UCONTEXT_FLOW_ACTION_FLAGS_ESP_AES_GCM_TX_IV_IS_ESN = 1 << 4,
+};
+
 struct mlx5_ib_alloc_ucontext_resp {
 	__u32	qp_tab_size;
 	__u32	bf_reg_size;
@@ -319,6 +327,7 @@ enum mlx5_rx_hash_fields {
 	MLX5_RX_HASH_DST_PORT_TCP	= 1 << 5,
 	MLX5_RX_HASH_SRC_PORT_UDP	= 1 << 6,
 	MLX5_RX_HASH_DST_PORT_UDP	= 1 << 7,
+	MLX5_RX_HASH_IPSEC_SPI		= 1 << 8,
 	/* Save bits for future fields */
 	MLX5_RX_HASH_INNER		= (1UL << 31),
 };
@@ -421,6 +430,7 @@ enum mlx5_ib_mmap_cmd {
 	MLX5_IB_MMAP_CORE_CLOCK                 = 5,
 	MLX5_IB_MMAP_ALLOC_WC                   = 6,
 	MLX5_IB_MMAP_CLOCK_INFO                 = 7,
+	MLX5_IB_MMAP_DEVICE_MEM                 = 8,
 };
 
 enum {

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Mellanox Technologies inc.  All rights reserved.
+ * Copyright (c) 2018, Mellanox Technologies inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU
@@ -40,5 +40,9 @@ enum mlx5_ib_create_flow_action_attrs {
 	MLX5_IB_ATTR_CREATE_FLOW_ACTION_FLAGS = (1U << UVERBS_ID_NS_SHIFT),
 };
 
-#endif
+enum mlx5_ib_alloc_dm_attrs {
+	MLX5_IB_ATTR_ALLOC_DM_RESP_START_OFFSET = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_ATTR_ALLOC_DM_RESP_PAGE_INDEX,
+};
 
+#endif

--- a/kernel-headers/rdma/mlx5_user_ioctl_verbs.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_verbs.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Mellanox Technologies inc.  All rights reserved.
+ * Copyright (c) 2018, Mellanox Technologies inc.  All rights reserved.
  *
  * This software is available to you under a choice of one of two
  * licenses.  You may choose to be licensed under the terms of the GNU

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -30,6 +30,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   1 1.1.${PACKAGE_VERSION}
   cmd.c
   cmd_cq.c
+  cmd_dm.c
   cmd_fallback.c
   cmd_flow_action.c
   cmd_ioctl.c

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -262,6 +262,15 @@ int ibv_cmd_query_device_ex(struct ibv_context *context,
 		}
 	}
 
+	if (attr_size >= offsetof(struct ibv_device_attr_ex, max_dm_size) +
+			sizeof(attr->max_dm_size)) {
+		if (resp->response_length >=
+		    offsetof(struct ib_uverbs_ex_query_device_resp, max_dm_size) +
+		    sizeof(resp->max_dm_size)) {
+			attr->max_dm_size = resp->max_dm_size;
+		}
+	}
+
 	return 0;
 }
 

--- a/libibverbs/cmd_dm.c
+++ b/libibverbs/cmd_dm.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infiniband/cmd_write.h>
+
+int ibv_cmd_alloc_dm(struct ibv_context *ctx,
+		     const struct ibv_alloc_dm_attr *dm_attr,
+		     struct verbs_dm *dm,
+		     struct ibv_command_buffer *link)
+{
+	DECLARE_COMMAND_BUFFER_LINK(cmdb, UVERBS_OBJECT_DM,
+				    UVERBS_METHOD_DM_ALLOC, 3, link);
+	struct ib_uverbs_attr *handle;
+	int ret;
+
+	handle = fill_attr_out_obj(cmdb, UVERBS_ATTR_ALLOC_DM_HANDLE);
+	fill_attr_in_uint64(cmdb, UVERBS_ATTR_ALLOC_DM_LENGTH,
+			    dm_attr->length);
+	fill_attr_in_uint32(cmdb, UVERBS_ATTR_ALLOC_DM_ALIGNMENT,
+			    dm_attr->log_align_req);
+
+	ret = execute_ioctl(ctx, cmdb);
+	if (ret)
+		return errno;
+
+	dm->handle = read_attr_obj(UVERBS_ATTR_ALLOC_DM_HANDLE, handle);
+	dm->dm.context = ctx;
+
+	return 0;
+}
+
+int ibv_cmd_free_dm(struct verbs_dm *dm)
+{
+	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_DM, UVERBS_METHOD_DM_FREE,
+			       1);
+
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_FREE_DM_HANDLE, dm->handle);
+
+	return execute_ioctl(dm->dm.context, cmdb);
+}
+
+int ibv_cmd_reg_dm_mr(struct ibv_pd *pd, struct verbs_dm *dm,
+		      uint64_t offset, size_t length,
+		      unsigned int access, struct ibv_mr *mr,
+		      struct ibv_command_buffer *link)
+{
+	DECLARE_COMMAND_BUFFER_LINK(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_DM_MR_REG,
+				    8, link);
+	struct ib_uverbs_attr *handle;
+	uint32_t lkey, rkey;
+	int ret;
+
+	/*
+	 * DM MRs are always 0 based since the mmap pointer, if it exists, is
+	 * hidden from the user.
+	 */
+	if (!(access & IBV_ACCESS_ZERO_BASED)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	handle = fill_attr_out_obj(cmdb, UVERBS_ATTR_REG_DM_MR_HANDLE);
+	fill_attr_out_ptr(cmdb, UVERBS_ATTR_REG_DM_MR_RESP_LKEY, &lkey);
+	fill_attr_out_ptr(cmdb, UVERBS_ATTR_REG_DM_MR_RESP_RKEY, &rkey);
+
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_REG_DM_MR_PD_HANDLE, pd->handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_REG_DM_MR_DM_HANDLE, dm->handle);
+	fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_DM_MR_OFFSET, offset);
+	fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_DM_MR_LENGTH, length);
+	fill_attr_in_uint32(cmdb, UVERBS_ATTR_REG_DM_MR_ACCESS_FLAGS, access);
+
+	ret = execute_ioctl(pd->context, cmdb);
+	if (ret)
+		return errno;
+
+	mr->handle = read_attr_obj(UVERBS_ATTR_REG_DM_MR_HANDLE, handle);
+	mr->context = pd->context;
+	mr->lkey = lkey;
+	mr->rkey = rkey;
+	mr->length = length;
+	mr->pd = pd;
+	mr->addr = NULL;
+
+	return 0;
+}

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -33,6 +33,13 @@
 #include "ibverbs.h"
 #include <errno.h>
 
+static struct ibv_dm *alloc_dm(struct ibv_context *context,
+			       struct ibv_alloc_dm_attr *attr)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
 static struct ibv_mw *alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
 {
 	errno = ENOSYS;
@@ -230,6 +237,11 @@ static int detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid,
 	return ENOSYS;
 }
 
+static int free_dm(struct ibv_dm *dm)
+{
+	return ENOSYS;
+}
+
 static int get_srq_num(struct ibv_srq *srq, uint32_t *srq_num)
 {
 	return ENOSYS;
@@ -347,6 +359,14 @@ static int query_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr)
 	return ENOSYS;
 }
 
+static struct ibv_mr *reg_dm_mr(struct ibv_pd *pd, struct ibv_dm *dm,
+				uint64_t dm_offset, size_t length,
+				unsigned int access)
+{
+	errno = ENOSYS;
+	return NULL;
+}
+
 static struct ibv_mr *reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 			     int access)
 {
@@ -383,6 +403,7 @@ static int resize_cq(struct ibv_cq *cq, int cqe)
  * Keep sorted.
  */
 const struct verbs_context_ops verbs_dummy_ops = {
+	alloc_dm,
 	alloc_mw,
 	alloc_parent_domain,
 	alloc_pd,
@@ -416,6 +437,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	destroy_srq,
 	destroy_wq,
 	detach_mcast,
+	free_dm,
 	get_srq_num,
 	modify_cq,
 	modify_flow_action_esp,
@@ -436,6 +458,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	query_qp,
 	query_rt_values,
 	query_srq,
+	reg_dm_mr,
 	reg_mr,
 	req_notify_cq,
 	rereg_mr,
@@ -464,6 +487,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 			(ptr)->iname = ops->name;                              \
 	} while (0)
 
+	SET_OP(vctx, alloc_dm);
 	SET_OP(ctx, alloc_mw);
 	SET_OP(ctx, alloc_pd);
 	SET_OP(vctx, alloc_parent_domain);
@@ -497,6 +521,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_OP(ctx, destroy_srq);
 	SET_OP(vctx, destroy_wq);
 	SET_OP(ctx, detach_mcast);
+	SET_OP(vctx, free_dm);
 	SET_OP(vctx, get_srq_num);
 	SET_OP(vctx, modify_cq);
 	SET_OP(vctx, modify_flow_action_esp);
@@ -517,6 +542,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_OP(ctx, query_qp);
 	SET_OP(vctx, query_rt_values);
 	SET_OP(ctx, query_srq);
+	SET_OP(vctx, reg_dm_mr);
 	SET_OP(ctx, reg_mr);
 	SET_OP(ctx, req_notify_cq);
 	SET_OP(ctx, rereg_mr);

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -552,6 +552,10 @@ static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)
 		print_packet_pacing_caps(&device_attr.packet_pacing_caps);
 		print_tm_caps(&device_attr.tm_caps);
 		print_cq_moderation_caps(&device_attr.cq_mod_caps);
+
+		if (device_attr.max_dm_size)
+			printf("\tmaximum available device memory:\t%" PRIu64"Bytes\n\n",
+			      device_attr.max_dm_size);
 	}
 
 	for (port = 1; port <= device_attr.orig_attr.phys_port_cnt; ++port) {

--- a/libibverbs/examples/rc_pingpong.c
+++ b/libibverbs/examples/rc_pingpong.c
@@ -376,14 +376,14 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
 
 		if (ibv_query_device_ex(ctx->context, NULL, &attrx)) {
 			fprintf(stderr, "Couldn't query device for its features\n");
-			goto clean_comp_channel;
+			goto clean_pd;
 		}
 
 		if (use_odp) {
 			if (!(attrx.odp_caps.general_caps & IBV_ODP_SUPPORT) ||
 			    (attrx.odp_caps.per_transport_caps.rc_odp_caps & rc_caps_mask) != rc_caps_mask) {
 				fprintf(stderr, "The device isn't ODP capable or does not support RC send and receive with ODP\n");
-				goto clean_comp_channel;
+				goto clean_pd;
 			}
 			access_flags |= IBV_ACCESS_ON_DEMAND;
 		}
@@ -391,7 +391,7 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
 		if (use_ts) {
 			if (!attrx.completion_timestamp_mask) {
 				fprintf(stderr, "The device isn't completion timestamp capable\n");
-				goto clean_comp_channel;
+				goto clean_pd;
 			}
 			ctx->completion_timestamp_mask = attrx.completion_timestamp_mask;
 		}

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -115,6 +115,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		/* These historical symbols are now private to libibverbs */
 		__ioctl_final_num_attrs;
 		_verbs_init_and_alloc_context;
+		ibv_cmd_alloc_dm;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;
 		ibv_cmd_attach_mcast;
@@ -143,6 +144,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_destroy_srq;
 		ibv_cmd_destroy_wq;
 		ibv_cmd_detach_mcast;
+		ibv_cmd_free_dm;
 		ibv_cmd_get_context;
 		ibv_cmd_modify_flow_action_esp;
 		ibv_cmd_modify_qp;
@@ -160,6 +162,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_query_port;
 		ibv_cmd_query_qp;
 		ibv_cmd_query_srq;
+		ibv_cmd_reg_dm_mr;
 		ibv_cmd_reg_mr;
 		ibv_cmd_req_notify_cq;
 		ibv_cmd_rereg_mr;

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,4 +1,5 @@
 rdma_man_pages(
+  ibv_alloc_dm.3
   ibv_alloc_mw.3
   ibv_alloc_parent_domain.3
   ibv_alloc_pd.3
@@ -64,6 +65,10 @@ rdma_man_pages(
   ibv_xsrq_pingpong.1
   )
 rdma_alias_man_pages(
+  ibv_alloc_dm.3 ibv_free_dm.3
+  ibv_alloc_dm.3 ibv_reg_dm_mr.3
+  ibv_alloc_dm.3 ibv_memcpy_to_dm.3
+  ibv_alloc_dm.3 ibv_memcpy_from_dm.3
   ibv_alloc_mw.3 ibv_dealloc_mw.3
   ibv_alloc_pd.3 ibv_dealloc_pd.3
   ibv_alloc_td.3 ibv_dealloc_td.3

--- a/libibverbs/man/ibv_alloc_dm.3
+++ b/libibverbs/man/ibv_alloc_dm.3
@@ -1,0 +1,116 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH IBV_ALLOC_DM 3 2017-07-25 libibverbs "Libibverbs Programmer's Manual"
+.SH "NAME"
+ibv_alloc_dm, ibv_free_dm, ibv_memcpy_to/from_dm \- allocate or free a device memory buffer (DMs) and perform memory copy to or
+from it
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/verbs.h>
+.sp
+.BI "struct ibv_dm *ibv_alloc_dm(struct ibv_context " "*context",
+.BI "                            struct ibv_alloc_dm_attr " "*attr");
+.sp
+.BI "int ibv_free_dm(struct ibv_dm " "*dm");
+.fi
+.SH "DESCRIPTION"
+.B ibv_alloc_dm()
+allocates a device memory buffer for the RDMA device context
+.I context\fR.
+The argument
+.I attr
+is a pointer to an ibv_alloc_dm_attr struct, as defined in <infiniband/verbs.h>.
+.PP
+.B ibv_free_dm()
+free the device memory buffer
+.I dm\fR.
+.PP
+.nf
+struct ibv_alloc_dm_attr {
+.in +8
+size_t length;			/* Length of desired device memory buffer */
+uint32_t log_align_req;		/* Log base 2 of address alignment requirement */
+uint32_t comp_mask;		/* Compatibility mask that defines which of the following variables are valid */
+.in -8
+};
+
+Address alignment may be required in cases where RDMA atomic operations will be performed using the device memory.
+.PP
+In such cases, the user may specify the device memory start address alignment using the log_align_req parameter
+.PP
+in the allocation attributes struct.
+.PP
+.SH "Accessing an allocated device memory"
+.nf
+In order to perform a write/read memory access to an allocated device memory, a user could use the ibv_memcpy_to_dm
+and ibv_memcpy_from_dm calls respectively.
+.sp
+.BI "int ibv_memcpy_to_dm(struct ibv_dm " "*dm" ", uint64_t " "dm_offset",
+.BI "                     void " "*host_addr" ", size_t " "length" ");
+.sp
+.BI "int ibv_memcpy_from_dm(void " "*host_addr" ", struct ibv_dm " "*dm" ",
+.BI "			    uint64_t " "dm_offset" ", size_t " "length" ");
+.sp
+.I dm_offest
+is the byte offset from the beginning of the allocated device memory buffer to access.
+.sp
+.I host_addr
+is the host memory buffer address to access.
+.sp
+.I length
+is the copy length in bytes.
+.sp
+.fi
+.SH "Device memory registration"
+.nf
+User may register the allocated device memory as a memory region and use the lkey/rkey inside sge when posting receive
+or sending work request. This type of MR is defined as zero based and therefore any reference to it (specifically in sge)
+is done with a byte offset from the beginning of the region.
+.sp
+This type of registration is done using ibv_reg_dm_mr.
+.sp
+.BI "int ibv_reg_dm_mr(struct ibv_pd " "*pd" ", struct ibv_dm " "*dm" ", uint64_t " "dm_offset",
+.BI "                  size_t " "length" ", uint32_t " "access");
+.sp
+.I pd
+the associated pd for this registration.
+.sp
+.I dm
+the associated dm for this registartion.
+.sp
+.I dm_offest
+is the byte offset from the beginning of the allocated device memory buffer to register.
+.sp
+.I length
+the memory length to register.
+.sp
+.I access
+mr access flags (Use enum ibv_access_flags). For this type of registration, user must set the IBV_ACCESS_ZERO_BASED
+flag.
+
+.SH "RETURN VALUE"
+.B ibv_alloc_dm()
+returns a pointer to an ibv_dm struct or NULL if the request fails.
+.PP
+.B ibv_free_dm()
+returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+.PP
+.B ibv_reg_dm_mr()
+returns a pointer to an ibv_mr struct on success or NULL if request fails.
+.PP
+.B ibv_memcpy_to_dm()/ibv_memcpy_from_dm()
+returns 0 on success or the failure reason value on failure.
+.SH "NOTES"
+.B ibv_alloc_dm()
+may fail if device has no more free device memory left, where the maximum amount of allocated memory is provided by the
+.I max_dm_size\fR attribute in
+.I ibv_device_attr_ex\fR struct.
+.B ibv_free_dm()
+may fail if any other resources (such as an MR) is still associated with the DM being
+freed.
+.SH "SEE ALSO"
+.BR ibv_query_device_ex (3),
+.SH "AUTHORS"
+.TP
+Ariel Levkovich <lariel@mellanox.com>

--- a/libibverbs/man/ibv_post_send.3
+++ b/libibverbs/man/ibv_post_send.3
@@ -111,7 +111,8 @@ int                      mw_access_flags; /* Access flags to the MW. Use ibv_acc
 .nf
 struct ibv_sge {
 .in +8
-uint64_t                addr;                   /* Start address of the local memory buffer */
+uint64_t                addr;                   /* Start address of the local memory buffer or number of bytes from the
+                                                   start of the MR for MRs which are IBV_ZERO_BASED */
 uint32_t                length;                 /* Length of the buffer */
 uint32_t                lkey;                   /* Key of the local Memory Region */
 .in -8

--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -35,6 +35,7 @@ struct ibv_packet_pacing_caps packet_pacing_caps; /* Packet pacing capabilities 
 uint32_t               raw_packet_caps;            /* Raw packet capabilities, use enum ibv_raw_packet_caps */
 struct ibv_tm_caps     tm_caps;                    /* Tag matching capabilities */
 struct ibv_cq_moderation_caps  cq_mod_caps;        /* CQ moderation max capabilities */
+uint64_t     	       max_dm_size;		   /* Max Device Memory size (in bytes) available for allocation */
 .in -8
 };
 

--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -36,6 +36,8 @@ describes the desired memory protection attributes; it is either 0 or the bitwis
 .TP
 .B IBV_ACCESS_MW_BIND\fR       Enable Memory Window Binding
 .TP
+.B IBV_ACCESS_ZERO_BASED\fR    Use byte offset from beginning of MR to access this MR, instead of a pointer address
+.TP
 .B IBV_ACCESS_ON_DEMAND\fR    Create an on-demand paging MR
 .PP
 If

--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -596,7 +596,7 @@ static int ibv_madvise_range(void *base, size_t size, int advice)
 	int ret = 0;
 	unsigned long range_page_size;
 
-	if (!size)
+	if (!size || !base)
 		return 0;
 
 	if (huge_page_enabled)

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -134,6 +134,21 @@ enum ibv_atomic_cap {
 	IBV_ATOMIC_GLOB
 };
 
+struct ibv_alloc_dm_attr {
+	size_t length;
+	uint32_t log_align_req;
+	uint32_t comp_mask;
+};
+
+struct ibv_dm {
+	struct ibv_context *context;
+	int (*memcpy_to_dm)(struct ibv_dm *dm, uint64_t dm_offset,
+			    const void *host_addr, size_t length);
+	int (*memcpy_from_dm)(void *host_addr, struct ibv_dm *dm,
+			      uint64_t dm_offset, size_t length);
+	uint32_t comp_mask;
+};
+
 struct ibv_device_attr {
 	char			fw_ver[64];
 	__be64			node_guid;
@@ -1715,6 +1730,12 @@ struct ibv_values_ex {
 
 struct verbs_context {
 	/*  "grows up" - new fields go here */
+	struct ibv_mr *(*reg_dm_mr)(struct ibv_pd *pd, struct ibv_dm *dm,
+				    uint64_t dm_offset, size_t length,
+				    unsigned int access);
+	struct ibv_dm *(*alloc_dm)(struct ibv_context *context,
+				   struct ibv_alloc_dm_attr *attr);
+	int (*free_dm)(struct ibv_dm *dm);
 	int (*modify_flow_action_esp)(struct ibv_flow_action *action,
 				      struct ibv_flow_action_esp_attr *attr);
 	int (*destroy_flow_action)(struct ibv_flow_action *action);
@@ -2064,6 +2085,84 @@ struct ibv_comp_channel *ibv_create_comp_channel(struct ibv_context *context);
  * ibv_destroy_comp_channel - Destroy a completion event channel
  */
 int ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
+
+/**
+ * ibv_alloc_dm - Allocate device memory
+ * @context - Context DM will be attached to
+ * @attr - Attributes to allocate the DM with
+ */
+static inline
+struct ibv_dm *ibv_alloc_dm(struct ibv_context *context,
+			    struct ibv_alloc_dm_attr *attr)
+{
+	struct verbs_context *vctx = verbs_get_ctx_op(context, alloc_dm);
+
+	if (!vctx) {
+		errno = ENOSYS;
+		return NULL;
+	}
+
+	return vctx->alloc_dm(context, attr);
+}
+
+/**
+ * ibv_free_dm - Free device allocated memory
+ * @dm - The DM to free
+ */
+static inline
+int ibv_free_dm(struct ibv_dm *dm)
+{
+	struct verbs_context *vctx = verbs_get_ctx_op(dm->context, free_dm);
+
+	if (!vctx)
+		return ENOSYS;
+
+	return vctx->free_dm(dm);
+}
+
+/**
+ * ibv_memcpy_to/from_dm - copy to/from device allocated memory
+ * @dm - The DM to copy to/from
+ * @dm_offset - Offset in bytes from beginning of DM to start copy to/form
+ * @host_addr - Host memory address to copy to/from
+ * @length - Number of bytes to copy
+ */
+static inline
+int ibv_memcpy_to_dm(struct ibv_dm *dm, uint64_t dm_offset,
+		     const void *host_addr, size_t length)
+{
+	return dm->memcpy_to_dm(dm, dm_offset, host_addr, length);
+}
+
+static inline
+int ibv_memcpy_from_dm(void *host_addr, struct ibv_dm *dm,
+		       uint64_t dm_offset, size_t length)
+{
+	return dm->memcpy_from_dm(host_addr, dm, dm_offset, length);
+}
+
+/**
+ * ibv_reg_dm_mr - Register device memory as a memory region
+ * @pd - The PD to associated this MR with
+ * @dm - The DM to register
+ * @dm_offset - Offset in bytes from beginning of DM to start registration from
+ * @length - Number of bytes to register
+ * @access - memory region access flags
+ */
+static inline
+struct ibv_mr *ibv_reg_dm_mr(struct ibv_pd *pd, struct ibv_dm *dm,
+			     uint64_t dm_offset,
+			     size_t length, unsigned int access)
+{
+	struct verbs_context *vctx = verbs_get_ctx_op(pd->context, reg_dm_mr);
+
+	if (!vctx) {
+		errno = ENOSYS;
+		return NULL;
+	}
+
+	return vctx->reg_dm_mr(pd, dm, dm_offset, length, access);
+}
 
 /**
  * ibv_create_cq - Create a completion queue

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -292,6 +292,7 @@ struct ibv_device_attr_ex {
 	uint32_t		raw_packet_caps; /* Use ibv_raw_packet_caps */
 	struct ibv_tm_caps	tm_caps;
 	struct ibv_cq_moderation_caps  cq_mod_caps;
+	uint64_t max_dm_size;
 };
 
 enum ibv_mtu {

--- a/providers/mlx5/man/mlx5dv_init_obj.3
+++ b/providers/mlx5/man/mlx5dv_init_obj.3
@@ -79,6 +79,14 @@ uint64_t        comp_mask;
 .in -8
 };
 
+struct mlx5dv_dm {
+.in +8
+void		*buf;
+uint64_t	length;
+uint64_t	comp_mask;
+.in -8
+};
+
 struct mlx5dv_obj {
 .in +8
 struct {
@@ -105,6 +113,12 @@ struct ibv_wq           *in;
 struct mlx5dv_rwq       *out;
 .in -8
 } rwq;
+struct {
+.in +8
+struct ibv_dm		*in;
+struct mlx5dv_dm	*out;
+.in -8
+} dm;
 .in -8
 };
 
@@ -114,6 +128,7 @@ MLX5DV_OBJ_QP   = 1 << 0,
 MLX5DV_OBJ_CQ   = 1 << 1,
 MLX5DV_OBJ_SRQ  = 1 << 2,
 MLX5DV_OBJ_RWQ  = 1 << 3,
+MLX5DV_OBJ_DM   = 1 << 4,
 .in -8
 };
 .fi

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -813,6 +813,18 @@ static int mlx5dv_get_srq(struct ibv_srq *srq_in,
 	return 0;
 }
 
+static int mlx5dv_get_dm(struct ibv_dm *dm_in,
+			  struct mlx5dv_dm *dm_out)
+{
+	struct mlx5_dm *mdm = to_mdm(dm_in);
+
+	dm_out->comp_mask = 0;
+	dm_out->buf       = mdm->start_va;
+	dm_out->length    = mdm->length;
+
+	return 0;
+}
+
 LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		   int,
 		   struct mlx5dv_obj *obj, uint64_t obj_type)
@@ -827,6 +839,8 @@ LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		ret = mlx5dv_get_srq(obj->srq.in, obj->srq.out);
 	if (!ret && (obj_type & MLX5DV_OBJ_RWQ))
 		ret = mlx5dv_get_rwq(obj->rwq.in, obj->rwq.out);
+	if (!ret && (obj_type & MLX5DV_OBJ_DM))
+		ret = mlx5dv_get_dm(obj->dm.in, obj->dm.out);
 
 	return ret;
 }

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -46,6 +46,7 @@
 
 #include "mlx5.h"
 #include "mlx5-abi.h"
+#include "wqe.h"
 
 #ifndef PCI_VENDOR_ID_MELLANOX
 #define PCI_VENDOR_ID_MELLANOX			0x15b3
@@ -1065,6 +1066,12 @@ static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
 	context->cmds_supp_uhw = resp.cmds_supp_uhw;
 	context->vendor_cap_flags = 0;
 	context->start_dyn_bfregs_index = gross_uuars;
+
+	if (resp.eth_min_inline)
+		context->eth_min_inline_size = (resp.eth_min_inline == MLX5_USER_INLINE_MODE_NONE) ?
+						0 : MLX5_ETH_L2_INLINE_HEADER_SIZE;
+	else
+		context->eth_min_inline_size = MLX5_ETH_L2_INLINE_HEADER_SIZE;
 
 	pthread_mutex_init(&context->qp_table_mutex, NULL);
 	pthread_mutex_init(&context->srq_table_mutex, NULL);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -114,6 +114,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.attach_mcast  = mlx5_attach_mcast,
 	.detach_mcast  = mlx5_detach_mcast,
 
+	.alloc_dm = mlx5_alloc_dm,
 	.alloc_parent_domain = mlx5_alloc_parent_domain,
 	.alloc_td = mlx5_alloc_td,
 	.close_xrcd = mlx5_close_xrcd,
@@ -129,6 +130,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.destroy_flow_action = mlx5_destroy_flow_action,
 	.destroy_rwq_ind_table = mlx5_destroy_rwq_ind_table,
 	.destroy_wq = mlx5_destroy_wq,
+	.free_dm = mlx5_free_dm,
 	.get_srq_num = mlx5_get_srq_num,
 	.modify_cq = mlx5_modify_cq,
 	.modify_flow_action_esp = mlx5_modify_flow_action_esp,
@@ -138,6 +140,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.post_srq_ops = mlx5_post_srq_ops,
 	.query_device_ex = mlx5_query_device_ex,
 	.query_rt_values = mlx5_query_rt_values,
+	.reg_dm_mr = mlx5_reg_dm_mr,
 };
 
 static const struct verbs_context_ops mlx5_ctx_cqev1_ops = {
@@ -912,8 +915,6 @@ int mlx5dv_set_context_attr(struct ibv_context *ibv_ctx,
 	return 0;
 }
 
-typedef _Atomic(uint32_t) atomic_uint32_t;
-
 int mlx5dv_get_clock_info(struct ibv_context *ctx_in,
 			  struct mlx5dv_clock_info *clock_info)
 {
@@ -1149,6 +1150,7 @@ static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
 			device_attr.orig_attr.device_cap_flags;
 		context->atomic_cap = device_attr.orig_attr.atomic_cap;
 		context->cached_tso_caps = device_attr.tso_caps;
+		context->max_dm_size = device_attr.max_dm_size;
 	}
 
 	for (j = 0; j < min(MLX5_MAX_PORTS_NUM, context->num_ports); ++j) {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -50,6 +50,7 @@
 
 #define PFX		"mlx5: "
 
+typedef _Atomic(uint32_t) atomic_uint32_t;
 
 enum {
 	MLX5_IB_MMAP_CMD_SHIFT	= 8,
@@ -298,6 +299,7 @@ struct mlx5_context {
 	uint32_t			*count_dyn_bfregs;
 	uint32_t			start_dyn_bfregs_index;
 	uint16_t			flow_action_flags;
+	uint64_t			max_dm_size;
 };
 
 struct mlx5_bitmap {
@@ -474,6 +476,13 @@ struct mlx5_bf {
 	uint32_t			bfreg_dyn_index;
 };
 
+struct mlx5_dm {
+	struct verbs_dm			verbs_dm;
+	size_t				length;
+	void			       *mmap_va;
+	void			       *start_va;
+};
+
 struct mlx5_mr {
 	struct ibv_mr			ibv_mr;
 	struct mlx5_buf			buf;
@@ -624,6 +633,11 @@ static inline struct mlx5_qp *to_mqp(struct ibv_qp *ibqp)
 static inline struct mlx5_rwq *to_mrwq(struct ibv_wq *ibwq)
 {
 	return container_of(ibwq, struct mlx5_rwq, wq);
+}
+
+static inline struct mlx5_dm *to_mdm(struct ibv_dm *ibdm)
+{
+	return container_of(ibdm, struct mlx5_dm, verbs_dm.dm);
 }
 
 static inline struct mlx5_mr *to_mmr(struct ibv_mr *ibmr)
@@ -807,6 +821,13 @@ struct ibv_flow_action *mlx5_create_flow_action_esp(struct ibv_context *ctx,
 int mlx5_destroy_flow_action(struct ibv_flow_action *action);
 int mlx5_modify_flow_action_esp(struct ibv_flow_action *action,
 				struct ibv_flow_action_esp_attr *attr);
+
+struct ibv_dm *mlx5_alloc_dm(struct ibv_context *context,
+			     struct ibv_alloc_dm_attr *dm_attr);
+int mlx5_free_dm(struct ibv_dm *ibdm);
+struct ibv_mr *mlx5_reg_dm_mr(struct ibv_pd *pd, struct ibv_dm *ibdm,
+			      uint64_t dm_offset, size_t length,
+			      unsigned int acc);
 
 struct ibv_td *mlx5_alloc_td(struct ibv_context *context, struct ibv_td_init_attr *init_attr);
 int mlx5_dealloc_td(struct ibv_td *td);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -300,6 +300,7 @@ struct mlx5_context {
 	uint32_t			start_dyn_bfregs_index;
 	uint16_t			flow_action_flags;
 	uint64_t			max_dm_size;
+	uint32_t                        eth_min_inline_size;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -257,6 +257,12 @@ struct mlx5dv_rwq {
 	uint64_t	comp_mask;
 };
 
+struct mlx5dv_dm {
+	void		*buf;
+	uint64_t	length;
+	uint64_t	comp_mask;
+};
+
 struct mlx5dv_obj {
 	struct {
 		struct ibv_qp		*in;
@@ -274,6 +280,10 @@ struct mlx5dv_obj {
 		struct ibv_wq		*in;
 		struct mlx5dv_rwq	*out;
 	} rwq;
+	struct {
+		struct ibv_dm		*in;
+		struct mlx5dv_dm	*out;
+	} dm;
 };
 
 enum mlx5dv_obj_type {
@@ -281,6 +291,7 @@ enum mlx5dv_obj_type {
 	MLX5DV_OBJ_CQ	= 1 << 1,
 	MLX5DV_OBJ_SRQ	= 1 << 2,
 	MLX5DV_OBJ_RWQ	= 1 << 3,
+	MLX5DV_OBJ_DM	= 1 << 4,
 };
 
 enum mlx5dv_wq_init_attr_mask {

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -383,7 +383,7 @@ static inline int copy_eth_inline_headers(struct ibv_qp *ibqp,
 					  struct mlx5_wqe_eth_seg *eseg,
 					  struct mlx5_sg_copy_ptr *sg_copy_ptr)
 {
-	uint32_t inl_hdr_size = MLX5_ETH_L2_INLINE_HEADER_SIZE;
+	uint32_t inl_hdr_size = to_mctx(ibqp->context)->eth_min_inline_size;
 	int inl_hdr_copy_size = 0;
 	int j = 0;
 	FILE *fp = to_mctx(ibqp->context)->dbg_fp;
@@ -395,29 +395,31 @@ static inline int copy_eth_inline_headers(struct ibv_qp *ibqp,
 	}
 
 	if (likely(wr->sg_list[0].length >= MLX5_ETH_L2_INLINE_HEADER_SIZE)) {
-		inl_hdr_copy_size = MLX5_ETH_L2_INLINE_HEADER_SIZE;
+		inl_hdr_copy_size = inl_hdr_size;
 		memcpy(eseg->inline_hdr_start,
 		       (void *)(uintptr_t)wr->sg_list[0].addr,
 		       inl_hdr_copy_size);
 	} else {
-		for (j = 0; j < wr->num_sge && inl_hdr_size > 0; ++j) {
+		uint32_t inl_hdr_size_left = inl_hdr_size;
+
+		for (j = 0; j < wr->num_sge && inl_hdr_size_left > 0; ++j) {
 			inl_hdr_copy_size = min(wr->sg_list[j].length,
-						inl_hdr_size);
+						inl_hdr_size_left);
 			memcpy(eseg->inline_hdr_start +
-			       (MLX5_ETH_L2_INLINE_HEADER_SIZE - inl_hdr_size),
+			       (MLX5_ETH_L2_INLINE_HEADER_SIZE - inl_hdr_size_left),
 			       (void *)(uintptr_t)wr->sg_list[j].addr,
 			       inl_hdr_copy_size);
-			inl_hdr_size -= inl_hdr_copy_size;
+			inl_hdr_size_left -= inl_hdr_copy_size;
 		}
-		if (unlikely(inl_hdr_size)) {
+		if (unlikely(inl_hdr_size_left)) {
 			mlx5_dbg(fp, MLX5_DBG_QP_SEND, "Ethernet headers < 16 bytes\n");
 			return EINVAL;
 		}
-		--j;
+		if (j)
+			--j;
 	}
 
-
-	eseg->inline_hdr_sz = htobe16(MLX5_ETH_L2_INLINE_HEADER_SIZE);
+	eseg->inline_hdr_sz = htobe16(inl_hdr_size);
 
 	/* If we copied all the sge into the inline-headers, then we need to
 	 * start copying from the next sge into the data-segment.
@@ -972,7 +974,19 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 					*bad_wr = wr;
 					goto out;
 				}
+
+				/* For TSO WR we always copy at least MLX5_ETH_L2_MIN_HEADER_SIZE
+				 * bytes of inline header which is included in struct mlx5_wqe_eth_seg.
+				 * If additional bytes are copied, 'seg' and 'size' are adjusted
+				 * inside set_tso_eth_seg().
+				 */
+
+				seg += sizeof(struct mlx5_wqe_eth_seg);
+				size += sizeof(struct mlx5_wqe_eth_seg) / 16;
 			} else {
+				uint32_t inl_hdr_size =
+					to_mctx(ibqp->context)->eth_min_inline_size;
+
 				err = copy_eth_inline_headers(ibqp, wr, seg, &sg_copy_ptr);
 				if (unlikely(err)) {
 					*bad_wr = wr;
@@ -981,10 +995,18 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 						 err);
 					goto out;
 				}
-			}
 
-			seg += sizeof(struct mlx5_wqe_eth_seg);
-			size += sizeof(struct mlx5_wqe_eth_seg) / 16;
+				/* The eth segment size depends on the device's min inline
+				 * header requirement which can be 0 or 18. The basic eth segment
+				 * always includes room for first 2 inline header bytes (even if
+				 * copy size is 0) so the additional seg size is adjusted accordingly.
+				 */
+
+				seg += (offsetof(struct mlx5_wqe_eth_seg, inline_hdr) +
+						inl_hdr_size) & ~0xf;
+				size += (offsetof(struct mlx5_wqe_eth_seg, inline_hdr) +
+						inl_hdr_size) >> 4;
+			}
 			break;
 
 		default:


### PR DESCRIPTION
Many types of user space applications can get a real performance gain by
using the internal memory of an IB device.

This series is the supplementary part of the kernel series that was sent to rdma-next and enables user space applications to alloc and use directly the device memory.

This PR is on top of the IPSEC/ESP PR that is pending to be merged as it touches few shared places.