### PR TITLE
verbs: Allow destroy after device disassociation

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -45,6 +45,8 @@
 #include "ibverbs.h"
 #include <ccan/minmax.h>
 
+bool verbs_allow_disassociate_destroy;
+
 int ibv_cmd_get_context(struct verbs_context *context_ex,
 			struct ibv_get_context *cmd, size_t cmd_size,
 			struct ib_uverbs_get_context_resp *resp, size_t resp_size)

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -41,6 +41,7 @@
 #include <alloca.h>
 #include <string.h>
 
+#include <infiniband/cmd_write.h>
 #include "ibverbs.h"
 #include <ccan/minmax.h>
 
@@ -334,15 +335,12 @@ int ibv_cmd_alloc_pd(struct ibv_context *context, struct ibv_pd *pd,
 
 int ibv_cmd_dealloc_pd(struct ibv_pd *pd)
 {
-	struct ibv_dealloc_pd cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEALLOC_PD);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, DEALLOC_PD);
-	cmd.pd_handle = pd->handle;
-
-	if (write(pd->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_dealloc_pd) {
+		.pd_handle = pd->handle,
+	};
+	return execute_write(pd->context, req, NULL);
 }
 
 int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
@@ -379,15 +377,12 @@ int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
 
 int ibv_cmd_close_xrcd(struct verbs_xrcd *xrcd)
 {
-	struct ibv_close_xrcd cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_CLOSE_XRCD);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, CLOSE_XRCD);
-	cmd.xrcd_handle = xrcd->handle;
-
-	if (write(xrcd->xrcd.context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_close_xrcd){
+		.xrcd_handle = xrcd->handle,
+	};
+	return execute_write(xrcd->xrcd.context, req, NULL);
 }
 
 int ibv_cmd_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
@@ -450,16 +445,12 @@ int ibv_cmd_rereg_mr(struct verbs_mr *vmr, uint32_t flags, void *addr,
 
 int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
 {
-	struct ibv_dereg_mr cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEREG_MR);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, DEREG_MR);
-	cmd.mr_handle = vmr->ibv_mr.handle;
-
-	if (write(vmr->ibv_mr.context->cmd_fd, &cmd, sizeof(cmd)) !=
-	    sizeof(cmd))
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_dereg_mr){
+		.mr_handle = vmr->ibv_mr.handle,
+	};
+	return execute_write(vmr->ibv_mr.context, req, NULL);
 }
 
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
@@ -486,16 +477,14 @@ int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 	return 0;
 }
 
-int ibv_cmd_dealloc_mw(struct ibv_mw *mw,
-		       struct ibv_dealloc_mw *cmd, size_t cmd_size)
+int ibv_cmd_dealloc_mw(struct ibv_mw *mw)
 {
-	IBV_INIT_CMD(cmd, cmd_size, DEALLOC_MW);
-	cmd->mw_handle = mw->handle;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEALLOC_MW);
 
-	if (write(mw->context->cmd_fd, cmd, cmd_size) != cmd_size)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_dealloc_mw) {
+		.mw_handle = mw->handle,
+	};
+	return execute_write(mw->context, req, NULL);
 }
 
 int ibv_cmd_poll_cq(struct ibv_cq *ibcq, int ne, struct ibv_wc *wc)
