### PR TITLE
Please pull rdma-core change for hns

### DIFF
--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -53,6 +53,7 @@ struct hns_roce_ib_create_qp {
 	__u8    log_sq_stride;
 	__u8    sq_no_prefetch;
 	__u8    reserved[5];
+	__aligned_u64 sdb_addr;
 };
 
 struct hns_roce_ib_create_qp_resp {

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -69,6 +69,7 @@ static const struct verbs_context_ops hns_common_ops = {
 	.dealloc_pd = hns_roce_u_free_pd,
 	.dereg_mr = hns_roce_u_dereg_mr,
 	.destroy_cq = hns_roce_u_destroy_cq,
+	.modify_cq = hns_roce_u_modify_cq,
 	.query_device = hns_roce_u_query_device,
 	.query_port = hns_roce_u_query_port,
 	.query_qp = hns_roce_u_query_qp,

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -279,6 +279,7 @@ struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
 				    struct ibv_comp_channel *channel,
 				    int comp_vector);
 
+int hns_roce_u_modify_cq(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
 int hns_roce_u_destroy_cq(struct ibv_cq *cq);
 void hns_roce_u_cq_event(struct ibv_cq *cq);
 

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -211,6 +211,7 @@ struct hns_roce_qp {
 	struct hns_roce_wq		sq;
 	struct hns_roce_wq		rq;
 	uint32_t			*rdb;
+	uint32_t			*sdb;
 	struct hns_roce_sge_ex		sge;
 	unsigned int			next_sge;
 	int				port_num;

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -406,7 +406,7 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 		case HNS_ROCE_RECV_OP_RDMA_WRITE_IMM:
 			wc->opcode = IBV_WC_RECV_RDMA_WITH_IMM;
 			wc->wc_flags = IBV_WC_WITH_IMM;
-			wc->imm_data = cqe->immtdata;
+			wc->imm_data = htobe32(le32toh(cqe->immtdata));
 			break;
 
 		case HNS_ROCE_RECV_OP_SEND:
@@ -417,7 +417,7 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 		case HNS_ROCE_RECV_OP_SEND_WITH_IMM:
 			wc->opcode = IBV_WC_RECV;
 			wc->wc_flags = IBV_WC_WITH_IMM;
-			wc->imm_data = cqe->immtdata;
+			wc->imm_data = htobe32(le32toh(cqe->immtdata));
 			break;
 
 		case HNS_ROCE_RECV_OP_SEND_WITH_INV:
@@ -593,7 +593,7 @@ static int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 
 		if (wr->opcode == IBV_WR_SEND_WITH_IMM ||
 		    wr->opcode == IBV_WR_RDMA_WRITE_WITH_IMM)
-			rc_sq_wqe->immtdata = wr->imm_data;
+			rc_sq_wqe->immtdata = htole32(be32toh(wr->imm_data));
 
 		roce_set_field(rc_sq_wqe->byte_16, RC_SQ_WQE_BYTE_16_SGE_NUM_M,
 			       RC_SQ_WQE_BYTE_16_SGE_NUM_S, wr->num_sge);

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -173,7 +173,7 @@ struct hns_roce_v2_cqe {
 	__le32	byte_4;
 	union {
 		__le32	rkey;
-		__be32	immtdata;
+		__le32	immtdata;
 	};
 	__le32	byte_12;
 	__le32	byte_16;
@@ -227,7 +227,7 @@ struct hns_roce_rc_sq_wqe {
 	__le32	msg_len;
 	union {
 		__le32	inv_key;
-		__be32	immtdata;
+		__le32	immtdata;
 	};
 	__le32	byte_16;
 	__le32	byte_20;

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -42,6 +42,7 @@
 
 enum {
 	HNS_ROCE_SUPPORT_RQ_RECORD_DB = 1 << 0,
+	HNS_ROCE_SUPPORT_SQ_RECORD_DB = 1 << 1,
 };
 
 enum {

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -338,6 +338,13 @@ void hns_roce_u_cq_event(struct ibv_cq *cq)
 	to_hr_cq(cq)->arm_sn++;
 }
 
+int hns_roce_u_modify_cq(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr)
+{
+	struct ibv_modify_cq cmd = {};
+
+	return ibv_cmd_modify_cq(cq, attr, &cmd, sizeof(cmd));
+}
+
 int hns_roce_u_destroy_cq(struct ibv_cq *cq)
 {
 	int ret;


### PR DESCRIPTION
These patch series include the two patch-sets. The first patch-set
 is("Two updates for libhns"), the second patch-set
 is ("libhns: Support flush cqe for hip08 in user space")