### PR TITLE
mlx5: new mini-CQE format

### DIFF
--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -163,7 +163,7 @@ struct mlx5_ib_rss_caps {
 enum mlx5_ib_cqe_comp_res_format {
 	MLX5_IB_CQE_RES_FORMAT_HASH	= 1 << 0,
 	MLX5_IB_CQE_RES_FORMAT_CSUM	= 1 << 1,
-	MLX5_IB_CQE_RES_RESERVED	= 1 << 2,
+	MLX5_IB_CQE_RES_FORMAT_CSUM_STRIDX = 1 << 2,
 };
 
 struct mlx5_ib_cqe_comp_caps {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -483,7 +483,7 @@ enum {
 enum mlx5dv_cqe_comp_res_format {
 	MLX5DV_CQE_RES_FORMAT_HASH		= 1 << 0,
 	MLX5DV_CQE_RES_FORMAT_CSUM		= 1 << 1,
-	MLX5DV_CQE_RES_FORMAT_RESERVED		= 1 << 2,
+	MLX5DV_CQE_RES_FORMAT_CSUM_STRIDX       = 1 << 2,
 };
 
 enum mlx5dv_sw_parsing_offloads {


### PR DESCRIPTION
Introduce a new mlx5 mini-CQE format in the DV API, the matching kernel part was already sent into rdma-next for 4.18.