@@ -547,16 +536,13 @@ out:
 
 int ibv_cmd_req_notify_cq(struct ibv_cq *ibcq, int solicited_only)
 {
-	struct ibv_req_notify_cq cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_REQ_NOTIFY_CQ);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, REQ_NOTIFY_CQ);
-	cmd.cq_handle = ibcq->handle;
-	cmd.solicited_only = !!solicited_only;
-
-	if (write(ibcq->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_req_notify_cq){
+		.cq_handle = ibcq->handle,
+		.solicited_only = !!solicited_only,
+	};
+	return execute_write(ibcq->context, req, NULL);
 }
 
 int ibv_cmd_resize_cq(struct ibv_cq *cq, int cqe,
@@ -771,17 +757,16 @@ int ibv_cmd_query_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
 
 int ibv_cmd_destroy_srq(struct ibv_srq *srq)
 {
-	struct ibv_destroy_srq      cmd;
-	struct ib_uverbs_destroy_qp_resp resp;
+	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_SRQ);
+	int ret;
 
-	IBV_INIT_CMD_RESP(&cmd, sizeof cmd, DESTROY_SRQ, &resp, sizeof resp);
-	cmd.srq_handle = srq->handle;
-	cmd.reserved   = 0;
+	*req = (struct ib_uverbs_destroy_srq){
+		.srq_handle = srq->handle,
+	};
 
-	if (write(srq->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	(void) VALGRIND_MAKE_MEM_DEFINED(&resp, sizeof resp);
+	ret = execute_write(srq->context, req, &resp);
+	if (ret)
+		return ret;
 
 	pthread_mutex_lock(&srq->mutex);
 	while (srq->events_completed != resp.events_reported)
@@ -1571,30 +1556,26 @@ int ibv_cmd_create_ah(struct ibv_pd *pd, struct ibv_ah *ah,
 
 int ibv_cmd_destroy_ah(struct ibv_ah *ah)
 {
-	struct ibv_destroy_ah cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DESTROY_AH);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, DESTROY_AH);
-	cmd.ah_handle = ah->handle;
-
-	if (write(ah->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_destroy_ah){
+		.ah_handle = ah->handle,
+	};
+	return execute_write(ah->context, req, NULL);
 }
 
 int ibv_cmd_destroy_qp(struct ibv_qp *qp)
 {
-	struct ibv_destroy_qp      cmd;
-	struct ib_uverbs_destroy_qp_resp resp;
+	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_QP);
+	int ret;
 
-	IBV_INIT_CMD_RESP(&cmd, sizeof cmd, DESTROY_QP, &resp, sizeof resp);
-	cmd.qp_handle = qp->handle;
-	cmd.reserved  = 0;
+	*req = (struct ib_uverbs_destroy_qp){
+		.qp_handle = qp->handle,
+	};
 
-	if (write(qp->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	(void) VALGRIND_MAKE_MEM_DEFINED(&resp, sizeof resp);
+	ret = execute_write(qp->context, req, &resp);
+	if (ret)
+		return ret;
 
 	pthread_mutex_lock(&qp->mutex);
 	while (qp->events_completed != resp.events_reported)
@@ -1606,34 +1587,26 @@ int ibv_cmd_destroy_qp(struct ibv_qp *qp)
 
 int ibv_cmd_attach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid)
 {
-	struct ibv_attach_mcast cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_ATTACH_MCAST);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, ATTACH_MCAST);
-	memcpy(cmd.gid, gid->raw, sizeof cmd.gid);
-	cmd.qp_handle = qp->handle;
-	cmd.mlid      = lid;
-	cmd.reserved  = 0;
-
-	if (write(qp->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_attach_mcast){
+		.qp_handle = qp->handle,
+		.mlid = lid,
+	};
+	memcpy(req->gid, gid->raw, sizeof(req->gid));
+	return execute_write(qp->context, req, NULL);
 }
 
 int ibv_cmd_detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid)
 {
-	struct ibv_detach_mcast cmd;
+	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DETACH_MCAST);
 
-	IBV_INIT_CMD(&cmd, sizeof cmd, DETACH_MCAST);
-	memcpy(cmd.gid, gid->raw, sizeof cmd.gid);
-	cmd.qp_handle = qp->handle;
-	cmd.mlid      = lid;
-	cmd.reserved  = 0;
-
-	if (write(qp->context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd)
-		return errno;
-
-	return 0;
+	*req = (struct ib_uverbs_detach_mcast){
+		.qp_handle = qp->handle,
+		.mlid = lid,
+	};
+	memcpy(req->gid, gid->raw, sizeof(req->gid));
+	return execute_write(qp->context, req, NULL);
 }
 
 static int buffer_is_zero(char *addr, ssize_t size)
@@ -1893,16 +1866,12 @@ err:
 
 int ibv_cmd_destroy_flow(struct ibv_flow *flow_id)
 {
-	struct ibv_destroy_flow cmd;
-	int ret = 0;
+	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_FLOW);
 
-	memset(&cmd, 0, sizeof(cmd));
-	IBV_INIT_CMD_EX(&cmd, sizeof(cmd), DESTROY_FLOW);
-	cmd.flow_handle = flow_id->handle;
-
-	if (write(flow_id->context->cmd_fd, &cmd, sizeof(cmd)) != sizeof(cmd))
-		ret = errno;
-	return ret;
+	*req = (struct ib_uverbs_destroy_flow){
+		.flow_handle = flow_id->handle,
+	};
+	return execute_write_ex(flow_id->context, req);
 }
 
 int ibv_cmd_create_wq(struct ibv_context *context,
@@ -1997,18 +1966,16 @@ int ibv_cmd_modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *attr,
 
 int ibv_cmd_destroy_wq(struct ibv_wq *wq)
 {
-	struct ibv_destroy_wq cmd;
-	struct ib_uverbs_ex_destroy_wq_resp resp;
-	int ret = 0;
+	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_WQ);
+	int ret;
 
-	memset(&cmd, 0, sizeof(cmd));
-	memset(&resp, 0, sizeof(resp));
+	*req = (struct ib_uverbs_ex_destroy_wq){
+		.wq_handle = wq->handle,
+	};
 
-	IBV_INIT_CMD_RESP_EX(&cmd, sizeof(cmd), DESTROY_WQ, &resp, sizeof(resp));
-	cmd.wq_handle = wq->handle;
-
-	if (write(wq->context->cmd_fd, &cmd, sizeof(cmd)) != sizeof(cmd))
-		return errno;
+	ret = execute_write_ex(wq->context, req);
+	if (ret)
+		return ret;
 
 	if (resp.response_length < sizeof(resp))
 		return EINVAL;
@@ -2018,7 +1985,7 @@ int ibv_cmd_destroy_wq(struct ibv_wq *wq)
 		pthread_cond_wait(&wq->cond, &wq->mutex);
 	pthread_mutex_unlock(&wq->mutex);
 
-	return ret;
+	return 0;
 }
 
 int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
@@ -2076,17 +2043,12 @@ int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
 
 int ibv_cmd_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
 {
-	struct ibv_destroy_rwq_ind_table cmd;
-	int ret = 0;
+	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL);
 
-	memset(&cmd, 0, sizeof(cmd));
-	IBV_INIT_CMD_EX(&cmd, sizeof(cmd), DESTROY_RWQ_IND_TBL);
-	cmd.ind_tbl_handle = rwq_ind_table->ind_tbl_handle;
-
-	if (write(rwq_ind_table->context->cmd_fd, &cmd, sizeof(cmd)) != sizeof(cmd))
-		ret = errno;
-
-	return ret;
+	*req = (struct ib_uverbs_ex_destroy_rwq_ind_table){
+		.ind_tbl_handle = rwq_ind_table->ind_tbl_handle,
+	};
+	return execute_write_ex(rwq_ind_table->context, req);
 }
 
 

