### PR TITLE
mlx5: Fix bug in disabling lock on extended CQ

### DIFF
--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -634,6 +634,10 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 		return NULL;
 	}
 
+	if (cq_attr->comp_mask & IBV_CQ_INIT_ATTR_MASK_FLAGS &&
+	    cq_attr->flags & IBV_CREATE_CQ_ATTR_SINGLE_THREADED)
+		cq->flags |= MLX5_CQ_FLAGS_SINGLE_THREADED;
+
 	if (cq_alloc_flags & MLX5_CQ_FLAGS_EXTENDED) {
 		rc = mlx5_cq_fill_pfns(cq, cq_attr, mctx);
 		if (rc) {
@@ -679,9 +683,6 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	cq->cqe_sz			= cqe_sz;
 	cq->flags			= cq_alloc_flags;
 
-	if (cq_attr->comp_mask & IBV_CQ_INIT_ATTR_MASK_FLAGS &&
-	    cq_attr->flags & IBV_CREATE_CQ_ATTR_SINGLE_THREADED)
-		cq->flags |= MLX5_CQ_FLAGS_SINGLE_THREADED;
 	cmd.buf_addr = (uintptr_t) cq->buf_a.buf;
 	cmd.db_addr  = (uintptr_t) cq->dbrec;
 	cmd.cqe_size = cqe_sz;


### PR DESCRIPTION
Currently, the lock on an extended CQ is still taken even if the user
sets the IBV_CREATE_CQ_ATTR_SINGLE_THREADED flag. This is because the
MLX5_CQ_FLAGS_SINGLE_THREADED flag is not set before mlx5_cq_fill_pfns.

This patch sets the MLX5_CQ_FLAGS_SINGLE_THREADED flag after allocating
the extended CQ and before calling mlx5_cq_fill_pfns, allowing correct
control on the lock in mlx5_start_poll and mlx5_end_poll.

