### PR TITLE
ibacm: fix ibacm service if ib_umad is not loaded

### DIFF
--- a/ibacm/ibacm.service.in
+++ b/ibacm/ibacm.service.in
@@ -10,6 +10,8 @@ Wants=rdma-load-modules@rdma.service
 After=rdma-load-modules@rdma.service
 # Order ibacm startup after basic RDMA hw setup.
 After=rdma-hw.target
+# Do not start the service if ib_umad is not loaded or not working
+ConditionPathExists=/sys/class/infiniband_mad/abi_version
 
 # Implicitly after basic.target, note that ibacm writes to /var/log directly
 # and thus needs writable filesystems setup.


### PR DESCRIPTION
The default modules config that is processed is kernel-boot/modules/rdma.conf
which does not contain ib_umad (infiniband.conf and opa.conf would). But
no matter what the default configs are - they could be modified by an admin,
due to that today there are cases the service would start ibacm with the module
not loaded.

That will trigger the service to immediately fail with:
ibacm[1796]: ibwarn: [1796] umad_init: can't read ABI version from
  /sys/class/infiniband_mad/abi_version (No such file or directory): is
  ib_umad module loaded?
systemd[1]: ibacm.service: Main process exited, code=exited, status=255/n/a

Avoid this bad status by not starting the service if we know it will
fail, that is much cleaner and makes a default installation having one
less failing service.

Also in Debian/Ubuntu a service of a package has to be (re-)started on
install/upgrade which fails due to this error as the default config will
let the service fail.

To avoid all thses issues check the condition of the abi_version to exist in
sysfs before trying to start the daemon.

Signed-off-by: Christian Ehrhardt <christian.ehrhardt@canonical.com>