### PR TITLE
Support rdma write with immediate and write with completion WRs

### DIFF
--- a/kernel-headers/rdma/cxgb4-abi.h
+++ b/kernel-headers/rdma/cxgb4-abi.h
@@ -65,7 +65,8 @@ struct c4iw_create_cq_resp {
 };
 
 enum {
-	C4IW_QPF_ONCHIP = (1 << 0)
+	C4IW_QPF_ONCHIP	= (1 << 0),
+	C4IW_QPF_WRITE_W_IMM = (1 << 1)
 };
 
 struct c4iw_create_qp_resp {

--- a/providers/cxgb4/cq.c
+++ b/providers/cxgb4/cq.c
@@ -764,10 +764,17 @@ static int c4iw_poll_cq_one(struct c4iw_cq *chp, struct ibv_wc *wc)
 			wc->byte_len = CQE_LEN(com);
 		else
 			wc->byte_len = 0;
-		wc->opcode = IBV_WC_RECV;
+		if (CQE_OPCODE(com) == FW_RI_WRITE_IMMEDIATE) {
+			wc->opcode = IBV_WC_RECV_RDMA_WITH_IMM;
+			wc->imm_data = CQE_IMM_DATA(&cqe.b64);
+			wc->wc_flags |= IBV_WC_WITH_IMM;
+		} else {
+			wc->opcode = IBV_WC_RECV;
+		}
 	} else {
 		switch (CQE_OPCODE(com)) {
 		case FW_RI_RDMA_WRITE:
+		case FW_RI_WRITE_IMMEDIATE:
 			wc->opcode = IBV_WC_RDMA_WRITE;
 			break;
 		case FW_RI_READ_REQ:

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -190,6 +190,8 @@ static struct verbs_context *c4iw_alloc_context(struct ibv_device *ibdev,
 		rhp->cqid2ptr = calloc(rhp->max_cq, sizeof(void *));
 		if (!rhp->cqid2ptr)
 			goto err_unmap;
+		rhp->write_cmpl_supported =
+				context->status_page->write_cmpl_supported;
 	}
 
 	return &context->ibv_ctx;

--- a/providers/cxgb4/libcxgb4.h
+++ b/providers/cxgb4/libcxgb4.h
@@ -63,6 +63,7 @@ struct c4iw_dev {
 	pthread_spinlock_t lock;
 	struct list_node list;
 	int abi_version;
+	bool write_cmpl_supported;
 };
 
 static inline int dev_is_t6(struct c4iw_dev *dev)

--- a/providers/cxgb4/t4.h
+++ b/providers/cxgb4/t4.h
@@ -125,6 +125,9 @@ struct t4_status_page {
 #define T4_RQ_NUM_BYTES (T4_EQ_ENTRY_SIZE * T4_RQ_NUM_SLOTS)
 #define T4_MAX_RECV_SGE 4
 
+#define T4_WRITE_CMPL_MAX_SGL 4
+#define T4_WRITE_CMPL_MAX_CQE 16
+
 union t4_wr {
 	struct fw_ri_res_wr res;
 	struct fw_ri_wr init;
@@ -134,6 +137,7 @@ union t4_wr {
 	struct fw_ri_bind_mw_wr bind;
 	struct fw_ri_fr_nsmr_wr fr;
 	struct fw_ri_inv_lstag_wr inv;
+	struct fw_ri_rdma_write_cmpl_wr write_cmpl;
 	struct t4_status_page status;
 	__be64 flits[T4_EQ_ENTRY_SIZE / sizeof(__be64) * T4_SQ_NUM_SLOTS];
 };
@@ -928,7 +932,7 @@ static inline void t4_reset_cq_in_error(struct t4_cq *cq)
 struct t4_dev_status_page 
 {
 	u8 db_off;
-	u8 pad1;
+	u8 write_cmpl_supported;
 	u16 pad2;
 	u32 pad3;
 	u64 qp_start;

--- a/providers/cxgb4/t4.h
+++ b/providers/cxgb4/t4.h
@@ -220,6 +220,10 @@ struct t4_cqe_common {
 			__be32 stag;
 			__be32 msn;
 		} srcqe;
+		struct {
+			__be32 mo;
+			__be32 msn;
+		} imm_data_rcqe;
 		u64 drain_cookie;
 	} u;
 };
@@ -237,6 +241,13 @@ struct t4_cqe_b64 {
 			__be32 reserved;
 			__be32 abs_rqe_idx;
 		} srcqe;
+		union {
+			struct {
+				__be32 imm_data32;
+				u32 reserved;
+			} ib_imm_data;
+			__be64 imm_data64;
+		} imm_data_rcqe;
 		__be64 flits[3];
 	} u;
 	__be64 reserved[2];
@@ -297,6 +308,7 @@ union t4_cqe {
 #define CQE_WRID_STAG(x)  (be32toh((x)->u.rcqe.stag))
 #define CQE_WRID_MSN(x)   (be32toh((x)->u.rcqe.msn))
 #define CQE_ABS_RQE_IDX(x) (be32toh((x)->u.srcqe.abs_rqe_idx))
+#define CQE_IMM_DATA(x)   ((x)->u.imm_data_rcqe.ib_imm_data.imm_data32)
 
 /* used for SQ completion processing */
 #define CQE_WRID_SQ_IDX(x)	(x)->u.scqe.cidx
@@ -345,7 +357,8 @@ struct t4_swsqe {
 };
 
 enum {
-	T4_SQ_ONCHIP = (1<<0),
+	T4_SQ_ONCHIP = (1 << 0),
+	T4_SQ_WRITE_W_IMM = (1 << 1)
 };
 
 struct t4_sq {

--- a/providers/cxgb4/t4fw_api.h
+++ b/providers/cxgb4/t4fw_api.h
@@ -102,6 +102,7 @@ enum fw_wr_opcodes {
 	FW_RI_RECV_WR                  = 0x17,
 	FW_RI_BIND_MW_WR               = 0x18,
 	FW_RI_FR_NSMR_WR               = 0x19,
+	FW_RI_RDMA_WRITE_CMPL_WR       = 0x21,
 	FW_RI_INV_LSTAG_WR             = 0x1a,
 	FW_ISCSI_TX_DATA_WR	       = 0x45,
 	FW_LASTC2E_WR                  = 0x70

--- a/providers/cxgb4/t4fw_ri_api.h
+++ b/providers/cxgb4/t4fw_ri_api.h
@@ -591,6 +591,37 @@ struct fw_ri_send_wr {
 #define FW_RI_SEND_WR_SENDOP_G(x)	\
 	(((x) >> FW_RI_SEND_WR_SENDOP_S) & FW_RI_SEND_WR_SENDOP_M)
 
+struct fw_ri_rdma_write_cmpl_wr {
+	__u8   opcode;
+	__u8   flags;
+	__u16  wrid;
+	__u8   r1[3];
+	__u8   len16;
+	__u8   r2;
+	__u8   flags_send;
+	__u16  wrid_send;
+	__be32 stag_inv;
+	__be32 plen;
+	__be32 stag_sink;
+	__be64 to_sink;
+	union fw_ri_cmpl {
+		struct fw_ri_immd_cmpl {
+			__u8   op;
+			__u8   r1[6];
+			__u8   immdlen;
+			__u8   data[16];
+		} immd_src;
+		struct fw_ri_isgl isgl_src;
+	} u_cmpl;
+	__be64 r3;
+#ifndef C99_NOT_SUPPORTED
+	union fw_ri_write {
+		struct fw_ri_immd immd_src[0];
+		struct fw_ri_isgl isgl_src[0];
+	} u;
+#endif
+};
+
 struct fw_ri_rdma_read_wr {
 	__u8   opcode;
 	__u8   flags;

--- a/providers/cxgb4/t4fw_ri_api.h
+++ b/providers/cxgb4/t4fw_ri_api.h
@@ -50,7 +50,8 @@ enum fw_ri_wr_opcode {
 	FW_RI_BYPASS			= 0xd,
 	FW_RI_RECEIVE			= 0xe,
 
-	FW_RI_SGE_EC_CR_RETURN		= 0xf
+	FW_RI_SGE_EC_CR_RETURN		= 0xf,
+	FW_RI_WRITE_IMMEDIATE		= FW_RI_RDMA_INIT,
 };
 
 enum fw_ri_wr_flags {
@@ -59,7 +60,8 @@ enum fw_ri_wr_flags {
 	FW_RI_SOLICITED_EVENT_FLAG	= 0x04,
 	FW_RI_READ_FENCE_FLAG		= 0x08,
 	FW_RI_LOCAL_FENCE_FLAG		= 0x10,
-	FW_RI_RDMA_READ_INVALIDATE	= 0x20
+	FW_RI_RDMA_READ_INVALIDATE	= 0x20,
+	FW_RI_RDMA_WRITE_WITH_IMMEDIATE = 0x40,
 };
 
 enum fw_ri_mpa_attrs {
@@ -546,7 +548,13 @@ struct fw_ri_rdma_write_wr {
 	__u16  wrid;
 	__u8   r1[3];
 	__u8   len16;
-	__be64 r2;
+	union {
+		struct {
+			__be32 imm_data32;
+			u32 reserved;
+		} ib_imm_data;
+		__be64 imm_data64;
+	} iw_imm_data;
 	__be32 plen;
 	__be32 stag_sink;
 	__be64 to_sink;

--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -561,6 +561,8 @@ static struct ibv_qp *create_qp(struct ibv_pd *pd,
 	qhp->wq.sq.size = resp.sq_size;
 	qhp->wq.sq.memsize = resp.sq_memsize;
 	qhp->wq.sq.flags = resp.flags & C4IW_QPF_ONCHIP ? T4_SQ_ONCHIP : 0;
+	if (resp.flags & C4IW_QPF_WRITE_W_IMM)
+		qhp->wq.sq.flags |= T4_SQ_WRITE_W_IMM;
 	qhp->wq.sq.flush_cidx = -1;
 	qhp->wq.rq.msn = 1;
 	qhp->srq = to_c4iw_srq(attr->srq);


### PR DESCRIPTION
This series adds support for rdma write with immediate and write with completion
 WRs.

These are generated on top of the following iw_cxgb4 submission
#359 #360 

Corresponding kernel submission for this PR is at
https://marc.info/?l=linux-rdma&m=153181311509759&w=2

