### PR TITLE
rpm: Set perl dependencies on Fedora

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -134,7 +134,7 @@ class centos7_epel(centos7):
 
 class fc28(Environment):
     docker_parent = "fedora:28";
-    pkgs = (centos7.pkgs - {"make"}) | {"ninja-build","pandoc"};
+    pkgs = (centos7.pkgs - {"make"}) | {"ninja-build","pandoc","perl-generators"};
     name = "fc28";
     specfile = "redhat/rdma-core.spec";
     ninja_cmd = "ninja-build";

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -22,6 +22,9 @@ BuildRequires: valgrind-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 BuildRequires: python
+%if 0%{?fedora} >= 21
+BuildRequires: perl-generators
+%endif
 
 Requires: dracut, kmod, systemd
 # Red Hat/Fedora previously shipped redhat/ as a stand-alone


### PR DESCRIPTION
RHEL gets perl dependencies automatically, but Fedora requires the
perl-generators BuildRequires for it to work right.

Cc: stable@linux-rdma.org
Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>