### PR TITLE
verbs: Fix number of attributes allocated in read command buffer

### DIFF
--- a/libibverbs/cmd_counters.c
+++ b/libibverbs/cmd_counters.c
@@ -78,7 +78,7 @@ int ibv_cmd_read_counters(struct verbs_counters *vcounters,
 {
 	DECLARE_COMMAND_BUFFER_LINK(cmd, UVERBS_OBJECT_COUNTERS,
 				    UVERBS_METHOD_COUNTERS_READ,
-				    4,
+				    3,
 				    link);
 
 	if (!is_attr_size_valid(ncounters, sizeof(uint64_t)))


### PR DESCRIPTION
The read counters verb uses 3 attributes and not 4, fix the number of
allocated attributes by the macro DECLARE_COMMAND_BUFFER to avoid
allocation of unnecessary memory.