### PR TITLE
ibacm: Option "acme_plus_kernel_only" is ignored if controlled by "--…

### DIFF
--- a/ibacm/ibacm.socket
+++ b/ibacm/ibacm.socket
@@ -1,3 +1,21 @@
+# Please copy this file to /etc/systemd/system/ibacm.socket
+# before modification, if not done already.
+#
+# When using socket-based activation of the 'ibacm' service
+# ibacm's configuration option 'acme_plus_kernel_only' is ignored
+# (i.e. an implicit 'acme_plus_kernel_only no')
+#
+# In order to get the equivalent behavior of
+# configuration 'acme_plus_kernel_only yes'
+# Please add a comment (i.e. a '#' character) in front
+# of the line 'Symlinks' below, and ensure that file
+# file '/run/ibacm.sock' does not exist:
+# e.g. by using "rm -f /run/ibacm.sock" after modifying
+# the copy of this file that lives in /etc/systemd/system.
+#
+# Please also remember to reload the systemd configuration by running:
+# % systemctl --system daemon-reload
+
 [Unit]
 Description=Socket for InfiniBand Address Cache Manager Daemon
 Documentation=man:ibacm
@@ -7,7 +25,8 @@ Before=rdma-hw.target
 # ibacm.socket always starts
 
 [Socket]
-ListenStream=/run/ibacm.sock
+ListenStream=/run/ibacm-unix.sock
+Symlinks=/run/ibacm.sock
 
 # Bind to PF_NETLINK, NETLINK_RDMA, RDMA_NL_GROUP_LS
 # Supported in systemd > 234

--- a/ibacm/src/acme.c
+++ b/ibacm/src/acme.c
@@ -217,6 +217,10 @@ static void gen_opts_temp(FILE *f)
 	fprintf(f, "# If set to 'true', 'yes' or a non-zero number\n");
 	fprintf(f, "# ibacm will only serve requests originating\n");
 	fprintf(f, "# from the kernel or the ib_acme utility.\n");
+	fprintf(f, "# Please note that this option is ignored if the ibacm\n");
+	fprintf(f, "# service is started on demand by systemd,\n");
+	fprintf(f, "# in which case this option is treated\n");
+	fprintf(f, "# as if it were set to 'no'\n");
 	fprintf(f, "\n");
 #if IBACM_ACME_PLUS_KERNEL_ONLY_DEFAULT
 	fprintf(f, "acme_plus_kernel_only yes\n");


### PR DESCRIPTION
…systemd"

Commit "95df9ed596" introduced an option "acme_plus_kernel_only",
that made a distinction between communcation with
* "ib_acme" via socket "/run/ibacm-unix.sock"
* "librdmacm" via symlink "/run/ibacm.sock".

Since systemd does not parse "ibacm_opts.cfg" (nor should it),
simply ignore this option if "ibacm" is controlled by "systemd":
Assume that option is set to "no".

Also make that fact known to the generated comments of "ibacm_opts.cfg"

Signed-off-by: Gerd Rausch <gerd.rausch@oracle.com>