### PR TITLE
bnxt_re/lib: libnxt_re bug fixes

### DIFF
--- a/providers/bnxt_re/db.c
+++ b/providers/bnxt_re/db.c
@@ -36,7 +36,7 @@
  * Description: Doorbell handling functions.
  */
 
-#include <util/udma_barrier.h>
+#include <util/mmio.h>
 #include "main.h"
 
 static void bnxt_re_ring_db(struct bnxt_re_dpi *dpi,
@@ -44,11 +44,10 @@ static void bnxt_re_ring_db(struct bnxt_re_dpi *dpi,
 {
 	__le64 *dbval;
 
-	pthread_spin_lock(&dpi->db_lock);
 	dbval = (__le64 *)&hdr->indx;
-	udma_to_device_barrier();
-	iowrite64(dpi->dbpage, dbval);
-	pthread_spin_unlock(&dpi->db_lock);
+	mmio_wc_start();
+	mmio_write64_le(dpi->dbpage, *dbval);
+	mmio_flush_writes();
 }
 
 static void bnxt_re_init_db_hdr(struct bnxt_re_db_hdr *hdr, uint32_t indx,

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -168,7 +168,6 @@ static void bnxt_re_free_context(struct ibv_context *ibvctx)
 	 * allocated in this context.
 	 */
 	if (cntx->udpi.dbpage && cntx->udpi.dbpage != MAP_FAILED) {
-		pthread_spin_destroy(&cntx->udpi.db_lock);
 		munmap(cntx->udpi.dbpage, dev->pg_size);
 		cntx->udpi.dbpage = NULL;
 	}

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -59,7 +59,6 @@
 struct bnxt_re_dpi {
 	__u32 dpindx;
 	__u64 *dbpage;
-	pthread_spinlock_t db_lock;
 };
 
 struct bnxt_re_pd {

--- a/providers/bnxt_re/memory.h
+++ b/providers/bnxt_re/memory.h
@@ -81,16 +81,6 @@ static inline unsigned long roundup_pow_of_two(unsigned long val)
 int bnxt_re_alloc_aligned(struct bnxt_re_queue *que, uint32_t pg_size);
 void bnxt_re_free_aligned(struct bnxt_re_queue *que);
 
-static inline void iowrite64(__u64 *dst, __le64 *src)
-{
-	*(volatile __le64 *)dst = *src;
-}
-
-static inline void iowrite32(__u32 *dst, __le32 *src)
-{
-	*(volatile __le32 *)dst = *src;
-}
-
 /* Basic queue operation */
 static inline uint32_t bnxt_re_is_que_full(struct bnxt_re_queue *que)
 {

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -686,12 +686,13 @@ int bnxt_re_poll_cq(struct ibv_cq *ibvcq, int nwc, struct ibv_wc *wc)
 		cq->deferred_arm_flags = 0;
 	}
 	pthread_spin_unlock(&cq->cqq.qlock);
-	/* Check if anything is there to flush. */
-	pthread_spin_lock(&cntx->fqlock);
 	left = nwc - dqed;
-	if (left)
+	if (left) {
+		/* Check if anything is there to flush. */
+		pthread_spin_lock(&cntx->fqlock);
 		dqed += bnxt_re_poll_flush_lists(cq, left, (wc + dqed));
-	pthread_spin_unlock(&cntx->fqlock);
+		pthread_spin_unlock(&cntx->fqlock);
+	}
 
 	return dqed;
 }

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -110,8 +110,6 @@ struct ibv_pd *bnxt_re_alloc_pd(struct ibv_context *ibvctx)
 			(void)ibv_cmd_dealloc_pd(&pd->ibvpd);
 			goto out;
 		}
-		pthread_spin_init(&cntx->udpi.db_lock,
-				  PTHREAD_PROCESS_PRIVATE);
         }
 
 	return &pd->ibvpd;


### PR DESCRIPTION
libnxt_re bug fixes

This pull request mainly handles the performance improvement
fixes done in the libbnxt_re code with an exception of patch
0004 which handles a bug in flush wqe management code.

Patch 0001, 0002 and 0003 are focused to optimize the doorbell
code and acquire-lock optimizations.

Devesh Sharma (3):
  bnxt_re/lib: Reduce memory barrier calls
  bnxt_re/lib: Remove db_lock around doorbell ring
  bnxt_re/lib: Fix the frequency of acquiring flush lock

Selvin Xavier (1):
  bnxt_re/lib: Fix flush list processing during poll_cq