### PR TITLE
Enable allocating a context with vendor data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ set(PACKAGE_NAME "RDMA")
 set(PACKAGE_VERSION "21.0")
 # When this is changed the values in these files need changing too:
 #   debian/libibverbs1.symbols
-set(IBVERBS_PABI_VERSION "20")
+set(IBVERBS_PABI_VERSION "21")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/control
+++ b/debian/control
@@ -149,7 +149,7 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ibverbs-providers
-Breaks: ibverbs-providers (<< 20~)
+Breaks: ibverbs-providers (<< 21~)
 Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -27,3 +27,4 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_create_flow@MLX5_1.6 20
  mlx5dv_create_flow_action_modify_header@MLX5_1.7 21
  mlx5dv_create_flow_action_packet_reformat@MLX5_1.7 21
+ mlx5dv_open_device@MLX5_1.7 21

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -2,7 +2,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
  IBVERBS_1.5@IBVERBS_1.5 20
- (symver)IBVERBS_PRIVATE_20 20
+ (symver)IBVERBS_PRIVATE_21 21
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -266,9 +266,7 @@ static void set_lib_ops(struct verbs_context *vctx)
 	vctx->create_cq_ex = __lib_ibv_create_cq_ex;
 }
 
-LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
-		   struct ibv_context *,
-		   struct ibv_device *device)
+struct ibv_context *verbs_open_device(struct ibv_device *device, void *private_data)
 {
 	struct verbs_device *verbs_device = verbs_get_device(device);
 	char *devpath;
@@ -292,13 +290,20 @@ LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
 	 * cmd_fd ownership is transferred into alloc_context, if it fails
 	 * then it closes cmd_fd and returns NULL
 	 */
-	context_ex = verbs_device->ops->alloc_context(device, cmd_fd);
+	context_ex = verbs_device->ops->alloc_context(device, cmd_fd, private_data);
 	if (!context_ex)
 		return NULL;
 
 	set_lib_ops(context_ex);
 
 	return &context_ex->context;
+}
+
+LATEST_SYMVER_FUNC(ibv_open_device, 1_1, "IBVERBS_1.1",
+		   struct ibv_context *,
+		   struct ibv_device *device)
+{
+	return verbs_open_device(device, NULL);
 }
 
 void verbs_uninit_context(struct verbs_context *context_ex)

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -187,7 +187,8 @@ struct verbs_device_ops {
 	bool (*match_device)(struct verbs_sysfs_dev *sysfs_dev);
 
 	struct verbs_context *(*alloc_context)(struct ibv_device *device,
-					       int cmd_fd);
+					       int cmd_fd,
+					       void *private_data);
 	void (*free_context)(struct ibv_context *context);
 
 	struct verbs_device *(*alloc_device)(struct verbs_sysfs_dev *sysfs_dev);
@@ -383,6 +384,8 @@ void verbs_init_cq(struct ibv_cq *cq, struct ibv_context *context,
 		       struct ibv_comp_channel *channel,
 		       void *cq_context);
 
+struct ibv_context *verbs_open_device(struct ibv_device *device,
+				      void *private_data);
 int ibv_cmd_get_context(struct verbs_context *context,
 			struct ibv_get_context *cmd, size_t cmd_size,
 			struct ib_uverbs_get_context_resp *resp, size_t resp_size);

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -178,6 +178,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_query_gid_type;
 		ibv_register_driver;
 		verbs_allow_disassociate_destroy;
