### PR TITLE
Debian avoid unconditional ibacm start

### DIFF
--- a/debian/ibacm.install
+++ b/debian/ibacm.install
@@ -1,4 +1,3 @@
-etc/init.d/ibacm
 lib/systemd/system/ibacm.service
 lib/systemd/system/ibacm.socket
 usr/bin/ib_acme

--- a/debian/ibacm.maintscript
+++ b/debian/ibacm.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/init.d/ibacm 19.0-1ubuntu1~

--- a/debian/rules
+++ b/debian/rules
@@ -53,6 +53,7 @@ endif
 
 # The following files are not used on Debian (we ship our own sysvinit script)
 INST_EXCLUDE := "etc/init.d/srpd" \
+		"etc/init.d/ibacm" \
 		"usr/sbin/run_srp_daemon" \
 		"usr/sbin/srp_daemon.sh"
 INST_EXCLUDE := $(addprefix -X,$(INST_EXCLUDE))
@@ -62,9 +63,13 @@ override_dh_install:
 # cmake installs the correct init scripts in the correct place, just setup the
 # pre-postrms
 override_dh_installinit:
-	dh_installinit -pibacm --onlyscripts
 	dh_installinit -prdma-core --onlyscripts --name=iwpmd
 	dh_installinit --remaining-packages
+
+override_dh_installsystemd:
+	dh_installsystemd -pibacm --no-start ibacm.service
+	dh_installsystemd -pibacm ibacm.socket
+	dh_installsystemd --remaining-packages
 
 # Provider plugin libaries are not shared libraries and do not belong in the
 # shlibs file.


### PR DESCRIPTION
This is a successor to the abandoned #393

Per Discussion on the [Mailing list](https://www.spinics.net/lists/linux-rdma/msg70203.html) and some iterations on the [Launchpad bug](https://bugs.launchpad.net/ubuntu/+source/rdma-core/+bug/1794825) I think we should drop the sysV script.

For now it seems the most clear way to get rid of unconditionally starting ibacm (including failing to do so depending on the environment and breaking the postinst actions) due to debhelper actions and IMHO I don't think pre-systemd backports are important for the .deb packages anymore.

I'm open to suggestions how to convince dh_* otherwise to do the right thing, but please check out the [LP bug](https://bugs.launchpad.net/ubuntu/+source/rdma-core/+bug/1794825) about the most obvious approaches that were already tried.