### PR TITLE
Fix SSE support for older GCC     

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,8 @@ if (NOT HAVE_SPARSE)
   RDMA_DoFixup("${HAVE_STDATOMIC}" "stdatomic.h")
 endif()
 
+RDMA_Check_SSE(HAVE_TARGET_SSE)
+
 # Enable development support features
 # Prune unneeded shared libraries during linking
 RDMA_AddOptLDFlag(CMAKE_EXE_LINKER_FLAGS SUPPORTS_AS_NEEDED "-Wl,--as-needed")
@@ -640,4 +642,7 @@ if (NOT HAVE_C_WREDUNDANT_DECLS)
 endif()
 if (NOT HAVE_GLIBC_UAPI_COMPAT)
   message(STATUS " libc netinet/in.h and linux/in.h do NOT coexist")
+endif()
+if (NOT HAVE_TARGET_SSE)
+  message(STATUS " attribute(target(\"sse\")) does NOT work")
 endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -16,6 +16,7 @@ if (HAVE_COHERENT_DMA)
   set(C_FILES ${C_FILES}
     mmio.c
     )
+  set_source_files_properties(mmio.c PROPERTIES COMPILE_FLAGS "${SSE_FLAGS}")
 endif()
 
 add_library(rdma_util STATIC ${C_FILES})


### PR DESCRIPTION
On older GCC versions (at least on v4.8), SSE is not enabled by default for x86.
This causes rdma-core compilation to fail on util/mmio.c as it uses SSE functions.
    
This series adds a CMake helper that enables -msse if available and
adds a HAVE_SSE_EXTENSIONS flags.
mmio.c was also tweaked to support compiler without SSE.