### PR TITLE
debian: Add ibacm-dev package

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+rdma-core (18.1-2) unstable; urgency=medium
+
+  * Add ibacm-dev package
+
+ -- Roland Fehrenbacher <rf@q-leap.de>  Fri, 15 Jun 2018 08:36:17 +0000
+
 rdma-core (18.1-1) unstable; urgency=medium
 
   * New upstream bugfix release.


### PR DESCRIPTION
Hi Benjamin,

could you please apply this patch, build and upload the new deb to unstable? The new package opa-ff (currently in the NEW queue) needs ibacm-dev a as a build dependency. It would also be nice if you could put the package under the debian-hpc salsa group umbrella.

Thanks,

Roland