### PR TITLE
Python binding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,10 @@ addons:
       - gcc-8-multilib
       - lib32gcc-8-dev
 
+      # pyverbs
+      - python3-dev
+      - cython3
+
 service:
     - docker
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,14 @@
 #  -DIBACM_ACME_PLUS_KERNEL_ONLY_DEFAULT (default 0)
 #      If non-zero, limit incoming requests to kernel or the ib_acme utility
 #      (i.e. do not serve librdmacm requests)
+#  -DPYTHON_EXECUTABLE
+#      Override automatic detection of python to use a certain
+#      exectuable. This can be used to force the build to use python2 on a
+#      system that has python3 installed. Otherwise the build automatically
+#      prefers python3 if available.
+#   -DNO_PYVERBS=1 (default, build pyverbs)
+#      Invoke cython to build pyverbs. Usually you will run with this option
+#      is set, but it will be disabled for travis runs.
 
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project(rdma-core C)
@@ -87,6 +95,7 @@ set(BUILD_LIB ${CMAKE_BINARY_DIR}/lib)
 set(BUILD_STATIC_LIB ${CMAKE_BINARY_DIR}/lib/statics)
 # Used for IN_PLACE configuration
 set(BUILD_ETC ${CMAKE_BINARY_DIR}/etc)
+set(BUILD_PYTHON ${CMAKE_BINARY_DIR}/python)
 
 set(CMAKE_INSTALL_INITDDIR "${CMAKE_INSTALL_SYSCONFDIR}/init.d"
   CACHE PATH "Location for init.d files")
@@ -149,6 +158,7 @@ include(RDMA_BuildType)
 include(RDMA_DoFixup)
 include(publish_headers)
 include(rdma_functions)
+include(pyverbs_functions)
 include(rdma_man)
 
 if (NOT DEFINED ENABLE_STATIC)
@@ -350,8 +360,45 @@ else()
   set(HAVE_FULL_SYMBOL_VERSIONS 1)
 endif()
 
-# Look for Python
-FIND_PACKAGE(PythonInterp REQUIRED)
+if (${NO_PYVERBS})
+  set(CYTHON_EXECUTABLE "")
+else ()
+  # Look for Python. We prefer some variant of python 3 if the system has it.
+  FIND_PACKAGE(PythonInterp 3 QUIET)
+  if (NOT ${PythonInterp_FOUND})
+    FIND_PACKAGE(PythonInterp REQUIRED)
+  endif()
+  FIND_PACKAGE(cython)
+endif()
+
+# Look for Python. We prefer some variant of python 3 if the system has it.
+FIND_PACKAGE(PythonInterp 3 QUIET)
+if (NOT ${PythonInterp_FOUND})
+  FIND_PACKAGE(PythonInterp REQUIRED)
+endif()
+# A cython & python-devel installation that matches our selected interpreter.
+if (CYTHON_EXECUTABLE)
+ # cmake has really bad logic here, if PythonIterp has been run it tries to
+ # find a matching -devel installation but will happily return a non-matching
+ # one too. We need them both to match exactly to guarantee cython does the
+ # right thing.
+  FIND_PACKAGE(PythonLibs ${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
+    EXACT REQUIRED)
+
+ # Get a default installation path
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+    "from distutils.sysconfig import get_python_lib; print(get_python_lib(True, False, '${CMAKE_INSTALL_PREFIX}'))"
+  OUTPUT_VARIABLE py_path)
+  string(STRIP ${py_path} py_path)
+  set(CMAKE_INSTALL_PYTHON_ARCH_LIB "${py_path}"
+  CACHE PATH "Location for architecture specific python libraries")
+
+ # See PEP3149
+  execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+    "import sysconfig; x = sysconfig.get_config_var(\"EXT_SUFFIX\"); print(x if x else '.so')"
+    OUTPUT_VARIABLE py_path)
+  string(STRIP ${py_path} CMAKE_PYTHON_SO_SUFFIX)
+endif()
 
 # Look for pandoc
 FIND_PACKAGE(pandoc)
@@ -550,6 +597,10 @@ add_subdirectory(providers/ipathverbs)
 add_subdirectory(providers/rxe)
 add_subdirectory(providers/rxe/man)
 
+if (CYTHON_EXECUTABLE)
+  add_subdirectory(pyverbs)
+endif()
+
 # Binaries
 add_subdirectory(ibacm) # NO SPARSE
 if (NOT NL_KIND EQUAL 0)
@@ -607,6 +658,9 @@ if (NOT PANDOC_FOUND)
   else()
     message(STATUS " pandoc NOT found (using prebuilt man pages)")
   endif()
+endif()
+if (NOT CYTHON_EXECUTABLE)
+  message(STATUS " cython NOT found (disabling pyverbs)")
 endif()
 if (NOT SYSTEMD_FOUND)
   message(STATUS " libsystemd NOT found (disabling features)")

--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -1,0 +1,98 @@
+# Pyverbs
+
+Pyverbs provides a Python API over rdma-core, the Linux userspace C API for
+the RDMA stack.
+
+## Goals
+
+1. Provide easier access to RDMA: RDMA has a steep learning curve as is and
+   the C interface requires the user to initialize multiple structs before
+   having usable objects. Pyverbs attempts to remove much of this overhead and
+   provide a smoother user experience.
+2. Improve our code by providing a test suite for rdma-core. This means that
+   new features will be tested before merge, and it also means that users and
+   distros will have tests for new and existing features, as well as the means
+   to create them quickly.
+3. Stay up-to-date with rdma-core - cover new features during development and
+   provide a test / unit-test alongside the feature.
+
+## Limitations
+
+Python handles memory for users. As a result, memory is allocated by Pyverbs
+when needed (e.g. user buffer for memory region). The memory will be accessible
+to the users, but not allocated or freed by them.
+
+## Usage Examples
+##### Open an IB device
+
+Import the device module and open a device by name:
+
+```python
+import pyverbs.device as d
+ctx = d.Context(name='mlx5_0')
+```
+
+'ctx' is Pyverbs' equivalent to rdma-core's ibv_context. At this point, the IB
+device is already open and ready to use.
+
+##### Query a device
+```python
+import pyverbs.device as d
+ctx = d.Context(name='mlx5_0')
+attr = ctx.query_device()
+print(attr)
+FW version            : 16.24.0185
+Node guid             : 9803:9b03:0000:e4c6
+Sys image GUID        : 9803:9b03:0000:e4c6
+Max MR size           : 0xffffffffffffffff
+Page size cap         : 0xfffffffffffff000
+Vendor ID             : 0x2c9
+Vender part ID        : 4119
+HW version            : 0
+Max QP                : 262144
+Max QP WR             : 32768
+Device cap flags      : 3983678518
+Max SGE               : 30
+Max SGE RD            : 30
+MAX CQ                : 16777216
+Max CQE               : 4194303
+Max MR                : 16777216
+Max PD                : 16777216
+Max QP RD atom        : 16
+Max EE RD atom        : 0
+Max res RD atom       : 4194304
+Max QP init RD atom   : 16
+Max EE init RD atom   : 0
+Atomic caps           : 1
+Max EE                : 0
+Max RDD               : 0
+Max MW                : 16777216
+Max raw IPv6 QPs      : 0
+Max raw ethy QP       : 0
+Max mcast group       : 2097152
+Max mcast QP attach   : 240
+Max AH                : 2147483647
+Max FMR               : 0
+Max map per FMR       : 2147483647
+Max SRQ               : 8388608
+Max SRQ WR            : 32767
+Max SRQ SGE           : 31
+Max PKeys             : 128
+local CA ack delay    : 16
+Phys port count       : 1
+```
+
+'attr' is Pyverbs' equivalent to ibv_device_attr. Pyverbs will provide it to
+the user upon completion of the call to ibv_query_device.
+
+##### Query GID
+
+```python
+import pyverbs.device as d
+ctx = d.Context(name='mlx5_0')
+gid = ctx.query_gid(port_num=1, index=3)
+print(gid)
+0000:0000:0000:0000:0000:ffff:0b87:3c08
+```
+
+'gid' is Pyverbs' equivalent to ibv_gid, provided to the user by Pyverbs.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ $ apt-get install build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-
 ### Fedora
 
 ```sh
-$ dnf install cmake gcc libnl3-devel libudev-devel pkgconfig valgrind-devel ninja-build
+$ dnf install cmake gcc libnl3-devel libudev-devel pkgconfig valgrind-devel ninja-build python3-devel python3-Cython
 ```
 
 NOTE: Fedora Core uses the name 'ninja-build' for the 'ninja' command.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ only load from the system path.
 ### Debian Derived
 
 ```sh
-$ apt-get install build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind
+$ apt-get install build-essential cmake gcc libudev-dev libnl-3-dev libnl-route-3-dev ninja-build pkg-config valgrind python3-dev cython3
 ```
 
 ### Fedora

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NOTE: Fedora Core uses the name 'ninja-build' for the 'ninja' command.
 ### OpenSuSE
 
 ```sh
-$ zypper install cmake gcc libnl3-devel libudev-devel ninja pkg-config valgrind-devel
+$ zypper install cmake gcc libnl3-devel libudev-devel ninja pkg-config valgrind-devel python3-deve python3-Cython
 ```
 
 ## Building on CentOS 6/7

