### PR TITLE
librdmacm: Allow RDMA CM use with connected QP when it is not managing the QP

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -1023,7 +1023,7 @@ static int ucma_modify_qp_rtr(struct rdma_cm_id *id, uint8_t resp_res)
 	uint8_t link_layer;
 
 	if (!id->qp)
-		return ERR(EINVAL);
+		return 0;
 
 	/* Need to update QP attributes from default values. */
 	qp_attr.qp_state = IBV_QPS_INIT;
@@ -1059,6 +1059,9 @@ static int ucma_modify_qp_rts(struct rdma_cm_id *id, uint8_t init_depth)
 {
 	struct ibv_qp_attr qp_attr;
 	int qp_attr_mask, ret;
+
+	if (!id->qp)
+		return 0;
 
 	qp_attr.qp_state = IBV_QPS_RTS;
 	ret = rdma_init_qp_attr(id, &qp_attr, &qp_attr_mask);


### PR DESCRIPTION
The RDMA CM documentation indicates it supports being used for communication
management only (I.E. application manages QP). This change enables using the
RDMA CM for connected QP communication management without it managing the QP.
Since the Connection Response event is consumed in the library on the active
side, the application must ensure it closes the race of transitioning the QP
to RTR.

This change only impacts the current error path when QP are not managed
and is consistent with the other unmanaged QP checks done throughout the code.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>
Signed-off-by: James Swaro <jswaro@cray.com>