### PR TITLE
librdmacm: Update message in example tools when no RDMA devices

### DIFF
--- a/librdmacm/examples/CMakeLists.txt
+++ b/librdmacm/examples/CMakeLists.txt
@@ -7,10 +7,10 @@ rdma_executable(cmtime cmtime.c)
 target_link_libraries(cmtime LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT} rdmacm_tools)
 
 rdma_executable(mckey mckey.c)
-target_link_libraries(mckey LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(mckey LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT} rdmacm_tools)
 
 rdma_executable(rcopy rcopy.c)
-target_link_libraries(rcopy LINK_PRIVATE rdmacm)
+target_link_libraries(rcopy LINK_PRIVATE rdmacm rdmacm_tools)
 
 rdma_executable(rdma_client rdma_client.c)
 target_link_libraries(rdma_client LINK_PRIVATE rdmacm)
@@ -28,7 +28,7 @@ rdma_executable(riostream riostream.c)
 target_link_libraries(riostream LINK_PRIVATE rdmacm rdmacm_tools)
 
 rdma_executable(rping rping.c)
-target_link_libraries(rping LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(rping LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT} rdmacm_tools)
 
 rdma_executable(rstream rstream.c)
 target_link_libraries(rstream LINK_PRIVATE rdmacm rdmacm_tools)

--- a/librdmacm/examples/cmatose.c
+++ b/librdmacm/examples/cmatose.c
@@ -699,9 +699,8 @@ int main(int argc, char **argv)
 
 	test.connects_left = connections;
 
-	test.channel = rdma_create_event_channel();
+	test.channel = create_first_event_channel();
 	if (!test.channel) {
-		printf("failed to create event channel\n");
 		exit(1);
 	}
 

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -652,9 +652,8 @@ int main(int argc, char **argv)
 	init_qp_attr.cap.max_recv_sge = 1;
 	init_qp_attr.qp_type = IBV_QPT_RC;
 
-	channel = rdma_create_event_channel();
+	channel = create_first_event_channel();
 	if (!channel) {
-		printf("failed to create event channel\n");
 		exit(1);
 	}
 

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -161,3 +161,17 @@ int do_poll(struct pollfd *fds, int timeout)
 
 	return ret == 1 ? (fds->revents & (POLLERR | POLLHUP)) : ret;
 }
+
+struct rdma_event_channel *create_first_event_channel(void)
+{
+	struct rdma_event_channel *channel;
+
+	channel = rdma_create_event_channel();
+	if (!channel) {
+		if (errno == ENODEV)
+			fprintf(stderr, "No RDMA devices were detected\n");
+		else
+			perror("failed to create RDMA CM event channel");
+	}
+	return channel;
+}

--- a/librdmacm/examples/mckey.c
+++ b/librdmacm/examples/mckey.c
@@ -46,6 +46,8 @@
 #include <rdma/rdma_cma.h>
 #include <infiniband/ib.h>
 
+#include "common.h"
+
 struct cmatest_node {
 	int			id;
 	struct rdma_cm_id	*cma_id;
@@ -622,9 +624,8 @@ int main(int argc, char **argv)
 	test.dst_addr = (struct sockaddr *) &test.dst_in;
 	test.connects_left = connections;
 
-	test.channel = rdma_create_event_channel();
+	test.channel = create_first_event_channel();
 	if (!test.channel) {
-		perror("failed to create event channel");
 		exit(1);
 	}
 

--- a/librdmacm/examples/rcopy.c
+++ b/librdmacm/examples/rcopy.c
@@ -45,6 +45,8 @@
 
 #include <rdma/rsocket.h>
 
+#include "common.h"
+
 union rsocket_address {
 	struct sockaddr		sa;
 	struct sockaddr_in	sin;
@@ -190,9 +192,8 @@ static int server_listen(void)
 		return ret;
 	}
 
-	rs = rsocket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	rs = rs_socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (rs < 0) {
-		perror("rsocket failed\n");
 		ret = rs;
 		goto free;
 	}
@@ -400,9 +401,8 @@ static int client_connect(void)
 		return ret;
 	}
 
-	rs = rsocket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	rs = rs_socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (rs < 0) {
-		perror("rsocket failed\n");
 		goto free;
 	}
 

--- a/librdmacm/examples/riostream.c
+++ b/librdmacm/examples/riostream.c
@@ -367,10 +367,9 @@ static int server_listen(void)
 		return ret;
 	}
 
