### PR TITLE
Fix compilation on 32 bit systems when sse3 is on

### DIFF
--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -17,7 +17,7 @@ ninja
 cd ../build32
 # travis's trusty is not configured in a way that enables all 32 bit
 # packages. We could fix this with some sudo stuff.. For now turn off libnl
-CC=gcc-7 CFLAGS="-Werror -m32" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both
+CC=gcc-7 CFLAGS="-Werror -m32 -msse3" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both
 ninja
 
 # aarch64 build to check compilation on ARM 64bit platform

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -786,7 +786,9 @@ void mlx5dv_x86_set_data_seg(struct mlx5_wqe_data_seg *seg,
 			     uint32_t length, uint32_t lkey,
 			     uintptr_t address)
 {
-	__m128i val  = _mm_set_epi32((uint32_t)address, (uint32_t)(address >> 32), lkey, length);
+
+	uint64_t address64 = address;
+	__m128i val  = _mm_set_epi32((uint32_t)address64, (uint32_t)(address64 >> 32), lkey, length);
 	__m128i mask = _mm_set_epi8(12, 13, 14, 15,	/* local address low */
 				     8, 9, 10, 11,	/* local address high */
 				     4, 5, 6, 7,	/* l_key */


### PR DESCRIPTION
This series fixes compilation on 32 bit systems when sse3 is on and turns on a Travis check for that mode.