### PR TITLE
ibacm: Flush cache in provider when local address is removed

### DIFF
--- a/ibacm/prov/acmp/src/acmp.c
+++ b/ibacm/prov/acmp/src/acmp.c
@@ -2412,8 +2412,43 @@ static int acmp_add_addr(const struct acm_address *addr, void *ep_context,
 static void acmp_remove_addr(void *addr_context)
 {
 	struct acmp_addr *address = addr_context;
+	struct acmp_device *dev;
+	struct acmp_dest *dest;
+	struct acmp_ep *ep;
+	int i;
 
 	acm_log(2, "\n");
+
+	/*
+	 * The address may be a local destination address. If so,
+	 * delete it from the cache.
+	 */
+
+	pthread_mutex_lock(&acmp_dev_lock);
+	list_for_each(&acmp_dev_list, dev, entry) {
+		pthread_mutex_unlock(&acmp_dev_lock);
+
+		for (i = 0; i < dev->port_cnt; i++) {
+			struct acmp_port *port = &dev->port[i];
+
+			pthread_mutex_lock(&port->lock);
+			list_for_each(&port->ep_list, ep, entry) {
+				pthread_mutex_unlock(&port->lock);
+				dest = acmp_get_dest(ep, address->type, address->addr->info.addr);
+				if (dest) {
+					acm_log(2, "Found a dest addr, deleting it\n");
+					pthread_mutex_lock(&ep->lock);
+					acmp_remove_dest(ep, dest);
+					pthread_mutex_unlock(&ep->lock);
+				}
+				pthread_mutex_lock(&port->lock);
+			}
+			pthread_mutex_unlock(&port->lock);
+		}
+		pthread_mutex_lock(&acmp_dev_lock);
+	}
+	pthread_mutex_unlock(&acmp_dev_lock);
+
 	memset(address, 0, sizeof(*address));
 }
 


### PR DESCRIPTION
Some use cases establish IB communication within an IB port or between
local ports. That is, both the source and destination addresses could
be local to the node. When an IP address is removed,
acmp_remove_addr() destroys the address, but does not anticipate that
the address could be a local destination address as well. Hence, in
addition to deleting the source address, we iterate over all devices,
their ports, and endpoints, to see if the address we are removing also
is a local destination address. If so, we delete it from the cache.

Without this fix, we have:

 # ip addr show|grep inet' '|grep ib
    inet 192.168.200.202/24 scope global ib0
    inet 192.168.200.203/24 scope global ib1
 # ib_acme -s 192.168.200.203 -d 192.168.200.202 | egrep 192\|id:
Destination: 192.168.200.202
Source: 192.168.200.203
  dgid: fe80::21:2800:1ce:ac17
  sgid: fe80::21:2800:1ce:ac18
  dlid: 245
  slid: 246

Now, move the ib0 address to ib1:

 # ip addr del 192.168.200.202/24 dev ib0
 # ip addr add 192.168.200.202/24 dev ib1
 # ib_acme -s 192.168.200.203 -d 192.168.200.202 | egrep 192\|id:
    inet 192.168.200.203/24 scope global ib1
    inet 192.168.200.202/24 scope global secondary ib1

Check the Path Record again:

 # ib_acme -s 192.168.200.203 -d 192.168.200.202 | egrep 192\|id:
Destination: 192.168.200.202
Source: 192.168.200.203
  dgid: fe80::21:2800:1ce:ac17
  sgid: fe80::21:2800:1ce:ac18
  dlid: 245
  slid: 246

The destination addresses (dgid and dlid) are wrong, still associated
with ib0.

Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>