--- a/buildlib/Findcython.cmake
+++ b/buildlib/Findcython.cmake
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
+
+execute_process(COMMAND "${PYTHON_EXECUTABLE}" -c
+  "from Cython.Compiler.Main import main; import Cython; print(Cython.__version__);"
+  OUTPUT_VARIABLE _VERSION
+  RESULT_VARIABLE _VERSION_RESULT
+  ERROR_QUIET)
+
+if(NOT _VERSION_RESULT)
+  # We make our own cython script because it is very hard to figure out which
+  # cython exectuable wrapper is appropriately matched to the python
+  # interpreter we want to use. Cython must use the matching version of python
+  # or things will go wrong.
+  string(STRIP "${_VERSION}" CYTHON_VERSION_STRING)
+  set(CYTHON_EXECUTABLE "${BUILD_PYTHON}/cython")
+  file(WRITE "${CYTHON_EXECUTABLE}" "#!${PYTHON_EXECUTABLE}
+from Cython.Compiler.Main import main
+main(command_line = 1)")
+  execute_process(COMMAND "chmod" "a+x" "${CYTHON_EXECUTABLE}")
+endif()
+unset(_VERSION_RESULT)
+unset(_VERSION)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(cython
+  REQUIRED_VARS CYTHON_EXECUTABLE CYTHON_VERSION_STRING
+  VERSION_VAR CYTHON_VERSION_STRING)
+mark_as_advanced(CYTHON_EXECUTABLE)

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -158,7 +158,7 @@ class fc29(Environment):
 
 class APTEnvironment(Environment):
     is_deb = True;
-    build_python = False;
+    build_python = True;
     def get_docker_file(self):
         res = DockerFile(self.docker_parent);
         res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s && apt-get clean"%(
@@ -180,7 +180,6 @@ class trusty(APTEnvironment):
         'ninja-build',
         'pandoc',
         'pkg-config',
-        'python',
         'valgrind',
         };
     pkgs = common_pkgs | {
@@ -190,10 +189,12 @@ class trusty(APTEnvironment):
         };
     name = "ubuntu-14.04";
     aliases = {"trusty"};
+    python_cmd = "python";
+    build_pyverbs = False;
 
 class xenial(APTEnvironment):
     docker_parent = "ubuntu:16.04"
-    pkgs = trusty.common_pkgs | {"libsystemd-dev"};
+    pkgs = trusty.common_pkgs | {"libsystemd-dev", "python3-dev", "cython3"};
     name = "ubuntu-16.04";
     aliases = {"xenial"};
 
@@ -208,7 +209,7 @@ class jessie(APTEnvironment):
     pkgs = xenial.pkgs;
     name = "debian-8";
     aliases = {"jessie"};
-    python_cmd = "python";
+    build_pyverbs = False;
 
 class stretch(APTEnvironment):
     docker_parent = "debian:9"
@@ -640,6 +641,10 @@ def run_deb_build(args,env):
             "-e","DEB_BUILD_OPTIONS=parallel=%u"%(multiprocessing.cpu_count()),
         ];
 
+        if not env.build_pyverbs:
+            opts.append("-e");
+            opts.append("EXTRA_CMAKE_FLAGS=%s"%(' '.join(["-DNO_PYVERBS=1"])));
+
         # Create a go.py that will let us run the compilation as the user and
         # then switch to root only for the packaging step.
         with open(os.path.join(tmpdir,"go.py"),"w") as F:
@@ -661,7 +666,7 @@ subprocess.check_call(["debian/rules","debian/rules","binary"]);
         if args.run_shell:
             opts.append("/bin/bash");
         else:
-            opts.extend(["python",os.path.join(home,"go.py")]);
+            opts.extend(["python3",os.path.join(home,"go.py")]);
 
         docker_cmd(args,*opts);
 
@@ -806,6 +811,9 @@ def cmd_make(args):
             dirs.append(BUILD_r);
 
         cmake_args = []
+        if not env.build_pyverbs:
+            cmake_args.extend(["-DNO_PYVERBS=1"]);
+
         cmake_envs = []
         ninja_args = []
         for I in args.ARGS:
@@ -815,7 +823,6 @@ def cmd_make(args):
                 cmake_envs.append(I);
             else:
                 ninja_args.append(I);
-
         if env.use_make:
             need_cmake = not os.path.exists(os.path.join(BUILD_r,"Makefile"));
         else:

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -321,7 +321,6 @@ class travis(APTEnvironment):
 
 class ZypperEnvironment(Environment):
     is_rpm = True;
-    build_pyverbs = False;
     def get_docker_file(self):
         res = DockerFile(self.docker_parent);
         res.lines.append("RUN zypper --non-interactive refresh");
@@ -348,6 +347,8 @@ class leap(ZypperEnvironment):
         'rpm-build',
         'systemd-devel',
         'valgrind-devel',
+        'python3-Cython',
+        'python3-devel',
     };
     rpmbuild_options = [ "--without=curlmini" ];
     name = "opensuse-15.0";
@@ -359,9 +360,6 @@ class tumbleweed(ZypperEnvironment):
     name = "tumbleweed";
     specfile = "suse/rdma-core.spec";
     rpmbuild_options = [ "--without=curlmini" ];
