### PR TITLE
Add Microsoft Azure RDMA device to MLX4 HCA table

### DIFF
--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -76,6 +76,7 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x100e),	/* MT27551 Family */
 	HCA(MELLANOX, 0x100f),	/* MT27560 Family */
 	HCA(MELLANOX, 0x1010),	/* MT27561 Family */
+	VERBS_MODALIAS_MATCH("vmbus:3daf2e8ca732094bab99bd1f1c86b501", NULL), /* Microsoft Azure Network Direct */
 	{}
 };
 


### PR DESCRIPTION
Microsoft Azure supports Mellanox MLX4 RDMA devices in HPC VM SKUs. The device
is virtualized and exposed over VMBUS, and registered as a MLX4 Infininband
hardware in RDMA layer.

This devcie is on VMBUS, not on PCI tree. Add it to the HCA table so it can
be properly discovered by user-mode driver.