### PR TITLE
mlx5 flow steering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(PACKAGE_NAME "RDMA")
 set(PACKAGE_VERSION "20.0")
 # When this is changed the values in these files need changing too:
 #   debian/libibverbs1.symbols
-set(IBVERBS_PABI_VERSION "19")
+set(IBVERBS_PABI_VERSION "20")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/control
+++ b/debian/control
@@ -149,7 +149,7 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ibverbs-providers
-Breaks: ibverbs-providers (<< 19~)
+Breaks: ibverbs-providers (<< 20~)
 Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -11,6 +11,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.3@MLX5_1.3 16
  MLX5_1.4@MLX5_1.4 17
  MLX5_1.5@MLX5_1.5 18
+ MLX5_1.6@MLX5_1.6 20
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -20,3 +21,5 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_create_wq@MLX5_1.3 16
  mlx5dv_get_clock_info@MLX5_1.4 17
  mlx5dv_create_flow_action_esp@MLX5_1.5 18
+ mlx5dv_create_flow_matcher@MLX5_1.6 20
+ mlx5dv_destroy_flow_matcher@MLX5_1.6 20

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -23,3 +23,4 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_create_flow_action_esp@MLX5_1.5 18
  mlx5dv_create_flow_matcher@MLX5_1.6 20
  mlx5dv_destroy_flow_matcher@MLX5_1.6 20
+ mlx5dv_create_flow@MLX5_1.6 20

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -1,7 +1,7 @@
 libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
- (symver)IBVERBS_PRIVATE_19 19
+ (symver)IBVERBS_PRIVATE_20 20
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6

--- a/kernel-headers/rdma/ib_user_ioctl_verbs.h
+++ b/kernel-headers/rdma/ib_user_ioctl_verbs.h
@@ -40,6 +40,17 @@
 #define RDMA_UAPI_PTR(_type, _name)	__aligned_u64 _name
 #endif
 