-    # tumbleweed no longer includes python2 in the base docker images, only python3,
-    # use that instead.
-    python_cmd = "python3";
 
 # -------------------------------------------------------------------------
 

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -74,10 +74,11 @@ class DockerFile(object):
 
 class Environment(object):
     pandoc = True;
-    python_cmd = "python";
+    python_cmd = "python3";
     aliases = set();
     use_make = False;
     proxy = True;
+    build_pyverbs = True;
 
     def image_name(self):
         return "build-%s/%s"%(project,self.name);
@@ -110,6 +111,8 @@ class centos6(YumEnvironment):
     use_make = True;
     pandoc = False;
     is_rpm = False;
+    build_pyverbs = False;
+    python_cmd = "python";
 
 class centos7(YumEnvironment):
     docker_parent = "centos:7";
@@ -117,10 +120,12 @@ class centos7(YumEnvironment):
     name = "centos7";
     use_make = True;
     pandoc = False;
+    build_pyverbs = False;
     specfile = "redhat/rdma-core.spec";
+    python_cmd = "python";
 
 class centos7_epel(centos7):
-    pkgs = (centos7.pkgs - {"cmake","make"}) | {"ninja-build","cmake3","pandoc"};
+    pkgs = (centos7.pkgs - {"cmake","make"}) | {"ninja-build","cmake3","pandoc", 'python3-Cython', 'python3-devel'};
     name = "centos7_epel";
     use_make = False;
     pandoc = True;
@@ -136,7 +141,7 @@ class centos7_epel(centos7):
 
 class fc29(Environment):
     docker_parent = "fedora:29";
-    pkgs = (centos7.pkgs - {"make", "python-argparse" }) | {"ninja-build","pandoc","perl-generators"};
+    pkgs = (centos7.pkgs - {"make", "python-argparse" }) | {"ninja-build","pandoc","perl-generators","python3-Cython","python3-devel"};
     name = "fc29";
     specfile = "redhat/rdma-core.spec";
     ninja_cmd = "ninja-build";
@@ -153,6 +158,7 @@ class fc29(Environment):
 
 class APTEnvironment(Environment):
     is_deb = True;
+    build_python = False;
     def get_docker_file(self):
         res = DockerFile(self.docker_parent);
         res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s && apt-get clean"%(
@@ -202,6 +208,7 @@ class jessie(APTEnvironment):
     pkgs = xenial.pkgs;
     name = "debian-8";
     aliases = {"jessie"};
+    python_cmd = "python";
 
 class stretch(APTEnvironment):
     docker_parent = "debian:9"
@@ -314,6 +321,7 @@ class travis(APTEnvironment):
 
 class ZypperEnvironment(Environment):
     is_rpm = True;
+    build_pyverbs = False;
     def get_docker_file(self):
         res = DockerFile(self.docker_parent);
         res.lines.append("RUN zypper --non-interactive refresh");
@@ -583,6 +591,9 @@ os.symlink({tarfn!r},os.path.join(b"SOURCES",tarfn));
                 bopts.extend(["--with", arg]);
             for arg in args.without_flags:
                 bopts.extend(["--without", arg]);
+            if "pyverbs" not in args.with_flags + args.without_flags:
+                if env.build_pyverbs:
+                    bopts.extend(["--with", "pyverbs"]);
 
             print >> F,'os.execlp("rpmbuild","rpmbuild",%s)'%(
                 ",".join(repr(I) for I in bopts));

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
+
+function(rdma_cython_module PY_MODULE)
+  foreach(PYX_FILE ${ARGN})
+    get_filename_component(FILENAME ${PYX_FILE} NAME_WE)
+    set(PYX "${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}.pyx")
+    set(CFILE "${CMAKE_CURRENT_BINARY_DIR}/${FILENAME}.c")
+    include_directories(${PYTHON_INCLUDE_DIRS})
+    add_custom_command(
+      OUTPUT "${CFILE}"
+      COMMAND ${CYTHON_EXECUTABLE} "${PYX}" -o "${CFILE}"
+      "-I${PYTHON_INCLUDE_DIRS}"
+      COMMENT "Cythonizing ${PYX}"
+      )
+
+    string(REGEX REPLACE "\\.so$" "" SONAME "${FILENAME}${CMAKE_PYTHON_SO_SUFFIX}")
+    add_library(${SONAME} SHARED ${CFILE})
+    set_target_properties(${SONAME} PROPERTIES
+	    COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option"
+      LIBRARY_OUTPUT_DIRECTORY "${BUILD_PYTHON}/${PY_MODULE}"
+      PREFIX "")
+    target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs)
+    install(TARGETS ${SONAME}
+      DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
+  endforeach()
+endfunction()
+
+function(rdma_python_module PY_MODULE)
+  foreach(PY_FILE ${ARGN})
+    get_filename_component(LINK "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" ABSOLUTE)
+    rdma_create_symlink("${LINK}" "${BUILD_PYTHON}/${PY_MODULE}/${PY_FILE}")
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}
+      DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
+  endforeach()
+endfunction()

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -34,3 +34,27 @@ function(rdma_python_module PY_MODULE)
       DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
   endforeach()
 endfunction()
