### PR TITLE
mlx5: Extend flow steering support

### DIFF
--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -125,6 +125,7 @@ enum mlx5_ib_flow_matcher_create_attrs {
 	MLX5_IB_ATTR_FLOW_MATCHER_MATCH_MASK,
 	MLX5_IB_ATTR_FLOW_MATCHER_FLOW_TYPE,
 	MLX5_IB_ATTR_FLOW_MATCHER_MATCH_CRITERIA,
+	MLX5_IB_ATTR_FLOW_MATCHER_FLOW_FLAGS,
 };
 
 enum mlx5_ib_flow_matcher_destroy_attrs {
@@ -155,6 +156,7 @@ enum mlx5_ib_create_flow_attrs {
 	MLX5_IB_ATTR_CREATE_FLOW_DEST_QP,
 	MLX5_IB_ATTR_CREATE_FLOW_DEST_DEVX,
 	MLX5_IB_ATTR_CREATE_FLOW_MATCHER,
+	MLX5_IB_ATTR_CREATE_FLOW_ARR_FLOW_ACTIONS,
 };
 
 enum mlx5_ib_destoy_flow_attrs {

--- a/kernel-headers/rdma/rdma_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/rdma_user_ioctl_cmds.h
@@ -53,7 +53,7 @@ enum {
 
 struct ib_uverbs_attr {
 	__u16 attr_id;		/* command specific type attribute */
-	__u16 len;		/* only for pointers */
+	__u16 len;		/* only for pointers and IDRs array */
 	__u16 flags;		/* combination of UVERBS_ATTR_F_XXXX */
 	union {
 		struct {
@@ -63,7 +63,10 @@ struct ib_uverbs_attr {
 		__u16 reserved;
 	} attr_data;
 	union {
-		/* Used by PTR_IN/OUT, ENUM_IN and IDR */
+		/*
+		 * ptr to command, inline data, idr/fd or
+		 * ptr to __u32 array of IDRs
+		 */
 		__aligned_u64 data;
 		/* Used by FD_IN and FD_OUT */
 		__s64 data_s64;

--- a/libibverbs/cmd_counters.c
+++ b/libibverbs/cmd_counters.c
@@ -87,12 +87,9 @@ int ibv_cmd_read_counters(struct verbs_counters *vcounters,
 				    3,
 				    link);
 
-	if (!is_attr_size_valid(ncounters, sizeof(uint64_t)))
-		return EINVAL;
-
 	fill_attr_in_obj(cmd, UVERBS_ATTR_READ_COUNTERS_HANDLE, vcounters->handle);
-	fill_attr_out(cmd, UVERBS_ATTR_READ_COUNTERS_BUFF, counters_value,
-		      ncounters * sizeof(uint64_t));
+	fill_attr_out_ptr_array(cmd, UVERBS_ATTR_READ_COUNTERS_BUFF, counters_value,
+				ncounters);
 	fill_attr_in_uint32(cmd, UVERBS_ATTR_READ_COUNTERS_FLAGS, flags);
 
 	return execute_ioctl(vcounters->counters.context, cmd);

--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -394,4 +394,13 @@ fill_attr_in_enum(struct ibv_command_buffer *cmd, uint16_t attr_id,
 	return attr;
 }
 
+/* Send attributes of kernel type UVERBS_ATTR_TYPE_IDRS_ARRAY */
+static inline struct ib_uverbs_attr *
+fill_attr_in_objs_arr(struct ibv_command_buffer *cmd, uint16_t attr_id,
+		      const uint32_t *idrs_arr, size_t nelems)
+{
+	return fill_attr_in(cmd, attr_id, idrs_arr,
+			    _array_len(sizeof(*idrs_arr), nelems));
+}
+
 #endif

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -1,6 +1,8 @@
 rdma_man_pages(
+  mlx5dv_create_flow.3.md
   mlx5dv_create_flow_action_modify_header.3.md
   mlx5dv_create_flow_action_packet_reformat.3.md
+  mlx5dv_create_flow_matcher.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3

--- a/providers/mlx5/man/mlx5dv_create_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_create_flow.3.md
@@ -1,0 +1,78 @@
+---
+layout: page
+title: mlx5dv_create_flow
+section: 3
+tagline: Verbs
+date: 2018-9-19
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+mlx5dv_create_flow - creates a steering flow rule
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct ibv_flow *
+mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
+		   struct mlx5dv_flow_match_parameters *match_value,
+		   size_t num_actions,
+		   struct mlx5dv_flow_action_attr actions_attr[])
+```
+
+
+# DESCRIPTION
+**mlx5dv_create_flow()** creates a steering flow rule with the ability
+to specify specific driver properties.
+
+# ARGUMENTS
+
+Please see *mlx5dv_create_flow_matcher(3)* for *flow_matcher* and *match_value*.
+
+*num_actions*
+:	Specifies how many actions are passed in *actions_attr*
+
+## *actions_attr*
+
+```c
+struct mlx5dv_flow_action_attr {
+	enum mlx5dv_flow_action_type type;
+	union {
+		struct ibv_qp *qp;
+		struct ibv_counters *counter;
+		struct ibv_flow_action *action;
+		uint32_t tag_value;
+	};
+};
+```
+
+*type*
+:	MLX5DV_FLOW_ACTION_DEST_IBV_QP
+		The QP passed will receive the matched packets.
+	MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION
+		The flow action to be applied.
+
+*qp*
+:	QP passed, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_IBV_QP*.
+
+*action*
+:	Flow action, to be used with *type* *MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION*
+	see *mlx5dv_create_flow_action_modify_header(3)* and *mlx5dv_create_flow_action_packet_reformat(3)*.
+
+# RETURN VALUE
+
+**mlx5dv_create_flow**
+returns a pointer to the created flow rule, on error NULL will be returned and errno will be set.
+
+# SEE ALSO
+
+*mlx5dv_create_flow_action_modify_header(3)*, *mlx5dv_create_flow_action_packet_reformat(3)*,
+*mlx5dv_create_flow_matcher(3)*, *mlx5dv_create_qp(3)*, *ibv_create_qp_ex(3)*
+*ibv_create_cq_ex(3)* *ibv_create_counters(3)*
+
+# AUTHOR
+
+Mark Bloch <marb@mellanox.com>

--- a/providers/mlx5/man/mlx5dv_create_flow_matcher.3.md
+++ b/providers/mlx5/man/mlx5dv_create_flow_matcher.3.md
@@ -1,0 +1,91 @@
+---
+layout: page
+title: mlx5dv_create_flow_matcher
+section: 3
+tagline: Verbs
+date: 2018-9-19
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+mlx5dv_create_flow_matcher - creates a matcher to be used with *mlx5dv_create_flow(3)*
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_flow_matcher *
+mlx5dv_create_flow_matcher(struct ibv_context *context,
+			   struct mlx5dv_flow_matcher_attr *attr)
+```
+
+# DESCRIPTION
+
+**mlx5dv_create_flow_matcher()** creates a flow matcher (mask) to be used
+with *mlx5dv_create_flow(3)*.
+
+# ARGUMENTS
+
+Please see *ibv_open_device(3)* for *context*.
+
+## *attr*
+
+```c
+struct mlx5dv_flow_matcher_attr {
+	enum ibv_flow_attr_type type;
+	uint32_t flags; /* From enum ibv_flow_flags */
+	uint16_t priority;
+	uint8_t match_criteria_enable; /* Device spec format */
+	struct mlx5dv_flow_match_parameters *match_mask;
+	uint64_t comp_mask;
+};
+```
+
+*type*
+:	Type of matcher to be created:
+	IBV_FLOW_ATTR_NORMAL:
+		Normal rule according to specification.
+
+*flags*
+:	special flags to control rule:
+	0:
+		Nothing or zero value means matcher will store ingress flow rules.
+	IBV_FLOW_ATTR_FLAGS_EGRESS:
+		Specified this matcher will store egress flow rules.
+
+*priority*
+:	See *ibv_create_flow(3)*.
+
+*match_criteria_enable*
+:	What match criteria is configured in *match_mask*, passed in
+	device spec format.
+
+## *match_mask*
+```c
+struct mlx5dv_flow_match_parameters {
+	size_t match_sz;
+	uint64_t match_buf[]; /* Device spec format */
+};
+```
+
+*match_sz*
+:	Size in bytes of *match_buf*.
+
+*match_buf*
+:	Set which mask to be used, passed in
+	device spec format.
+
+# RETURN VALUE
+
+**mlx5dv_create_flow_matcher**
+returns a pointer to *mlx5dv_flow_matcher*, on error NULL will be returned and errno will be set.
+
+# SEE ALSO
+
+*ibv_open_device(3)*, *ibv_create_flow(3)*
+
+# AUTHOR
+
+Mark Bloch <markb@mellanox.com>

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3731,24 +3731,25 @@ int mlx5dv_destroy_flow_matcher(struct mlx5dv_flow_matcher *flow_matcher)
 	return 0;
 }
 
+#define CREATE_FLOW_MAX_FLOW_ACTIONS_SUPPORTED 8
 struct ibv_flow *
 mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		   struct mlx5dv_flow_match_parameters *match_value,
 		   size_t num_actions,
 		   struct mlx5dv_flow_action_attr actions_attr[])
 {
+	uint32_t flow_actions[CREATE_FLOW_MAX_FLOW_ACTIONS_SUPPORTED];
+	struct verbs_flow_action *vaction;
+	int num_flow_actions = 0;
 	struct mlx5_flow *mflow;
+	bool have_qp = false;
 	int ret;
+	int i;
 	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_FLOW,
 			       MLX5_IB_METHOD_CREATE_FLOW,
-			       4);
+			       5);
 	struct ib_uverbs_attr *handle;
 	enum mlx5dv_flow_action_type type;
-
-	if (num_actions != 1) {
-		errno = EOPNOTSUPP;
-		return NULL;
-	}
 
 	mflow = calloc(1, sizeof(*mflow));
 	if (!mflow) {
@@ -3762,17 +3763,42 @@ mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		    match_value->match_sz);
 	fill_attr_in_obj(cmd, MLX5_IB_ATTR_CREATE_FLOW_MATCHER, flow_matcher->handle);
 
-	type = actions_attr[0].type;
-	switch (type) {
-	case MLX5DV_FLOW_ACTION_DEST_IBV_QP:
-		fill_attr_in_obj(cmd, MLX5_IB_ATTR_CREATE_FLOW_DEST_QP,
-				actions_attr[0].qp->handle);
-		break;
-	default:
-		errno = EOPNOTSUPP;
-		goto err;
+	for (i = 0; i < num_actions; i++) {
+		type = actions_attr[i].type;
+		switch (type) {
+		case MLX5DV_FLOW_ACTION_DEST_IBV_QP:
+			if (have_qp) {
+				errno = EOPNOTSUPP;
+				goto err;
+			}
+			fill_attr_in_obj(cmd, MLX5_IB_ATTR_CREATE_FLOW_DEST_QP,
+					 actions_attr[i].qp->handle);
+			have_qp = true;
+			break;
+		case MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION:
+			if (num_flow_actions ==
+			    CREATE_FLOW_MAX_FLOW_ACTIONS_SUPPORTED) {
+				errno = EOPNOTSUPP;
+				goto err;
+			}
+			vaction = container_of(actions_attr[i].action,
+					       struct verbs_flow_action,
+					       action);
+
+			flow_actions[num_flow_actions] = vaction->handle;
+			num_flow_actions++;
+			break;
+		default:
+			errno = EOPNOTSUPP;
+			goto err;
+		}
 	}
 
+	if (num_flow_actions)
+		fill_attr_in_objs_arr(cmd,
+				      MLX5_IB_ATTR_CREATE_FLOW_ARR_FLOW_ACTIONS,
+				      flow_actions,
+				      num_flow_actions);
 	ret = execute_ioctl(flow_matcher->context, cmd);
 	if (ret)
 		goto err;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3665,7 +3665,7 @@ mlx5dv_create_flow_matcher(struct ibv_context *context,
 {
 	DECLARE_COMMAND_BUFFER(cmd, MLX5_IB_OBJECT_FLOW_MATCHER,
 			       MLX5_IB_METHOD_FLOW_MATCHER_CREATE,
-			       4);
+			       5);
 	struct mlx5dv_flow_matcher *flow_matcher;
 	struct ib_uverbs_attr *handle;
 	int ret;
@@ -3695,6 +3695,9 @@ mlx5dv_create_flow_matcher(struct ibv_context *context,
 	fill_attr_in_enum(cmd, MLX5_IB_ATTR_FLOW_MATCHER_FLOW_TYPE,
 			  IBV_FLOW_ATTR_NORMAL, &attr->priority,
 			  sizeof(attr->priority));
+	if (attr->flags)
+		fill_attr_const_in(cmd, MLX5_IB_ATTR_FLOW_MATCHER_FLOW_FLAGS,
+				   attr->flags);
 
 	ret = execute_ioctl(context, cmd);
 	if (ret)


### PR DESCRIPTION
This series extends the existing mlx5 DV flow steering APIs to support flow actions and egress traffic. 

The verbs infrastructure was aligned with the kernel code to support passing an array of IDRs, this is used for passing an array of flow actions.