### PR TITLE
Build static libraries for rdma-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,8 @@ set(BUILD_INCLUDE ${CMAKE_BINARY_DIR}/include)
 set(BUILD_BIN ${CMAKE_BINARY_DIR}/bin)
 # Libraries
 set(BUILD_LIB ${CMAKE_BINARY_DIR}/lib)
+# Static library pre-processing
+set(BUILD_STATIC_LIB ${CMAKE_BINARY_DIR}/lib/statics)
 # Used for IN_PLACE configuration
 set(BUILD_ETC ${CMAKE_BINARY_DIR}/etc)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,6 +562,7 @@ if (UDEV_FOUND)
 endif()
 add_subdirectory(srp_daemon)
 
+ibverbs_finalize()
 rdma_finalize_libs()
 
 #-------------------------

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -102,6 +102,7 @@ class centos6(YumEnvironment):
         'make',
         'pkgconfig',
         'python',
+        'python-argparse',
         'rpm-build',
         'valgrind-devel',
     };

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -11,6 +11,8 @@ import subprocess
 import tempfile
 import sys
 import copy
+import shlex
+import pipes
 from contextlib import contextmanager;
 
 def get_src_dir():
@@ -307,6 +309,144 @@ def test_installed_headers(args):
                     raise ValueError("No extern C in %r"%(I));
 
         compile_test_headers(tmpd,incdir,includes,with_cxx=True);
