### PR TITLE
CQ ignore overrun

### DIFF
--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -142,6 +142,9 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)
 		flags |= IB_UVERBS_CQ_FLAGS_TIMESTAMP_COMPLETION;
 
+	if (cq_attr->flags & IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN)
+		flags |= IB_UVERBS_CQ_FLAGS_IGNORE_OVERRUN;
+
 	return ibv_icmd_create_cq(context, cq_attr->cqe, cq_attr->channel,
 				  cq_attr->comp_vector, flags,
 				  ibv_cq_ex_to_cq(cq), cmdb);

--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -52,6 +52,9 @@ enum ibv_cq_init_attr_mask {
 
 enum ibv_create_cq_attr_flags {
         IBV_CREATE_CQ_ATTR_SINGLE_THREADED      = 1 << 0, /* This CQ is used from a single threaded, thus no locking is required */
+        IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN       = 1 << 1, /* This CQ will not pass to error state if overrun, CQE always will be written to next entry.
+                                                           * An application must be designed to avoid ever overflowing the CQ, otherwise CQEs might be lost.
+                                                           */
 };
 
 .SH "Polling an extended CQ"

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1717,6 +1717,7 @@ enum ibv_cq_init_attr_mask {
 
 enum ibv_create_cq_attr_flags {
 	IBV_CREATE_CQ_ATTR_SINGLE_THREADED = 1 << 0,
+	IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN  = 1 << 1,
 };
 
 struct ibv_cq_init_attr_ex {

--- a/providers/mlx5/mlx5-abi.h
+++ b/providers/mlx5/mlx5-abi.h
@@ -59,6 +59,8 @@ DECLARE_DRV_CMD(mlx5_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
 		empty, mlx5_ib_alloc_pd_resp);
 DECLARE_DRV_CMD(mlx5_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		mlx5_ib_create_cq, mlx5_ib_create_cq_resp);
+DECLARE_DRV_CMD(mlx5_create_cq_ex, IB_USER_VERBS_EX_CMD_CREATE_CQ,
+		mlx5_ib_create_cq, mlx5_ib_create_cq_resp);
 DECLARE_DRV_CMD(mlx5_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
 		mlx5_ib_create_srq, mlx5_ib_create_srq_resp);
 DECLARE_DRV_CMD(mlx5_create_srq_ex, IB_USER_VERBS_CMD_CREATE_XSRQ,


### PR DESCRIPTION
This series enables creating a CQ which doesn't pass to error state if overrun, CQE always will be written to the next entry by the device.

The kernel part was accepted long time ago, this is the supplementary user space part.

