### PR TITLE
verbs: Allow creation of inner MPLS flow spec

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1774,6 +1774,7 @@ static int ib_spec_to_kern_spec(struct ibv_flow_spec *ib_spec,
 		       sizeof(struct ibv_flow_gre_filter));
 		break;
 	case IBV_FLOW_SPEC_MPLS:
+	case IBV_FLOW_SPEC_MPLS | IBV_FLOW_SPEC_INNER:
 		kern_spec->mpls.size = sizeof(struct ib_uverbs_flow_spec_mpls);
 		memcpy(&kern_spec->mpls.val, &ib_spec->mpls.val,
 		       sizeof(struct ibv_flow_mpls_filter));

--- a/libibverbs/man/ibv_create_flow.3
+++ b/libibverbs/man/ibv_create_flow.3
@@ -118,6 +118,12 @@ An application can provide the ibv_flow_spec_xxx rules in an un-ordered scheme. 
 defined and match a specific network header layer.
 In some cases, when certain flow spec types are present in the spec list, it is required to provide the list in an
 ordered manner so that the position of that flow spec type in the protocol stack is strictly defined.
+When the certain spec type, which requires the ordering, resides in the inner network protocol stack (in tunnel
+protocols) the ordering should be applied to the inner network specs and should be combined with the inner spec indication using
+the IBV_FLOW_SPEC_INNER flag.
+For example: An MPLS spec which attempts to match an MPLS tag in the inner network should have the
+IBV_FLOW_SPEC_INNER flag set and so do the rest of the inner network specs. On top of that, all the inner network specs should be provided in
+an ordered manner.
 This is essential to represent many of the encapsulation tunnel protocols.
 .br
 


### PR DESCRIPTION
This change allows user to provide an inner MPLS flow specification among the filters list.
The matching kernel code was already accepted into rdma-next for 4.18 as part of the MPLS series.