### PR TITLE
mlx5: Expose device WQE address vector via DV

### DIFF
--- a/providers/mlx5/man/mlx5dv_init_obj.3
+++ b/providers/mlx5/man/mlx5dv_init_obj.3
@@ -87,6 +87,13 @@ uint64_t	comp_mask;
 .in -8
 };
 
+struct mlx5dv_ah {
+.in +8
+struct mlx5_wqe_av    *av;
+uint64_t              comp_mask;
+.in -8
+};
+
 struct mlx5dv_obj {
 .in +8
 struct {
@@ -119,6 +126,12 @@ struct ibv_dm		*in;
 struct mlx5dv_dm	*out;
 .in -8
 } dm;
+struct {
+.in +8
+struct ibv_ah		*in;
+struct mlx5dv_ah	*out;
+.in -8
+} ah;
 .in -8
 };
 
@@ -129,6 +142,7 @@ MLX5DV_OBJ_CQ   = 1 << 1,
 MLX5DV_OBJ_SRQ  = 1 << 2,
 MLX5DV_OBJ_RWQ  = 1 << 3,
 MLX5DV_OBJ_DM   = 1 << 4,
+MLX5DV_OBJ_AH   = 1 << 5,
 .in -8
 };
 .fi

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -833,6 +833,17 @@ static int mlx5dv_get_dm(struct ibv_dm *dm_in,
 	return 0;
 }
 
+static int mlx5dv_get_av(struct ibv_ah *ah_in,
+			 struct mlx5dv_ah *ah_out)
+{
+	struct mlx5_ah *mah = to_mah(ah_in);
+
+	ah_out->comp_mask = 0;
+	ah_out->av	  = &mah->av;
+
+	return 0;
+}
+
 LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		   int,
 		   struct mlx5dv_obj *obj, uint64_t obj_type)
@@ -849,6 +860,8 @@ LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		ret = mlx5dv_get_rwq(obj->rwq.in, obj->rwq.out);
 	if (!ret && (obj_type & MLX5DV_OBJ_DM))
 		ret = mlx5dv_get_dm(obj->dm.in, obj->dm.out);
+	if (!ret && (obj_type & MLX5DV_OBJ_AH))
+		ret = mlx5dv_get_av(obj->ah.in, obj->ah.out);
 
 	return ret;
 }

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -311,6 +311,13 @@ struct mlx5dv_dm {
 	uint64_t	comp_mask;
 };
 
+struct mlx5_wqe_av;
+
+struct mlx5dv_ah {
+	struct mlx5_wqe_av      *av;
+	uint64_t		comp_mask;
+};
+
 struct mlx5dv_obj {
 	struct {
 		struct ibv_qp		*in;
@@ -332,6 +339,10 @@ struct mlx5dv_obj {
 		struct ibv_dm		*in;
 		struct mlx5dv_dm	*out;
 	} dm;
+	struct {
+		struct ibv_ah		*in;
+		struct mlx5dv_ah	*out;
+	} ah;
 };
 
 enum mlx5dv_obj_type {
@@ -340,6 +351,7 @@ enum mlx5dv_obj_type {
 	MLX5DV_OBJ_SRQ	= 1 << 2,
 	MLX5DV_OBJ_RWQ	= 1 << 3,
 	MLX5DV_OBJ_DM	= 1 << 4,
+	MLX5DV_OBJ_AH	= 1 << 5,
 };
 
 enum mlx5dv_wq_init_attr_mask {


### PR DESCRIPTION
Extend mlx5dv_init_obj() function to extract the device WQE address vector for the given ibv_ah.