+
+function(rdma_python_test PY_MODULE)
+  foreach(PY_FILE ${ARGN})
+    get_filename_component(LINK "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" ABSOLUTE)
+    rdma_create_symlink("${LINK}" "${BUILD_PYTHON}/${PY_MODULE}/${PY_FILE}")
+    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}
+      DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
+  endforeach()
+endfunction()
+
+# Make a python script runnable from the build/bin directory with all the
+# correct paths filled in
+function(rdma_internal_binary)
+  foreach(PY_FILE ${ARGN})
+    get_filename_component(ABS "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" ABSOLUTE)
+    get_filename_component(FN "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" NAME)
+    set(BIN_FN "${BUILD_BIN}/${FN}")
+
+    file(WRITE "${BIN_FN}" "#!/bin/sh
+PYTHONPATH='${BUILD_PYTHON}' exec '${PYTHON_EXECUTABLE}' '${ABS}' \"$@\"
+")
+    execute_process(COMMAND "chmod" "a+x" "${BIN_FN}")
+  endforeach()
+endfunction()

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -54,7 +54,7 @@ cp ../util/udma_barrier.h.old ../util/udma_barrier.h
 # instead force it on by changing the CMakeLists.txt
 cd ..
 echo 'set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")' >> buildlib/RDMA_EnableCStd.cmake
-sed -i -e 's/-DCMAKE_BUILD_TYPE=Release//g' debian/rules
+sed -i -e 's/-DCMAKE_BUILD_TYPE=Release/-DCMAKE_BUILD_TYPE=Debug/g' debian/rules
 sed -i -e 's/ninja \(.*\)-v/ninja \1/g' debian/rules
 
 CC=gcc-8 debian/rules build

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -17,19 +17,19 @@ ninja
 cd ../build32
 # travis is not configured in a way that enables all 32 bit
 # packages. We could fix this with some sudo stuff.. For now turn off libnl
-CC=gcc-8 CFLAGS="-Werror -m32 -msse3" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both
+CC=gcc-8 CFLAGS="-Werror -m32 -msse3" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both -DNO_PYVERBS=1
 ninja
 
 # aarch64 build to check compilation on ARM 64bit platform
 cd ../build-aarch64
-CC=$HOME/aarch64/bin/aarch64-linux-gnu-gcc CFLAGS="-Werror -Wno-maybe-uninitialized" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=ioctl
+CC=$HOME/aarch64/bin/aarch64-linux-gnu-gcc CFLAGS="-Werror -Wno-maybe-uninitialized" cmake -GNinja .. -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=ioctl -DNO_PYVERBS=1
 ninja
 
 # Run sparse on the subdirectories which are sparse clean
 cd ../build-sparse
 mv ../CMakeLists.txt ../CMakeLists-orig.txt
 grep -v "# NO SPARSE" ../CMakeLists-orig.txt > ../CMakeLists.txt
-CC=cgcc CFLAGS="-Werror" cmake -GNinja .. -DIOCTL_MODE=both
+CC=cgcc CFLAGS="-Werror" cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1
 ninja | grep -v '^\[' | tee out
 # sparse does not fail gcc on messages
 if [ -s out ]; then

--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,8 @@ Build-Depends: cmake (>= 2.8.11),
                ninja-build,
                pandoc,
                pkg-config,
-               python,
+               python3-dev,
+               cython3,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
@@ -324,3 +325,10 @@ Description: Tools for Infiniband attached storage (SRP)
  In conjunction with the kernel ib_srp driver, srptools allows you to
  discover and use Infiniband attached storage devices which use the
  SCSI RDMA Protocol (SRP).
+
+Package: python3-pyverbs
+Architecture: linux-any
+Depends: rdma-core (>= 21),
+         ${python3:Depends}
+Description: Pyverbs is a python bindings for rdma-core.
+ It allows an easy development in python language of RDMA applications.

--- a/debian/python3-pyverbs.install
+++ b/debian/python3-pyverbs.install
@@ -1,0 +1,1 @@
+usr/lib/python3/dist-packages/pyverbs

--- a/debian/rules
+++ b/debian/rules
@@ -7,7 +7,7 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 powerpc powerpcspe ppc64 ppc64el s390x sparc64 x32
 
 %:
-	dh $@ --with systemd --builddirectory=build-deb
+	dh $@ --with python3,systemd --builddirectory=build-deb
 
 override_dh_auto_clean:
 	dh_auto_clean
@@ -22,19 +22,29 @@ override_dh_auto_clean:
 #
 # Upstream encourages the use of Ninja to build the source, convince dh to use
 # it until someone writes native support for dh+cmake+ninja.
+DH_AUTO_CONFIGURE := "--" \
+	             "-GNinja" \
+		     "-DDISTRO_FLAVOUR=Debian" \
+		     "-DCMAKE_BUILD_TYPE=Release" \
+		     "-DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc" \
+		     "-DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system" \
+		     "-DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d" \
+		     "-DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib" \
+		     "-DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib" \
+		     "-DCMAKE_INSTALL_RUNDIR:PATH=/run" \
+		     "-DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d" \
+		     "-DENABLE_STATIC=1" \
+		     $(EXTRA_CMAKE_FLAGS)
+
 override_dh_auto_configure:
-	dh_auto_configure -- -GNinja \
-			-DDISTRO_FLAVOUR=Debian \
-			-DCMAKE_BUILD_TYPE=Release \
-			-DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc \
-			-DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system \
-			-DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d \
-			-DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib \
-			-DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib \
-			-DCMAKE_INSTALL_RUNDIR:PATH=/run \
-			-DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d \
-			-DENABLE_STATIC=1 \
-			$(EXTRA_CMAKE_FLAGS)
+ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
+	dh_auto_configure $(DH_AUTO_CONFIGURE)
+else
+	dh_auto_configure $(DH_AUTO_CONFIGURE) \
+		        -DNO_PYVERBS=0 \
+			-DPYTHON_EXECUTABLE:PATH=/usr/bin/python3 \
+			-DCMAKE_INSTALL_PYTHON_ARCH_LIB:PATH=/usr/lib/python3/dist-packages
+endif
 
 override_dh_auto_build:
 	ninja -C build-deb -v
@@ -57,6 +67,9 @@ INST_EXCLUDE := "etc/init.d/srpd" \
 		"etc/init.d/ibacm" \
 		"usr/sbin/run_srp_daemon" \
 		"usr/sbin/srp_daemon.sh"
+ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
+	INST_EXCLUDE := $(INST_EXCLUDE) "usr/lib/python3/dist-packages/pyverbs"
+endif
 INST_EXCLUDE := $(addprefix -X,$(INST_EXCLUDE))
 override_dh_install:
 	dh_install --fail-missing $(INST_EXCLUDE)
@@ -85,6 +98,13 @@ override_dh_strip:
 	dh_strip -plibibverbs1 --dbg-package=libibverbs1-dbg
 	dh_strip -plibrdmacm1 --dbg-package=librdmacm1-dbg
 	dh_strip --remaining-packages
+
+override_dh_builddeb:
+ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
+	dh_builddeb -Npython3-pyverbs --remaining-packages
+else
+	dh_builddeb --remaining-package
+endif
 
 # Upstream encourages the use of 'build' as the developer build output
 # directory, allow that directory to be present and still allow dh to work.

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -11,4 +11,14 @@ rdma_cython_module(pyverbs
 rdma_python_module(pyverbs
   pyverbs_error.py
   __init__.py
+  run_tests.py
+  )
+
+rdma_python_test(pyverbs/tests
+  tests/__init__.py
+  tests/device.py
+  )
+
+rdma_internal_binary(
+  run_tests.py
   )

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+rdma_cython_module(pyverbs
+  enums.pyx
+  base.pyx
+  device.pyx
+  addr.pyx
+  )
+
+rdma_python_module(pyverbs
+  pyverbs_error.py
+  __init__.py
+  )

--- a/pyverbs/addr.pxd
+++ b/pyverbs/addr.pxd
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+from .base cimport PyverbsObject
+from pyverbs cimport libibverbs as v
+
+
+cdef class Gid(PyverbsObject):
+    cdef v.ibv_gid gid

--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -1,0 +1,50 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+import sys
+from libc.stdint cimport uint8_t
+from .pyverbs_error import PyverbsUserError
+
+cdef extern from 'endian.h':
+    unsigned long be64toh(unsigned long host_64bits)
+
+
+cdef class Gid(PyverbsObject):
+    """
+    GID class represents ibv_gid. It enables user to query for GIDs values.
+    """
+    property gid:
+        def __get__(self):
+            """
+            Expose the inner GID
+            :return: A GID string in an 8 words format:
+            'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
+            """
+            return self.__str__()
+        def __set__(self, val):
+            """
+            Sets the inner GID
+            :param val: A GID string in an 8 words format:
+            'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
+            :return: None
+            """
+            val = val.split(':')
+            if len(val) != 8:
+                raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
+            if any([len(v) != 4 for v in val]):
+                raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
+            val_int = int("".join(val), 16)
+            vals = []
+            for i in range(8):
+                vals.append(val[i][0:2])
+                vals.append(val[i][2:4])
+
+            for i in range(16):
+                self.gid.raw[i] = <uint8_t>int(vals[i],16)
+
+    def __str__(self):
+        hex_values = '%016x%016x' % (be64toh(self.gid._global.subnet_prefix),
+                                   be64toh(self.gid._global.interface_id))
+        return ':'.join([hex_values[0:4], hex_values[4:8], hex_values[8:12],
+                         hex_values[12:16], hex_values[16:20], hex_values[20:24],
+                         hex_values[24:28],hex_values[28:32]])

--- a/pyverbs/base.pxd
+++ b/pyverbs/base.pxd
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.
+
+cdef class PyverbsObject(object):
+    cdef object logger

--- a/pyverbs/base.pyx
+++ b/pyverbs/base.pyx
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.
+
+import logging
+from pyverbs.pyverbs_error import PyverbsRDMAError
+
+
+cdef extern from 'errno.h':
+    int errno
+
+cpdef PyverbsRDMAErrno(str msg):
+    return PyverbsRDMAError(msg, errno)
+
+LOG_LEVEL=logging.INFO
+LOG_FORMAT='[%(levelname)s] %(asctime)s %(filename)s:%(lineno)s: %(message)s'
+logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL, datefmt='%d %b %Y %H:%M:%S')
+
+cdef class PyverbsObject(object):
+
+    def __cinit__(self):
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def set_log_level(self, val):
+        self.logger.setLevel(val)

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+from .base cimport PyverbsObject
+cimport pyverbs.libibverbs as v
+
+
+cdef class Context(PyverbsObject):
+    cdef v.ibv_context *context
+    cdef object name
+    cdef _close(self)
+
+cdef class DeviceAttr(PyverbsObject):
+    cdef v.ibv_device_attr dev_attr
+

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -12,4 +12,3 @@ cdef class Context(PyverbsObject):
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr
-

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -10,6 +10,7 @@ from .pyverbs_error import PyverbsRDMAError
 from .pyverbs_error import PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
 cimport pyverbs.libibverbs as v
+from pyverbs.addr cimport Gid
 
 cdef extern from 'errno.h':
     int errno
@@ -131,6 +132,14 @@ cdef class Context(PyverbsObject):
             raise PyverbsRDMAErrno('Failed to query device {name}'.
                                    format(name=self.name), errno)
         return dev_attr
+
+    def query_gid(self, unsigned int port_num, int index):
+        gid = Gid()
+        rc = v.ibv_query_gid(self.context, port_num, index, &gid.gid)
+        if rc != 0:
+            raise PyverbsRDMAError('Failed to query gid {idx} of port {port}'.
+								   format(idx=index, port=port_num))
+        return gid
 
 
 cdef class DeviceAttr(PyverbsObject):

--- a/pyverbs/enums.pyx
+++ b/pyverbs/enums.pyx
@@ -1,0 +1,1 @@
+libibverbs_enums.pxd

--- a/pyverbs/examples/ib_devices.py
+++ b/pyverbs/examples/ib_devices.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+from pyverbs import device as d
+import sys
+
+
+lst = d.get_device_list()
+dev = 'Device'
+node = 'Node Type'
+trans = 'Transport Type'
+guid = 'Node GUID'
+print_format = '{:^20}{:^20}{:^20}{:^20}'
+print (print_format.format(dev, node, trans, guid))
+print (print_format.format('-'*len(dev), '-'*len(node), '-'*len(trans),
+	   '-'*len(guid)))
+for i in lst:
+	print (print_format.format(i.name.decode(), d.translate_node_type(i.node_type),
+		   d.translate_transport_type(i.transport_type),
+		   d.guid_to_hex(i.guid)))

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+
+include 'libibverbs_enums.pxd'
+from libc.stdint cimport uint8_t, uint64_t
+
+cdef extern from 'infiniband/verbs.h':
+
+    cdef struct ibv_device:
+        char *name
+        int node_type
+        int transport_type
+
+    cdef struct ibv_context:
+        ibv_device *device
+
+    cdef struct ibv_device_attr:
+        char            *fw_ver
+        unsigned long   node_guid;
+        unsigned long   sys_image_guid;
+        unsigned long   max_mr_size;
+        unsigned long   page_size_cap;
+        unsigned int    vendor_id;
+        unsigned int    vendor_part_id;
+        unsigned int    hw_ver;
+        unsigned int    max_qp
+        unsigned int    max_qp_wr
+        unsigned int    device_cap_flags
+        unsigned int    max_sge
+        unsigned int    max_sge_rd
+        unsigned int    max_cq
+        unsigned int    max_cqe
+        unsigned int    max_mr
+        unsigned int    max_pd
+        unsigned int    max_qp_rd_atom
+        unsigned int    max_ee_rd_atom
+        unsigned int    max_res_rd_atom
+        unsigned int    max_qp_init_rd_atom
+        unsigned int    max_ee_init_rd_atom
+        ibv_atomic_cap  atomic_cap
+        unsigned int    max_ee;
+        unsigned int    max_rdd;
+        unsigned int    max_mw;
+        unsigned int    max_raw_ipv6_qp;
+        unsigned int    max_raw_ethy_qp;
+        unsigned int    max_mcast_grp;
+        unsigned int    max_mcast_qp_attach;
+        unsigned int    max_total_mcast_qp_attach;
+        unsigned int    max_ah;
+        unsigned int    max_fmr;
+        unsigned int    max_map_per_fmr;
+        unsigned int    max_srq;
+        unsigned int    max_srq_wr;
+        unsigned int    max_srq_sge;
+        unsigned int    max_pkeys;
+        unsigned int    local_ca_ack_delay;
+        unsigned int    phys_port_cnt;
+
+    ibv_device **ibv_get_device_list(int *n)
+    void ibv_free_device_list(ibv_device **list);
+    ibv_context *ibv_open_device(ibv_device *device);
+    int ibv_close_device(ibv_context *context)
+    int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -6,6 +6,14 @@ from libc.stdint cimport uint8_t, uint64_t
 
 cdef extern from 'infiniband/verbs.h':
 
+    cdef struct anon:
+        unsigned long subnet_prefix
+        unsigned long interface_id
+
+    cdef union ibv_gid:
+        anon _global "global"
+        uint8_t raw[16]
+
     cdef struct ibv_device:
         char *name
         int node_type
@@ -62,3 +70,5 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_close_device(ibv_context *context)
     int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)
     unsigned long ibv_get_device_guid(ibv_device *device)
