### PR TITLE
ibacm: remove endpoint IP address from provider when address deleted

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -400,6 +400,7 @@ static void acm_mark_addr_invalid(struct acmc_ep *ep,
 		     !memcmp(ep->addr_info[i].addr.info.addr, data->info.addr,
 			     ACM_MAX_ADDRESS)) {
 			ep->addr_info[i].addr.type = ACM_ADDRESS_INVALID;
+			ep->port->prov->remove_address(ep->addr_info[i].prov_addr_context);
 			break;
 		}
 	}


### PR DESCRIPTION
When addresses are deleted, ibacm needs to call the provider to
let it know that the address has been deleted and allow it to
remove the address from its addr_info[].