### PR TITLE
ibacm: Unable to assign EP name for limited pkey

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2071,7 +2071,9 @@ static void acm_ep_ip_iter_cb(char *ifname, union ibv_gid *gid, uint16_t pkey,
 
 	dev = acm_get_device_from_gid(gid, &port_num);
 	if (dev && ep->port->dev == dev
-	    && ep->port->port.port_num == port_num && ep->endpoint.pkey == pkey) {
+	    && ep->port->port.port_num == port_num &&
+		/* pkey retrieved from ipoib has always full mmbr bit set */
+		(ep->endpoint.pkey | IB_PKEY_FULL_MEMBER) == pkey) {
 		if (!acm_ep_insert_addr(ep, ip_str, addr, addr_len, addr_type)) {
 			acm_log(0, "Added %s %s %d 0x%x from %s\n", ip_str,
 				dev->device.verbs->device->name, port_num, pkey,


### PR DESCRIPTION
Using limited IB pkeys, ibacm compares pkeys retrieved using the OF-UV
API, ibv_query_pkey(), with the sysfs interface of ipoib,
/sys/class/net/<some_ipoib_if>/pkey.

The problem is that the latter always has the full member bit set
(0x8000). But the partition could be limited.

Using a limited partition, we see the following error in the ibacm.log
file (using the limited partition 0x0123):

acm_find_ep: pkey 0x123
acm_ep_up: creating endpoint for pkey 0x123
acm_ep_up: ERROR - unable to assign EP name for pkey 0x123

This is fixed by ORing in the full membership bit when comparing to a
pkey retrieved from the ipoib sysfs. With the fix, the above log lines
will read:

cm_find_ep: pkey 0x123
acm_ep_up: creating endpoint for pkey 0x123
acm_assign_ep_names: device mlx4_0, port 2, pkey 0x123
acmp_get_ep: dev 0x21280001a17c96 port 2 pkey 0x123
acmp_open_endpoint: creating endpoint for pkey 0x123
acmp_get_port: dev 0x21280001a17c96 port 2 pkey 0x123
acmp_ep_join: mlx4_0-2-0x123
acmp_join_group: mlx4_0 2 pkey 0x123, sl 0x0, rate 0x3, mtu 0x4
acmp_ep_join: join for mlx4_0-2-0x123 complete
acm_ep_ip_iter_cb: Added 192.168.213.213 mlx4_0 2 0x8123 from test_if

Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>