### PR TITLE
mlx5: Introduce DEVX APIs for UAR and EQ

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -27,11 +27,13 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_create_flow@MLX5_1.6 20
  mlx5dv_create_flow_action_modify_header@MLX5_1.7 21
  mlx5dv_create_flow_action_packet_reformat@MLX5_1.7 21
- mlx5dv_open_device@MLX5_1.7 21
+ mlx5dv_devx_alloc_uar@MLX5_1.7 21
+ mlx5dv_devx_free_uar@MLX5_1.7 21
  mlx5dv_devx_general_cmd@MLX5_1.7 21
  mlx5dv_devx_obj_create@MLX5_1.7 21
  mlx5dv_devx_obj_destroy@MLX5_1.7 21
- mlx5dv_devx_obj_query@MLX5_1.7 21
  mlx5dv_devx_obj_modify@MLX5_1.7 21
+ mlx5dv_devx_obj_query@MLX5_1.7 21
  mlx5dv_devx_umem_dereg@MLX5_1.7 21
  mlx5dv_devx_umem_reg@MLX5_1.7 21
+ mlx5dv_open_device@MLX5_1.7 21

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -34,6 +34,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_obj_destroy@MLX5_1.7 21
  mlx5dv_devx_obj_modify@MLX5_1.7 21
  mlx5dv_devx_obj_query@MLX5_1.7 21
+ mlx5dv_devx_query_eqn@MLX5_1.7 21
  mlx5dv_devx_umem_dereg@MLX5_1.7 21
  mlx5dv_devx_umem_reg@MLX5_1.7 21
  mlx5dv_open_device@MLX5_1.7 21

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -45,12 +45,14 @@ MLX5_1.7 {
 	global:
 		mlx5dv_create_flow_action_modify_header;
 		mlx5dv_create_flow_action_packet_reformat;
-		mlx5dv_open_device;
+		mlx5dv_devx_alloc_uar;
+		mlx5dv_devx_free_uar;
 		mlx5dv_devx_general_cmd;
 		mlx5dv_devx_obj_create;
 		mlx5dv_devx_obj_destroy;
-		mlx5dv_devx_obj_query;
 		mlx5dv_devx_obj_modify;
+		mlx5dv_devx_obj_query;
 		mlx5dv_devx_umem_dereg;
 		mlx5dv_devx_umem_reg;
+		mlx5dv_open_device;
 } MLX5_1.6;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -52,6 +52,7 @@ MLX5_1.7 {
 		mlx5dv_devx_obj_destroy;
 		mlx5dv_devx_obj_modify;
 		mlx5dv_devx_obj_query;
+		mlx5dv_devx_query_eqn;
 		mlx5dv_devx_umem_dereg;
 		mlx5dv_devx_umem_reg;
 		mlx5dv_open_device;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -6,6 +6,7 @@ rdma_man_pages(
   mlx5dv_create_qp.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_obj_create.3.md
+  mlx5dv_devx_query_eqn.3.md
   mlx5dv_devx_umem_reg.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -4,6 +4,7 @@ rdma_man_pages(
   mlx5dv_create_flow_action_packet_reformat.3.md
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_qp.3.md
+  mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_obj_create.3.md
   mlx5dv_devx_umem_reg.3.md
   mlx5dv_flow_action_esp.3.md
@@ -15,6 +16,7 @@ rdma_man_pages(
   mlx5dv.7
 )
 rdma_alias_man_pages(
+ mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_general_cmd.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_destroy.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_obj_query.3

--- a/providers/mlx5/man/mlx5dv_devx_alloc_uar.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_alloc_uar.3.md
@@ -1,0 +1,74 @@
+---
+layout: page
+title: mlx5dv_devx_alloc_uar / mlx5dv_devx_free_uar
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_devx_alloc_uar -  Allocates a DEVX UAR
+
+mlx5dv_devx_free_uar -   Frees a DEVX UAR
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(struct ibv_context *context,
+                                              uint32_t flags);
+
+void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *devx_uar);
+```
+
+# DESCRIPTION
+
+Create / free a DEVX UAR which is needed for other device commands over the DEVX interface.
+
+The DEVX API enables direct access from the user space area to the mlx5 device
+driver, the UAR information is needed for few commands as of QP creation.
+
+
+# ARGUMENTS
+*context*
+:	RDMA device context to work on.
+
+*flags*
+:	Allocation flags for the UAR.
+
+## devx_uar
+
+```c
+struct mlx5dv_devx_uar {
+	void *reg_addr;
+	void *base_addr;
+	uint32_t page_id;
+	off_t mmap_off;
+	uint64_t comp_mask;
+};
+```
+*reg_addr*
+:	The write address of DB/BF.
+
+*base_addr*
+:	The base address of the UAR.
+
+*page_id*
+:	The device page id to be used.
+
+*mmap_off*
+:	The mmap offset parameter to be used for re-mapping, to be used by a secondary process.
+
+# RETURN VALUE
+
+Upon success *mlx5dv_devx_alloc_uar* will return a new *struct
+mlx5dv_devx_uar*,  on error NULL will be returned and errno will be set.
+
+# SEE ALSO
+
+**mlx5dv_open_device**, **mlx5dv_devx_obj_create**
+
+#AUTHOR
+
+Yishai Hadas  <yishaih@mellanox.com>

--- a/providers/mlx5/man/mlx5dv_devx_query_eqn.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_query_eqn.3.md
@@ -1,0 +1,49 @@
+---
+layout: page
+title: mlx5dv_devx_query_eqn
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_devx_query_eqn -  Query EQN for a given vector id.
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_devx_query_eqn(struct ibv_context *context, uint32_t vector,
+                          uint32_t *eqn);
+```
+
+# DESCRIPTION
+
+Query EQN for a given input vector, the EQN is needed for other device commands over the DEVX interface.
+
+The DEVX API enables direct access from the user space area to the mlx5 device
+driver, the EQN information is needed for few commands such as CQ creation.
+
+
+# ARGUMENTS
+*context*
+:	RDMA device context to work on.
+
+*vector*
+:	Completion vector number.
+
+*eqn*
+:	The device EQ number which relates to the given input vector.
+
+# RETURN VALUE
+
+returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+
+# SEE ALSO
+
+**mlx5dv_open_device**, **mlx5dv_devx_obj_create**
+
+#AUTHOR
+
+Yishai Hadas  <yishaih@mellanox.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -460,6 +460,11 @@ struct mlx5_wq {
 	uint32_t			*wr_data;
 };
 
+struct mlx5_devx_uar {
+	struct mlx5dv_devx_uar dv_devx_uar;
+	struct ibv_context *context;
+};
+
 struct mlx5_bf {
 	void			       *reg;
 	int				need_lock;
@@ -472,6 +477,7 @@ struct mlx5_bf {
 	void				*uar;
 	/* Index in the dynamic bfregs portion */
 	uint32_t			bfreg_dyn_index;
+	struct mlx5_devx_uar		devx_uar;
 };
 
 struct mlx5_dm {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1040,6 +1040,18 @@ struct mlx5dv_devx_umem *
 mlx5dv_devx_umem_reg(struct ibv_context *ctx, void *addr, size_t size, uint32_t access);
 int mlx5dv_devx_umem_dereg(struct mlx5dv_devx_umem *umem);
 
+struct mlx5dv_devx_uar {
+	void *reg_addr;
+	void *base_addr;
+	uint32_t page_id;
+	off_t mmap_off;
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(struct ibv_context *context,
+					      uint32_t flags);
+void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *devx_uar);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1051,6 +1051,8 @@ struct mlx5dv_devx_uar {
 struct mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(struct ibv_context *context,
 					      uint32_t flags);
 void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *devx_uar);
+int mlx5dv_devx_query_eqn(struct ibv_context *context, uint32_t vector,
+			  uint32_t *eqn);
 
 #ifdef __cplusplus
 }

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4083,3 +4083,17 @@ void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *dv_devx_uar)
 
 	mlx5_detach_dedicated_bf(bf->devx_uar.context, bf);
 }
+
+int mlx5dv_devx_query_eqn(struct ibv_context *context, uint32_t vector,
+			  uint32_t *eqn)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       MLX5_IB_OBJECT_DEVX,
+			       MLX5_IB_METHOD_DEVX_QUERY_EQN,
+			       2);
+
+	fill_attr_in_uint32(cmd, MLX5_IB_ATTR_DEVX_QUERY_EQN_USER_VEC, vector);
+	fill_attr_out_ptr(cmd, MLX5_IB_ATTR_DEVX_QUERY_EQN_DEV_EQN, eqn);
+
+	return execute_ioctl(context, cmd);
+}

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4036,3 +4036,50 @@ int mlx5dv_devx_general_cmd(struct ibv_context *context, const void *in, size_t 
 
 	return execute_ioctl(context, cmd);
 }
