### PR TITLE
mlx5: Allow passing a flow tag value in mlx5dv_create_flow

### DIFF
--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -157,6 +157,7 @@ enum mlx5_ib_create_flow_attrs {
 	MLX5_IB_ATTR_CREATE_FLOW_DEST_DEVX,
 	MLX5_IB_ATTR_CREATE_FLOW_MATCHER,
 	MLX5_IB_ATTR_CREATE_FLOW_ARR_FLOW_ACTIONS,
+	MLX5_IB_ATTR_CREATE_FLOW_TAG,
 };
 
 enum mlx5_ib_destoy_flow_attrs {

--- a/providers/mlx5/man/mlx5dv_create_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_create_flow.3.md
@@ -54,6 +54,8 @@ struct mlx5dv_flow_action_attr {
 		The QP passed will receive the matched packets.
 	MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION
 		The flow action to be applied.
+	MLX5DV_FLOW_ACTION_TAG
+		Flow tag to be provided in work completion.
 
 *qp*
 :	QP passed, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_IBV_QP*.
@@ -61,6 +63,10 @@ struct mlx5dv_flow_action_attr {
 *action*
 :	Flow action, to be used with *type* *MLX5DV_FLOW_ACTION_IBV_FLOW_ACTION*
 	see *mlx5dv_create_flow_action_modify_header(3)* and *mlx5dv_create_flow_action_packet_reformat(3)*.
+
+*tag_value*
+:	tag value to be passed in the work completion, to be used with *type*
+	*MLX5DV_FLOW_ACTION_TAG* see *ibv_create_cq_ex(3)*.
 
 # RETURN VALUE
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3776,11 +3776,12 @@ mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 	struct mlx5_flow *mflow;
 	bool have_qp = false;
 	bool have_dest_devx = false;
+	bool have_flow_tag = false;
 	int ret;
 	int i;
 	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_FLOW,
 			       MLX5_IB_METHOD_CREATE_FLOW,
-			       5);
+			       6);
 	struct ib_uverbs_attr *handle;
 	enum mlx5dv_flow_action_type type;
 
@@ -3829,6 +3830,16 @@ mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 			fill_attr_in_obj(cmd, MLX5_IB_ATTR_CREATE_FLOW_DEST_DEVX,
 					 actions_attr[i].obj->handle);
 			have_dest_devx = true;
+			break;
+		case MLX5DV_FLOW_ACTION_TAG:
+			if (have_flow_tag) {
+				errno = EINVAL;
+				goto err;
+			}
+			fill_attr_in_uint32(cmd,
+					    MLX5_IB_ATTR_CREATE_FLOW_TAG,
+					    actions_attr[i].tag_value);
+			have_flow_tag = true;
 			break;
 		default:
 			errno = EOPNOTSUPP;


### PR DESCRIPTION
Allow passing a flow tag value in mlx5dv_create_flow, the matching kernel code was already merged into 'for-next'.