### PR TITLE
mlx5: CQE size control

### DIFF
--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -1,4 +1,5 @@
 rdma_man_pages(
+  mlx5dv_create_cq.3.md
   mlx5dv_create_flow.3.md
   mlx5dv_create_flow_action_modify_header.3.md
   mlx5dv_create_flow_action_packet_reformat.3.md

--- a/providers/mlx5/man/mlx5dv_create_cq.3.md
+++ b/providers/mlx5/man/mlx5dv_create_cq.3.md
@@ -1,0 +1,93 @@
+---
+layout: page
+title: mlx5dv_create_cq
+section: 3
+tagline: Verbs
+date: 2018-9-1
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_create_cq - creates a completion queue (CQ)
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct ibv_cq_ex *mlx5dv_create_cq(struct ibv_context *context,
+				   struct ibv_cq_init_attr_ex *cq_attr,
+				   struct mlx5dv_cq_init_attr *mlx5_cq_attr);
+```
+
+
+# DESCRIPTION
+
+**mlx5dv_create_cq()** creates a completion queue (CQ) with specific driver properties.
+
+# ARGUMENTS
+
+Please see **ibv_create_cq_ex(3)** man page for **context** and **cq_attr**
+
+## mlx5_cq_attr
+
+```c
+struct mlx5dv_cq_init_attr {
+	uint64_t comp_mask;
+	uint8_t  cqe_comp_res_format;
+	uint32_t flags;
+	uint16_t cqe_size;
+};
+```
+
+*comp_mask*
+:	Bitmask specifying what fields in the structure are valid:
+
+	MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE
+		enables creating a CQ in a mode that few CQEs may be compressed into
+		a single CQE, valid values in *cqe_comp_res_format*
+
+	MLX5DV_CQ_INIT_ATTR_MASK_FLAGS
+	      valid values in *flags*
+
+	MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE
+	      valid values in *cqe_size*
+
+*cqe_comp_res_format*
+:	A bitwise OR of the various CQE response formats of the responder side:
+
+	MLX5DV_CQE_RES_FORMAT_HASH
+		CQE compression with hash
+
+	MLX5DV_CQE_RES_FORMAT_CSUM
+		CQE compression with RX checksum
+
+	MLX5DV_CQE_RES_FORMAT_CSUM_STRIDX
+		CQE compression with stride index
+
+*flags*
+:	A bitwise OR of the various values described below:
+
+	MLX5DV_CQ_INIT_ATTR_FLAGS_CQE_PAD
+		create a padded 128B CQE
+
+*cqe_size*
+:	configure the CQE size to be 64 or 128 bytes
+	other values will fail mlx5dv_create_cq.
+
+# RETURN VALUE
+
+**mlx5dv_create_cq()**
+returns a pointer to the created CQ, or NULL if the request fails
+and errno will be set.
+
+
+# SEE ALSO
+
+**ibv_create_cq_ex**(3),
+
+# AUTHOR
+
+Yonatan Cohen <yonatanc@mellanox.com>

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -138,7 +138,7 @@ enum mlx5dv_context_flags {
 enum mlx5dv_cq_init_attr_mask {
 	MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE	= 1 << 0,
 	MLX5DV_CQ_INIT_ATTR_MASK_FLAGS		= 1 << 1,
-	MLX5DV_CQ_INIT_ATTR_MASK_RESERVED	= 1 << 2,
+	MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE = 1 << 2,
 };
 
 enum mlx5dv_cq_init_attr_flags {
@@ -150,6 +150,7 @@ struct mlx5dv_cq_init_attr {
 	uint64_t comp_mask; /* Use enum mlx5dv_cq_init_attr_mask */
 	uint8_t cqe_comp_res_format; /* Use enum mlx5dv_cqe_comp_res_format */
 	uint32_t flags; /* Use enum mlx5dv_cq_init_attr_flags */
+	uint16_t cqe_size; /* when MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE set */
 };
 
 struct ibv_cq_ex *mlx5dv_create_cq(struct ibv_context *context,

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -548,14 +548,19 @@ static int align_queue_size(long long req)
 	return mlx5_round_up_power_of_two(req);
 }
 
-static int get_cqe_size(void)
+static int get_cqe_size(struct mlx5dv_cq_init_attr *mlx5cq_attr)
 {
 	char *env;
 	int size = 64;
 
-	env = getenv("MLX5_CQE_SIZE");
-	if (env)
-		size = atoi(env);
+	if (mlx5cq_attr &&
+	    (mlx5cq_attr->comp_mask & MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE)) {
+		size = mlx5cq_attr->cqe_size;
+	} else {
+		env = getenv("MLX5_CQE_SIZE");
+		if (env)
+			size = atoi(env);
+	}
 
 	switch (size) {
 	case 64:
@@ -619,6 +624,13 @@ enum {
 		IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN
 };
 
+enum {
+	MLX5_DV_CREATE_CQ_SUP_COMP_MASK =
+		(MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE |
+		 MLX5DV_CQ_INIT_ATTR_MASK_FLAGS |
+		 MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE),
+};
+
 static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 				   const struct ibv_cq_init_attr_ex *cq_attr,
 				   int cq_alloc_flags,
@@ -666,6 +678,15 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 		return NULL;
 	}
 
+	if (mlx5cq_attr &&
+	    !check_comp_mask(mlx5cq_attr->comp_mask,
+			     MLX5_DV_CREATE_CQ_SUP_COMP_MASK)) {
+		mlx5_dbg(fp, MLX5_DBG_CQ,
+			 "unsupported vendor comp_mask for %s\n", __func__);
+		errno = EINVAL;
+		return NULL;
+	}
+
 	cq =  calloc(1, sizeof *cq);
 	if (!cq) {
 		mlx5_dbg(fp, MLX5_DBG_CQ, "\n");
@@ -702,7 +723,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 		goto err_spl;
 	}
 
-	cqe_sz = get_cqe_size();
+	cqe_sz = get_cqe_size(mlx5cq_attr);
 	if (cqe_sz < 0) {
 		mlx5_dbg(fp, MLX5_DBG_CQ, "\n");
 		errno = -cqe_sz;
@@ -731,14 +752,6 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	cmd_drv->cqe_size = cqe_sz;
 
 	if (mlx5cq_attr) {
-		if (!check_comp_mask(mlx5cq_attr->comp_mask,
-				     MLX5DV_CQ_INIT_ATTR_MASK_RESERVED - 1)) {
-			mlx5_dbg(fp, MLX5_DBG_CQ,
-				   "Unsupported vendor comp_mask for create_cq\n");
-			errno = EINVAL;
-			goto err_db;
-		}
-
 		if (mlx5cq_attr->comp_mask & MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE) {
 			if (mctx->cqe_comp_caps.max_num &&
 			    (mlx5cq_attr->cqe_comp_res_format &


### PR DESCRIPTION
Adds an option for mlx5dv_create_cq to control the CQE size
per CQ in a thread safe manner.