+
+struct mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(struct ibv_context *context,
+					      uint32_t flags)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       MLX5_IB_OBJECT_DEVX,
+			       MLX5_IB_METHOD_DEVX_QUERY_UAR,
+			       2);
+
+	int ret;
+	struct mlx5_bf *bf;
+
+	if (flags) {
+		errno = ENOTSUP;
+		return NULL;
+	}
+
+	bf = mlx5_attach_dedicated_bf(context);
+	if (!bf)
+		return NULL;
+
+	fill_attr_in_uint32(cmd, MLX5_IB_ATTR_DEVX_QUERY_UAR_USER_IDX,
+			    bf->bfreg_dyn_index);
+	fill_attr_out_ptr(cmd, MLX5_IB_ATTR_DEVX_QUERY_UAR_DEV_IDX,
+		      &bf->devx_uar.dv_devx_uar.page_id);
+
+	ret = execute_ioctl(context, cmd);
+	if (ret) {
+		mlx5_detach_dedicated_bf(context, bf);
+		return NULL;
+	}
+
+	bf->devx_uar.dv_devx_uar.reg_addr = bf->reg;
+	bf->devx_uar.dv_devx_uar.base_addr = bf->uar;
+	bf->devx_uar.dv_devx_uar.mmap_off = bf->uar_mmap_offset;
+	bf->devx_uar.dv_devx_uar.comp_mask = 0;
+	bf->devx_uar.context = context;
+	return &bf->devx_uar.dv_devx_uar;
+}
+
+void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *dv_devx_uar)
+{
+	struct mlx5_bf *bf = container_of(dv_devx_uar, struct mlx5_bf,
+					  devx_uar.dv_devx_uar);
+
+	mlx5_detach_dedicated_bf(bf->devx_uar.context, bf);
+}


### PR DESCRIPTION
This series introduces the DEVX APIs to work with UAR and EQ, the matching kernel size was already merged  upstream.