### PR TITLE
cbuild: Fix fc28 RPM creation

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -135,7 +135,7 @@ class centos7_epel(centos7):
 
 class fc28(Environment):
     docker_parent = "fedora:28";
-    pkgs = (centos7.pkgs - {"make"}) | {"ninja-build","pandoc","perl-generators"};
+    pkgs = (centos7.pkgs - {"make", "python-argparse" }) | {"ninja-build","pandoc","perl-generators"};
     name = "fc28";
     specfile = "redhat/rdma-core.spec";
     ninja_cmd = "ninja-build";


### PR DESCRIPTION
The python-argparse is part of python standard library and doesn't need
to be installed separately.

The following error is solved by this patch:
 No match for argument: python-argparse
 Error: Unable to find a match

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>