### PR TITLE
verbs: Fix warning from gcc-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,6 +168,7 @@ RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WMISSING_PROTOTYPES "-Wmissing-prototypes"
 RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WMISSING_DECLARATIONS "-Wmissing-declarations")
 RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WWRITE_STRINGS "-Wwrite-strings")
 RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WFORMAT_2 "-Wformat=2")
+RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WCAST_FUNCTION "-Wcast-function-type")
 
 # At some point after 4.4 gcc fixed shadow to ignore function vs variable
 # conflicts

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -523,7 +523,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	do {                                                                   \
 		if (ops->name) {                                               \
 			priv->ops.name = ops->name;                            \
-			(ptr)->_compat_##name = (void *(*)(void))ops->name;    \
+			(ptr)->_compat_##name = (void *)ops->name;             \
 		}                                                              \
 	} while (0)
 


### PR DESCRIPTION
gcc-8 now warns on the void (*)(void) cast, use the less pedantically
correct (void *) cast instead.

../libibverbs/dummy_ops.c:526:28: warning: cast between incompatible function types from ‘struct ibv_pd * (* const)(struct ibv_context *)’ to ‘void * (*)(void)’ [-Wcast-function-type]
    (ptr)->_compat_##name = (void *(*)(void))ops->name;    \

Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>
Reviewed-by: Bart Van Assche <bart.vanassche@wdc.com>
Signed-off-by: Leon Romanovsky <leon@kernel.org>