### PR TITLE
mlx5: Enhance RAW QP support via the DV API

### DIFF
--- a/kernel-headers/rdma/ib_user_verbs.h
+++ b/kernel-headers/rdma/ib_user_verbs.h
@@ -763,10 +763,28 @@ struct ib_uverbs_sge {
 	__u32 lkey;
 };
 
+enum ib_uverbs_wr_opcode {
+	IB_UVERBS_WR_RDMA_WRITE = 0,
+	IB_UVERBS_WR_RDMA_WRITE_WITH_IMM = 1,
+	IB_UVERBS_WR_SEND = 2,
+	IB_UVERBS_WR_SEND_WITH_IMM = 3,
+	IB_UVERBS_WR_RDMA_READ = 4,
+	IB_UVERBS_WR_ATOMIC_CMP_AND_SWP = 5,
+	IB_UVERBS_WR_ATOMIC_FETCH_AND_ADD = 6,
+	IB_UVERBS_WR_LOCAL_INV = 7,
+	IB_UVERBS_WR_BIND_MW = 8,
+	IB_UVERBS_WR_SEND_WITH_INV = 9,
+	IB_UVERBS_WR_TSO = 10,
+	IB_UVERBS_WR_RDMA_READ_WITH_INV = 11,
+	IB_UVERBS_WR_MASKED_ATOMIC_CMP_AND_SWP = 12,
+	IB_UVERBS_WR_MASKED_ATOMIC_FETCH_AND_ADD = 13,
+	/* Review enum ib_wr_opcode before modifying this */
+};
+
 struct ib_uverbs_send_wr {
 	__aligned_u64 wr_id;
 	__u32 num_sge;
-	__u32 opcode;
+	__u32 opcode;		/* see enum ib_uverbs_wr_opcode */
 	__u32 send_flags;
 	union {
 		__be32 imm_data;

--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -45,6 +45,8 @@ enum {
 	MLX5_QP_FLAG_BFREG_INDEX	= 1 << 3,
 	MLX5_QP_FLAG_TYPE_DCT		= 1 << 4,
 	MLX5_QP_FLAG_TYPE_DCI		= 1 << 5,
+	MLX5_QP_FLAG_TIR_ALLOW_SELF_LB_UC = 1 << 6,
+	MLX5_QP_FLAG_TIR_ALLOW_SELF_LB_MC = 1 << 7,
 };
 
 enum {
@@ -349,9 +351,22 @@ struct mlx5_ib_create_qp_rss {
 	__u32	flags;
 };
 
+enum mlx5_ib_create_qp_resp_mask {
+	MLX5_IB_CREATE_QP_RESP_MASK_TIRN = 1UL << 0,
+	MLX5_IB_CREATE_QP_RESP_MASK_TISN = 1UL << 1,
+	MLX5_IB_CREATE_QP_RESP_MASK_RQN  = 1UL << 2,
+	MLX5_IB_CREATE_QP_RESP_MASK_SQN  = 1UL << 3,
+};
+
 struct mlx5_ib_create_qp_resp {
 	__u32	bfreg_index;
 	__u32   reserved;
+	__u32	comp_mask;
+	__u32	tirn;
+	__u32	tisn;
+	__u32	rqn;
+	__u32	sqn;
+	__u32   reserved1;
 };
 
 struct mlx5_ib_alloc_mw {

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -3,6 +3,7 @@ rdma_man_pages(
   mlx5dv_create_flow_action_modify_header.3.md
   mlx5dv_create_flow_action_packet_reformat.3.md
   mlx5dv_create_flow_matcher.3.md
+  mlx5dv_create_qp.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3

--- a/providers/mlx5/man/mlx5dv_create_qp.3.md
+++ b/providers/mlx5/man/mlx5dv_create_qp.3.md
@@ -1,0 +1,98 @@
+---
+layout: page
+title: mlx5dv_create_qp
+section: 3
+tagline: Verbs
+date: 2018-9-1
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_create_qp - creates a queue pair (QP)
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct ibv_qp *mlx5dv_create_qp(struct ibv_context         *context,
+                                struct ibv_qp_init_attr_ex *qp_attr,
+                                struct mlx5dv_qp_init_attr *mlx5_qp_attr)
+```
+
+
+# DESCRIPTION
+
+**mlx5dv_create_qp()** creates a queue pair (QP) with specific driver properties.
+
+# ARGUMENTS
+
+Please see *ibv_create_qp_ex(3)* man page for *context* and *qp_attr*.
+
+## mlx5_qp_attr
+
+```c
+struct mlx5dv_qp_init_attr {
+	uint64_t comp_mask;
+	uint32_t create_flags;
+	struct mlx5dv_dc_init_attr  dc_init_attr;
+};
+```
+
+*comp_mask*
+:	Bitmask specifying what fields in the structure are valid:
+	MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS:
+		valid values in *create_flags*
+	MLX5DV_QP_INIT_ATTR_MASK_DC:
+		valid values in *dc_init_attr*
+
+*create_flags*
+:	A bitwise OR of the various values described below.
+
+	MLX5DV_QP_CREATE_TUNNEL_OFFLOADS:
+		Enable offloading such as checksum and LRO for incoming
+		tunneling traffic.
+
+	MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_UC:
+		Allow receiving loopback unicast traffic.
+
+	MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_MC:
+		Allow receiving loopback multicast traffic.
+
+*dc_init_attr*
+:	DC init attributes.
+
+## *dc_init_attr*
+
+```c
+struct mlx5dv_dc_init_attr {
+	enum mlx5dv_dc_type	dc_type;
+	uint64_t dct_access_key;
+};
+```
+
+*dc_type*
+:	MLX5DV_DCTYPE_DCT
+		QP type: Target DC.
+	MLX5DV_DCTYPE_DCI
+		QP type: Initiator DC.
+
+*dct_access_key*
+:	used to create a DCT QP.
+
+
+# RETURN VALUE
+
+**mlx5dv_create_qp()**
+returns a pointer to the created QP, on error NULL will be returned and errno will be set.
+
+
+# SEE ALSO
+
+**ibv_query_device_ex**(3), **ibv_create_qp_ex**(3),
+
+# AUTHOR
+
+Yonatan Cohen <yonatanc@mellanox.com>

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -761,6 +761,14 @@ static int mlx5dv_get_qp(struct ibv_qp *qp_in,
 		mask_out |= MLX5DV_QP_MASK_UAR_MMAP_OFFSET;
 	}
 
+	if (qp_out->comp_mask & MLX5DV_QP_MASK_RAW_QP_HANDLES) {
+		qp_out->tirn = mqp->tirn;
+		qp_out->tisn = mqp->tisn;
+		qp_out->rqn = mqp->rqn;
+		qp_out->sqn = mqp->sqn;
+		mask_out |= MLX5DV_QP_MASK_RAW_QP_HANDLES;
+	}
+
 	if (mqp->bf->uuarn > 0)
 		qp_out->bf.size = mqp->bf->buf_size;
 	else

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -518,6 +518,10 @@ struct mlx5_qp {
 	int                             rss_qp;
 	uint32_t			flags; /* Use enum mlx5_qp_flags */
 	enum mlx5dv_dc_type		dc_type;
+	uint32_t			tirn;
+	uint32_t			tisn;
+	uint32_t			rqn;
+	uint32_t			sqn;
 };
 
 struct mlx5_ah {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -158,6 +158,8 @@ struct ibv_cq_ex *mlx5dv_create_cq(struct ibv_context *context,
 
 enum mlx5dv_qp_create_flags {
 	MLX5DV_QP_CREATE_TUNNEL_OFFLOADS = 1 << 0,
+	MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_UC = 1 << 1,
+	MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_MC = 1 << 2,
 };
 
 enum mlx5dv_qp_init_attr_mask {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -288,6 +288,7 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 
 enum mlx5dv_qp_comp_mask {
 	MLX5DV_QP_MASK_UAR_MMAP_OFFSET		= 1 << 0,
+	MLX5DV_QP_MASK_RAW_QP_HANDLES		= 1 << 1,
 };
 
 struct mlx5dv_qp {
@@ -308,6 +309,10 @@ struct mlx5dv_qp {
 	} bf;
 	uint64_t		comp_mask;
 	off_t			uar_mmap_offset;
+	uint32_t		tirn;
+	uint32_t		tisn;
+	uint32_t		rqn;
+	uint32_t		sqn;
 };
 
 struct mlx5dv_cq {


### PR DESCRIPTION
This series enhances the RAW QP support as follows:
1) It enables configuring self-loopback traffic.
2) It enables getting the low level device handles for the created QP.

The kernel part was already merged into 'for-next'.