### PR TITLE
libhns: Add atomic support for hip08 user mode

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -275,4 +275,9 @@ struct hns_roce_v2_wqe_raddr_seg {
 	__le64		raddr;
 };
 
+struct hns_roce_wqe_atomic_seg {
+	__le64		fetchadd_swap_data;
+	__le64		cmp_data;
+};
+
 #endif /* _HNS_ROCE_U_HW_V2_H */


### PR DESCRIPTION
It needs to post the work request of atomic type
when the run atomic function by the hardware
supported. it incldues fetchadd and cmpswap
operation.

Signed-off-by: Lijun Ou <oulijun@huawei.com>