+    int ibv_query_gid(ibv_context *context, unsigned int port_num,
+                      int index, ibv_gid *gid)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -61,3 +61,4 @@ cdef extern from 'infiniband/verbs.h':
     ibv_context *ibv_open_device(ibv_device *device);
     int ibv_close_device(ibv_context *context)
     int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)
+    unsigned long ibv_get_device_guid(ibv_device *device)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -1,0 +1,339 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.
+
+cdef extern from '<infiniband/verbs.h>':
+
+    cpdef enum ibv_atomic_cap:
+        IBV_ATOMIC_NONE
+        IBV_ATOMIC_HCA
+        IBV_ATOMIC_GLOB
+
+    cpdef enum ibv_port_state:
+        IBV_PORT_NOP                = 0
+        IBV_PORT_DOWN               = 1
+        IBV_PORT_INIT               = 2
+        IBV_PORT_ARMED              = 3
+        IBV_PORT_ACTIVE             = 4
+        IBV_PORT_ACTIVE_DEFER       = 5
+
+    cpdef enum ibv_port_cap_flags:
+        IBV_PORT_SM                         = 1 <<  1
+        IBV_PORT_NOTICE_SUP                 = 1 <<  2
+        IBV_PORT_TRAP_SUP                   = 1 <<  3
+        IBV_PORT_OPT_IPD_SUP                = 1 <<  4
+        IBV_PORT_AUTO_MIGR_SUP              = 1 <<  5
+        IBV_PORT_SL_MAP_SUP                 = 1 <<  6
+        IBV_PORT_MKEY_NVRAM                 = 1 <<  7
+        IBV_PORT_PKEY_NVRAM                 = 1 <<  8
+        IBV_PORT_LED_INFO_SUP               = 1 <<  9
+        IBV_PORT_SYS_IMAGE_GUID_SUP         = 1 << 11
+        IBV_PORT_PKEY_SW_EXT_PORT_TRAP_SUP  = 1 << 12
+        IBV_PORT_EXTENDED_SPEEDS_SUP        = 1 << 14
+        IBV_PORT_CM_SUP                     = 1 << 16
+        IBV_PORT_SNMP_TUNNEL_SUP            = 1 << 17
+        IBV_PORT_REINIT_SUP                 = 1 << 18
+        IBV_PORT_DEVICE_MGMT_SUP            = 1 << 19
+        IBV_PORT_VENDOR_CLASS_SUP           = 1 << 20
+        IBV_PORT_DR_NOTICE_SUP              = 1 << 21
+        IBV_PORT_CAP_MASK_NOTICE_SUP        = 1 << 22
+        IBV_PORT_BOOT_MGMT_SUP              = 1 << 23
+        IBV_PORT_LINK_LATENCY_SUP           = 1 << 24
+        IBV_PORT_CLIENT_REG_SUP             = 1 << 25
+        IBV_PORT_IP_BASED_GIDS              = 1 << 26
+
+    cpdef enum ibv_mtu:
+        IBV_MTU_256     = 1
+        IBV_MTU_512     = 2
+        IBV_MTU_1024    = 3
+        IBV_MTU_2048    = 4
+        IBV_MTU_4096    = 5
+
+    cpdef enum ibv_event_type:
+        IBV_EVENT_CQ_ERR
+        IBV_EVENT_QP_FATAL
+        IBV_EVENT_QP_REQ_ERR
+        IBV_EVENT_QP_ACCESS_ERR
+        IBV_EVENT_COMM_EST
+        IBV_EVENT_SQ_DRAINED
+        IBV_EVENT_PATH_MIG
+        IBV_EVENT_PATH_MIG_ERR
+        IBV_EVENT_DEVICE_FATAL
+        IBV_EVENT_PORT_ACTIVE
+        IBV_EVENT_PORT_ERR
+        IBV_EVENT_LID_CHANGE
+        IBV_EVENT_PKEY_CHANGE
+        IBV_EVENT_SM_CHANGE
+        IBV_EVENT_SRQ_ERR
+        IBV_EVENT_SRQ_LIMIT_REACHED
+        IBV_EVENT_QP_LAST_WQE_REACHED
+        IBV_EVENT_CLIENT_REREGISTER
+        IBV_EVENT_GID_CHANGE
+        IBV_EVENT_WQ_FATAL
+
+    cpdef enum ibv_access_flags:
+        IBV_ACCESS_LOCAL_WRITE      = 1
+        IBV_ACCESS_REMOTE_WRITE     = (1 << 1)
+        IBV_ACCESS_REMOTE_READ      = (1 << 2)
+        IBV_ACCESS_REMOTE_ATOMIC    = (1 << 3)
+        IBV_ACCESS_MW_BIND          = (1 << 4)
+        IBV_ACCESS_ZERO_BASED       = (1 << 5)
+        IBV_ACCESS_ON_DEMAND        = (1 << 6)
+
+    cpdef enum ibv_wr_opcode:
+        IBV_WR_RDMA_WRITE
+        IBV_WR_RDMA_WRITE_WITH_IMM
+        IBV_WR_SEND
+        IBV_WR_SEND_WITH_IMM
+        IBV_WR_RDMA_READ
+        IBV_WR_ATOMIC_CMP_AND_SWP
+        IBV_WR_ATOMIC_FETCH_AND_ADD
+        IBV_WR_LOCAL_INV
+        IBV_WR_BIND_MW
+        IBV_WR_SEND_WITH_INV
+        IBV_WR_TSO
+
+    cpdef enum ibv_send_flags:
+        IBV_SEND_FENCE      = 1 << 0
+        IBV_SEND_SIGNALED   = 1 << 1
+        IBV_SEND_SOLICITED  = 1 << 2
+        IBV_SEND_INLINE     = 1 << 3
+        IBV_SEND_IP_CSUM    = 1 << 4
+
+    cpdef enum ibv_qp_type:
+        IBV_QPT_RC          = 2
+        IBV_QPT_UC          = 3
+        IBV_QPT_UD          = 4
+        IBV_QPT_RAW_PACKET  = 8
+        IBV_QPT_XRC_SEND    = 9
+        IBV_QPT_XRC_RECV    = 10
+        IBV_QPT_DRIVER      = 0xff
+
+    cpdef enum ibv_qp_state:
+        IBV_QPS_RESET
+        IBV_QPS_INIT
+        IBV_QPS_RTR
+        IBV_QPS_RTS
+        IBV_QPS_SQD
+        IBV_QPS_SQE
+        IBV_QPS_ERR
+        IBV_QPS_UNKNOWN
+
+    cpdef enum ibv_mw_type:
+        IBV_MW_TYPE_1   = 1
+        IBV_MW_TYPE_2   = 2
+
+    cpdef enum ibv_wc_status:
+        IBV_WC_SUCCESS
+        IBV_WC_LOC_LEN_ERR
+        IBV_WC_LOC_QP_OP_ERR
+        IBV_WC_LOC_EEC_OP_ERR
+        IBV_WC_LOC_PROT_ERR
+        IBV_WC_WR_FLUSH_ERR
+        IBV_WC_MW_BIND_ERR
+        IBV_WC_BAD_RESP_ERR
+        IBV_WC_LOC_ACCESS_ERR
+        IBV_WC_REM_INV_REQ_ERR
+        IBV_WC_REM_ACCESS_ERR
+        IBV_WC_REM_OP_ERR
+        IBV_WC_RETRY_EXC_ERR
+        IBV_WC_RNR_RETRY_EXC_ERR
+        IBV_WC_LOC_RDD_VIOL_ERR
+        IBV_WC_REM_INV_RD_REQ_ERR
+        IBV_WC_REM_ABORT_ERR
+        IBV_WC_INV_EECN_ERR
+        IBV_WC_INV_EEC_STATE_ERR
+        IBV_WC_FATAL_ERR
+        IBV_WC_RESP_TIMEOUT_ERR
+        IBV_WC_GENERAL_ERR
+
+    cpdef enum ibv_wc_opcode:
+        IBV_WC_SEND
+        IBV_WC_RDMA_WRITE
+        IBV_WC_RDMA_READ
+        IBV_WC_COMP_SWAP
+        IBV_WC_FETCH_ADD
+        IBV_WC_BIND_MW
+        IBV_WC_LOCAL_INV
+        IBV_WC_TSO
+        IBV_WC_RECV         = 1 << 7
+        IBV_WC_RECV_RDMA_WITH_IMM
+
+    cpdef enum ibv_create_cq_wc_flags:
+        IBV_WC_EX_WITH_BYTE_LEN                 = 1 << 0
+        IBV_WC_EX_WITH_IMM                      = 1 << 1
+        IBV_WC_EX_WITH_QP_NUM                   = 1 << 2
+        IBV_WC_EX_WITH_SRC_QP                   = 1 << 3
+        IBV_WC_EX_WITH_SLID                     = 1 << 4
+        IBV_WC_EX_WITH_SL                       = 1 << 5
+        IBV_WC_EX_WITH_DLID_PATH_BITS           = 1 << 6
+        IBV_WC_EX_WITH_COMPLETION_TIMESTAMP     = 1 << 7
+        IBV_WC_EX_WITH_CVLAN                    = 1 << 8
+        IBV_WC_EX_WITH_FLOW_TAG                 = 1 << 9
+        IBV_WC_EX_WITH_TM_INFO                  = 1 << 10
+
+    cpdef enum ibv_wc_flags:
+        IBV_WC_GRH              = 1 << 0
+        IBV_WC_WITH_IMM         = 1 << 1
+        IBV_WC_IP_CSUM_OK       = 1 << 2
+        IBV_WC_WITH_INV         = 1 << 3
+        IBV_WC_TM_SYNC_REQ      = 1 << 4
+        IBV_WC_TM_MATCH         = 1 << 5
+        IBV_WC_TM_DATA_VALID    = 1 << 6
+
+    cpdef enum ibv_tm_cap_flags:
+        IBV_TM_CAP_RC       = 1 << 0,
+
+    cpdef enum ibv_srq_attr_mask:
+        IBV_SRQ_MAX_WR      = 1 << 0,
+        IBV_SRQ_LIMIT       = 1 << 1
+
+    cpdef enum ibv_srq_type:
+        IBV_SRQT_BASIC
+        IBV_SRQT_XRC
+        IBV_SRQT_TM
+
+    cpdef enum ibv_srq_init_attr_mask:
+        IBV_SRQ_INIT_ATTR_TYPE      = 1 << 0
+        IBV_SRQ_INIT_ATTR_PD        = 1 << 1
+        IBV_SRQ_INIT_ATTR_XRCD      = 1 << 2
+        IBV_SRQ_INIT_ATTR_CQ        = 1 << 3
+        IBV_SRQ_INIT_ATTR_TM        = 1 << 4
+        IBV_SRQ_INIT_ATTR_RESERVED  = 1 << 5
+
+    cpdef enum ibv_mig_state:
+        IBV_MIG_MIGRATED
+        IBV_MIG_REARM
+        IBV_MIG_ARMED
+
+    cpdef enum ibv_qp_init_attr_mask:
+        IBV_QP_INIT_ATTR_PD             = 1 << 0
+        IBV_QP_INIT_ATTR_XRCD           = 1 << 1
+        IBV_QP_INIT_ATTR_CREATE_FLAGS   = 1 << 2
+        IBV_QP_INIT_ATTR_MAX_TSO_HEADER = 1 << 3
+        IBV_QP_INIT_ATTR_IND_TABLE      = 1 << 4
+        IBV_QP_INIT_ATTR_RX_HASH        = 1 << 5
+        IBV_QP_INIT_ATTR_RESERVED       = 1 << 6
+
+    cpdef enum ibv_qp_create_flags:
+        IBV_QP_CREATE_BLOCK_SELF_MCAST_LB   = 1 << 1
+        IBV_QP_CREATE_SCATTER_FCS           = 1 << 8
+        IBV_QP_CREATE_CVLAN_STRIPPING       = 1 << 9
+        IBV_QP_CREATE_SOURCE_QPN            = 1 << 10
+        IBV_QP_CREATE_PCI_WRITE_END_PADDING = 1 << 11
+
+    cpdef enum ibv_qp_attr_mask:
+        IBV_QP_STATE                = 1 << 0
+        IBV_QP_CUR_STATE            = 1 << 1
+        IBV_QP_EN_SQD_ASYNC_NOTIFY  = 1 << 2
+        IBV_QP_ACCESS_FLAGS         = 1 << 3
+        IBV_QP_PKEY_INDEX           = 1 << 4
+        IBV_QP_PORT                 = 1 << 5
+        IBV_QP_QKEY                 = 1 << 6
+        IBV_QP_AV                   = 1 << 7
+        IBV_QP_PATH_MTU             = 1 << 8
+        IBV_QP_TIMEOUT              = 1 << 9
+        IBV_QP_RETRY_CNT            = 1 << 10
+        IBV_QP_RNR_RETRY            = 1 << 11
+        IBV_QP_RQ_PSN               = 1 << 12
+        IBV_QP_MAX_QP_RD_ATOMIC     = 1 << 13
+        IBV_QP_ALT_PATH             = 1 << 14
+        IBV_QP_MIN_RNR_TIMER        = 1 << 15
+        IBV_QP_SQ_PSN               = 1 << 16
+        IBV_QP_MAX_DEST_RD_ATOMIC   = 1 << 17
+        IBV_QP_PATH_MIG_STATE       = 1 << 18
+        IBV_QP_CAP                  = 1 << 19
+        IBV_QP_DEST_QPN             = 1 << 20
+        IBV_QP_RATE_LIMIT           = 1 << 25
+
+    cpdef enum ibv_wq_type:
+        IBV_WQT_RQ
+
+    cpdef enum ibv_wq_init_attr_mask:
+        IBV_WQ_INIT_ATTR_FLAGS      = 1 << 0
+        IBV_WQ_INIT_ATTR_RESERVED   = 1 << 1
+
+    cpdef enum ibv_wq_flags:
+        IBV_WQ_FLAGS_CVLAN_STRIPPING        = 1 << 0
+        IBV_WQ_FLAGS_SCATTER_FCS            = 1 << 1
+        IBV_WQ_FLAGS_DELAY_DROP             = 1 << 2
+        IBV_WQ_FLAGS_PCI_WRITE_END_PADDING  = 1 << 3
+        IBV_WQ_FLAGS_RESERVED               = 1 << 4
+
+    cpdef enum ibv_wq_state:
+        IBV_WQS_RESET
+        IBV_WQS_RDY
+        IBV_WQS_ERR
+        IBV_WQS_UNKNOWN
+
+    cpdef enum ibv_wq_attr_mask:
+        IBV_WQ_ATTR_STATE       = 1 << 0
+        IBV_WQ_ATTR_CURR_STATE  = 1 << 1
+        IBV_WQ_ATTR_FLAGS       = 1 << 2
+        IBV_WQ_ATTR_RESERVED    = 1 << 3
+
+    cpdef enum ibv_rx_hash_function_flags:
+        IBV_RX_HASH_FUNC_TOEPLITZ   = 1 << 0
+
+    cpdef enum ibv_rx_hash_fields:
+        IBV_RX_HASH_SRC_IPV4        = 1 << 0
+        IBV_RX_HASH_DST_IPV4        = 1 << 1
+        IBV_RX_HASH_SRC_IPV6        = 1 << 2
+        IBV_RX_HASH_DST_IPV6        = 1 << 3
+        IBV_RX_HASH_SRC_PORT_TCP    = 1 << 4
+        IBV_RX_HASH_DST_PORT_TCP    = 1 << 5
+        IBV_RX_HASH_SRC_PORT_UDP    = 1 << 6
+        IBV_RX_HASH_DST_PORT_UDP    = 1 << 7
+
+    cpdef enum ibv_ops_wr_opcode:
+        IBV_WR_TAG_ADD
+        IBV_WR_TAG_DEL
+        IBV_WR_TAG_SYNC
+
+    cpdef enum ibv_ops_flags:
+        IBV_OPS_SIGNALED            = 1 << 0
+        IBV_OPS_TM_SYNC             = 1 << 1
+
+    cpdef enum ibv_flow_flags:
+        IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK = 1 << 0
+        IBV_FLOW_ATTR_FLAGS_DONT_TRAP       = 1 << 1
+        IBV_FLOW_ATTR_FLAGS_EGRESS          = 1 << 2
+
+    cpdef enum ibv_flow_attr_type:
+        IBV_FLOW_ATTR_NORMAL      = 0x0
+        IBV_FLOW_ATTR_ALL_DEFAULT = 0x1
+        IBV_FLOW_ATTR_MC_DEFAULT  = 0x2
+        IBV_FLOW_ATTR_SNIFFER     = 0x3
+
+    cpdef enum ibv_flow_spec_type:
+        IBV_FLOW_SPEC_ETH           = 0x20
+        IBV_FLOW_SPEC_IPV4          = 0x30
+        IBV_FLOW_SPEC_IPV6          = 0x31
+        IBV_FLOW_SPEC_IPV4_EXT      = 0x32
+        IBV_FLOW_SPEC_ESP           = 0x34
+        IBV_FLOW_SPEC_TCP           = 0x40
+        IBV_FLOW_SPEC_UDP           = 0x41
+        IBV_FLOW_SPEC_VXLAN_TUNNEL  = 0x50
+        IBV_FLOW_SPEC_GRE           = 0x51
+        IBV_FLOW_SPEC_MPLS          = 0x60
+        IBV_FLOW_SPEC_INNER         = 0x100
+        IBV_FLOW_SPEC_ACTION_TAG    = 0x1000
+        IBV_FLOW_SPEC_ACTION_DROP   = 0x1001
+        IBV_FLOW_SPEC_ACTION_HANDLE = 0x1002
+        IBV_FLOW_SPEC_ACTION_COUNT  = 0x1003
+
+    cpdef enum:
+        IBV_QPF_GRH_REQUIRED
+
+    cpdef enum ibv_counter_description:
+        IBV_COUNTER_PACKETS
+        IBV_COUNTER_BYTES
+
+    cpdef enum ibv_read_counters_flags:
+        IBV_READ_COUNTERS_ATTR_PREFER_CACHED = 1 << 0
+
+cdef extern from "<infiniband/tm_types.h>":
+    cpdef enum ibv_tmh_op:
+        IBV_TMH_NO_TAG        = 0
+        IBV_TMH_RNDV          = 1
+        IBV_TMH_FIN           = 2
+        IBV_TMH_EAGER         = 3