--- a/libibverbs/cmd_counters.c
+++ b/libibverbs/cmd_counters.c
@@ -33,6 +33,7 @@
 #include <infiniband/cmd_ioctl.h>
 #include <rdma/ib_user_ioctl_cmds.h>
 #include <infiniband/driver.h>
+#include <infiniband/cmd_write.h>
 
 int ibv_cmd_create_counters(struct ibv_context *context,
 			    struct ibv_counters_init_attr *init_attr,
@@ -65,9 +66,14 @@ int ibv_cmd_destroy_counters(struct verbs_counters *vcounters)
 	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_COUNTERS,
 			       UVERBS_METHOD_COUNTERS_DESTROY,
 			       1);
+	int ret;
 
 	fill_attr_in_obj(cmd, UVERBS_ATTR_DESTROY_COUNTERS_HANDLE, vcounters->handle);
-	return execute_ioctl(vcounters->counters.context, cmd);
+	ret = execute_ioctl(vcounters->counters.context, cmd);
+	if (verbs_is_destroy_err(&ret))
+		return ret;
+
+	return 0;
 }
 
 int ibv_cmd_read_counters(struct verbs_counters *vcounters,

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -60,7 +60,7 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 
 	switch (execute_ioctl_fallback(cq->context, create_cq, cmdb, &ret)) {
 	case TRY_WRITE: {
-		DECLARE_LEGACY_UHW_BUFS(link, create_cq);
+		DECLARE_LEGACY_UHW_BUFS(link, IB_USER_VERBS_CMD_CREATE_CQ);
 
 		*req = (struct ib_uverbs_create_cq){
 			.user_handle = (uintptr_t)cq,
@@ -69,8 +69,7 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			.comp_channel = channel ? channel->fd : -1,
 		};
 
-		ret = execute_write_bufs(IB_USER_VERBS_CMD_CREATE_CQ,
-					 cq->context, req, resp);
+		ret = execute_write_bufs(cq->context, req, resp);
 		if (ret)
 			return ret;
 
@@ -80,7 +79,8 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 		return 0;
 	}
 	case TRY_WRITE_EX: {
-		DECLARE_LEGACY_UHW_BUFS_EX(link, create_cq);
+		DECLARE_LEGACY_UHW_BUFS_EX(link,
+					   IB_USER_VERBS_EX_CMD_CREATE_CQ);
 
 		*req = (struct ib_uverbs_ex_create_cq){
 			.user_handle = (uintptr_t)cq,
@@ -90,8 +90,7 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			.flags = flags,
 		};
 
-		ret = execute_write_bufs_ex(IB_USER_VERBS_EX_CMD_CREATE_CQ,
-					    cq->context, req, resp);
+		ret = execute_write_bufs_ex(cq->context, req);
 		if (ret)
 			return ret;
 
@@ -152,7 +151,7 @@ int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 {
 	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_DESTROY, 2,
 			     NULL);
-	DECLARE_LEGACY_CORE_BUFS(destroy_cq);
+	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_CQ);
 	int ret;
 
 	fill_attr_out_ptr(cmdb, UVERBS_ATTR_DESTROY_CQ_RESP, &resp);
@@ -164,8 +163,7 @@ int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 			.cq_handle = cq->handle,
 		};
 
-		ret = execute_write(IB_USER_VERBS_CMD_DESTROY_CQ, cq->context,
-				    req, &resp);
+		ret = execute_write(cq->context, req, &resp);
 		break;
 	}
 

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -171,7 +171,7 @@ int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 		break;
 	}
 
