### PR TITLE
libhns: Add mw support for hip08 in user space

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -62,10 +62,13 @@ static const struct verbs_match_ent hca_table[] = {
 };
 
 static const struct verbs_context_ops hns_common_ops = {
+	.alloc_mw = hns_roce_u_alloc_mw,
 	.alloc_pd = hns_roce_u_alloc_pd,
+	.bind_mw = hns_roce_u_bind_mw,
 	.cq_event = hns_roce_u_cq_event,
 	.create_cq = hns_roce_u_create_cq,
 	.create_qp = hns_roce_u_create_qp,
+	.dealloc_mw = hns_roce_u_dealloc_mw,
 	.dealloc_pd = hns_roce_u_free_pd,
 	.dereg_mr = hns_roce_u_dereg_mr,
 	.destroy_cq = hns_roce_u_destroy_cq,

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -275,6 +275,11 @@ int hns_roce_u_rereg_mr(struct verbs_mr *mr, int flags, struct ibv_pd *pd,
 			void *addr, size_t length, int access);
 int hns_roce_u_dereg_mr(struct verbs_mr *mr);
 
+struct ibv_mw *hns_roce_u_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type);
+int hns_roce_u_dealloc_mw(struct ibv_mw *mw);
+int hns_roce_u_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
+		       struct ibv_mw_bind *mw_bind);
+
 struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
 				    struct ibv_comp_channel *channel,
 				    int comp_vector);

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -228,6 +228,7 @@ struct hns_roce_rc_sq_wqe {
 	union {
 		__le32	inv_key;
 		__le32	immtdata;
+		__le32	new_rkey;
 	};
 	__le32	byte_16;
 	__le32	byte_20;
@@ -250,6 +251,14 @@ struct hns_roce_rc_sq_wqe {
 #define RC_SQ_WQE_BYTE_4_SE_S 11
 
 #define RC_SQ_WQE_BYTE_4_INLINE_S 12
+
+#define RC_SQ_WQE_BYTE_4_MW_TYPE_S 14
+
+#define RC_SQ_WQE_BYTE_4_ATOMIC_S 20
+
+#define RC_SQ_WQE_BYTE_4_RDMA_READ_S 21
+
+#define RC_SQ_WQE_BYTE_4_RDMA_WRITE_S 22
 
 #define RC_SQ_WQE_BYTE_16_XRC_SRQN_S 0
 #define RC_SQ_WQE_BYTE_16_XRC_SRQN_M \
@@ -279,5 +288,8 @@ struct hns_roce_wqe_atomic_seg {
 	__le64		fetchadd_swap_data;
 	__le64		cmp_data;
 };
+
+int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
+			    struct ibv_send_wr **bad_wr);
 
 #endif /* _HNS_ROCE_U_HW_V2_H */


### PR DESCRIPTION
This patchset adds memory window (mw) support for hip08,
including mw alloc, dealloc and bind.

Signed-off-by: Yixian Liu liuyixian@huawei.com
---
v2->v3:
1. according to Jason'comments, give the list of supported, not unsupported.
v1->v2:
1. revise according to Jason'comments, remove unsupported checking, reture 0.