### PR TITLE
libibumad: Restore umad_sa_set_rate_mtu_or_life to original implementation ( using defines)

### DIFF
--- a/libibumad/umad_sa.h
+++ b/libibumad/umad_sa.h
@@ -138,6 +138,7 @@ enum {
 
 #define UMAD_SA_SELECTOR_SHIFT		6
 #define UMAD_SA_RATE_MTU_PKT_LIFE_MASK	0x3f
+#define UMAD_SA_SELECTOR_MASK		0x3
 
 /*
  *  sm_key is not aligned on an 8-byte boundary, so is defined as a byte array
@@ -161,7 +162,7 @@ umad_sa_get_rate_mtu_or_life(uint8_t rate_mtu_or_life)
 static inline uint8_t
 umad_sa_set_rate_mtu_or_life(uint8_t selector, uint8_t rate_mtu_or_life)
 {
-	return (((selector & UMAD_SA_RATE_MTU_PKT_LIFE_MASK) << UMAD_SA_SELECTOR_SHIFT) |
+	return (((selector & UMAD_SA_SELECTOR_MASK) << UMAD_SA_SELECTOR_SHIFT) |
 		(rate_mtu_or_life & UMAD_SA_RATE_MTU_PKT_LIFE_MASK));
 }
 


### PR DESCRIPTION
umad_sa_set_rate_mtu_or_life was changed to mask selector
with 0x3f (UMAD_SA_RATE_MTU_PKT_LIFE_MASK) rather than 0x3.
While this should work due to using left shift by 6 on 8 bit variable,
a more literal translation is better.
    
Fixes: 0ff0e21b89e2 ("ibacm: Use helper functions and existing defines to avoid literal use")

Signed-off-by: Hal Rosenstock <hal@mellanox.com>