-	if (ret)
+	if (verbs_is_destroy_err(&ret))
 		return ret;
 
 	pthread_mutex_lock(&cq->mutex);

--- a/libibverbs/cmd_dm.c
+++ b/libibverbs/cmd_dm.c
@@ -62,10 +62,15 @@ int ibv_cmd_free_dm(struct verbs_dm *dm)
 {
 	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_DM, UVERBS_METHOD_DM_FREE,
 			       1);
+	int ret;
 
 	fill_attr_in_obj(cmdb, UVERBS_ATTR_FREE_DM_HANDLE, dm->handle);
 
-	return execute_ioctl(dm->dm.context, cmdb);
+	ret = execute_ioctl(dm->dm.context, cmdb);
+	if (verbs_is_destroy_err(&ret))
+		return ret;
+
+	return 0;
 }
 
 int ibv_cmd_reg_dm_mr(struct ibv_pd *pd, struct verbs_dm *dm,

--- a/libibverbs/cmd_flow_action.c
+++ b/libibverbs/cmd_flow_action.c
@@ -33,6 +33,7 @@
 #include <infiniband/cmd_ioctl.h>
 #include <rdma/ib_user_ioctl_cmds.h>
 #include <infiniband/driver.h>
+#include <infiniband/cmd_write.h>
 
 static void scrub_esp_encap(struct ibv_flow_action_esp_encap *esp_encap)
 {
@@ -120,9 +121,14 @@ int ibv_cmd_destroy_flow_action(struct verbs_flow_action *action)
 {
 	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_FLOW_ACTION,
 			       UVERBS_METHOD_FLOW_ACTION_DESTROY, 1);
+	int ret;
 
 	fill_attr_in_obj(cmd, UVERBS_ATTR_DESTROY_FLOW_ACTION_HANDLE,
 			 action->handle);
-	return execute_ioctl(action->action.context, cmd);
+	ret = execute_ioctl(action->action.context, cmd);
+	if (verbs_is_destroy_err(&ret))
+		return ret;
+
+	return 0;
 }
 

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -291,4 +291,21 @@ _execute_write_only(struct ibv_context *context, struct ibv_command_buffer *cmd,
 
 #endif
 
+extern bool verbs_allow_disassociate_destroy;
+
+/*
+ * Return true if 'ret' indicates that a destroy operation has failed
+ * and the function should exit. If the kernel destroy failure is being
+ * ignored then this will set ret to 0, so the calling function appears to succeed.
+ */
+static inline bool verbs_is_destroy_err(int *ret)
+{
+	if (*ret == EIO && verbs_allow_disassociate_destroy) {
+		*ret = 0;
+		return true;
+	}
+
+	return *ret != 0;
+}
+
 #endif

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -435,8 +435,7 @@ int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,
 		     struct ib_uverbs_alloc_mw_resp *resp, size_t resp_size);
-int ibv_cmd_dealloc_mw(struct ibv_mw *mw,
-		       struct ibv_dealloc_mw *cmd, size_t cmd_size);
+int ibv_cmd_dealloc_mw(struct ibv_mw *mw);
 int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 		      struct ibv_comp_channel *channel,
 		      int comp_vector, struct ibv_cq *cq,

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -699,12 +699,18 @@ out:
 int ibverbs_init(void)
 {
 	const char *sysfs_path;
+	char *env_value;
 	int ret;
 
 	if (getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
 		if (ibv_fork_init())
 			fprintf(stderr, PFX "Warning: fork()-safety requested "
 				"but init failed\n");
+
+	/* Backward compatibility for the mlx4 driver env */
+	env_value = getenv("MLX4_DEVICE_FATAL_CLEANUP");
+	if (env_value)
+		verbs_allow_disassociate_destroy = strcmp(env_value, "0") != 0;
 
 	if (getenv("RDMAV_ALLOW_DISASSOC_DESTROY"))
 		verbs_allow_disassociate_destroy = true;

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -50,6 +50,7 @@
 
 #include <util/util.h>
 #include "ibverbs.h"
+#include <infiniband/cmd_write.h>
 
 int abi_ver;
 
@@ -704,6 +705,9 @@ int ibverbs_init(void)
 		if (ibv_fork_init())
 			fprintf(stderr, PFX "Warning: fork()-safety requested "
 				"but init failed\n");
+
+	if (getenv("RDMAV_ALLOW_DISASSOC_DESTROY"))
+		verbs_allow_disassociate_destroy = true;
 
 	sysfs_path = ibv_get_sysfs_path();
 	if (!sysfs_path)

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -177,6 +177,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_resize_cq;
 		ibv_query_gid_type;
 		ibv_register_driver;
+		verbs_allow_disassociate_destroy;
 		verbs_register_driver_@IBVERBS_PABI_VERSION@;
 		verbs_set_ops;
 		verbs_uninit_context;

--- a/libibverbs/man/ibv_open_device.3
+++ b/libibverbs/man/ibv_open_device.3
@@ -33,6 +33,14 @@ does not release all the resources allocated using context
 .I context\fR.
 To avoid resource leaks, the user should release all associated
 resources before closing a context.
+
+Setting the environment variable **RDMAV_ALLOW_DISASSOC_DESTROY** tells the
+library to relate an EIO from destroy commands as a success as the kernel
+resources were already released. This comes to prevent memory leakage in the
+user space area upon device disassociation. Applications using this flag cannot
+call ibv_get_cq_event or ibv_get_async_event concurrently with any call to an
+object destruction function.
+
 .SH "SEE ALSO"
 .BR ibv_get_device_list (3),
 .BR ibv_query_device (3),

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -43,8 +43,6 @@
 #include "mlx4.h"
 #include "mlx4-abi.h"
 
-int mlx4_cleanup_upon_device_fatal = 0;
-
 #ifndef PCI_VENDOR_ID_MELLANOX
 #define PCI_VENDOR_ID_MELLANOX			0x15b3
 #endif
@@ -133,15 +131,6 @@ static const struct verbs_context_ops mlx4_ctx_ops = {
 	.query_rt_values = mlx4_query_rt_values,
 };
 
-static void mlx4_read_env(void)
-{
-	char *env_value;
-
-	env_value = getenv("MLX4_DEVICE_FATAL_CLEANUP");
-	if (env_value)
-		mlx4_cleanup_upon_device_fatal = (strcmp(env_value, "0")) ? 1 : 0;
-}
-
 static int mlx4_map_internal_clock(struct mlx4_device *mdev,
 				   struct ibv_context *ibv_ctx)
 {
@@ -184,7 +173,6 @@ static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
 
 	verbs_ctx = &context->ibv_ctx;
 
-	mlx4_read_env();
 	if (dev->abi_version <= MLX4_UVERBS_NO_DEV_CAPS_ABI_VERSION) {
 		if (ibv_cmd_get_context(verbs_ctx, &cmd, sizeof(cmd),
 					&resp_v3.ibv_resp, sizeof(resp_v3)))

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -299,12 +299,6 @@ static inline void mlx4_update_cons_index(struct mlx4_cq *cq)
 	*cq->set_ci_db = htobe32(cq->cons_index & 0xffffff);
 }
 
-extern int mlx4_cleanup_upon_device_fatal;
-static inline int cleanup_on_fatal(int ret)
-{
-	return (ret == EIO && mlx4_cleanup_upon_device_fatal);
-}
-
 int mlx4_alloc_buf(struct mlx4_buf *buf, size_t size, int page_size);
 void mlx4_free_buf(struct mlx4_buf *buf);
 

--- a/providers/mlx4/srq.c
+++ b/providers/mlx4/srq.c
@@ -307,7 +307,7 @@ int mlx4_destroy_xrc_srq(struct ibv_srq *srq)
 	pthread_spin_unlock(&mcq->lock);
 
 	ret = ibv_cmd_destroy_srq(srq);
-	if (ret && !cleanup_on_fatal(ret)) {
+	if (ret) {
 		pthread_spin_lock(&mcq->lock);
 		mlx4_store_xsrq(&mctx->xsrq_table, msrq->verbs_srq.srq_num, msrq);
 		pthread_spin_unlock(&mcq->lock);

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -232,7 +232,7 @@ int mlx4_free_pd(struct ibv_pd *pd)
 	int ret;
 
 	ret = ibv_cmd_dealloc_pd(pd);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(to_mpd(pd));
@@ -269,7 +269,7 @@ int mlx4_close_xrcd(struct ibv_xrcd *ib_xrcd)
 	int ret;
 
 	ret = ibv_cmd_close_xrcd(xrcd);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(xrcd);
@@ -322,7 +322,7 @@ int mlx4_dereg_mr(struct verbs_mr *vmr)
 	int ret;
 
 	ret = ibv_cmd_dereg_mr(vmr);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(vmr);
@@ -356,7 +356,7 @@ int mlx4_dealloc_mw(struct ibv_mw *mw)
 	int ret;
 
 	ret = ibv_cmd_dealloc_mw(mw);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(mw);
@@ -647,7 +647,7 @@ int mlx4_destroy_cq(struct ibv_cq *cq)
 	int ret;
 
 	ret = ibv_cmd_destroy_cq(cq);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	mlx4_free_db(to_mctx(cq->context), MLX4_DB_TYPE_CQ, to_mcq(cq)->set_ci_db);
@@ -751,7 +751,7 @@ int mlx4_destroy_srq(struct ibv_srq *srq)
 		return mlx4_destroy_xrc_srq(srq);
 
 	ret = ibv_cmd_destroy_srq(srq);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	mlx4_free_db(to_mctx(srq->context), MLX4_DB_TYPE_RQ, to_msrq(srq)->db);
@@ -1220,7 +1220,7 @@ static int _mlx4_destroy_qp_rss(struct ibv_qp *ibqp)
 	int ret;
 
 	ret = ibv_cmd_destroy_qp(ibqp);
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(qp);
@@ -1238,7 +1238,7 @@ int mlx4_destroy_qp(struct ibv_qp *ibqp)
 
 	pthread_mutex_lock(&to_mctx(ibqp->context)->qp_table_mutex);
 	ret = ibv_cmd_destroy_qp(ibqp);
-	if (ret && !cleanup_on_fatal(ret)) {
+	if (ret) {
 		pthread_mutex_unlock(&to_mctx(ibqp->context)->qp_table_mutex);
 		return ret;
 	}
@@ -1567,7 +1567,7 @@ int mlx4_destroy_flow(struct ibv_flow *flow_id)
 
 	ret = ibv_cmd_destroy_flow(flow_id);
 
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(flow_id);
@@ -1584,7 +1584,7 @@ int mlx4_destroy_wq(struct ibv_wq *ibwq)
 	pthread_mutex_lock(&mcontext->qp_table_mutex);
 
 	ret = ibv_cmd_destroy_wq(ibwq);
-	if (ret && !cleanup_on_fatal(ret)) {
+	if (ret) {
 		pthread_mutex_unlock(&mcontext->qp_table_mutex);
 		return ret;
 	}
@@ -1658,7 +1658,7 @@ int mlx4_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
 
 	ret = ibv_cmd_destroy_rwq_ind_table(rwq_ind_table);
 
-	if (ret && !cleanup_on_fatal(ret))
+	if (ret)
 		return ret;
 
 	free(rwq_ind_table);

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -354,9 +354,8 @@ struct ibv_mw *mlx4_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
 int mlx4_dealloc_mw(struct ibv_mw *mw)
 {
 	int ret;
-	struct ibv_dealloc_mw cmd;
 
-	ret = ibv_cmd_dealloc_mw(mw, &cmd, sizeof(cmd));
+	ret = ibv_cmd_dealloc_mw(mw);
 	if (ret && !cleanup_on_fatal(ret))
 		return ret;
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -518,9 +518,8 @@ struct ibv_mw *mlx5_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
 int mlx5_dealloc_mw(struct ibv_mw *mw)
 {
 	int ret;
-	struct ibv_dealloc_mw cmd;
 
-	ret = ibv_cmd_dealloc_mw(mw, &cmd, sizeof(cmd));
+	ret = ibv_cmd_dealloc_mw(mw);
 	if (ret)
 		return ret;
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -50,6 +50,7 @@
 #include <util/mmio.h>
 #include <rdma/ib_user_ioctl_cmds.h>
 #include <rdma/mlx5_user_ioctl_cmds.h>
+#include <infiniband/cmd_write.h>
 
 #include "mlx5.h"
 #include "mlx5-abi.h"
@@ -3606,6 +3607,7 @@ int mlx5dv_destroy_flow_matcher(struct mlx5dv_flow_matcher *flow_matcher)
 
 	fill_attr_in_obj(cmd, MLX5_IB_ATTR_FLOW_MATCHER_DESTROY_HANDLE, flow_matcher->handle);
 	ret = execute_ioctl(flow_matcher->context, cmd);
+	verbs_is_destroy_err(&ret);
 
 	if (ret)
 		return ret;


### PR DESCRIPTION
This series allows destroy commands to succeed after device disassociation, this comes to prevent memory leakage in the user space area.

Setting the environment variable RDMAV_ALLOW_DISASSOC_DESTROY tells the library to relate an EIO from destroy commands as a success as the kernel resources were already released.
Applications using this flag cannot call ibv_get_cq_event or ibv_get_async_event concurrently with any call to an object destruction function.