+
+# -------------------------------------------------------------------------
+
+
+def get_symbol_names(fn):
+    """Return the defined, public, symbols from a ELF shlib"""
+    syms = subprocess.check_output(["readelf", "--wide", "-s", fn])
+    go = False
+    res = set()
+    for I in syms.splitlines():
+        if I.startswith("Symbol table '.dynsym'"):
+            go = True
+            continue
+
+        if I.startswith(" ") and go:
+            g = re.match(
+                r"\s+\d+:\s+[0-9a-f]+\s+\d+.*(?:FUNC|OBJECT)\s+GLOBAL\s+DEFAULT\s+\d+\s+(\S+)@@(\S+)$",
+                I)
+            if not g or "PRIVATE" in g.group(2):
+                continue
+            res.add(g.group(1))
+        else:
+            go = False
+
+    return res
+
+
+def get_cc_args_from_pkgconfig(args, name, static):
+    """Get the compile arguments from pkg-config for the named librarary"""
+    os.environ["PKG_CONFIG_PATH"] = os.path.join(args.BUILD, "lib",
+                                                 "pkgconfig")
+    flags = ["pkg-config", "--errors-to-stdout", "--cflags", "--libs"]
+    if static:
+        flags.append("--static")
+    opts = subprocess.check_output(flags + ["lib" + name])
+    opts = shlex.split(opts)
+
+    opts.insert(0, "-Wall")
+    opts.insert(0, "-Werror")
+    opts.insert(0, "-L%s" % (os.path.join(args.BUILD, "lib")))
+    opts.insert(1, "-I%s" % (os.path.join(args.BUILD, "include")))
+    if not static:
+        return opts
+
+    # The old pkg-config that travis uses incorrectly removes duplicated
+    # flags, which breaks linking.
+    if (name == "ibverbs" and
+        subprocess.check_output(["pkg-config", "--version"]).strip() == "0.26"):
+        opts.insert(0, "-libverbs")
+
+    # Only static link the pkg-config stuff, otherwise we get warnings about
+    # static linking portions of glibc that need NSS.
+    opts.insert(0, "-Wl,-Bstatic")
+    opts.append("-Wl,-Bdynamic")
+
+    # We need this extra libpthread/m because libnl's pkgconfig file is
+    # broken and doesn't include the private libraries it requires. :(
+    if "-lnl-3" in opts:
+        opts.append("-lm")
+        opts.append("-lpthread")
+
+    # Put glibc associated libraries out side the static link section,
+    if "-lpthread" in opts:
+        while "-lpthread" in opts:
+            opts.remove("-lpthread")
+        opts.append("-lpthread")
+    if "-lm" in opts:
+        while "-lm" in opts:
+            opts.remove("-lm")
+        opts.append("-lm")
+    return opts
+
+
+def compile_ninja(args, Fninja, name, cfn, opts):
+    print >> Fninja, """
+rule comp_{name}
+    command = {CC} -Wall -o $out $in {opts}
+    description = Compile and link $out
+build {name} : comp_{name} {cfn}
+default {name}""".format(
+        name=name,
+        CC=args.CC,
+        cfn=cfn,
+        opts=" ".join(pipes.quote(I) for I in opts))
+
+
+def check_static_lib(args, tmpd, Fninja, static_lib, shared_lib, name):
+    syms = get_symbol_names(shared_lib)
+    if not syms:
+        return
+
+    cfn = os.path.join(tmpd, "%s-test.c" % (name))
+    with open(cfn, "wt") as F:
+        F.write("#include <stdio.h>\n")
+        for I in syms:
+            F.write("extern void %s(void);\n" % (I))
+        F.write("int main(int argc,const char *argv[]) {\n")
+        for I in syms:
+            F.write('printf("%%p",&%s);\n' % (I))
+        F.write("return 0; }\n")
+
+    compile_ninja(args, Fninja, "%s-static-out" % (name), cfn,
+                  get_cc_args_from_pkgconfig(args, name, static=True))
+    compile_ninja(args, Fninja, "%s-shared-out" % (name), cfn,
+                  get_cc_args_from_pkgconfig(args, name, static=False))
+
+
+def test_static_libs(args):
+    """Compile then link statically and dynamically a dummy program that touches
+    every symbol in the libraries using pkgconfig output to guide the link
+    options. This tests that pkgconfig is setup properly and that all the
+    magic with incorporating the internal libraries for static linking has
+    done its job."""
+    libd = os.path.join(args.BUILD, "lib")
+    success = True
+    libs = []
+    with inDirectory(libd):
+        fns = set(fn for fn in os.listdir(".") if not os.path.islink(fn))
+        for static_lib in fns:
+            g = re.match(r"lib(.+)\.a", static_lib)
+            if g:
+                for shared_lib in fns:
+                    if re.match(r"lib%s.*\.so" % (g.group(1)), shared_lib):
+                        libs.append((os.path.join(libd, static_lib),
+                                     os.path.join(libd, shared_lib),
+                                     g.group(1)))
+                        break
+                else:
+                    raise ValueError(
+                        "Failed to find matching shared library for %r" %
+                        (static_lib))
+
+    with private_tmp() as tmpd:
+        with open(os.path.join(tmpd, "build.ninja"), "wt") as Fninja:
+            for I in libs:
+                check_static_lib(args, tmpd, Fninja, I[0], I[1], I[2])
+        subprocess.check_call(["ninja"], cwd=tmpd)
+
 
 # -------------------------------------------------------------------------
 

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -395,6 +395,13 @@ default {name}""".format(
         opts=" ".join(pipes.quote(I) for I in opts))
 
 
+def get_providers(args):
+    """Return a list of provider names"""
+    return set(
+        I for I in os.listdir(os.path.join(args.SRC, "providers"))
+        if not I.startswith("."))
+
+
 def check_static_lib(args, tmpd, Fninja, static_lib, shared_lib, name):
     syms = get_symbol_names(shared_lib)
     if not syms:
@@ -414,6 +421,32 @@ def check_static_lib(args, tmpd, Fninja, static_lib, shared_lib, name):
                   get_cc_args_from_pkgconfig(args, name, static=True))
     compile_ninja(args, Fninja, "%s-shared-out" % (name), cfn,
                   get_cc_args_from_pkgconfig(args, name, static=False))
+
+
+def check_static_providers(args, tmpd, Fninja):
+    """Test that expected values for RDMA_STATIC_PROVIDERS are accepted and the
+    link works"""
+    cfn = os.path.join(tmpd, "provider-test.c")
+    with open(cfn, "wt") as F:
+        F.write("#include <infiniband/verbs.h>\n")
+        F.write("int main(int argc,const char *argv[]) {\n")
+        F.write('ibv_get_device_list(NULL);\n')
+        F.write("return 0; }\n")
+
+    opts = get_cc_args_from_pkgconfig(
+        args, "ibverbs", static=True)
+
+    providers = get_providers(args)
+    for I in sorted(providers | {
+            "none",
+            "all",
+    }):
+        compile_ninja(args, Fninja, "providers-%s-static-out" % (I), cfn,
+                      ["-DRDMA_STATIC_PROVIDERS=%s" % (I)] + opts)
+
+    compile_ninja(
+        args, Fninja, "providers-static-out", cfn,
+        ["-DRDMA_STATIC_PROVIDERS=%s" % (",".join(providers))] + opts)
 
 
 def test_static_libs(args):
@@ -445,6 +478,7 @@ def test_static_libs(args):
         with open(os.path.join(tmpd, "build.ninja"), "wt") as Fninja:
             for I in libs:
                 check_static_lib(args, tmpd, Fninja, I[0], I[1], I[2])
+            check_static_providers(args, tmpd, Fninja)
         subprocess.check_call(["ninja"], cwd=tmpd)
 
 

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -7,6 +7,9 @@
 # Global list of tuples of (SHARED STATIC MAP) library target names
 set(RDMA_STATIC_LIBS "" CACHE INTERNAL "Doc" FORCE)
 
+# Global list of tuples of (PROVIDER_NAME LIB_NAME)
+set(RDMA_PROVIDER_LIST "" CACHE INTERNAL "Doc" FORCE)
+
 set(COMMON_LIBS_PIC ccan_pic rdma_util_pic)
 set(COMMON_LIBS ccan rdma_util)
 
@@ -130,6 +133,9 @@ function(rdma_shared_provider DEST VERSION_SCRIPT SOVERSION VERSION)
   file(MAKE_DIRECTORY "${BUILD_ETC}/libibverbs.d/")
   file(WRITE "${BUILD_ETC}/libibverbs.d/${DEST}.driver" "driver ${BUILD_LIB}/lib${DEST}\n")
 
+  list(APPEND RDMA_PROVIDER_LIST ${DEST} ${DEST})
+  set(RDMA_PROVIDER_LIST "${RDMA_PROVIDER_LIST}" CACHE INTERNAL "")
+
   # Create a static provider library
   if (ENABLE_STATIC)
     add_library(${DEST}-static STATIC ${ARGN})
@@ -173,14 +179,13 @@ function(rdma_provider DEST)
   file(MAKE_DIRECTORY "${BUILD_ETC}/libibverbs.d/")
   file(WRITE "${BUILD_ETC}/libibverbs.d/${DEST}.driver" "driver ${BUILD_LIB}/lib${DEST}\n")
 
+  list(APPEND RDMA_PROVIDER_LIST ${DEST} "${DEST}-rdmav${IBVERBS_PABI_VERSION}")
+  set(RDMA_PROVIDER_LIST "${RDMA_PROVIDER_LIST}" CACHE INTERNAL "")
+
   # Create a static provider library
-  # FIXME: This is probably pointless, the provider library has no symbols so
-  # what good is it? Presumably it should be used with -Wl,--whole-archive,
-  # but we don't have any directions on how to make static linking work..
   if (ENABLE_STATIC)
     add_library(${DEST} STATIC ${ARGN})
     rdma_public_static_lib("${DEST}-rdmav${IBVERBS_PABI_VERSION}" ${DEST} ${BUILDLIB}/provider.map)
-    set_target_properties(${DEST} PROPERTIES OUTPUT_NAME ${DEST})
   endif()
 
   # Create the plugin shared library

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -295,12 +295,13 @@ function(rdma_pkg_config PC_LIB_NAME PC_REQUIRES_PRIVATE PC_LIB_PRIVATE)
   set(PC_REQUIRES_PRIVATE "${PC_REQUIRES_PRIVATE}")
   get_target_property(PC_VERSION ${PC_LIB_NAME} VERSION)
 
-  # With IN_PLACE=1 the install step is not ran, so generate the file in the build dir
+  # With IN_PLACE=1 the install step is not run, so generate the file in the build dir
   if (IN_PLACE)
     set(PC_RPATH "-Wl,-rpath,\${libdir}")
-    configure_file(${CMAKE_SOURCE_DIR}/buildlib/template.pc.in ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig/lib${PC_LIB_NAME}.pc @ONLY)
-  else()
-    configure_file(${CMAKE_SOURCE_DIR}/buildlib/template.pc.in ${CMAKE_CURRENT_BINARY_DIR}/lib${PC_LIB_NAME}.pc @ONLY)
-    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/lib${PC_LIB_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
+  endif()
+
+  configure_file(${BUILDLIB}/template.pc.in ${BUILD_LIB}/pkgconfig/lib${PC_LIB_NAME}.pc @ONLY)
+  if (NOT IN_PLACE)
+    install(FILES ${BUILD_LIB}/pkgconfig/lib${PC_LIB_NAME}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
   endif()
 endfunction()

--- a/buildlib/sanitize_static_lib.py
+++ b/buildlib/sanitize_static_lib.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python
+# Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+# Licensed under BSD (MIT variant) or GPLv2. See COPYING.
+"""This tool is used to create installable versions of the static libraries in rdma-core.
+
+This is complicated because rdma-core was not designed with static libraries
+in mind and relies on the dynamic linker to hide a variety of internal
+details.
+
+The build uses several internal utility libraries across the providers and the
+libraries. When building statically these libraries have to become inlined
+into the various main libraries. This script figures out which static
+libraries should include which internal libraries and inlines them
+appropriately.
+
+rdma-core is not careful to use globally unique names throughout all the
+libraries and all the providers.  Normally the map file in the dynamic linker
+will hide these external symbols. This script does something similar for static
+linking by analyzing the libraries and map files then renaming internal
+symbols with a globally unique prefix.
+
+This is far too complicated to handle internally with cmake, so we have cmake
+produce the nearly completed libraries, then process them here using bintuils,
+and finally produce the final installation ready libraries."""
+
+import collections
+import subprocess
+import argparse
+import tempfile
+import itertools
+import sys
+import os
+import re
+
+SymVer = collections.namedtuple(
+    "SymVer", ["version", "prior_version", "globals", "locals"])
+
+try:
+    from tempfile import TemporaryDirectory
+except ImportError:
+    import shutil
+    import tempfile
+
+    # From /usr/lib/python3/dist-packages/setuptools/py31compat.py
+    class TemporaryDirectory(object):
+        def __init__(self):
+            self.name = None
+            self.name = tempfile.mkdtemp()
+
+        def __enter__(self):
+            return self.name
+
+        def __exit__(self, exctype, excvalue, exctrace):
+            try:
+                shutil.rmtree(self.name, True)
+            except OSError:
+                pass
+            self.name = None
+
+
+try:
+    from subprocess import check_output
+except ImportError:
+    # From /usr/lib/python2.7/subprocess.py
+    def check_output(*popenargs, **kwargs):
+        if 'stdout' in kwargs:
+            raise ValueError(
+                'stdout argument not allowed, it will be overridden.')
+        process = subprocess.Popen(
+            stdout=subprocess.PIPE, *popenargs, **kwargs)
+        output, unused_err = process.communicate()
+        retcode = process.poll()
+        if retcode:
+            cmd = kwargs.get("args")
+            if cmd is None:
+                cmd = popenargs[0]
+            raise CalledProcessError(retcode, cmd, output=output)
+        return output
+
+    subprocess.check_output = check_output
+
+
+def parse_stanza(version, prior_version, lines):
+    gbl = []
+    local = []
+    cur = None
+
+    cur = 0
+    for I in re.finditer(
+            r"\s*(?:(global:)|(local:)(\s*\*\s*;)|(?:(\w+)\s*;))",
+            lines,
+            flags=re.DOTALL | re.MULTILINE):
+        if I.group(1):  # global
+            lst = gbl
+        if I.group(2):  # local
+            lst = local
+        if I.group(3):  # wildcard
+            lst.append("*")
+            assert (cur is not gbl)
+        if I.group(4):  # symbol name
+            lst.append(I.group(4))
+
+        assert cur == I.start()
+        cur = I.end()
+    assert cur == len(lines)
+
+    return SymVer(version or "", prior_version or "", gbl, local)
+
+
+def load_map(fn):
+    """This is a lame regex based parser for GNU linker map files. It asserts if
+    the map file is invalid. It returns a list of the global symbols"""
+    with open(fn, "rt") as F:
+        lines = F.read()
+    p = re.compile(r"/\*.*?\*/", flags=re.DOTALL)
+    lines = re.sub(p, "", lines)
+    lines = lines.strip()
+
+    # Extract each stanza
+    res = []
+    cur = 0
+    for I in re.finditer(
+            r"\s*(?:(\S+)\s+)?{(.*?)\s*}(\s*\S+)?\s*;",
+            lines,
+            flags=re.DOTALL | re.MULTILINE):
+        assert cur == I.start()
+        res.append(parse_stanza(I.group(1), I.group(3), I.group(2)))
+        cur = I.end()
+    assert cur == len(lines)
+
+    return res
+
+
+class Lib(object):
+    def __init__(self, libfn, tmpdir):
+        self.libfn = os.path.basename(libfn)
+        self.objdir = os.path.join(tmpdir, self.libfn)
+        self.final_objdir = os.path.join(tmpdir, "r-" + self.libfn)
+        self.final_lib = os.path.join(os.path.dirname(libfn), "..", self.libfn)
+        self.needs = set()
+        self.needed = set()
+
+        os.makedirs(self.objdir)
+        os.makedirs(self.final_objdir)
+
+        subprocess.check_call([args.ar, "x", libfn], cwd=self.objdir)
+        self.objects = [I for I in os.listdir(self.objdir)]
+        self.get_syms()
+
+    def get_syms(self):
+        """Read the definedsymbols from each object file"""
+        self.syms = set()
+        self.needed_syms = set()
+        for I in self.objects:
+            I = os.path.join(self.objdir, I)
+            syms = subprocess.check_output([args.nm, "--defined-only", I])
+            for ln in syms.decode().splitlines():
+                ln = ln.split()
+                if ln[1].isupper():
+                    self.syms.add(ln[2])
+
+            syms = subprocess.check_output([args.nm, "--undefined-only", I])
+            for ln in syms.decode().splitlines():
+                ln = ln.split()
+                if ln[0].isupper():
+                    self.needed_syms.add(ln[1])
+
+    def rename_syms(self, rename_fn):
+        """Invoke objcopy on all the objects to rename their symbols"""
+        for I in self.objects:
+            subprocess.check_call([
+                args.objcopy,
+                "--redefine-syms=%s" % (rename_fn),
+                os.path.join(self.objdir, I),
+                os.path.join(self.final_objdir, I)
+            ])
+
+    def incorporate_internal(self, internal_libs):
+        """If this library requires an internal library then we want to inline it into
+        this lib when we reconstruct it."""
+        for lib in self.needs.intersection(internal_libs):
+            self.objects.extend(
+                os.path.join(lib.final_objdir, I) for I in lib.objects)
+
+    def finalize(self):
+        """Write out the now modified library"""
+        try:
+            os.unlink(self.final_lib)
+        except OSError:
+            pass
+        subprocess.check_call(
+            [args.ar, "qsc", self.final_lib] +
+            [os.path.join(self.final_objdir, I) for I in self.objects])
+
+
+def compute_graph(libs):
+    """Look at the symbols each library provides vs the symbols each library needs
+    and organize the libraries into a graph."""
+    for a, b in itertools.permutations(libs, 2):
+        if not a.syms.isdisjoint(b.needed_syms):
+            b.needs.add(a)
+            a.needed.add(b)
+
+    # Use transitivity to prune the needs list
+    def prune(cur_lib, to_prune):
+        for I in cur_lib.needed:
+            I.needs.discard(to_prune)
+            to_prune.needed.discard(I)
+            prune(I, to_prune)
+
+    for cur_lib in libs:
+        for I in list(cur_lib.needed):
+            prune(I, cur_lib)
+
+
+parser = argparse.ArgumentParser(
+    description='Generate static libraries for distribution')
+parser.add_argument(
+    "--map",
+    dest="maps",
+    action="append",
+    help="List of map files defining all the public symbols",
+    default=[])
+parser.add_argument(
+    "--lib", dest="libs", action="append", help="The input static libraries")
+parser.add_argument(
+    "--internal_lib",
+    dest="internal_libs",
+    action="append",
+    help=
+    "The internal static libraries, these will be merged into other libraries")
+parser.add_argument(
+    "--version", action="store", help="Package version number", required=True)
+parser.add_argument("--ar", action="store", help="ar tool", required=True)
+parser.add_argument("--nm", action="store", help="nm tool", required=True)
+parser.add_argument(
+    "--objcopy", action="store", help="objcopy tool", required=True)
+args = parser.parse_args()
+
+global_syms = set()
+for fn in sorted(set(args.maps)):
+    for I in load_map(fn):
+        # Private symbols in libibverbs are also mangled for maximum safety.
+        if "PRIVATE" not in I.version:
+            global_syms.update(I.globals)
+
+with TemporaryDirectory() as tmpdir:
+    libs = set(Lib(fn, tmpdir) for fn in args.libs)
+    internal_libs = set(Lib(fn, tmpdir) for fn in args.internal_libs)
+    all_libs = libs | internal_libs
+
+    all_syms = set()
+    for I in all_libs:
+        all_syms.update(I.syms)
+    compute_graph(all_libs)
+
+    # Generate a redefine file for objcopy that will sanitize the internal names
+    prefix = re.sub(r"\W", "_", args.version)
+    redefine_fn = os.path.join(tmpdir, "redefine")
+    with open(redefine_fn, "wt") as F:
+        for I in sorted(all_syms - global_syms):
+            F.write("%s rdmacore%s_%s\n" % (I, prefix, I))
+
+    for I in all_libs:
+        I.rename_syms(redefine_fn)
+
+    for I in libs:
+        I.incorporate_internal(internal_libs)
+        I.finalize()

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -9,7 +9,7 @@ mkdir build-travis build32 build-sparse build-aarch64
 
 # Build with latest clang first
 cd build-travis
-CC=clang-5.0 CFLAGS=-Werror cmake -GNinja .. -DIOCTL_MODE=both
+CC=clang-5.0 CFLAGS=-Werror cmake -GNinja .. -DIOCTL_MODE=both -DENABLE_STATIC=1
 ninja
 ../buildlib/check-build --src .. --cc clang-5.0
 

--- a/debian/control
+++ b/debian/control
@@ -127,6 +127,8 @@ Architecture: linux-any
 Multi-Arch: same
 Depends: ibverbs-providers (= ${binary:Version}),
          libibverbs1 (= ${binary:Version}),
+         libnl-3-dev,
+         libnl-route-3-dev,
          ${misc:Depends}
 Description: Development files for the libibverbs library
  libibverbs is a library that allows userspace processes to use RDMA

--- a/debian/libibumad-dev.install
+++ b/debian/libibumad-dev.install
@@ -1,4 +1,5 @@
 usr/include/infiniband/umad*.h
 usr/lib/*/libibumad*.so
+usr/lib/*/libibumad.a
 usr/lib/*/pkgconfig/libibumad.pc
 usr/share/man/man3/umad_*

--- a/debian/libibverbs-dev.install
+++ b/debian/libibverbs-dev.install
@@ -10,8 +10,12 @@ usr/include/infiniband/sa.h
 usr/include/infiniband/tm_types.h
 usr/include/infiniband/verbs.h
 usr/include/infiniband/verbs_api.h
+usr/lib/*/lib*-rdmav20.a
 usr/lib/*/libibverbs*.so
+usr/lib/*/libibverbs.a
+usr/lib/*/libmlx4.a
 usr/lib/*/libmlx4.so
+usr/lib/*/libmlx5.a
 usr/lib/*/libmlx5.so
 usr/lib/*/pkgconfig/libibverbs.pc
 usr/lib/*/pkgconfig/libmlx4.pc

--- a/debian/librdmacm-dev.install
+++ b/debian/librdmacm-dev.install
@@ -4,6 +4,7 @@ usr/include/rdma/rdma_cma_abi.h
 usr/include/rdma/rdma_verbs.h
 usr/include/rdma/rsocket.h
 usr/lib/*/librdmacm*.so
+usr/lib/*/librdmacm.a
 usr/lib/*/pkgconfig/librdmacm.pc
 usr/share/man/man3/rdma_accept.3
 usr/share/man/man3/rdma_ack_cm_event.3

--- a/debian/rules
+++ b/debian/rules
@@ -33,6 +33,7 @@ override_dh_auto_configure:
 			-DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib \
 			-DCMAKE_INSTALL_RUNDIR:PATH=/run \
 			-DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d \
+			-DENABLE_STATIC=1 \
 			$(EXTRA_CMAKE_FLAGS)
 
 override_dh_auto_build:

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -54,4 +54,11 @@ target_link_libraries(ibverbs LINK_PRIVATE
   kern-abi
   )
 
-rdma_pkg_config("ibverbs" "" "${CMAKE_THREAD_LIBS_INIT}")
+if (ENABLE_STATIC)
+  if (NOT NL_KIND EQUAL 0)
+    set(REQUIRES "libnl-3.0, libnl-route-3.0")
+  endif()
+  rdma_pkg_config("ibverbs" "${REQUIRES}" "${CMAKE_THREAD_LIBS_INIT}")
+else()
+  rdma_pkg_config("ibverbs" "" "${CMAKE_THREAD_LIBS_INIT}")
+endif()

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -28,6 +28,7 @@ configure_file("libibverbs.map.in"
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
   1 1.5.${PACKAGE_VERSION}
+  all_providers.c
   cmd.c
   cmd_counters.c
   cmd_cq.c
@@ -44,6 +45,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   marshall.c
   memory.c
   ${NEIGH}
+  static_driver.c
   sysfs.c
   verbs.c
   )
@@ -54,11 +56,30 @@ target_link_libraries(ibverbs LINK_PRIVATE
   kern-abi
   )
 
-if (ENABLE_STATIC)
-  if (NOT NL_KIND EQUAL 0)
-    set(REQUIRES "libnl-3.0, libnl-route-3.0")
+function(ibverbs_finalize)
+  if (ENABLE_STATIC)
+    # In static mode the .pc file lists all of the providers for static
+    # linking. The user should set RDMA_STATIC_PROVIDERS to select which ones
+    # to include.
+    list(LENGTH RDMA_PROVIDER_LIST LEN)
+    math(EXPR LEN ${LEN}-1)
+    foreach(I RANGE 0 ${LEN} 2)
+      list(GET RDMA_PROVIDER_LIST ${I} PROVIDER_NAME)
+      math(EXPR I ${I}+1)
+      list(GET RDMA_PROVIDER_LIST ${I} LIB_NAME)
+      math(EXPR I ${I}+1)
+
+      set(PROVIDER_LIBS "${PROVIDER_LIBS} -l${LIB_NAME}")
+      set(FOR_EACH_PROVIDER "${FOR_EACH_PROVIDER} FOR_PROVIDER(${PROVIDER_NAME})")
+    endforeach()
+
+    if (NOT NL_KIND EQUAL 0)
+      set(REQUIRES "libnl-3.0, libnl-route-3.0")
+    endif()
+    rdma_pkg_config("ibverbs" "${REQUIRES}" "${PROVIDER_LIBS} -libverbs ${CMAKE_THREAD_LIBS_INIT}")
+
+    file(WRITE ${BUILD_INCLUDE}/infiniband/all_providers.h "#define FOR_EACH_PROVIDER() ${FOR_EACH_PROVIDER}")
+  else()
+    rdma_pkg_config("ibverbs" "" "${CMAKE_THREAD_LIBS_INIT}")
   endif()
-  rdma_pkg_config("ibverbs" "${REQUIRES}" "${CMAKE_THREAD_LIBS_INIT}")
-else()
-  rdma_pkg_config("ibverbs" "" "${CMAKE_THREAD_LIBS_INIT}")
-endif()
+endfunction()

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -38,6 +38,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   compat-1_0.c
   device.c
   dummy_ops.c
+  dynamic_driver.c
   enum_strs.c
   init.c
   marshall.c

--- a/libibverbs/all_providers.c
+++ b/libibverbs/all_providers.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifdef _STATIC_LIBRARY_BUILD_
+#define RDMA_STATIC_PROVIDERS none
+#include <infiniband/verbs.h>
+#include <infiniband/driver.h>
+#include <infiniband/all_providers.h>
+
+/* When static linking this object will be included in the final link only if
+ * something refers to the 'verbs_provider_all' symbol. It in turn brings all
+ * the providers into the link as well. Otherwise the static linker will not
+ * include this. It is important this is the only thing in this file.
+ */
+#define FOR_PROVIDER(x) &verbs_provider_ ## x,
+static const struct verbs_device_ops *all_providers[] = {
+	FOR_EACH_PROVIDER()
+	NULL
+};
+
+const struct verbs_device_ops verbs_provider_all = {
+	.static_providers = all_providers,
+};
+
+#endif

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -355,11 +355,18 @@ typedef struct verbs_device *(*verbs_driver_init_func)(const char *uverbs_sys_pa
 
 void verbs_register_driver(const struct verbs_device_ops *ops);
 
-/* Macro for providers to use to supply verbs_device_ops to the core code */
-#define PROVIDER_DRIVER(drv)                                                   \
+/*
+ * Macro for providers to use to supply verbs_device_ops to the core code.
+ * This creates a global symbol for the provider structure to be used by the
+ * ibv_static_providers() machinery, and a global constructor for the dlopen
+ * machinery.
+ */
+#define PROVIDER_DRIVER(provider_name, drv_struct)                             \
+	extern const struct verbs_device_ops verbs_provider_##provider_name    \
+		__attribute__((alias(stringify(drv_struct))));                 \
 	static __attribute__((constructor)) void drv##__register_driver(void)  \
 	{                                                                      \
-		verbs_register_driver(&drv);                                   \
+		verbs_register_driver(&drv_struct);                            \
 	}
 
 void *_verbs_init_and_alloc_context(struct ibv_device *device, int cmd_fd,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -183,6 +183,7 @@ struct verbs_device_ops {
 	int match_min_abi_version;
 	int match_max_abi_version;
 	const struct verbs_match_ent *match_table;
+	const struct verbs_device_ops **static_providers;
 
 	bool (*match_device)(struct verbs_sysfs_dev *sysfs_dev);
 

--- a/libibverbs/dynamic_driver.c
+++ b/libibverbs/dynamic_driver.c
@@ -31,6 +31,7 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+#ifndef _STATIC_LIBRARY_BUILD_
 #define _GNU_SOURCE
 
 #include <dlfcn.h>
@@ -237,3 +238,4 @@ void load_drivers(void)
 		free(name);
 	}
 }
+#endif

--- a/libibverbs/dynamic_driver.c
+++ b/libibverbs/dynamic_driver.c
@@ -1,0 +1,239 @@
+/*
+ * Copyright (c) 2004, 2005 Topspin Communications.  All rights reserved.
+ * Copyright (c) 2006 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#define _GNU_SOURCE
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <dirent.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <ccan/list.h>
+
+#include "ibverbs.h"
+
+struct ibv_driver_name {
+	struct list_node entry;
+	char *name;
+};
+
+static LIST_HEAD(driver_name_list);
+
+static void read_config_file(const char *path)
+{
+	FILE *conf;
+	char *line = NULL;
+	char *config;
+	char *field;
+	size_t buflen = 0;
+	ssize_t len;
+
+	conf = fopen(path, "r" STREAM_CLOEXEC);
+	if (!conf) {
+		fprintf(stderr, PFX "Warning: couldn't read config file %s.\n",
+			path);
+		return;
+	}
+
+	while ((len = getline(&line, &buflen, conf)) != -1) {
+		config = line + strspn(line, "\t ");
+		if (config[0] == '\n' || config[0] == '#')
+			continue;
+
+		field = strsep(&config, "\n\t ");
+
+		if (strcmp(field, "driver") == 0 && config != NULL) {
+			struct ibv_driver_name *driver_name;
+
+			config += strspn(config, "\t ");
+			field = strsep(&config, "\n\t ");
+
+			driver_name = malloc(sizeof(*driver_name));
+			if (!driver_name) {
+				fprintf(stderr,
+					PFX
+					"Warning: couldn't allocate driver name '%s'.\n",
+					field);
+				continue;
+			}
+
+			driver_name->name = strdup(field);
+			if (!driver_name->name) {
+				fprintf(stderr,
+					PFX
+					"Warning: couldn't allocate driver name '%s'.\n",
+					field);
+				free(driver_name);
+				continue;
+			}
+
+			list_add(&driver_name_list, &driver_name->entry);
+		} else
+			fprintf(stderr,
+				PFX
+				"Warning: ignoring bad config directive '%s' in file '%s'.\n",
+				field, path);
+	}
+
+	if (line)
+		free(line);
+	fclose(conf);
+}
+
+static void read_config(void)
+{
+	DIR *conf_dir;
+	struct dirent *dent;
+	char *path;
+
+	conf_dir = opendir(IBV_CONFIG_DIR);
+	if (!conf_dir) {
+		fprintf(stderr,
+			PFX "Warning: couldn't open config directory '%s'.\n",
+			IBV_CONFIG_DIR);
+		return;
+	}
+
+	while ((dent = readdir(conf_dir))) {
+		struct stat buf;
+
+		if (asprintf(&path, "%s/%s", IBV_CONFIG_DIR, dent->d_name) <
+		    0) {
+			fprintf(stderr,
+				PFX
+				"Warning: couldn't read config file %s/%s.\n",
+				IBV_CONFIG_DIR, dent->d_name);
+			goto out;
+		}
+
+		if (stat(path, &buf)) {
+			fprintf(stderr,
+				PFX
+				"Warning: couldn't stat config file '%s'.\n",
+				path);
+			goto next;
+		}
+
+		if (!S_ISREG(buf.st_mode))
+			goto next;
+
+		read_config_file(path);
+next:
+		free(path);
+	}
+
+out:
+	closedir(conf_dir);
+}
+
+static void load_driver(const char *name)
+{
+	char *so_name;
+	void *dlhandle;
+
+	/* If the name is an absolute path then open that path after appending
+	 * the trailer suffix
+	 */
+	if (name[0] == '/') {
+		if (asprintf(&so_name, "%s" VERBS_PROVIDER_SUFFIX, name) < 0)
+			goto out_asprintf;
+		dlhandle = dlopen(so_name, RTLD_NOW);
+		if (!dlhandle)
+			goto out_dlopen;
+		free(so_name);
+		return;
+	}
+
+	/* If configured with a provider plugin path then try that next */
+	if (sizeof(VERBS_PROVIDER_DIR) > 1) {
+		if (asprintf(&so_name,
+			     VERBS_PROVIDER_DIR "/lib%s" VERBS_PROVIDER_SUFFIX,
+			     name) < 0)
+			goto out_asprintf;
+		dlhandle = dlopen(so_name, RTLD_NOW);
+		free(so_name);
+		if (dlhandle)
+			return;
+	}
+
+	/* Otherwise use the system library search path. This is the historical
+	 * behavior of libibverbs
+	 */
+	if (asprintf(&so_name, "lib%s" VERBS_PROVIDER_SUFFIX, name) < 0)
+		goto out_asprintf;
+	dlhandle = dlopen(so_name, RTLD_NOW);
+	if (!dlhandle)
+		goto out_dlopen;
+	free(so_name);
+	return;
+
+out_asprintf:
+	fprintf(stderr, PFX "Warning: couldn't load driver '%s'.\n", name);
+	return;
+out_dlopen:
+	fprintf(stderr, PFX "Warning: couldn't load driver '%s': %s\n", so_name,
+		dlerror());
+	free(so_name);
+}
+
+void load_drivers(void)
+{
+	struct ibv_driver_name *name, *next_name;
+	const char *env;
+	char *list, *env_name;
+
+	read_config();
+
+	/* Only use drivers passed in through the calling user's environment
+	 * if we're not running setuid.
+	 */
+	if (getuid() == geteuid()) {
+		if ((env = getenv("RDMAV_DRIVERS"))) {
+			list = strdupa(env);
+			while ((env_name = strsep(&list, ":;")))
+				load_driver(env_name);
+		} else if ((env = getenv("IBV_DRIVERS"))) {
+			list = strdupa(env);
+			while ((env_name = strsep(&list, ":;")))
+				load_driver(env_name);
+		}
+	}
+
+	list_for_each_safe (&driver_name_list, name, next_name, entry) {
+		load_driver(name->name);
+		free(name->name);
+		free(name);
+	}
+}

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -61,6 +61,7 @@ int ibverbs_get_device_list(struct list_head *list);
 int ibverbs_init(void);
 void ibverbs_device_put(struct ibv_device *dev);
 void ibverbs_device_hold(struct ibv_device *dev);
+void load_drivers(void);
 
 struct verbs_ex_private {
 	BITMAP_DECLARE(unsupported_ioctls, VERBS_OPS_NUM);

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -61,7 +61,14 @@ int ibverbs_get_device_list(struct list_head *list);
 int ibverbs_init(void);
 void ibverbs_device_put(struct ibv_device *dev);
 void ibverbs_device_hold(struct ibv_device *dev);
+
+#ifdef _STATIC_LIBRARY_BUILD_
+static inline void load_drivers(void)
+{
+}
+#else
 void load_drivers(void);
+#endif
 
 struct verbs_ex_private {
 	BITMAP_DECLARE(unsupported_ioctls, VERBS_OPS_NUM);

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -37,7 +37,6 @@
 #include <string.h>
 #include <glob.h>
 #include <stdio.h>
-#include <dlfcn.h>
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -54,17 +53,11 @@
 
 int abi_ver;
 
-struct ibv_driver_name {
-	struct list_node	entry;
-	char		       *name;
-};
-
 struct ibv_driver {
 	struct list_node	entry;
 	const struct verbs_device_ops *ops;
 };
 
-static LIST_HEAD(driver_name_list);
 static LIST_HEAD(driver_list);
 
 static int try_access_device(const struct verbs_sysfs_dev *sysfs_dev)
@@ -190,179 +183,6 @@ void verbs_register_driver(const struct verbs_device_ops *ops)
 	driver->ops = ops;
 
 	list_add_tail(&driver_list, &driver->entry);
-}
-
-static void load_driver(const char *name)
-{
-	char *so_name;
-	void *dlhandle;
-
-	/* If the name is an absolute path then open that path after appending
-	   the trailer suffix */
-	if (name[0] == '/') {
-		if (asprintf(&so_name, "%s" VERBS_PROVIDER_SUFFIX, name) < 0)
-			goto out_asprintf;
-		dlhandle = dlopen(so_name, RTLD_NOW);
-		if (!dlhandle)
-			goto out_dlopen;
-		free(so_name);
-		return;
-	}
-
-	/* If configured with a provider plugin path then try that next */
-	if (sizeof(VERBS_PROVIDER_DIR) > 1) {
-		if (asprintf(&so_name,
-			     VERBS_PROVIDER_DIR "/lib%s" VERBS_PROVIDER_SUFFIX,
-			     name) < 0)
-			goto out_asprintf;
-		dlhandle = dlopen(so_name, RTLD_NOW);
-		free(so_name);
-		if (dlhandle)
-			return;
-	}
-
-	/* Otherwise use the system libary search path. This is the historical
-	   behavior of libibverbs */
-	if (asprintf(&so_name, "lib%s" VERBS_PROVIDER_SUFFIX, name) < 0)
-		goto out_asprintf;
-	dlhandle = dlopen(so_name, RTLD_NOW);
-	if (!dlhandle)
-		goto out_dlopen;
-	free(so_name);
-	return;
-
-out_asprintf:
-	fprintf(stderr, PFX "Warning: couldn't load driver '%s'.\n", name);
-	return;
-out_dlopen:
-	fprintf(stderr, PFX "Warning: couldn't load driver '%s': %s\n", so_name,
-		dlerror());
-	free(so_name);
-	return;
-}
-
-static void load_drivers(void)
-{
-	struct ibv_driver_name *name, *next_name;
-	const char *env;
-	char *list, *env_name;
-
-	/*
-	 * Only use drivers passed in through the calling user's
-	 * environment if we're not running setuid.
-	 */
-	if (getuid() == geteuid()) {
-		if ((env = getenv("RDMAV_DRIVERS"))) {
-			list = strdupa(env);
-			while ((env_name = strsep(&list, ":;")))
-				load_driver(env_name);
-		} else if ((env = getenv("IBV_DRIVERS"))) {
-			list = strdupa(env);
-			while ((env_name = strsep(&list, ":;")))
-				load_driver(env_name);
-		}
-	}
-
-	list_for_each_safe(&driver_name_list, name, next_name, entry) {
-		load_driver(name->name);
-		free(name->name);
-		free(name);
-	}
-}
-
-static void read_config_file(const char *path)
-{
-	FILE *conf;
-	char *line = NULL;
-	char *config;
-	char *field;
-	size_t buflen = 0;
-	ssize_t len;
-
-	conf = fopen(path, "r" STREAM_CLOEXEC);
-	if (!conf) {
-		fprintf(stderr, PFX "Warning: couldn't read config file %s.\n",
-			path);
-		return;
-	}
-
-	while ((len = getline(&line, &buflen, conf)) != -1) {
-		config = line + strspn(line, "\t ");
-		if (config[0] == '\n' || config[0] == '#')
-			continue;
-
-		field = strsep(&config, "\n\t ");
-
-		if (strcmp(field, "driver") == 0 && config != NULL) {
-			struct ibv_driver_name *driver_name;
-
-			config += strspn(config, "\t ");
-			field = strsep(&config, "\n\t ");
-
-			driver_name = malloc(sizeof *driver_name);
-			if (!driver_name) {
-				fprintf(stderr, PFX "Warning: couldn't allocate "
-					"driver name '%s'.\n", field);
-				continue;
-			}
-
-			driver_name->name = strdup(field);
-			if (!driver_name->name) {
-				fprintf(stderr, PFX "Warning: couldn't allocate "
-					"driver name '%s'.\n", field);
-				free(driver_name);
-				continue;
-			}
-
-			list_add(&driver_name_list, &driver_name->entry);
-		} else
-			fprintf(stderr, PFX "Warning: ignoring bad config directive "
-				"'%s' in file '%s'.\n", field, path);
-	}
-
-	if (line)
-		free(line);
-	fclose(conf);
-}
-
-static void read_config(void)
-{
-	DIR *conf_dir;
-	struct dirent *dent;
-	char *path;
-
-	conf_dir = opendir(IBV_CONFIG_DIR);
-	if (!conf_dir) {
-		fprintf(stderr, PFX "Warning: couldn't open config directory '%s'.\n",
-			IBV_CONFIG_DIR);
-		return;
-	}
-
-	while ((dent = readdir(conf_dir))) {
-		struct stat buf;
-
-		if (asprintf(&path, "%s/%s", IBV_CONFIG_DIR, dent->d_name) < 0) {
-			fprintf(stderr, PFX "Warning: couldn't read config file %s/%s.\n",
-				IBV_CONFIG_DIR, dent->d_name);
-			goto out;
-		}
-
-		if (stat(path, &buf)) {
-			fprintf(stderr, PFX "Warning: couldn't stat config file '%s'.\n",
-				path);
-			goto next;
-		}
-
-		if (!S_ISREG(buf.st_mode))
-			goto next;
-
-		read_config_file(path);
-next:
-		free(path);
-	}
-
-out:
-	closedir(conf_dir);
 }
 
 /* Match a single modalias value */
@@ -616,7 +436,6 @@ int ibverbs_get_device_list(struct list_head *device_list)
 	struct verbs_device *vdev, *tmp;
 	static int drivers_loaded;
 	unsigned int num_devices = 0;
-	int statically_linked = 0;
 	int ret;
 
 	ret = find_sysfs_devs(&sysfs_list);
@@ -652,26 +471,6 @@ int ibverbs_get_device_list(struct list_head *device_list)
 	if (list_empty(&sysfs_list) || drivers_loaded)
 		goto out;
 
-	/*
-	 * Check if we can dlopen() ourselves.  If this fails,
-	 * libibverbs is probably statically linked into the
-	 * executable, and we should just give up, since trying to
-	 * dlopen() a driver module will fail spectacularly (loading a
-	 * driver .so will bring in dynamic copies of libibverbs and
-	 * libdl to go along with the static copies the executable
-	 * has, which quickly leads to a crash.
-	 */
-	{
-		void *hand = dlopen(NULL, RTLD_NOW);
-		if (!hand) {
-			fprintf(stderr, PFX "Warning: dlopen(NULL) failed, "
-				"assuming static linking.\n");
-			statically_linked = 1;
-			goto out;
-		}
-		dlclose(hand);
-	}
-
 	load_drivers();
 	drivers_loaded = 1;
 
@@ -686,9 +485,6 @@ out:
 			fprintf(stderr, PFX
 				"Warning: no userspace device-specific driver found for %s\n",
 				sysfs_dev->sysfs_path);
-			if (statically_linked)
-				fprintf(stderr,
-					"	When linking libibverbs statically, driver must be statically linked too.\n");
 		}
 		free(sysfs_dev);
 	}
@@ -724,8 +520,6 @@ int ibverbs_init(void)
 		return -ret;
 
 	check_memlock_limit();
-
-	read_config();
 
 	return 0;
 }

--- a/libibverbs/man/ibv_get_device_list.3.md
+++ b/libibverbs/man/ibv_get_device_list.3.md
@@ -63,6 +63,26 @@ Setting the environment variable **IBV_SHOW_WARNINGS** will cause warnings to
 be emitted to stderr if a kernel verbs device is discovered, but no
 corresponding userspace driver can be found for it.
 
+# STATIC LINKING
+
+If **libibverbs** is statically linked to the application then all provider
+drivers must also be statically linked. The library will not load dynamic
+providers when static linking is used.
+
+To link the providers set the **RDMA_STATIC_PROVIDERS** define to the comma
+separated list of desired providers when compiling the application. The
+special keyword 'all' will statically link all supported **libibverbs**
+providers.
+
+This is intended to be used along with **pkg-config(1)** to setup the proper
+flags for **libibverbs** linking.
+
+If this is not done then **ibv_get_device_list** will always return an empty
+list.
+
+Using only dynamic linking for **libibverbs** applications is strongly
+recommended.
+
 # SEE ALSO
 
 **ibv_fork_init**(3),

--- a/libibverbs/static_driver.c
+++ b/libibverbs/static_driver.c
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifdef _STATIC_LIBRARY_BUILD_
+#define RDMA_STATIC_PROVIDERS none
+#include <infiniband/verbs.h>
+#include <infiniband/driver.h>
+
+const struct verbs_device_ops verbs_provider_none;
+
+void ibv_static_providers(void *unused, ...)
+{
+	/*
+	 * We do not need to do anything with the VA_ARGs since we continue to
+	 * rely on the constructor attribute and simply referencing the
+	 * verbs_provider_X symbol will be enough to trigger the constructor.
+	 *
+	 * This would need to actually check and do the registration for
+	 * specialty cases like LTO or section-gc which may not work with the
+	 * constructor scheme.
+	 */
+}
+
+#endif

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1880,6 +1880,25 @@ static inline struct verbs_context *verbs_get_ctx(struct ibv_context *ctx)
  */
 struct ibv_device **ibv_get_device_list(int *num_devices);
 
+#ifdef RDMA_STATIC_PROVIDERS
+struct verbs_devices_ops;
+extern const struct verbs_device_ops verbs_provider_bnxt_re;
+extern const struct verbs_device_ops verbs_provider_cxgb3;
+extern const struct verbs_device_ops verbs_provider_cxgb4;
+extern const struct verbs_device_ops verbs_provider_hfi1verbs;
+extern const struct verbs_device_ops verbs_provider_hns;
+extern const struct verbs_device_ops verbs_provider_i40iw;
+extern const struct verbs_device_ops verbs_provider_ipathverbs;
+extern const struct verbs_device_ops verbs_provider_mlx4;
+extern const struct verbs_device_ops verbs_provider_mlx5;
+extern const struct verbs_device_ops verbs_provider_mthca;
+extern const struct verbs_device_ops verbs_provider_nes;
+extern const struct verbs_device_ops verbs_provider_ocrdma;
+extern const struct verbs_device_ops verbs_provider_qedr;
+extern const struct verbs_device_ops verbs_provider_rxe;
+extern const struct verbs_device_ops verbs_provider_vmw_pvrdma;
+#endif
+
 /**
  * ibv_free_device_list - Free list from ibv_get_device_list()
  *

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -197,4 +197,4 @@ static const struct verbs_device_ops bnxt_re_dev_ops = {
 	.alloc_context = bnxt_re_alloc_context,
 	.free_context = bnxt_re_free_context,
 };
-PROVIDER_DRIVER(bnxt_re_dev_ops);
+PROVIDER_DRIVER(bnxt_re, bnxt_re_dev_ops);

--- a/providers/cxgb3/iwch.c
+++ b/providers/cxgb3/iwch.c
@@ -267,4 +267,4 @@ static const struct verbs_device_ops iwch_dev_ops = {
 	.alloc_context = iwch_alloc_context,
 	.free_context = iwch_free_context,
 };
-PROVIDER_DRIVER(iwch_dev_ops);
+PROVIDER_DRIVER(cxgb3, iwch_dev_ops);

--- a/providers/cxgb4/dev.c
+++ b/providers/cxgb4/dev.c
@@ -504,7 +504,7 @@ static const struct verbs_device_ops c4iw_dev_ops = {
 	.alloc_context = c4iw_alloc_context,
 	.free_context = c4iw_free_context,
 };
-PROVIDER_DRIVER(c4iw_dev_ops);
+PROVIDER_DRIVER(cxgb4, c4iw_dev_ops);
 
 #ifdef STATS
 void __attribute__ ((destructor)) cs_fini(void);

--- a/providers/hfi1verbs/hfiverbs.c
+++ b/providers/hfi1verbs/hfiverbs.c
@@ -206,4 +206,4 @@ static const struct verbs_device_ops hfi1_dev_ops = {
 	.alloc_context = hfi1_alloc_context,
 	.free_context = hfi1_free_context,
 };
-PROVIDER_DRIVER(hfi1_dev_ops);
+PROVIDER_DRIVER(hfi1verbs, hfi1_dev_ops);

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -205,4 +205,4 @@ static const struct verbs_device_ops hns_roce_dev_ops = {
 	.alloc_context = hns_roce_alloc_context,
 	.free_context = hns_roce_free_context,
 };
-PROVIDER_DRIVER(hns_roce_dev_ops);
+PROVIDER_DRIVER(hns, hns_roce_dev_ops);

--- a/providers/i40iw/i40iw_umain.c
+++ b/providers/i40iw/i40iw_umain.c
@@ -226,4 +226,4 @@ static const struct verbs_device_ops i40iw_udev_ops = {
 	.alloc_context = i40iw_ualloc_context,
 	.free_context = i40iw_ufree_context,
 };
-PROVIDER_DRIVER(i40iw_udev_ops);
+PROVIDER_DRIVER(i40iw, i40iw_udev_ops);

--- a/providers/ipathverbs/ipathverbs.c
+++ b/providers/ipathverbs/ipathverbs.c
@@ -204,4 +204,4 @@ static const struct verbs_device_ops ipath_dev_ops = {
 	.alloc_context = ipath_alloc_context,
 	.free_context = ipath_free_context,
 };
-PROVIDER_DRIVER(ipath_dev_ops);
+PROVIDER_DRIVER(ipathverbs, ipath_dev_ops);

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -302,7 +302,7 @@ static const struct verbs_device_ops mlx4_dev_ops = {
 	.alloc_context = mlx4_alloc_context,
 	.free_context = mlx4_free_context,
 };
-PROVIDER_DRIVER(mlx4_dev_ops);
+PROVIDER_DRIVER(mlx4, mlx4_dev_ops);
 
 static int mlx4dv_get_qp(struct ibv_qp *qp_in,
 			 struct mlx4dv_qp *qp_out)

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1324,4 +1324,4 @@ static const struct verbs_device_ops mlx5_dev_ops = {
 	.alloc_context = mlx5_alloc_context,
 	.free_context = mlx5_free_context,
 };
-PROVIDER_DRIVER(mlx5_dev_ops);
+PROVIDER_DRIVER(mlx5, mlx5_dev_ops);

--- a/providers/mthca/mthca.c
+++ b/providers/mthca/mthca.c
@@ -239,4 +239,4 @@ static const struct verbs_device_ops mthca_dev_ops = {
 	.alloc_context = mthca_alloc_context,
 	.free_context = mthca_free_context,
 };
-PROVIDER_DRIVER(mthca_dev_ops);
+PROVIDER_DRIVER(mthca, mthca_dev_ops);

--- a/providers/nes/nes_umain.c
+++ b/providers/nes/nes_umain.c
@@ -218,4 +218,4 @@ static const struct verbs_device_ops nes_udev_ops = {
 	.alloc_context = nes_ualloc_context,
 	.free_context = nes_ufree_context,
 };
-PROVIDER_DRIVER(nes_udev_ops);
+PROVIDER_DRIVER(nes, nes_udev_ops);

--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -195,4 +195,4 @@ static const struct verbs_device_ops ocrdma_dev_ops = {
 	.alloc_context = ocrdma_alloc_context,
 	.free_context = ocrdma_free_context,
 };
-PROVIDER_DRIVER(ocrdma_dev_ops);
+PROVIDER_DRIVER(ocrdma, ocrdma_dev_ops);

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -250,4 +250,4 @@ static const struct verbs_device_ops qelr_dev_ops = {
 	.alloc_context = qelr_alloc_context,
 	.free_context = qelr_free_context,
 };
-PROVIDER_DRIVER(qelr_dev_ops);
+PROVIDER_DRIVER(qedr, qelr_dev_ops);

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -923,4 +923,4 @@ static const struct verbs_device_ops rxe_dev_ops = {
 	.alloc_context = rxe_alloc_context,
 	.free_context = rxe_free_context,
 };
-PROVIDER_DRIVER(rxe_dev_ops);
+PROVIDER_DRIVER(rxe, rxe_dev_ops);

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -209,4 +209,4 @@ static const struct verbs_device_ops pvrdma_dev_ops = {
 	.alloc_context = pvrdma_alloc_context,
 	.free_context  = pvrdma_free_context,
 };
-PROVIDER_DRIVER(pvrdma_dev_ops);
+PROVIDER_DRIVER(vmw_pvrdma, pvrdma_dev_ops);

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -10,6 +10,8 @@ Summary: RDMA core userspace libraries and daemons
 License: GPLv2 or BSD
 Url: https://github.com/linux-rdma/rdma-core
 Source: rdma-core-%{version}.tgz
+# Do not build static libs by default.
+%define with_static %{?_with_static: 1} %{?!_with_static: 0}
 
 BuildRequires: binutils
 BuildRequires: cmake >= 2.8.11
@@ -73,6 +75,13 @@ Obsoletes: librdmacm-devel < %{version}-%{release}
 Requires: ibacm = %{version}-%{release}
 Provides: ibacm-devel = %{version}-%{release}
 Obsoletes: ibacm-devel < %{version}-%{release}
+%if %{with_static}
+# Since our pkg-config files include private references to these packages they
+# need to have their .pc files installed too, even for dynamic linking, or
+# pkg-config breaks.
+BuildRequires: pkgconfig(libnl-3.0)
+BuildRequires: pkgconfig(libnl-route-3.0)
+%endif
 
 %description devel
 RDMA core development libraries and headers.
@@ -233,6 +242,9 @@ discover and use SCSI devices via the SCSI RDMA Protocol over InfiniBand.
          -DCMAKE_INSTALL_RUNDIR:PATH=%{_rundir} \
          -DCMAKE_INSTALL_DOCDIR:PATH=%{_docdir}/%{name}-%{version} \
          -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=%{_udevrulesdir} \
+%if %{with_static}
+         -DENABLE_STATIC=1 \
+%endif
          %{EXTRA_CMAKE_FLAGS}
 %make_jobs
 
@@ -352,6 +364,9 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %dir %{_includedir}/rdma
 %{_includedir}/infiniband/*
 %{_includedir}/rdma/*
+%if %{with_static}
+%{_libdir}/lib*.a
+%endif
 %{_libdir}/lib*.so
 %{_libdir}/pkgconfig/*.pc
 %{_mandir}/man3/ibv_*

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -17,6 +17,9 @@
 
 
 %bcond_without  systemd
+# Do not build static libs by default.
+%define with_static %{?_with_static: 1} %{?!_with_static: 0}
+
 %define         git_ver %{nil}
 Name:           rdma-core
 Version:        21.0
@@ -143,7 +146,14 @@ Obsoletes:      librdmacm-devel < %{version}-%{release}
 #Requires:       ibacm = %%{version}-%%{release}
 Provides:       ibacm-devel = %{version}-%{release}
 Obsoletes:      ibacm-devel < %{version}-%{release}
-
+%if %{with_static}
+# Since our pkg-config files include private references to these packages they
+# need to have their .pc files installed too, even for dynamic linking, or
+# pkg-config breaks.
+BuildRequires: pkgconfig(libnl-3.0)
+BuildRequires: pkgconfig(libnl-route-3.0)
+%endif
+ 
 %description devel
 RDMA core development libraries and headers.
 
@@ -348,6 +358,9 @@ on those changes.
          -DCMAKE_INSTALL_RUNDIR:PATH=%{_rundir} \
          -DCMAKE_INSTALL_DOCDIR:PATH=%{_docdir}/%{name}-%{version} \
          -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=%{_udevrulesdir} \
+%if %{with_static}
+         -DENABLE_STATIC=1 \
+%endif
          %{EXTRA_CMAKE_FLAGS}
 %make_jobs
 
@@ -526,6 +539,9 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %dir %{_includedir}/rdma
 %{_includedir}/infiniband/*
 %{_includedir}/rdma/*
+%if %{with_static}
+%{_libdir}/lib*.a
+%endif
 %{_libdir}/lib*.so
 %{_libdir}/pkgconfig/*.pc
 %{_mandir}/man3/ibv_*


### PR DESCRIPTION
Restore static library support. Before rdma-core we did produce some simplistic static libraries, and this was lost when things became more complicated.

This version is a complete solution and provides a simple way for applications to use the static libraries, including static providers, without having to resort to strange linker options.