--- a/pyverbs/pyverbs_error.py
+++ b/pyverbs/pyverbs_error.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.
+import os
+
+
+class PyverbsError(Exception):
+    """
+    Base exception class for Pyverbs. Inherited by PyverbsRDMAError (for errors
+    returned by rdma-core) and PyverbsUserError (for user-related errors
+    found by Pyverbs,  e.g. non-existing device name).
+    """
+    def __init__(self, msg, error_code = -1):
+        """
+        Initializes a PyverbsError instance
+        :param msg: The exception's message
+        :param error_code: errno value
+        """
+        if error_code != -1:
+            msg = '{msg}. Errno: {err}, {err_str}'.\
+                format(msg=msg, err=error_code, err_str=os.strerror(error_code))
+        super(PyverbsError, self).__init__(msg)
+
+class PyverbsRDMAError(PyverbsError):
+    """
+    This exception is raised when an rdma-core function returns an error.
+    """
+    pass
+
+class PyverbsUserError(PyverbsError):
+    """
+    This exception is raised when Pyverbs encounters an error resulting from
+    user's action or input.
+    """
+    def __init__(self, msg):
+        """
+        Initializes a PyverbsUserError instance
+        :param msg: The exception's message
+        """
+        super(PyverbsUserError, self).__init__(msg)
+

