### PR TITLE
mlx5: Fix flow tag mask

### DIFF
--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -188,7 +188,7 @@ enum mlx5_vendor_cap_flags {
 };
 
 enum {
-	MLX5_FLOW_TAG_MASK	= 0x000fffff,
+	MLX5_FLOW_TAG_MASK	= 0x00ffffff,
 };
 
 struct mlx5_resource {


### PR DESCRIPTION
Flow tag is 24 bits so the mask should be 0x00ffffff instead of 0x000fffff. 
20 bits mask caused loss of MSBs in read_flow_tag().