### PR TITLE
mlx5: Expose device handles via the DV API

### DIFF
--- a/providers/mlx5/man/mlx5dv_init_obj.3
+++ b/providers/mlx5/man/mlx5dv_init_obj.3
@@ -94,6 +94,13 @@ uint64_t              comp_mask;
 .in -8
 };
 
+struct mlx5dv_pd {
+.in +8
+uint32_t              pdn;
+uint64_t              comp_mask;
+.in -8
+};
+
 struct mlx5dv_obj {
 .in +8
 struct {
@@ -132,6 +139,12 @@ struct ibv_ah		*in;
 struct mlx5dv_ah	*out;
 .in -8
 } ah;
+struct {
+.in +8
+struct ibv_pd           *in;
+struct mlx5dv_pd        *out;
+.in -8
+} pd;
 .in -8
 };
 
@@ -143,6 +156,7 @@ MLX5DV_OBJ_SRQ  = 1 << 2,
 MLX5DV_OBJ_RWQ  = 1 << 3,
 MLX5DV_OBJ_DM   = 1 << 4,
 MLX5DV_OBJ_AH   = 1 << 5,
+MLX5DV_OBJ_PD   = 1 << 6,
 .in -8
 };
 .fi

--- a/providers/mlx5/man/mlx5dv_init_obj.3
+++ b/providers/mlx5/man/mlx5dv_init_obj.3
@@ -66,6 +66,7 @@ uint32_t                stride;
 uint32_t                head;
 uint32_t                tail;
 uint64_t                comp_mask;
+uint32_t                srqn;
 .in -8
 };
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -852,6 +852,17 @@ static int mlx5dv_get_av(struct ibv_ah *ah_in,
 	return 0;
 }
 
+static int mlx5dv_get_pd(struct ibv_pd *pd_in,
+			 struct mlx5dv_pd *pd_out)
+{
+	struct mlx5_pd *mpd = to_mpd(pd_in);
+
+	pd_out->comp_mask = 0;
+	pd_out->pdn = mpd->pdn;
+
+	return 0;
+}
+
 LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		   int,
 		   struct mlx5dv_obj *obj, uint64_t obj_type)
@@ -870,6 +881,8 @@ LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		ret = mlx5dv_get_dm(obj->dm.in, obj->dm.out);
 	if (!ret && (obj_type & MLX5DV_OBJ_AH))
 		ret = mlx5dv_get_av(obj->ah.in, obj->ah.out);
+	if (!ret && (obj_type & MLX5DV_OBJ_PD))
+		ret = mlx5dv_get_pd(obj->pd.in, obj->pd.out);
 
 	return ret;
 }

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -816,16 +816,22 @@ static int mlx5dv_get_srq(struct ibv_srq *srq_in,
 			  struct mlx5dv_srq *srq_out)
 {
 	struct mlx5_srq *msrq;
+	uint64_t mask_out = 0;
 
 	msrq = container_of(srq_in, struct mlx5_srq, vsrq.srq);
 
-	srq_out->comp_mask = 0;
 	srq_out->buf       = msrq->buf.buf;
 	srq_out->dbrec     = msrq->db;
 	srq_out->stride    = 1 << msrq->wqe_shift;
 	srq_out->head      = msrq->head;
 	srq_out->tail      = msrq->tail;
 
+	if (srq_out->comp_mask & MLX5DV_SRQ_MASK_SRQN) {
+		srq_out->srqn = msrq->srqn;
+		mask_out |= MLX5DV_SRQ_MASK_SRQN;
+	}
+
+	srq_out->comp_mask = mask_out;
 	return 0;
 }
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -360,6 +360,11 @@ struct mlx5dv_ah {
 	uint64_t		comp_mask;
 };
 
+struct mlx5dv_pd {
+	uint32_t		pdn;
+	uint64_t		comp_mask;
+};
+
 struct mlx5dv_obj {
 	struct {
 		struct ibv_qp		*in;
@@ -385,6 +390,10 @@ struct mlx5dv_obj {
 		struct ibv_ah		*in;
 		struct mlx5dv_ah	*out;
 	} ah;
+	struct {
+		struct ibv_pd		*in;
+		struct mlx5dv_pd	*out;
+	} pd;
 };
 
 enum mlx5dv_obj_type {
@@ -394,6 +403,7 @@ enum mlx5dv_obj_type {
 	MLX5DV_OBJ_RWQ	= 1 << 3,
 	MLX5DV_OBJ_DM	= 1 << 4,
 	MLX5DV_OBJ_AH	= 1 << 5,
+	MLX5DV_OBJ_PD	= 1 << 6,
 };
 
 enum mlx5dv_wq_init_attr_mask {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -330,6 +330,10 @@ struct mlx5dv_cq {
 	uint64_t		comp_mask;
 };
 
+enum mlx5dv_srq_comp_mask {
+	MLX5DV_SRQ_MASK_SRQN	= 1 << 0,
+};
+
 struct mlx5dv_srq {
 	void			*buf;
 	__be32			*dbrec;
@@ -337,6 +341,7 @@ struct mlx5dv_srq {
 	uint32_t		head;
 	uint32_t		tail;
 	uint64_t		comp_mask;
+	uint32_t		srqn;
 };
 
 struct mlx5dv_rwq {

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1541,6 +1541,7 @@ static int mlx5_cmd_create_rss_qp(struct ibv_context *context,
 {
 	struct mlx5_create_qp_ex_rss cmd_ex_rss = {};
 	struct mlx5_create_qp_ex_resp resp = {};
+	struct mlx5_ib_create_qp_resp *resp_drv;
 	int ret;
 
 	if (attr->rx_hash_conf.rx_hash_key_len > sizeof(cmd_ex_rss.rx_hash_key)) {
@@ -1562,6 +1563,11 @@ static int mlx5_cmd_create_rss_qp(struct ibv_context *context,
 					    sizeof(resp.ibv_resp), sizeof(resp));
 	if (ret)
 		return ret;
+
+	resp_drv = &resp.drv_payload;
+
+	if (resp_drv->comp_mask & MLX5_IB_CREATE_QP_RESP_MASK_TIRN)
+		qp->tirn = resp_drv->tirn;
 
 	qp->rss_qp = 1;
 	return 0;


### PR DESCRIPTION
This series exposes via the DV API few device handles that weren't handled yet, it includes: pdn, srqn and tirn for RSS QP.

The matching kernel code was already accepted.