+enum ib_uverbs_access_flags {
+	IB_UVERBS_ACCESS_LOCAL_WRITE = 1 << 0,
+	IB_UVERBS_ACCESS_REMOTE_WRITE = 1 << 1,
+	IB_UVERBS_ACCESS_REMOTE_READ = 1 << 2,
+	IB_UVERBS_ACCESS_REMOTE_ATOMIC = 1 << 3,
+	IB_UVERBS_ACCESS_MW_BIND = 1 << 4,
+	IB_UVERBS_ACCESS_ZERO_BASED = 1 << 5,
+	IB_UVERBS_ACCESS_ON_DEMAND = 1 << 6,
+	IB_UVERBS_ACCESS_HUGETLB = 1 << 7,
+};
+
 enum ib_uverbs_query_port_cap_flags {
 	IB_UVERBS_PCF_SM = 1 << 1,
 	IB_UVERBS_PCF_NOTICE_SUP = 1 << 2,
@@ -139,6 +150,11 @@ struct ib_uverbs_flow_action_esp {
 	__u32		tfc_pad;
 	__u32		flags;
 	__aligned_u64	hard_limit_pkts;
+};
+
+enum ib_uverbs_read_counters_flags {
+	/* prefer read values from driver cache */
+	IB_UVERBS_READ_COUNTERS_PREFER_CACHED = 1 << 0,
 };
 
 #endif

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -33,6 +33,7 @@
 #ifndef MLX5_USER_IOCTL_CMDS_H
 #define MLX5_USER_IOCTL_CMDS_H
 
+#include <linux/types.h>
 #include <rdma/ib_user_ioctl_cmds.h>
 
 enum mlx5_ib_create_flow_action_attrs {
@@ -112,10 +113,57 @@ enum mlx5_ib_devx_umem_methods {
 	MLX5_IB_METHOD_DEVX_UMEM_DEREG,
 };
 
-enum mlx5_ib_devx_objects {
+enum mlx5_ib_objects {
 	MLX5_IB_OBJECT_DEVX = (1U << UVERBS_ID_NS_SHIFT),
 	MLX5_IB_OBJECT_DEVX_OBJ,
 	MLX5_IB_OBJECT_DEVX_UMEM,
+	MLX5_IB_OBJECT_FLOW_MATCHER,
+};
+
+enum mlx5_ib_flow_matcher_create_attrs {
+	MLX5_IB_ATTR_FLOW_MATCHER_CREATE_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_ATTR_FLOW_MATCHER_MATCH_MASK,
+	MLX5_IB_ATTR_FLOW_MATCHER_FLOW_TYPE,
+	MLX5_IB_ATTR_FLOW_MATCHER_MATCH_CRITERIA,
+};
+
+enum mlx5_ib_flow_matcher_destroy_attrs {
+	MLX5_IB_ATTR_FLOW_MATCHER_DESTROY_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum mlx5_ib_flow_matcher_methods {
+	MLX5_IB_METHOD_FLOW_MATCHER_CREATE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_METHOD_FLOW_MATCHER_DESTROY,
+};
+
+#define MLX5_IB_DW_MATCH_PARAM 0x80
+
+struct mlx5_ib_match_params {
+	__u32	match_params[MLX5_IB_DW_MATCH_PARAM];
+};
+
+enum mlx5_ib_flow_type {
+	MLX5_IB_FLOW_TYPE_NORMAL,
+	MLX5_IB_FLOW_TYPE_SNIFFER,
+	MLX5_IB_FLOW_TYPE_ALL_DEFAULT,
+	MLX5_IB_FLOW_TYPE_MC_DEFAULT,
+};
+
+enum mlx5_ib_create_flow_attrs {
+	MLX5_IB_ATTR_CREATE_FLOW_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_ATTR_CREATE_FLOW_MATCH_VALUE,
+	MLX5_IB_ATTR_CREATE_FLOW_DEST_QP,
+	MLX5_IB_ATTR_CREATE_FLOW_DEST_DEVX,
+	MLX5_IB_ATTR_CREATE_FLOW_MATCHER,
+};
+
+enum mlx5_ib_destoy_flow_attrs {
+	MLX5_IB_ATTR_DESTROY_FLOW_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum mlx5_ib_flow_methods {
+	MLX5_IB_METHOD_CREATE_FLOW = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_METHOD_DESTROY_FLOW,
 };
 
 #endif

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -115,6 +115,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		/* These historical symbols are now private to libibverbs */
 		__ioctl_final_num_attrs;
 		_verbs_init_and_alloc_context;
+		execute_ioctl;
 		ibv_cmd_alloc_dm;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.5.${PACKAGE_VERSION}
+  1 1.6.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -38,4 +38,5 @@ MLX5_1.6 {
         global:
 		mlx5dv_create_flow_matcher;
 		mlx5dv_destroy_flow_matcher;
+		mlx5dv_create_flow;
 } MLX5_1.5;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -33,3 +33,9 @@ MLX5_1.5 {
 	global:
 		mlx5dv_create_flow_action_esp;
 } MLX5_1.4;
+
+MLX5_1.6 {
+        global:
+		mlx5dv_create_flow_matcher;
+		mlx5dv_destroy_flow_matcher;
+} MLX5_1.5;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -558,6 +558,11 @@ struct mlx5_flow {
 	struct mlx5_counters *mcounters;
 };
 
+struct mlx5dv_flow_matcher {
+	struct ibv_context *context;
+	uint32_t handle;
+};
+
 static inline int mlx5_ilog2(int n)
 {
 	int t;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -216,6 +216,30 @@ mlx5dv_create_flow_matcher(struct ibv_context *context,
 
 int mlx5dv_destroy_flow_matcher(struct mlx5dv_flow_matcher *matcher);
 
+enum mlx5dv_flow_action_type {
+	MLX5DV_FLOW_ACTION_DEST_IBV_QP,
+	MLX5DV_FLOW_ACTION_DROP,
+	MLX5DV_FLOW_ACTION_IBV_COUNTER,
+	MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION,
+	MLX5DV_FLOW_ACTION_TAG,
+};
+
+struct mlx5dv_flow_action_attr {
+	enum mlx5dv_flow_action_type type;
+	union {
+		struct ibv_qp *qp;
+		struct ibv_counters *counter;
+		struct ibv_flow_action *action;
+		uint32_t tag_value;
+	};
+};
+
+struct ibv_flow *
+mlx5dv_create_flow(struct mlx5dv_flow_matcher *matcher,
+		   struct mlx5dv_flow_match_parameters *match_value,
+		   size_t num_actions,
+		   struct mlx5dv_flow_action_attr actions_attr[]);
+
 struct ibv_flow_action *mlx5dv_create_flow_action_esp(struct ibv_context *ctx,
 						      struct ibv_flow_action_esp_attr *esp,
 						      struct mlx5dv_flow_action_esp *mlx5_attr);

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -194,6 +194,28 @@ struct mlx5dv_flow_action_esp {
 	uint32_t action_flags; /* Use enum mlx5dv_flow_action_flags */
 };
 
+struct mlx5dv_flow_match_parameters {
+	size_t match_sz;
+	uint64_t match_buf[]; /* Device spec format */
+};
+
+struct mlx5dv_flow_matcher_attr {
+	enum ibv_flow_attr_type type;
+	uint32_t flags; /* From enum ibv_flow_flags */
+	uint16_t priority;
+	uint8_t match_criteria_enable; /* Device spec format */
+	struct mlx5dv_flow_match_parameters *match_mask;
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_flow_matcher;
+
+struct mlx5dv_flow_matcher *
+mlx5dv_create_flow_matcher(struct ibv_context *context,
+			   struct mlx5dv_flow_matcher_attr *matcher_attr);
+
+int mlx5dv_destroy_flow_matcher(struct mlx5dv_flow_matcher *matcher);
+
 struct ibv_flow_action *mlx5dv_create_flow_action_esp(struct ibv_context *ctx,
 						      struct ibv_flow_action_esp_attr *esp,
 						      struct mlx5dv_flow_action_esp *mlx5_attr);


### PR DESCRIPTION
This series adds support for mlx5 flow steering to match the kernel series that was sent to rdma-next.

It's done in a way that enables the driver to get its specific device attributes in a raw data to match its underlying specification while still using the generic ibv_flow object for cleanup and code sharing.