### PR TITLE
mlx5: Introduce DEVX APIs

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -33,3 +33,5 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_obj_destroy@MLX5_1.7 21
  mlx5dv_devx_obj_query@MLX5_1.7 21
  mlx5dv_devx_obj_modify@MLX5_1.7 21
+ mlx5dv_devx_umem_dereg@MLX5_1.7 21
+ mlx5dv_devx_umem_reg@MLX5_1.7 21

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -28,3 +28,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_create_flow_action_modify_header@MLX5_1.7 21
  mlx5dv_create_flow_action_packet_reformat@MLX5_1.7 21
  mlx5dv_open_device@MLX5_1.7 21
+ mlx5dv_devx_general_cmd@MLX5_1.7 21
+ mlx5dv_devx_obj_create@MLX5_1.7 21
+ mlx5dv_devx_obj_destroy@MLX5_1.7 21
+ mlx5dv_devx_obj_query@MLX5_1.7 21
+ mlx5dv_devx_obj_modify@MLX5_1.7 21

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -51,4 +51,6 @@ MLX5_1.7 {
 		mlx5dv_devx_obj_destroy;
 		mlx5dv_devx_obj_query;
 		mlx5dv_devx_obj_modify;
+		mlx5dv_devx_umem_dereg;
+		mlx5dv_devx_umem_reg;
 } MLX5_1.6;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -46,4 +46,9 @@ MLX5_1.7 {
 		mlx5dv_create_flow_action_modify_header;
 		mlx5dv_create_flow_action_packet_reformat;
 		mlx5dv_open_device;
+		mlx5dv_devx_general_cmd;
+		mlx5dv_devx_obj_create;
+		mlx5dv_devx_obj_destroy;
+		mlx5dv_devx_obj_query;
+		mlx5dv_devx_obj_modify;
 } MLX5_1.6;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -5,6 +5,7 @@ rdma_man_pages(
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_qp.3.md
   mlx5dv_devx_obj_create.3.md
+  mlx5dv_devx_umem_reg.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3
@@ -18,4 +19,5 @@ rdma_alias_man_pages(
  mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_destroy.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_query.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_modify.3
+ mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_dereg.3
 )

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -4,6 +4,7 @@ rdma_man_pages(
   mlx5dv_create_flow_action_packet_reformat.3.md
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_qp.3.md
+  mlx5dv_devx_obj_create.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3
@@ -11,4 +12,10 @@ rdma_man_pages(
   mlx5dv_query_device.3
   mlx5dv_ts_to_ns.3
   mlx5dv.7
+)
+rdma_alias_man_pages(
+ mlx5dv_devx_obj_create.3 mlx5dv_devx_general_cmd.3
+ mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_destroy.3
+ mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_query.3
+ mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_modify.3
 )

--- a/providers/mlx5/man/mlx5dv_devx_obj_create.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_obj_create.3.md
@@ -1,0 +1,108 @@
+---
+layout: page
+title: mlx5dv_devx_obj_create / destroy / modify /query / general
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_devx_obj_create -   Creates a devx object
+
+mlx5dv_devx_obj_destroy -  Destroys a devx object
+
+mlx5dv_devx_obj_modify -   Modifies a devx object
+
+mlx5dv_devx_obj_query -    Queries a devx object
+
+mlx5dv_devx_general_cmd  - Issues a general command over the devx interface
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_devx_obj *
+mlx5dv_devx_obj_create(struct ibv_context *context, const void *in, size_t inlen,
+		       void *out, size_t outlen);
+int mlx5dv_devx_obj_query(struct mlx5dv_devx_obj *obj, const void *in, size_t inlen,
+			  void *out, size_t outlen);
+int mlx5dv_devx_obj_modify(struct mlx5dv_devx_obj *obj, const void *in, size_t inlen,
+			   void *out, size_t outlen);
+int mlx5dv_devx_obj_destroy(struct mlx5dv_devx_obj *obj);
+int mlx5dv_devx_general_cmd(struct ibv_context *context, const void *in, size_t inlen,
+			    void *out, size_t outlen);
+```
+
+# DESCRIPTION
+
+Create / destroy / modify / query a devx object, issue a general command over the devx interface.
+
+The DEVX API enables direct access from the user space area to the mlx5 device
+driver by using the KABI mechanism.  The main purpose is to make the user
+space driver as independent as possible from the kernel so that future device
+functionality and commands can be activated with minimal to none kernel changes.
+
+A DEVX object represents some underlay firmware object, the input command to
+create it is some raw data given by the user application which should match the
+device specification. Upon successful creation the output buffer includes the
+raw data from the device according to its specification, this data
+can be used as part of related firmware commands to this object.
+
+Once the DEVX object is created it can be queried/modified/destroyed by the
+matching mlx5dv_devx_obj_xxx() API. Both the input and the output for those APIs
+need to match the device specification as well.
+
+The mlx5dv_devx_general_cmd() API enables issuing some general command which is
+not related to an object such as query device capabilities.
+
+An application can gradually migrate to use DEVX according to its needs, it is
+not all or nothing.  For example it can create an ibv_cq via ibv_create_cq()
+verb and then use the returned cqn to create a DEVX QP object by the
+mlx5dv_devx_obj_create() API which needs that cqn.
+
+The above example can enable an application to create a QP with some driver
+specific attributes that are not exposed in the ibv_create_qp() API, in that
+case no user or kernel change may be needed at all as the command input reaches
+directly to the firmware.
+
+The expected users for the DEVX APIs are application that use the mlx5 DV APIs
+and are familiar with the device specification in both control and data path.
+
+To successfully create a DEVX object and work on, a DEVX context must be
+created, this is done by the mlx5dv_open_device() API with the
+*MLX5DV_CONTEXT_FLAGS_DEVX* flag.
+
+# ARGUMENTS
+*context*
+:	RDMA device context to create the action on.
+
+*in*
+:	A buffer which contains the command's input data provided in a device specification format.
+
+*inlen*
+:	The size of *in* buffer in bytes.
+
+*out*
+:	 A buffer which contains the command's output data according to the device specification format.
+
+*outlen*
+:	The size of *out* buffer in bytes.
+
+*obj*
+:	For query, modify, destroy: the devx object to work on.
+
+# RETURN VALUE
+
+Upon success *mlx5dv_devx_create_obj* will return a new *struct
+mlx5dv_devx_obj* on error NULL will be returned and errno will be set.
+
+Upon success query, modify, destroy, general commands, 0 is returned or the value of errno on a failure.
+
+# SEE ALSO
+
+**mlx5dv_open_device**
+
+AUTHOR
+
+Yishai Hadas  <yishaih@mellanox.com>

--- a/providers/mlx5/man/mlx5dv_devx_umem_reg.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_umem_reg.3.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: mlx5dv_devx_umem_reg, mlx5dv_devx_umem_dereg
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_devx_umem_reg - Register a user memory to be used by the devx interface
+
+mlx5dv_devx_umem_dereg - Deregister a devx umem object
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_devx_umem {
+	uint32_t umem_id;
+};
+
+struct mlx5dv_devx_umem *
+mlx5dv_devx_umem_reg(struct ibv_context *context, void *addr, size_t size,
+		     uint32_t access)
+
+int mlx5dv_devx_umem_dereg(struct mlx5dv_devx_umem *dv_devx_umem)
+```
+
+# DESCRIPTION
+
+Register or deregister a user memory to be used by the devx interface.
+
+The register verb exposes a UMEM DEVX object for user memory registration for
+DMA.  The API to register the user memory gets as input the user address,
+length and access flags, and provides to the user as output an object which
+holds the UMEM ID returned by the firmware to this registered memory.
+
+The user will use that UMEM ID in device direct commands that use this memory
+instead of the physical addresses list, for example upon
+*mlx5dv_devx_obj_create* to create a QP.
+
+# ARGUMENTS
+*context*
+:       RDMA device context to create the action on.
+
+*addr*
+:	The memory start address to register.
+
+*size*
+:       The size of *addr* buffer.
+
+*access*
+:	The desired memory protection attributes; it is either 0 or the bitwise OR of one or more of *enum ibv_access_flags*.
+
+
+# RETURN VALUE
+
+Upon success *mlx5dv_devx_umem_reg* will return a new *struct
+mlx5dv_devx_umem* object, on error NULL will be returned and errno will be set.
+
+*mlx5dv_devx_umem_dereg* returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+
+# SEE ALSO
+
+*mlx5dv_open_device(3)*, *ibv_reg_mr(3)*, *mlx5dv_devx_obj_create(3)*
+
+#AUTHOR
+
+Yishai Hadas <yishaih@mellanox.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -572,6 +572,12 @@ struct mlx5dv_devx_obj {
 	uint32_t handle;
 };
 
+struct mlx5_devx_umem {
+	struct mlx5dv_devx_umem dv_devx_umem;
+	struct ibv_context *context;
+	uint32_t handle;
+};
+
 static inline int mlx5_ilog2(int n)
 {
 	int t;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -567,6 +567,11 @@ struct mlx5dv_flow_matcher {
 	uint32_t handle;
 };
 
+struct mlx5dv_devx_obj {
+	struct ibv_context *context;
+	uint32_t handle;
+};
+
 static inline int mlx5_ilog2(int n)
 {
 	int t;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1015,6 +1015,18 @@ struct mlx5dv_context_attr {
 struct ibv_context *
 mlx5dv_open_device(struct ibv_device *device, struct mlx5dv_context_attr *attr);
 
+struct mlx5dv_devx_obj;
+
+struct mlx5dv_devx_obj *
+mlx5dv_devx_obj_create(struct ibv_context *context, const void *in, size_t inlen,
+		       void *out, size_t outlen);
+int mlx5dv_devx_obj_query(struct mlx5dv_devx_obj *obj, const void *in, size_t inlen,
+			  void *out, size_t outlen);
+int mlx5dv_devx_obj_modify(struct mlx5dv_devx_obj *obj, const void *in, size_t inlen,
+			   void *out, size_t outlen);
+int mlx5dv_devx_obj_destroy(struct mlx5dv_devx_obj *obj);
+int mlx5dv_devx_general_cmd(struct ibv_context *context, const void *in, size_t inlen,
+			    void *out, size_t outlen);
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -224,6 +224,7 @@ enum mlx5dv_flow_action_type {
 	MLX5DV_FLOW_ACTION_IBV_COUNTER,
 	MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION,
 	MLX5DV_FLOW_ACTION_TAG,
+	MLX5DV_FLOW_ACTION_DEST_DEVX,
 };
 
 struct mlx5dv_flow_action_attr {
@@ -233,6 +234,7 @@ struct mlx5dv_flow_action_attr {
 		struct ibv_counters *counter;
 		struct ibv_flow_action *action;
 		uint32_t tag_value;
+		struct mlx5dv_devx_obj *obj;
 	};
 };
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1027,6 +1027,15 @@ int mlx5dv_devx_obj_modify(struct mlx5dv_devx_obj *obj, const void *in, size_t i
 int mlx5dv_devx_obj_destroy(struct mlx5dv_devx_obj *obj);
 int mlx5dv_devx_general_cmd(struct ibv_context *context, const void *in, size_t inlen,
 			    void *out, size_t outlen);
+
+struct mlx5dv_devx_umem {
+	uint32_t umem_id;
+};
+
+struct mlx5dv_devx_umem *
+mlx5dv_devx_umem_reg(struct ibv_context *ctx, void *addr, size_t size, uint32_t access);
+int mlx5dv_devx_umem_dereg(struct mlx5dv_devx_umem *umem);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This series introduces the initial DEVX APIs for mlx5 driver, it enables to create a devx object and query/modify/destroy it.

In addition, the general DEVX command and the umem APIs are added as well.

The matching kernel size was already merged.