+		verbs_open_device;
 		verbs_register_driver_@IBVERBS_PABI_VERSION@;
 		verbs_set_ops;
 		verbs_uninit_context;

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -110,7 +110,8 @@ static const struct verbs_context_ops bnxt_re_cntx_ops = {
 
 /* Context Init functions */
 static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
-						   int cmd_fd)
+						   int cmd_fd,
+						   void *private_data)
 {
 	struct ibv_get_context cmd;
 	struct ubnxt_re_cntx_resp resp;

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -118,7 +118,8 @@ unsigned long iwch_page_shift;
 unsigned long iwch_page_mask;
 
 static struct verbs_context *iwch_alloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct iwch_context *context;
 	struct ibv_get_context cmd;

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -106,7 +106,8 @@ static const struct verbs_context_ops c4iw_ctx_t4_ops = {
 };
 
 static struct verbs_context *c4iw_alloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct c4iw_context *context;
 	struct ibv_get_context cmd;

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -137,7 +137,8 @@ static const struct verbs_context_ops hfi1_ctx_v1_ops = {
 };
 
 static struct verbs_context *hfi1_alloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct hfi1_context	    *context;
 	struct ibv_get_context       cmd;

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -78,7 +78,8 @@ static const struct verbs_context_ops hns_common_ops = {
 };
 
 static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
-						    int cmd_fd)
+						    int cmd_fd,
+						    void *private_data)
 {
 	int i;
 	struct ibv_get_context cmd;

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -127,7 +127,8 @@ static const struct verbs_context_ops i40iw_uctx_ops = {
  */
 
 static struct verbs_context *i40iw_ualloc_context(struct ibv_device *ibdev,
-						  int cmd_fd)
+						  int cmd_fd,
+						  void *private_data)
 {
 	struct ibv_pd *ibv_pd;
 	struct i40iw_uvcontext *iwvctx;

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -136,7 +136,8 @@ static const struct verbs_context_ops ipath_ctx_v1_ops = {
 };
 
 static struct verbs_context *ipath_alloc_context(struct ibv_device *ibdev,
-						 int cmd_fd)
+						 int cmd_fd,
+						 void *private_data)
 {
 	struct ipath_context	    *context;
 	struct ibv_get_context       cmd;

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -155,7 +155,8 @@ static int mlx4_map_internal_clock(struct mlx4_device *mdev,
 }
 
 static struct verbs_context *mlx4_alloc_context(struct ibv_device *ibdev,
-						  int cmd_fd)
+						  int cmd_fd,
+						  void *private_data)
 {
 	struct mlx4_context	       *context;
 	struct ibv_get_context		cmd;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -45,4 +45,5 @@ MLX5_1.7 {
 	global:
 		mlx5dv_create_flow_action_modify_header;
 		mlx5dv_create_flow_action_packet_reformat;
+		mlx5dv_open_device;
 } MLX5_1.6;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -4,6 +4,7 @@ rdma_man_pages(
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3
+  mlx5dv_open_device.3.md
   mlx5dv_query_device.3
   mlx5dv_ts_to_ns.3
   mlx5dv.7

--- a/providers/mlx5/man/mlx5dv_open_device.3.md
+++ b/providers/mlx5/man/mlx5dv_open_device.3.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: mlx5dv_open_device
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_open_device - Open an RDMA device context for the mlx5 provider
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct ibv_context *
+mlx5dv_open_device(struct ibv_device *device, struct mlx5dv_context_attr *attr);
+```
+
+# DESCRIPTION
+
+Open an RDMA device context with specific mlx5 provider attributes.
+
+# ARGUMENTS
+
+*device*
+:	RDMA device to open.
+
+## *attr* argument
+
+```c
+struct mlx5dv_context_attr {
+        uint32_t flags;
+        uint64_t comp_mask;
+};
+```
+
+*flags*
+:       A bitwise OR of the various values described below.
+
+        *MLX5DV_CONTEXT_FLAGS_DEVX*:
+        Allocate a DEVX context
+
+*comp_mask*
+:       Bitmask specifying what fields in the structure are valid
+
+# RETURN VALUE
+Returns a pointer to the allocated device context, or NULL if the request fails.
+
+# SEE ALSO
+
+*ibv_open_device(3)*
+
+# AUTHOR
+
+Yishai Hadas <yishaih@mellanox.com>

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1001,7 +1001,8 @@ static void adjust_uar_info(struct mlx5_device *mdev,
 }
 
 static struct verbs_context *mlx5_alloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct mlx5_context	       *context;
 	struct mlx5_alloc_ucontext	req;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -996,6 +996,18 @@ static inline uint64_t mlx5dv_ts_to_ns(struct mlx5dv_clock_info *clock_info,
 	return nsec;
 }
 
+enum mlx5dv_context_attr_flags {
+	MLX5DV_CONTEXT_FLAGS_DEVX = 1 << 0,
+};
+
+struct mlx5dv_context_attr {
+	uint32_t flags; /* Use enum mlx5dv_context_attr_flags */
+	uint64_t comp_mask;
+};
+
+struct ibv_context *
+mlx5dv_open_device(struct ibv_device *device, struct mlx5dv_context_attr *attr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -130,7 +130,8 @@ static const struct verbs_context_ops mthca_ctx_tavor_ops = {
 };
 
 static struct verbs_context *mthca_alloc_context(struct ibv_device *ibdev,
-						 int cmd_fd)
+						 int cmd_fd,
+						 void *private_data)
 {
 	struct mthca_context            *context;
 	struct ibv_get_context           cmd;

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -98,7 +98,8 @@ static const struct verbs_context_ops nes_uctx_no_db_ops = {
  * nes_ualloc_context
  */
 static struct verbs_context *nes_ualloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct ibv_pd *ibv_pd;
 	struct nes_uvcontext *nesvctx;

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -106,7 +106,8 @@ static void ocrdma_uninit_device(struct verbs_device *verbs_device)
  * ocrdma_alloc_context
  */
 static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
-						  int cmd_fd)
+						  int cmd_fd,
+						  void *private_data)
 {
 	struct ocrdma_devctx *ctx;
 	struct uocrdma_get_context cmd;

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -161,7 +161,8 @@ static void qelr_set_debug_mask(void)
 }
 
 static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
-						int cmd_fd)
+						int cmd_fd,
+						void *private_data)
 {
 	struct qelr_devctx *ctx;
 	struct qelr_get_context cmd;

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -855,7 +855,8 @@ static const struct verbs_context_ops rxe_ctx_ops = {
 };
 
 static struct verbs_context *rxe_alloc_context(struct ibv_device *ibdev,
-					       int cmd_fd)
+					       int cmd_fd,
+					       void *private_data)
 {
 	struct rxe_context *context;
 	struct ibv_get_context cmd;

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -143,7 +143,8 @@ static void pvrdma_free_context_shared(struct pvrdma_context *context,
 }
 
 static struct verbs_context *pvrdma_alloc_context(struct ibv_device *ibdev,
-						  int cmd_fd)
+						  int cmd_fd,
+						  void *private_data)
 {
 	struct pvrdma_context *context;
 


### PR DESCRIPTION
Extend verbs_device_ops to get vendor data as part of alloc_context, this functionality is used by mlx5 driver to allocate a DEVX context.