--- a/pyverbs/run_tests.py
+++ b/pyverbs/run_tests.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
+import unittest,os,os.path,fnmatch
+import tests
+
+
+def test_all():
+    # FIXME: This implementation is for older Python versions, will
+    # be replaced with discover()
+    return test_suite
+
+module = __import__("tests")
+fns = [os.path.splitext(I)[0] for I in fnmatch.filter(os.listdir(module.__path__[0]),"*.py")]
+fns.remove("__init__")
+for I in fns:
+    __import__("tests." + I)
+test_suite = unittest.TestSuite(unittest.defaultTestLoader.loadTestsFromNames(fns,module))
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="test_all")
+
+

--- a/pyverbs/tests/device.py
+++ b/pyverbs/tests/device.py
@@ -1,0 +1,41 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
+import unittest
+import pyverbs.device as d
+
+class device_test(unittest.TestCase):
+    """
+    Test various functionalities of the Device class.
+    """
+    def test_dev_list(self):
+        """
+        Verify that it's possible to get IB devices list.
+        """
+        lst = d.get_device_list()
+
+    def test_open_dev(self):
+        """
+        Test ibv_open_device()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            ctx = d.Context(name=dev.name.decode())
+
+    def test_query_device(self):
+        """
+        Test ibv_query_device()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            ctx = d.Context(name=dev.name.decode())
+            ctx.query_device()
+
+    def test_query_gid(self):
+        """
+        Test ibv_query_gid()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            ctx = d.Context(name=dev.name.decode())
+            ctx.query_gid(port_num=1, index=0)
+


### PR DESCRIPTION
In this patch set we introduce python bindings (pyverbs) for
rdma-core in its initial form. It will cover libibverbs and will be
expanded to support librdmacm in the future.
    
Prior to developing pyverbs, the existing python-rdma package [1] was
evaluated, but a new package was built using newer Cython and Python
versions, in order to provide a more comfortable user experience.
    
The main goal of pyverbs is to provide the user a simple API that
makes working with verbs easier. Among other things, it allows
setting up RDMA resources quickly.
    
In the future, it will also suggest default configuration (e.g.
default values for QP attributes, which the user can override) and
further bring up shortcuts will be provided (e.g. QPs can change state
internally, without user intervention).
The above means a significant cut in tests development time, which
will allow developers to send a feature with a test included,
increasing rdma-core's robustness.

A short example based on the preliminary abilities of this PR:
    
    >>>import pyverbs.device as d
    >>>ctx = d.Context(name='mlx5_0')
    >>>attr = ctx.query_device()
    print(attr)
    FW version            : 16.24.0185
    Node guid             : 9803:9b03:0000:e4c6
    Sys image GUID        : 9803:9b03:0000:e4c6
    Max MR size           : 0xffffffffffffffff
    [...]
    
Known limitations:
This PR contains an updated rdma-core.spec files, but it is not final.
   
Future plan:
Extend pyverbs' coverage over rdma-core (further RDMA objects such as PD, MR etc.).
Enrich examles section.
Provide tests for existing and new features.
    
