### PR TITLE
debian: Add ibacm-dev package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rdma-core (18.1-2) unstable; urgency=medium
+
+  * Add ibacm-dev package
+
+ -- Roland Fehrenbacher <rf@q-leap.de>  Fri, 15 Jun 2018 08:36:17 +0000
+
 rdma-core (18.1-1) unstable; urgency=medium
 
   * New upstream bugfix release.

--- a/debian/control
+++ b/debian/control
@@ -42,6 +42,17 @@ Description: RDMA core userspace infrastructure and documentation
     service in userspace for iWARP drivers to claim TCP ports through the
     standard socket interface.
 
+Package: ibacm-dev
+Section: libdevel
+Architecture: linux-any
+Multi-Arch: same
+Depends: ${misc:Depends}
+Breaks: ibacm (<< 18.1-1)
+Replaces: ibacm (<< 18.1-1)
+Description: Development files for the ibacm library
+ This package is needed to compile ibacm providers. It contains just the ibacm
+ header files. The corresponding library is part of the ibacm package.
+
 Package: ibacm
 Architecture: linux-any
 Depends: lsb-base (>= 3.2-14~),

--- a/debian/ibacm-dev.install
+++ b/debian/ibacm-dev.install
@@ -1,0 +1,2 @@
+usr/include/infiniband/acm.h
+usr/include/infiniband/acm_prov.h

--- a/debian/ibacm.install
+++ b/debian/ibacm.install
@@ -2,8 +2,6 @@ etc/init.d/ibacm
 lib/systemd/system/ibacm.service
 lib/systemd/system/ibacm.socket
 usr/bin/ib_acme
-usr/include/infiniband/acm.h
-usr/include/infiniband/acm_prov.h
 usr/lib/*/ibacm/libibacmp.so
 usr/sbin/ibacm
 usr/share/doc/rdma-core/ibacm.md usr/share/doc/ibacm/


### PR DESCRIPTION
Hi Benjamin,

could you please apply this patch, build and upload the new deb to unstable? The new package opa-ff (currently in the NEW queue) needs ibacm-dev a as a build dependency. It would also be nice if you could put the package under the debian-hpc salsa group umbrella.

Thanks,

Roland