### PR TITLE
ibacm: Use helper functions and existing defines to avoid literal use

### DIFF
--- a/ibacm/include/acm_mad.h
+++ b/ibacm/include/acm_mad.h
@@ -49,6 +49,8 @@
 #define ACM_CTRL_ACK     htobe16(0x8000)
 #define ACM_CTRL_RESOLVE htobe16(0x0001)
 
+#define IB_PKEY_FULL_MEMBER 0x8000
+
 struct acm_mad {
 	uint8_t  base_version;
 	uint8_t  mgmt_class;

--- a/libibumad/umad_sa.h
+++ b/libibumad/umad_sa.h
@@ -155,13 +155,14 @@ struct umad_sa_packet {
 static inline uint8_t
 umad_sa_get_rate_mtu_or_life(uint8_t rate_mtu_or_life)
 {
-	return (rate_mtu_or_life & 0x3f);
+	return (rate_mtu_or_life & UMAD_SA_RATE_MTU_PKT_LIFE_MASK);
 }
 
 static inline uint8_t
 umad_sa_set_rate_mtu_or_life(uint8_t selector, uint8_t rate_mtu_or_life)
 {
-	return (((selector & 0x3) << 6) | (rate_mtu_or_life & 0x3f));
+	return (((selector & UMAD_SA_RATE_MTU_PKT_LIFE_MASK) << UMAD_SA_SELECTOR_SHIFT) |
+		(rate_mtu_or_life & UMAD_SA_RATE_MTU_PKT_LIFE_MASK));
 }
 
 #ifdef __cplusplus

--- a/libibumad/umad_sa_mcm.h
+++ b/libibumad/umad_sa_mcm.h
@@ -69,6 +69,13 @@ enum {
 	UMAD_SA_MCM_JOIN_STATE_SEND_ONLY_FULL_MEMBER = (1 << 3)
 };
 
+enum {
+	UMAD_SA_MCM_ADDR_SCOPE_LINK_LOCAL = 0x2,
+	UMAD_SA_MCM_ADDR_SCOPE_SITE_LOCAL = 0x5,
+	UMAD_SA_MCM_ADDR_SCOPE_ORG_LOCAL  = 0x8,
+	UMAD_SA_MCM_ADDR_SCOPE_GLOBAL     = 0xE,
+};
+
 struct umad_sa_mcmember_record {
 	uint8_t mgid[16];	/* network-byte order */
 	uint8_t portgid[16];	/* network-byte order */


### PR DESCRIPTION
Use existing helper functions to avoid the use of literal
constants. Took the liberty to also use those defines in some helper
functions where appropriate.

Added an enum for the Multicast Address Scope values.

Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>