-	lrs = rai ? rsocket(rai->ai_family, SOCK_STREAM, 0) :
-		    rsocket(ai->ai_family, SOCK_STREAM, 0);
+	lrs = rai ? rs_socket(rai->ai_family, SOCK_STREAM, 0) :
+		    rs_socket(ai->ai_family, SOCK_STREAM, 0);
 	if (lrs < 0) {
-		perror("rsocket");
 		ret = lrs;
 		goto free;
 	}
@@ -448,10 +447,9 @@ static int client_connect(void)
 		return ret;
 	}
 
-	rs = rai ? rsocket(rai->ai_family, SOCK_STREAM, 0) :
-		   rsocket(ai->ai_family, SOCK_STREAM, 0);
+	rs = rai ? rs_socket(rai->ai_family, SOCK_STREAM, 0) :
+		   rs_socket(ai->ai_family, SOCK_STREAM, 0);
 	if (rs < 0) {
-		perror("rsocket");
 		ret = rs;
 		goto free;
 	}

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -44,6 +44,7 @@
 #include <pthread.h>
 #include <inttypes.h>
 #include <rdma/rdma_cma.h>
+#include "common.h"
 
 static int debug = 0;
 #define DEBUG_LOG if (debug) printf
@@ -1250,9 +1251,8 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	cb->cm_channel = rdma_create_event_channel();
+	cb->cm_channel = create_first_event_channel();
 	if (!cb->cm_channel) {
-		perror("rdma_create_event_channel");
 		ret = errno;
 		goto out;
 	}

--- a/librdmacm/examples/rstream.c
+++ b/librdmacm/examples/rstream.c
@@ -334,7 +334,6 @@ static int server_listen(void)
 	lrs = rai ? rs_socket(rai->ai_family, SOCK_STREAM, 0) :
 		    rs_socket(ai->ai_family, SOCK_STREAM, 0);
 	if (lrs < 0) {
-		perror("rsocket");
 		ret = lrs;
 		goto free;
 	}
@@ -433,7 +432,6 @@ static int client_connect(void)
 	rs = rai ? rs_socket(rai->ai_family, SOCK_STREAM, 0) :
 		   rs_socket(ai->ai_family, SOCK_STREAM, 0);
 	if (rs < 0) {
-		perror("rsocket");
 		ret = rs;
 		goto free;
 	}

--- a/librdmacm/examples/udaddy.c
+++ b/librdmacm/examples/udaddy.c
@@ -666,9 +666,8 @@ int main(int argc, char **argv)
 
 	test.connects_left = connections;
 
-	test.channel = rdma_create_event_channel();
+	test.channel = create_first_event_channel();
 	if (!test.channel) {
-		perror("failed to create event channel");
 		exit(1);
 	}
 

--- a/librdmacm/examples/udpong.c
+++ b/librdmacm/examples/udpong.c
@@ -272,7 +272,6 @@ static int svr_bind(void)
 
 	rs = rs_socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (rs < 0) {
-		perror("rsocket");
 		ret = rs;
 		goto out;
 	}
@@ -417,7 +416,6 @@ static int client_connect(void)
 
 	rs = rs_socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (rs < 0) {
-		perror("rsocket");
 		ret = rs;
 		goto out;
 	}
@@ -425,7 +423,10 @@ static int client_connect(void)
 	set_options(rs);
 	ret = rs_connect(rs, res->ai_addr, res->ai_addrlen);
 	if (ret) {
-		perror("rconnect");
+		if (errno == ENODEV)
+			fprintf(stderr, "No RDMA devices were detected\n");
+		else
+			perror("rconnect");
 		rs_close(rs);
 		goto out;
 	}


### PR DESCRIPTION
Most of the librdmacm demos call rdma_create_event_channel() as their
first call.  Currently, when there are no RDMA devices detected, the
user gets a message like "rdma_create_event_channel: No such device".
This can be confusing as it implies that there is an issue with the
event channel mechanism, rather than an issue with the RDMA device
configuration.

Since we know why this function sets errno to ENODEV, print a specific
error message indicating that no RDMA devices were detected, so that the
user knows where to start troubleshooting.

This fixes every librdmacm example program, except for udpong's server
side, which due to the control flow does not have an obvious call that
will check for the presence of an RDMA device before entering its main
loop.

Signed-off-by: Patrick MacArthur <patrick@patrickmacarthur.net>