### PR TITLE
bugfix, handled harmless warning when bonding is used

### DIFF
--- a/providers/rxe/rxe_cfg.in
+++ b/providers/rxe/rxe_cfg.in
@@ -135,12 +135,14 @@ sub get_dev_info {
 
     my @my_eth_list = ();
     foreach my $my_eth_dev (glob("/sys/class/net/*")) {
-	$my_eth_dev = basename($my_eth_dev);
-        my $my_dev_type = read_file("/sys/class/net/${my_eth_dev}/type");
-	chomp($my_dev_type);
-        if ($my_dev_type == "1") {
-            push(@my_eth_list, "$my_eth_dev");
-        }
+       $my_eth_dev = basename($my_eth_dev);
+          if ($my_eth_dev ne "bonding_masters"){
+             my $my_dev_type = read_file("/sys/class/net/${my_eth_dev}/type");
+             chomp($my_dev_type);
+             if ($my_dev_type == "1") {
+                push(@my_eth_list, "$my_eth_dev");
+             }
+          }
     }
 
     @list = @my_eth_list;


### PR DESCRIPTION
Hi,

rxe_cfg script is throwing a warning error when bonding is configured:
Argument "" isn't numeric in numeric eq (==) at /usr/bin/rxe_cfg line 141.

This seems to happens because mentioned script parse all /sys/class/net/ path expecting there only devices. However when bonding is in use, also the bonding_masters file will be present. This is the output from my RHEL7 test system:
$ uname -r
3.10.0-693.5.2.el7.x86_64
$ rpm -q libibverbs
libibverbs-15-7.el7_5.x86_64

$ ll /sys/class/net/
total 0
lrwxrwxrwx 1 root root    0 Jul 18 10:34 bond0 -> ../../devices/virtual/net/bond0
-rw-r--r-- 1 root root 4096 Jul 18 10:34 bonding_masters
lrwxrwxrwx 1 root root    0 Jul 17 14:16 enp0s10 -> ../../devices/pci0000:00/0000:00:0a.0/net/enp0s10
lrwxrwxrwx 1 root root    0 Jul 17 14:16 enp0s3 -> ../../devices/pci0000:00/0000:00:03.0/net/enp0s3
lrwxrwxrwx 1 root root    0 Jul 17 14:16 enp0s8 -> ../../devices/pci0000:00/0000:00:08.0/net/enp0s8
lrwxrwxrwx 1 root root    0 Jul 17 14:16 enp0s9 -> ../../devices/pci0000:00/0000:00:09.0/net/enp0s9
lrwxrwxrwx 1 root root    0 Jul 17 14:16 lo -> ../../devices/virtual/net/lo
lrwxrwxrwx 1 root root    0 Jul 17 14:17 virbr0 -> ../../devices/virtual/net/virbr0
lrwxrwxrwx 1 root root    0 Jul 17 14:17 virbr0-nic -> ../../devices/virtual/net/virbr0-nic

$ rxe_cfg status                                                  
Argument "" isn't numeric in numeric eq (==) at /usr/bin/rxe_cfg line 141.                
rdma_rxe module not loaded                                                                    
  Name        Link  Driver   Speed  NMTU  IPv4_addr  RDEV  RMTU                          
  bond0       no    bonding                                                                 
  enp0s10     yes   e1000                                                                       
  enp0s3      yes   e1000                                                                                                                  
  enp0s8      no    e1000                                                                                                                                     
  enp0s9      yes   e1000                                                                 
  virbr0      no    bridge                                                            
  virbr0-nic  no    tun 