### PR TITLE
Execute rework

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,9 @@ set(PACKAGE_NAME "RDMA")
 # See Documentation/versioning.md
 set(PACKAGE_VERSION "22.0")
 # When this is changed the values in these files need changing too:
+#   debian/control
 #   debian/libibverbs1.symbols
-set(IBVERBS_PABI_VERSION "21")
+set(IBVERBS_PABI_VERSION "22")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/control
+++ b/debian/control
@@ -151,7 +151,7 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ibverbs-providers
-Breaks: ibverbs-providers (<< 21~)
+Breaks: ibverbs-providers (<< 22~)
 Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -3,7 +3,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
  IBVERBS_1.5@IBVERBS_1.5 20
- (symver)IBVERBS_PRIVATE_21 21
+ (symver)IBVERBS_PRIVATE_22 22
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1425,7 +1425,7 @@ int ibv_cmd_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
 		      struct ibv_recv_wr **bad_wr)
 {
 	struct ibv_post_recv     *cmd;
-	struct ib_uverbs_post_send_resp resp;
+	struct ib_uverbs_post_recv_resp resp;
 	struct ibv_recv_wr       *i;
 	struct ib_uverbs_recv_wr  *n, *tmp;
 	struct ibv_sge           *s;
@@ -1486,7 +1486,7 @@ int ibv_cmd_post_srq_recv(struct ibv_srq *srq, struct ibv_recv_wr *wr,
 		      struct ibv_recv_wr **bad_wr)
 {
 	struct ibv_post_srq_recv *cmd;
-	struct ib_uverbs_post_recv_resp resp;
+	struct ib_uverbs_post_srq_recv_resp resp;
 	struct ibv_recv_wr       *i;
 	struct ib_uverbs_recv_wr  *n, *tmp;
 	struct ibv_sge           *s;
@@ -1841,7 +1841,7 @@ int ibv_cmd_create_flow(struct ibv_qp *qp,
 			size_t ucmd_size)
 {
 	struct ibv_create_flow *cmd;
-	struct ib_uverbs_destroy_flow  resp;
+	struct ib_uverbs_create_flow_resp resp;
 	size_t cmd_size;
 	size_t written_size;
 	int i, err;

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1853,13 +1853,15 @@ int ibv_cmd_create_flow(struct ibv_qp *qp,
 
 int ibv_cmd_destroy_flow(struct ibv_flow *flow_id)
 {
-	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_FLOW);
+	struct ibv_destroy_flow req;
 	int ret;
 
-	*req = (struct ib_uverbs_destroy_flow){
+	req.core_payload = (struct ib_uverbs_destroy_flow){
 		.flow_handle = flow_id->handle,
 	};
-	ret = execute_write_ex(flow_id->context, req);
+	ret = execute_cmd_write_ex_req(flow_id->context,
+				       IB_USER_VERBS_EX_CMD_DESTROY_FLOW, &req,
+				       sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -1947,14 +1949,16 @@ int ibv_cmd_modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *attr,
 
 int ibv_cmd_destroy_wq(struct ibv_wq *wq)
 {
-	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_WQ);
+	struct ibv_destroy_wq req;
+	struct ib_uverbs_ex_destroy_wq_resp resp;
 	int ret;
 
-	*req = (struct ib_uverbs_ex_destroy_wq){
+	req.core_payload = (struct ib_uverbs_ex_destroy_wq){
 		.wq_handle = wq->handle,
 	};
 
-	ret = execute_write_ex(wq->context, req);
+	ret = execute_cmd_write_ex(wq->context, IB_USER_VERBS_EX_CMD_DESTROY_WQ,
+				   &req, sizeof(req), &resp, sizeof(resp));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -2015,13 +2019,15 @@ int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
 
 int ibv_cmd_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
 {
-	DECLARE_LEGACY_CORE_BUFS_EX(IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL);
+	struct ibv_destroy_rwq_ind_table req;
 	int ret;
 
-	*req = (struct ib_uverbs_ex_destroy_rwq_ind_table){
+	req.core_payload = (struct ib_uverbs_ex_destroy_rwq_ind_table){
 		.ind_tbl_handle = rwq_ind_table->ind_tbl_handle,
 	};
-	ret = execute_write_ex(rwq_ind_table->context, req);
+	ret = execute_cmd_write_ex_req(rwq_ind_table->context,
+				       IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL,
+				       &req, sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -328,13 +328,14 @@ int ibv_cmd_alloc_pd(struct ibv_context *context, struct ibv_pd *pd,
 
 int ibv_cmd_dealloc_pd(struct ibv_pd *pd)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEALLOC_PD);
+	struct ibv_dealloc_pd req;
 	int ret;
 
-	*req = (struct ib_uverbs_dealloc_pd) {
+	req.core_payload = (struct ib_uverbs_dealloc_pd){
 		.pd_handle = pd->handle,
 	};
-	ret = execute_write(pd->context, req, NULL);
+	ret = execute_cmd_write_req(pd->context, IB_USER_VERBS_CMD_DEALLOC_PD,
+				    &req, sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -375,13 +376,15 @@ int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
 
 int ibv_cmd_close_xrcd(struct verbs_xrcd *xrcd)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_CLOSE_XRCD);
+	struct ibv_close_xrcd req;
 	int ret;
 
-	*req = (struct ib_uverbs_close_xrcd){
+	req.core_payload = (struct ib_uverbs_close_xrcd){
 		.xrcd_handle = xrcd->handle,
 	};
-	ret = execute_write(xrcd->xrcd.context, req, NULL);
+	ret = execute_cmd_write_req(xrcd->xrcd.context,
+				    IB_USER_VERBS_CMD_CLOSE_XRCD, &req,
+				    sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -447,13 +450,15 @@ int ibv_cmd_rereg_mr(struct verbs_mr *vmr, uint32_t flags, void *addr,
 
 int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEREG_MR);
+	struct ibv_dereg_mr req;
 	int ret;
 
-	*req = (struct ib_uverbs_dereg_mr){
+	req.core_payload = (struct ib_uverbs_dereg_mr){
 		.mr_handle = vmr->ibv_mr.handle,
 	};
-	ret = execute_write(vmr->ibv_mr.context, req, NULL);
+	ret = execute_cmd_write_req(vmr->ibv_mr.context,
+				    IB_USER_VERBS_CMD_DEREG_MR, &req,
+				    sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -487,13 +492,14 @@ int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 
 int ibv_cmd_dealloc_mw(struct ibv_mw *mw)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DEALLOC_MW);
+	struct ibv_dealloc_mw req;
 	int ret;
 
-	*req = (struct ib_uverbs_dealloc_mw) {
+	req.core_payload = (struct ib_uverbs_dealloc_mw) {
 		.mw_handle = mw->handle,
 	};
-	ret = execute_write(mw->context, req, NULL);
+	ret = execute_cmd_write_req(mw->context, IB_USER_VERBS_CMD_DEALLOC_MW,
+				    &req, sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -548,13 +554,15 @@ out:
 
 int ibv_cmd_req_notify_cq(struct ibv_cq *ibcq, int solicited_only)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_REQ_NOTIFY_CQ);
+	struct ibv_req_notify_cq req;
 
-	*req = (struct ib_uverbs_req_notify_cq){
+	req.core_payload = (struct ib_uverbs_req_notify_cq){
 		.cq_handle = ibcq->handle,
 		.solicited_only = !!solicited_only,
 	};
-	return execute_write(ibcq->context, req, NULL);
+	return execute_cmd_write_req(ibcq->context,
+				     IB_USER_VERBS_CMD_REQ_NOTIFY_CQ, &req,
+				     sizeof(req));
 }
 
 int ibv_cmd_resize_cq(struct ibv_cq *cq, int cqe,
@@ -762,14 +770,16 @@ int ibv_cmd_query_srq(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr,
 
 int ibv_cmd_destroy_srq(struct ibv_srq *srq)
 {
-	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_SRQ);
+	struct ibv_destroy_srq req;
+	struct ib_uverbs_destroy_srq_resp resp;
 	int ret;
 
-	*req = (struct ib_uverbs_destroy_srq){
+	req.core_payload = (struct ib_uverbs_destroy_srq){
 		.srq_handle = srq->handle,
 	};
 
-	ret = execute_write(srq->context, req, &resp);
+	ret = execute_cmd_write(srq->context, IB_USER_VERBS_CMD_DESTROY_SRQ,
+				&req, sizeof(req), &resp, sizeof(resp));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -1521,13 +1531,14 @@ int ibv_cmd_create_ah(struct ibv_pd *pd, struct ibv_ah *ah,
 
 int ibv_cmd_destroy_ah(struct ibv_ah *ah)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DESTROY_AH);
+	struct ibv_destroy_ah req;
 	int ret;
 
-	*req = (struct ib_uverbs_destroy_ah){
+	req.core_payload = (struct ib_uverbs_destroy_ah){
 		.ah_handle = ah->handle,
 	};
-	ret = execute_write(ah->context, req, NULL);
+	ret = execute_cmd_write_req(ah->context, IB_USER_VERBS_CMD_DESTROY_AH,
+				    &req, sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -1536,14 +1547,16 @@ int ibv_cmd_destroy_ah(struct ibv_ah *ah)
 
 int ibv_cmd_destroy_qp(struct ibv_qp *qp)
 {
-	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_QP);
+	struct ibv_destroy_qp req;
+	struct ib_uverbs_destroy_qp_resp resp;
 	int ret;
 
-	*req = (struct ib_uverbs_destroy_qp){
+	req.core_payload = (struct ib_uverbs_destroy_qp){
 		.qp_handle = qp->handle,
 	};
 
-	ret = execute_write(qp->context, req, &resp);
+	ret = execute_cmd_write(qp->context, IB_USER_VERBS_CMD_DESTROY_QP, &req,
+				sizeof(req), &resp, sizeof(resp));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 
@@ -1557,27 +1570,29 @@ int ibv_cmd_destroy_qp(struct ibv_qp *qp)
 
 int ibv_cmd_attach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_ATTACH_MCAST);
+	struct ibv_attach_mcast req;
 
-	*req = (struct ib_uverbs_attach_mcast){
+	req.core_payload = (struct ib_uverbs_attach_mcast){
 		.qp_handle = qp->handle,
 		.mlid = lid,
 	};
-	memcpy(req->gid, gid->raw, sizeof(req->gid));
-	return execute_write(qp->context, req, NULL);
+	memcpy(req.gid, gid->raw, sizeof(req.gid));
+	return execute_cmd_write_req(
+		qp->context, IB_USER_VERBS_CMD_ATTACH_MCAST, &req, sizeof(req));
 }
 
 int ibv_cmd_detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid)
 {
-	DECLARE_LEGACY_CORE_REQ(IB_USER_VERBS_CMD_DETACH_MCAST);
+	struct ibv_detach_mcast req;
 	int ret;
 
-	*req = (struct ib_uverbs_detach_mcast){
+	req.core_payload = (struct ib_uverbs_detach_mcast){
 		.qp_handle = qp->handle,
 		.mlid = lid,
 	};
-	memcpy(req->gid, gid->raw, sizeof(req->gid));
-	ret = execute_write(qp->context, req, NULL);
+	memcpy(req.gid, gid->raw, sizeof(req.gid));
+	ret = execute_cmd_write_req(qp->context, IB_USER_VERBS_CMD_DETACH_MCAST,
+				    &req, sizeof(req));
 	if (verbs_is_destroy_err(&ret))
 		return ret;
 

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -69,7 +69,8 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			.comp_channel = channel ? channel->fd : -1,
 		};
 
-		ret = execute_write_bufs(cq->context, req, resp);
+		ret = execute_write_bufs(
+			cq->context, IB_USER_VERBS_CMD_CREATE_CQ, req, resp);
 		if (ret)
 			return ret;
 
@@ -90,7 +91,8 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			.flags = flags,
 		};
 
-		ret = execute_write_bufs_ex(cq->context, req);
+		ret = execute_write_bufs_ex(
+			cq->context, IB_USER_VERBS_EX_CMD_CREATE_CQ, req, resp);
 		if (ret)
 			return ret;
 

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -158,7 +158,7 @@ int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 {
 	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_DESTROY, 2,
 			     NULL);
-	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_DESTROY_CQ);
+	struct ib_uverbs_destroy_cq_resp resp;
 	int ret;
 
 	fill_attr_out_ptr(cmdb, UVERBS_ATTR_DESTROY_CQ_RESP, &resp);
@@ -166,11 +166,15 @@ int ibv_cmd_destroy_cq(struct ibv_cq *cq)
 
 	switch (execute_ioctl_fallback(cq->context, destroy_cq, cmdb, &ret)) {
 	case TRY_WRITE: {
-		*req = (struct ib_uverbs_destroy_cq){
+		struct ibv_destroy_cq req;
+
+		req.core_payload = (struct ib_uverbs_destroy_cq){
 			.cq_handle = cq->handle,
 		};
 
-		ret = execute_write(cq->context, req, &resp);
+		ret = execute_cmd_write(cq->context,
+					IB_USER_VERBS_CMD_DESTROY_CQ, &req,
+					sizeof(req), &resp, sizeof(resp));
 		break;
 	}
 

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -119,7 +119,9 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 		      size_t cmd_size, struct ib_uverbs_create_cq_resp *resp,
 		      size_t resp_size)
 {
-	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE);
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ,
+				  UVERBS_METHOD_CQ_CREATE, cmd, cmd_size, resp,
+				  resp_size);
 
 	return ibv_icmd_create_cq(context, cqe, channel, comp_vector, 0, cq,
 				  cmdb);
@@ -133,7 +135,9 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
 			 size_t resp_size)
 {
-	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE);
+	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ,
+				  UVERBS_METHOD_CQ_CREATE, cmd, cmd_size, resp,
+				  resp_size);
 	uint32_t flags = 0;
 
 	if (!check_comp_mask(cq_attr->comp_mask, IBV_CQ_INIT_ATTR_MASK_FLAGS))

--- a/libibverbs/cmd_fallback.c
+++ b/libibverbs/cmd_fallback.c
@@ -244,6 +244,23 @@ int _execute_write_raw(struct ibv_context *ctx, struct ib_uverbs_cmd_hdr *hdr,
 	return 0;
 }
 
+int _execute_cmd_write(struct ibv_context *ctx, unsigned int write_method,
+		       struct ib_uverbs_cmd_hdr *req, size_t core_req_size,
+		       size_t req_size, void *resp, size_t core_resp_size,
+		       size_t resp_size)
+{
+	req->command = write_method;
+	req->in_words = __check_divide(req_size, 4);
+	req->out_words = __check_divide(resp_size, 4);
+
+	if (write(ctx->cmd_fd, req, req_size) != req_size)
+		return errno;
+
+	if (resp)
+		VALGRIND_MAKE_MEM_DEFINED(resp, resp_size);
+	return 0;
+}
+
 int _execute_write_raw_ex(struct ibv_context *ctx, struct ex_hdr *hdr)
 {
 	size_t write_bytes =

--- a/libibverbs/cmd_fallback.c
+++ b/libibverbs/cmd_fallback.c
@@ -120,8 +120,7 @@ enum write_fallback _execute_ioctl_fallback(struct ibv_context *ctx,
  * directly before the UHW memory (see _write_set_uhw)
  */
 void *_write_get_req(struct ibv_command_buffer *link,
-		     struct ib_uverbs_cmd_hdr *onstack, size_t size,
-		     uint32_t cmdnum)
+		     struct ib_uverbs_cmd_hdr *onstack, size_t size)
 {
 	struct ib_uverbs_cmd_hdr *hdr;
 
@@ -139,13 +138,11 @@ void *_write_get_req(struct ibv_command_buffer *link,
 		hdr->in_words = __check_divide(size, 4);
 	}
 
-	hdr->command = cmdnum;
-
 	return hdr + 1;
 }
 
 void *_write_get_req_ex(struct ibv_command_buffer *link, struct ex_hdr *onstack,
-			size_t size, uint32_t cmdnum)
+			size_t size)
 {
 	struct ex_hdr *hdr;
 	size_t full_size = size + sizeof(*hdr);
@@ -156,16 +153,11 @@ void *_write_get_req_ex(struct ibv_command_buffer *link, struct ex_hdr *onstack,
 		assert(uhw->attr_id == UVERBS_ATTR_UHW_IN);
 		assert(link->uhw_in_headroom_dwords * 4 >= full_size);
 		hdr = (void *)((uintptr_t)uhw->data - full_size);
-		hdr->hdr.in_words = __check_divide(size, 8);
 		hdr->ex_hdr.provider_in_words = __check_divide(uhw->len, 8);
 	} else {
 		hdr = onstack;
-		hdr->hdr.in_words = __check_divide(size, 8);
 		hdr->ex_hdr.provider_in_words = 0;
 	}
-
-	hdr->hdr.command = IB_USER_VERBS_CMD_FLAG_EXTENDED | cmdnum;
-	hdr->ex_hdr.cmd_hdr_reserved = 0;
 
 	return hdr + 1;
 }
@@ -205,44 +197,13 @@ void *_write_get_resp_ex(struct ibv_command_buffer *link,
 		assert(uhw->attr_id == UVERBS_ATTR_UHW_OUT);
 		assert(link->uhw_out_headroom_dwords * 4 >= resp_size);
 		resp_start = (void *)((uintptr_t)uhw->data - resp_size);
-		hdr->hdr.out_words = __check_divide(resp_size, 8);
 		hdr->ex_hdr.provider_out_words = __check_divide(uhw->len, 8);
 	} else {
 		resp_start = onstack;
-		hdr->hdr.out_words = __check_divide(resp_size, 8);
 		hdr->ex_hdr.provider_out_words = 0;
 	}
 
-	hdr->ex_hdr.response = ioctl_ptr_to_u64(resp_start);
-
 	return resp_start;
-}
-
-int _execute_write_raw(struct ibv_context *ctx, struct ib_uverbs_cmd_hdr *hdr,
-		       void *resp)
-{
-	/*
-	 * Users assumes the stack buffer is zeroed before passing to the
-	 * kernel for writing.
-	 */
-	if (resp) {
-		/*
-		 * The helper macros prove the response is at offset 0 of the
-		 * request.
-		 */
-		uint64_t *response = (uint64_t *)(hdr + 1);
-
-		*response = ioctl_ptr_to_u64(resp);
-		memset(resp, 0, hdr->out_words * 4);
-	}
-
-	if (write(ctx->cmd_fd, hdr, hdr->in_words * 4) != hdr->in_words * 4)
-		return errno;
-
-	if (resp)
-		VALGRIND_MAKE_MEM_DEFINED(resp, hdr->out_words * 4);
-
-	return 0;
 }
 
 int _execute_cmd_write(struct ibv_context *ctx, unsigned int write_method,
@@ -259,31 +220,6 @@ int _execute_cmd_write(struct ibv_context *ctx, unsigned int write_method,
 
 	if (resp)
 		VALGRIND_MAKE_MEM_DEFINED(resp, resp_size);
-	return 0;
-}
-
-int _execute_write_raw_ex(struct ibv_context *ctx, struct ex_hdr *hdr)
-{
-	size_t write_bytes =
-		sizeof(*hdr) +
-		(hdr->hdr.in_words + hdr->ex_hdr.provider_in_words) * 8;
-	size_t resp_bytes =
-		(hdr->hdr.out_words + hdr->ex_hdr.provider_out_words) * 8;
-	void *resp = (void *)(uintptr_t)hdr->ex_hdr.response;
-
-	/*
-	 * Users assumes the stack buffer is zeroed before passing to the
-	 * kernel for writing.
-	 */
-	if (resp)
-		memset(resp, 0, resp_bytes);
-
-	if (write(ctx->cmd_fd, hdr, write_bytes) != write_bytes)
-		return errno;
-
-	if (resp)
-		VALGRIND_MAKE_MEM_DEFINED(resp, resp_bytes);
-
 	return 0;
 }
 

--- a/libibverbs/cmd_ioctl.c
+++ b/libibverbs/cmd_ioctl.c
@@ -38,6 +38,7 @@
 #include <infiniband/driver.h>
 
 #include <rdma/ib_user_ioctl_cmds.h>
+#include <valgrind/memcheck.h>
 
 /* Number of attrs in this and all the link'd buffers */
 unsigned int __ioctl_final_num_attrs(unsigned int num_attrs,

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -98,7 +98,8 @@ void *_write_get_resp_ex(struct ibv_command_buffer *link,
 void _write_set_uhw(struct ibv_command_buffer *cmdb, const void *req,
 		    size_t core_req_size, size_t req_size, void *resp,
 		    size_t core_resp_size, size_t resp_size);
-#define DECLARE_CMD_BUFFER_COMPAT(_name, _object_id, _method_id)               \
+#define DECLARE_CMD_BUFFER_COMPAT(_name, _object_id, _method_id, cmd,          \
+				  cmd_size, resp, resp_size)                   \
 	DECLARE_COMMAND_BUFFER(_name, _object_id, _method_id, 2);              \
 	_write_set_uhw(_name, cmd, sizeof(*cmd), cmd_size, resp,               \
 		       sizeof(*resp), resp_size)

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -257,6 +257,36 @@ int _execute_cmd_write(struct ibv_context *ctx, unsigned int write_method,
 	})
 
 /*
+ * For write() commands that use the _ex protocol. _full allows the caller to
+ * specify all 4 sizes directly. This version is used when the core structs
+ * end in a flex array. The normal and req versions are similar to write() and
+ * deduce the length of the core struct from the enum.
+ */
+int _execute_cmd_write_ex(struct ibv_context *ctx, unsigned int write_method,
+			  struct ex_hdr *req, size_t core_req_size,
+			  size_t req_size, void *resp, size_t core_resp_size,
+			  size_t resp_size);
+#define execute_cmd_write_ex_full(ctx, enum, cmd, core_cmd_size, cmd_size,     \
+				  resp, core_resp_size, resp_size)             \
+	_execute_cmd_write_ex(                                                 \
+		ctx, enum, &(cmd)->hdr + check_type(cmd, IBV_ABI_REQ(enum) *), \
+		core_cmd_size, cmd_size,                                       \
+		resp + check_type(resp, IBV_KABI_RESP(enum) *),                \
+		core_resp_size, resp_size)
+#define execute_cmd_write_ex(ctx, enum, cmd, cmd_size, resp, resp_size)        \
+	execute_cmd_write_ex_full(ctx, enum, cmd, sizeof(*(cmd)), cmd_size,    \
+				  resp, sizeof(*(resp)), resp_size)
+#define execute_cmd_write_ex_req(ctx, enum, cmd, cmd_size)                     \
+	({                                                                     \
+		static_assert(sizeof(IBV_KABI_RESP(enum)) == 0,                \
+			      "Method has a response!");                       \
+		_execute_cmd_write_ex(                                         \
+			ctx, enum,                                             \
+			&(cmd)->hdr + check_type(cmd, IBV_ABI_REQ(enum) *),    \
+			sizeof(*(cmd)), cmd_size, NULL, 0, 0);                 \
+	})
+
+/*
  * These two macros are used only with execute_ioctl_fallback - they allow the
  * IOCTL code to be elided by the compiler when disabled.
  */

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -157,32 +157,6 @@ int _execute_write_raw_ex(struct ibv_context *ctx, struct ex_hdr *req);
 #define execute_write_bufs_ex(ctx, req)                                        \
 	_execute_write_raw_ex(ctx, get_req_hdr_ex(req))
 
-/* For users with no possible UHW bufs. */
-#define DECLARE_LEGACY_CORE_BUFS_EX(_enum)                                     \
-	IBV_ABI_REQ(_enum) __req_onstack;                                      \
-	IBV_KABI_RESP(_enum) resp;                                             \
-	IBV_KABI_REQ(_enum) *const req = ({                                    \
-		__req_onstack.hdr.hdr.command =                                \
-			IB_USER_VERBS_CMD_FLAG_EXTENDED | _enum;               \
-		__req_onstack.hdr.hdr.in_words =                               \
-			(sizeof(__req_onstack) - sizeof(struct ex_hdr)) / 8;   \
-		__req_onstack.hdr.hdr.out_words = sizeof(resp) / 8;            \
-		__req_onstack.hdr.ex_hdr.cmd_hdr_reserved = 0;                 \
-		__req_onstack.hdr.ex_hdr.provider_in_words = 0;                \
-		__req_onstack.hdr.ex_hdr.provider_out_words = 0;               \
-		__req_onstack.hdr.ex_hdr.response =                            \
-			(sizeof(resp) == 0) ? 0 : ioctl_ptr_to_u64(&resp);     \
-		&__req_onstack.core_payload;                                   \
-	})
-
-/*
- * For users with no UHW bufs. To be used in conjunction with
- * DECLARE_LEGACY_CORE_BUFS. req points to the core payload (with headroom for
- * the header).
- */
-#define execute_write_ex(ctx, req)                                             \
-	_execute_write_raw_ex(ctx, get_req_hdr_ex(req))
-
 /*
  * For write() only commands that have fixed core structures and may take uhw
  * driver data. The last arguments are the same ones passed into the typical

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -228,6 +228,17 @@ int _execute_cmd_write(struct ibv_context *ctx, unsigned int write_method,
 			sizeof(*(resp)), resp_size);                           \
 	})
 
+/* For write() commands that have no response */
+#define execute_cmd_write_req(ctx, enum, cmd, cmd_size)                        \
+	({                                                                     \
+		static_assert(sizeof(IBV_KABI_RESP(enum)) == 0,                \
+			      "Method has a response!");                       \
+		_execute_cmd_write(                                            \
+			ctx, enum,                                             \
+			&(cmd)->hdr + check_type(cmd, IBV_ABI_REQ(enum) *),    \
+			sizeof(*(cmd)), cmd_size, NULL, 0, 0);                 \
+	})
+
 /*
  * Execute a write command that does not have a uhw component. The cmd_size
  * and resp_size are the lengths of the core structure. This version is only

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -158,28 +158,6 @@ int _execute_write_raw_ex(struct ibv_context *ctx, struct ex_hdr *req);
 	_execute_write_raw_ex(ctx, get_req_hdr_ex(req))
 
 /* For users with no possible UHW bufs. */
-#define DECLARE_LEGACY_CORE_BUFS(_enum)                                        \
-	IBV_ABI_REQ(_enum) __req_onstack;                                      \
-	IBV_KABI_RESP(_enum) resp;                                             \
-	static_assert(offsetof(IBV_KABI_REQ(_enum), response) == 0,            \
-		      "Bad response offset");                                  \
-	IBV_KABI_REQ(_enum) *const req = ({                                    \
-		__req_onstack.hdr.command = _enum;                             \
-		__req_onstack.hdr.in_words = sizeof(__req_onstack) / 4;        \
-		__req_onstack.hdr.out_words = sizeof(resp) / 4;                \
-		&__req_onstack.core_payload;                                   \
-	})
-#define DECLARE_LEGACY_CORE_REQ(_enum)                                         \
-	IBV_ABI_REQ(_enum) __req_onstack;                                      \
-	static_assert(sizeof(IBV_KABI_RESP(_enum)) == 0,                       \
-		      "Method has a response!");                               \
-	IBV_KABI_REQ(_enum) *const req = ({                                    \
-		__req_onstack.hdr.command = _enum;                             \
-		__req_onstack.hdr.in_words = sizeof(__req_onstack) / 4;        \
-		__req_onstack.hdr.out_words = 0;                               \
-		&__req_onstack.core_payload;                                   \
-	})
-
 #define DECLARE_LEGACY_CORE_BUFS_EX(_enum)                                     \
 	IBV_ABI_REQ(_enum) __req_onstack;                                      \
 	IBV_KABI_RESP(_enum) resp;                                             \
@@ -202,8 +180,6 @@ int _execute_write_raw_ex(struct ibv_context *ctx, struct ex_hdr *req);
  * DECLARE_LEGACY_CORE_BUFS. req points to the core payload (with headroom for
  * the header).
  */
-#define execute_write(ctx, req, resp)                                          \
-	_execute_write_raw(ctx, get_req_hdr(req), resp)
 #define execute_write_ex(ctx, req)                                             \
 	_execute_write_raw_ex(ctx, get_req_hdr_ex(req))
 
@@ -321,13 +297,6 @@ static inline int execute_write_bufs(struct ibv_context *ctx, void *req,
 
 #undef execute_write_bufs_ex
 static inline int execute_write_bufs_ex(struct ibv_context *ctx, void *req)
-{
-	return ENOSYS;
-}
-
-#undef execute_write
-static inline int execute_write(struct ibv_context *ctx, void *req,
-				void *resp)
 {
 	return ENOSYS;
 }

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -562,11 +562,7 @@ int ibv_cmd_destroy_wq(struct ibv_wq *wq);
 int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
 				 struct ibv_rwq_ind_table_init_attr *init_attr,
 				 struct ibv_rwq_ind_table *rwq_ind_table,
-				 struct ibv_create_rwq_ind_table *cmd,
-				 size_t cmd_core_size,
-				 size_t cmd_size,
 				 struct ib_uverbs_ex_create_rwq_ind_table_resp *resp,
-				 size_t resp_core_size,
 				 size_t resp_size);
 int ibv_cmd_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table);
 int ibv_cmd_create_counters(struct ibv_context *context,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -413,10 +413,8 @@ int ibv_cmd_query_device_ex(struct ibv_context *context,
 			    struct ibv_device_attr_ex *attr, size_t attr_size,
 			    uint64_t *raw_fw_ver,
 			    struct ibv_query_device_ex *cmd,
-			    size_t cmd_core_size,
 			    size_t cmd_size,
 			    struct ib_uverbs_ex_query_device_resp *resp,
-			    size_t resp_core_size,
 			    size_t resp_size);
 int ibv_cmd_query_port(struct ibv_context *context, uint8_t port_num,
 		       struct ibv_port_attr *port_attr,
@@ -501,10 +499,8 @@ int ibv_cmd_create_qp_ex2(struct ibv_context *context,
 			  struct verbs_qp *qp, int vqp_sz,
 			  struct ibv_qp_init_attr_ex *qp_attr,
 			  struct ibv_create_qp_ex *cmd,
-			  size_t cmd_core_size,
 			  size_t cmd_size,
 			  struct ib_uverbs_ex_create_qp_resp *resp,
-			  size_t resp_core_size,
 			  size_t resp_size);
 int ibv_cmd_open_qp(struct ibv_context *context,
 		    struct verbs_qp *qp,  int vqp_sz,
@@ -520,9 +516,9 @@ int ibv_cmd_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		      struct ibv_modify_qp *cmd, size_t cmd_size);
 int ibv_cmd_modify_qp_ex(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 			 int attr_mask, struct ibv_modify_qp_ex *cmd,
-			 size_t cmd_core_size, size_t cmd_size,
+			 size_t cmd_size,
 			 struct ib_uverbs_ex_modify_qp_resp *resp,
-			 size_t resp_core_size, size_t resp_size);
+			 size_t resp_size);
 int ibv_cmd_destroy_qp(struct ibv_qp *qp);
 int ibv_cmd_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 		      struct ibv_send_wr **bad_wr);
@@ -548,16 +544,13 @@ int ibv_cmd_create_wq(struct ibv_context *context,
 		      struct ibv_wq_init_attr *wq_init_attr,
 		      struct ibv_wq *wq,
 		      struct ibv_create_wq *cmd,
-		      size_t cmd_core_size,
 		      size_t cmd_size,
 		      struct ib_uverbs_ex_create_wq_resp *resp,
-		      size_t resp_core_size,
 		      size_t resp_size);
 
 int ibv_cmd_destroy_flow_action(struct verbs_flow_action *action);
 int ibv_cmd_modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *attr,
-		      struct ibv_modify_wq *cmd, size_t cmd_core_size,
-		      size_t cmd_size);
+		      struct ibv_modify_wq *cmd, size_t cmd_size);
 int ibv_cmd_destroy_wq(struct ibv_wq *wq);
 int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
 				 struct ibv_rwq_ind_table_init_attr *init_attr,

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -86,13 +86,6 @@ static inline const struct verbs_context_ops *get_ops(struct ibv_context *ctx)
 	return &get_priv(ctx)->ops;
 }
 
-#define IBV_INIT_CMD(cmd, size, opcode)					\
-	do {								\
-		(cmd)->hdr.command = IB_USER_VERBS_CMD_##opcode;	\
-		(cmd)->hdr.in_words  = (size) / 4;			\
-		(cmd)->hdr.out_words = 0;				\
-	} while (0)
-
 static inline uint32_t _cmd_ex(uint32_t cmd)
 {
 	return IB_USER_VERBS_CMD_FLAG_EXTENDED | cmd;

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -37,9 +37,6 @@
 #include <pthread.h>
 
 #include <infiniband/driver.h>
-
-#include <valgrind/memcheck.h>
-
 #include <ccan/bitmap.h>
 
 #define INIT		__attribute__((constructor))
@@ -85,36 +82,5 @@ static inline const struct verbs_context_ops *get_ops(struct ibv_context *ctx)
 {
 	return &get_priv(ctx)->ops;
 }
-
-static inline uint32_t _cmd_ex(uint32_t cmd)
-{
-	return IB_USER_VERBS_CMD_FLAG_EXTENDED | cmd;
-}
-
-#define IBV_INIT_CMD_RESP_EX_V(cmd, cmd_size, size, opcode, out, resp_size,\
-		outsize)						   \
-	do {                                                               \
-		size_t c_size = cmd_size - sizeof(struct ex_hdr);	   \
-		(cmd)->hdr.hdr.command =				   \
-			_cmd_ex(IB_USER_VERBS_EX_CMD_##opcode);		   \
-		(cmd)->hdr.hdr.in_words  = ((c_size) / 8);                 \
-		(cmd)->hdr.hdr.out_words = ((resp_size) / 8);              \
-		(cmd)->hdr.ex_hdr.provider_in_words   = (((size) - (cmd_size))/8);\
-		(cmd)->hdr.ex_hdr.provider_out_words  =			   \
-			     (((outsize) - (resp_size)) / 8);              \
-		(cmd)->hdr.ex_hdr.response  = (uintptr_t) (out);           \
-		(cmd)->hdr.ex_hdr.cmd_hdr_reserved = 0;			   \
-	} while (0)
-
-#define IBV_INIT_CMD_RESP_EX_VCMD(cmd, cmd_size, size, opcode, out, outsize) \
-	IBV_INIT_CMD_RESP_EX_V(cmd, cmd_size, size, opcode, out,	     \
-			sizeof(*(out)), outsize)
-
-#define IBV_INIT_CMD_RESP_EX(cmd, size, opcode, out, outsize)		     \
-	IBV_INIT_CMD_RESP_EX_V(cmd, sizeof(*(cmd)), size, opcode, out,    \
-			sizeof(*(out)), outsize)
-
-#define IBV_INIT_CMD_EX(cmd, size, opcode)				     \
-	IBV_INIT_CMD_RESP_EX_V(cmd, sizeof(*(cmd)), size, opcode, NULL, 0, 0)
 
 #endif /* IB_VERBS_H */

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -93,14 +93,6 @@ static inline const struct verbs_context_ops *get_ops(struct ibv_context *ctx)
 		(cmd)->hdr.out_words = 0;				\
 	} while (0)
 
-#define IBV_INIT_CMD_RESP(cmd, size, opcode, out, outsize)		\
-	do {								\
-		(cmd)->hdr.command = IB_USER_VERBS_CMD_##opcode;	\
-		(cmd)->hdr.in_words  = (size) / 4;			\
-		(cmd)->hdr.out_words = (outsize) / 4;			\
-		(cmd)->response  = (uintptr_t) (out);			\
-	} while (0)
-
 static inline uint32_t _cmd_ex(uint32_t cmd)
 {
 	return IB_USER_VERBS_CMD_FLAG_EXTENDED | cmd;

--- a/libibverbs/kern-abi.h
+++ b/libibverbs/kern-abi.h
@@ -277,8 +277,7 @@ struct ibv_kern_spec {
 	};
 };
 
-struct ibv_modify_srq_v3 {
-	struct ib_uverbs_cmd_hdr hdr;
+struct ib_uverbs_modify_srq_v3 {
 	__u32 srq_handle;
 	__u32 attr_mask;
 	__u32 max_wr;
@@ -286,6 +285,9 @@ struct ibv_modify_srq_v3 {
 	__u32 srq_limit;
 	__u32 reserved;
 };
+#define _STRUCT_ib_uverbs_modify_srq_v3
+enum { IB_USER_VERBS_CMD_MODIFY_SRQ_V3 = IB_USER_VERBS_CMD_MODIFY_SRQ };
+DECLARE_CMDX(IB_USER_VERBS_CMD_MODIFY_SRQ_V3, ibv_modify_srq_v3, ib_uverbs_modify_srq_v3, empty);
 
 struct ibv_create_qp_resp_v3 {
 	__u32 qp_handle;

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -342,14 +342,17 @@ LATEST_SYMVER_FUNC(ibv_dereg_mr, 1_1, "IBVERBS_1.1",
 
 struct ibv_comp_channel *ibv_create_comp_channel(struct ibv_context *context)
 {
-	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL);
+	struct ibv_create_comp_channel req;
+	struct ib_uverbs_create_comp_channel_resp resp;
 	struct ibv_comp_channel            *channel;
 
 	channel = malloc(sizeof *channel);
 	if (!channel)
 		return NULL;
 
-	if (execute_write(context, req, &resp)) {
+	req.core_payload = (struct ib_uverbs_create_comp_channel){};
+	if (execute_cmd_write(context, IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL,
+			      &req, sizeof(req), &resp, sizeof(resp))) {
 		free(channel);
 		return NULL;
 	}

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -46,6 +46,7 @@
 
 #include <util/compiler.h>
 #include <util/symver.h>
+#include <infiniband/cmd_write.h>
 
 #include "ibverbs.h"
 #ifndef NRESOLVE_NEIGH
@@ -341,21 +342,17 @@ LATEST_SYMVER_FUNC(ibv_dereg_mr, 1_1, "IBVERBS_1.1",
 
 struct ibv_comp_channel *ibv_create_comp_channel(struct ibv_context *context)
 {
+	DECLARE_LEGACY_CORE_BUFS(IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL);
 	struct ibv_comp_channel            *channel;
-	struct ibv_create_comp_channel      cmd;
-	struct ib_uverbs_create_comp_channel_resp resp;
 
 	channel = malloc(sizeof *channel);
 	if (!channel)
 		return NULL;
 
-	IBV_INIT_CMD_RESP(&cmd, sizeof cmd, CREATE_COMP_CHANNEL, &resp, sizeof resp);
-	if (write(context->cmd_fd, &cmd, sizeof cmd) != sizeof cmd) {
+	if (execute_write(context, req, &resp)) {
 		free(channel);
 		return NULL;
 	}
-
-	(void) VALGRIND_MAKE_MEM_DEFINED(&resp, sizeof resp);
 
 	channel->context = context;
 	channel->fd      = resp.fd;

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -1613,42 +1613,23 @@ int mlx4_destroy_wq(struct ibv_wq *ibwq)
 struct ibv_rwq_ind_table *mlx4_create_rwq_ind_table(struct ibv_context *context,
 						    struct ibv_rwq_ind_table_init_attr *init_attr)
 {
-	struct ibv_create_rwq_ind_table *cmd;
 	struct ib_uverbs_ex_create_rwq_ind_table_resp resp = {};
 	struct ibv_rwq_ind_table *ind_table;
-	uint32_t required_tbl_size;
-	unsigned int num_tbl_entries;
-	int cmd_size;
 	int err;
-
-	num_tbl_entries = 1 << init_attr->log_ind_tbl_size;
-	/* Data must be u64 aligned */
-	required_tbl_size =
-		(num_tbl_entries * sizeof(uint32_t)) < sizeof(uint64_t) ?
-			sizeof(uint64_t) : (num_tbl_entries * sizeof(uint32_t));
-
-	cmd_size = required_tbl_size + sizeof(*cmd);
-	cmd = calloc(1, cmd_size);
-	if (!cmd)
-		return NULL;
 
 	ind_table = calloc(1, sizeof(*ind_table));
 	if (!ind_table)
-		goto free_cmd;
+		return NULL;
 
-	err = ibv_cmd_create_rwq_ind_table(context, init_attr, ind_table, cmd,
-					   cmd_size, cmd_size, &resp,
-					   sizeof(resp), sizeof(resp));
+	err = ibv_cmd_create_rwq_ind_table(context, init_attr, ind_table, &resp,
+					   sizeof(resp));
 	if (err)
 		goto err;
 
-	free(cmd);
 	return ind_table;
 
 err:
 	free(ind_table);
-free_cmd:
-	free(cmd);
 	return NULL;
 }
 

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -80,10 +80,8 @@ int mlx4_query_device_ex(struct ibv_context *context,
 	int err;
 
 	err = ibv_cmd_query_device_ex(context, input, attr, attr_size,
-				      &raw_fw_ver,
-				      &cmd.ibv_cmd, sizeof(cmd.ibv_cmd), sizeof(cmd),
-				      &resp.ibv_resp, sizeof(resp.ibv_resp),
-				      sizeof(resp));
+				      &raw_fw_ver, &cmd.ibv_cmd, sizeof(cmd),
+				      &resp.ibv_resp, sizeof(resp));
 	if (err)
 		return err;
 
@@ -785,10 +783,9 @@ static int mlx4_cmd_create_qp_ex_rss(struct ibv_context *context,
 	       sizeof(cmd_ex.rx_hash_key));
 
 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
-				    sizeof(qp->verbs_qp), attr,
-				    &cmd_ex.ibv_cmd, sizeof(cmd_ex.ibv_cmd),
+				    sizeof(qp->verbs_qp), attr, &cmd_ex.ibv_cmd,
 				    sizeof(cmd_ex), &resp.ibv_resp,
-				    sizeof(resp.ibv_resp), sizeof(resp));
+				    sizeof(resp));
 	return ret;
 }
 
@@ -841,10 +838,9 @@ static int mlx4_cmd_create_qp_ex(struct ibv_context *context,
 	cmd_ex.drv_payload = cmd->drv_payload;
 
 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
-				    sizeof(qp->verbs_qp), attr,
-				    &cmd_ex.ibv_cmd, sizeof(cmd_ex.ibv_cmd),
+				    sizeof(qp->verbs_qp), attr, &cmd_ex.ibv_cmd,
 				    sizeof(cmd_ex), &resp.ibv_resp,
-				    sizeof(resp.ibv_resp), sizeof(resp));
+				    sizeof(resp));
 	return ret;
 }
 
@@ -1479,10 +1475,7 @@ struct ibv_wq *mlx4_create_wq(struct ibv_context *context,
 	pthread_mutex_lock(&to_mctx(context)->qp_table_mutex);
 
 	ret = ibv_cmd_create_wq(context, attr, &qp->wq, &cmd.ibv_cmd,
-				sizeof(cmd.ibv_cmd),
-				sizeof(cmd),
-				&resp, sizeof(resp),
-				sizeof(resp));
+				sizeof(cmd), &resp, sizeof(resp));
 	if (ret)
 		goto err_rq_db;
 
@@ -1529,8 +1522,7 @@ int mlx4_modify_wq(struct ibv_wq *ibwq, struct ibv_wq_attr *attr)
 	struct mlx4_modify_wq cmd = {};
 	int ret;
 
-	ret = ibv_cmd_modify_wq(ibwq, attr, &cmd.ibv_cmd,  sizeof(cmd.ibv_cmd),
-				sizeof(cmd));
+	ret = ibv_cmd_modify_wq(ibwq, attr, &cmd.ibv_cmd, sizeof(cmd));
 
 	if (!ret && (attr->attr_mask & IBV_WQ_ATTR_STATE) &&
 	    (ibwq->state == IBV_WQS_RESET)) {

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1557,10 +1557,9 @@ static int mlx5_cmd_create_rss_qp(struct ibv_context *context,
 			attr->rx_hash_conf.rx_hash_key_len);
 
 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
-					    sizeof(qp->verbs_qp), attr,
-					    &cmd_ex_rss.ibv_cmd, sizeof(cmd_ex_rss.ibv_cmd),
-					    sizeof(cmd_ex_rss), &resp.ibv_resp,
-					    sizeof(resp.ibv_resp), sizeof(resp));
+				    sizeof(qp->verbs_qp), attr,
+				    &cmd_ex_rss.ibv_cmd, sizeof(cmd_ex_rss),
+				    &resp.ibv_resp, sizeof(resp));
 	if (ret)
 		return ret;
 
@@ -1588,10 +1587,9 @@ static int mlx5_cmd_create_qp_ex(struct ibv_context *context,
 	cmd_ex.drv_payload = cmd->drv_payload;
 
 	ret = ibv_cmd_create_qp_ex2(context, &qp->verbs_qp,
-				    sizeof(qp->verbs_qp), attr,
-				    &cmd_ex.ibv_cmd, sizeof(cmd_ex.ibv_cmd),
+				    sizeof(qp->verbs_qp), attr, &cmd_ex.ibv_cmd,
 				    sizeof(cmd_ex), &resp->ibv_resp,
-				    sizeof(resp->ibv_resp), sizeof(*resp));
+				    sizeof(*resp));
 
 	return ret;
 }
@@ -2154,11 +2152,8 @@ static int modify_dct(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 	bool dct_create;
 	int ret;
 
-	ret = ibv_cmd_modify_qp_ex(qp, attr, attr_mask,
-				   &cmd_ex,
-				   sizeof(cmd_ex), sizeof(cmd_ex),
-				   &resp.ibv_resp,
-				   sizeof(resp.ibv_resp), sizeof(resp));
+	ret = ibv_cmd_modify_qp_ex(qp, attr, attr_mask, &cmd_ex, sizeof(cmd_ex),
+				   &resp.ibv_resp, sizeof(resp));
 	if (ret)
 		return ret;
 
@@ -2249,11 +2244,8 @@ int mlx5_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 	}
 
 	if (attr_mask & MLX5_MODIFY_QP_EX_ATTR_MASK)
-		ret = ibv_cmd_modify_qp_ex(qp, attr, attr_mask,
-					   &cmd_ex,
-					   sizeof(cmd_ex), sizeof(cmd_ex),
-					   &resp,
-					   sizeof(resp), sizeof(resp));
+		ret = ibv_cmd_modify_qp_ex(qp, attr, attr_mask, &cmd_ex,
+					   sizeof(cmd_ex), &resp, sizeof(resp));
 	else
 		ret = ibv_cmd_modify_qp(qp, attr, attr_mask,
 					&cmd, sizeof(cmd));
@@ -2320,10 +2312,8 @@ int mlx5_modify_qp_rate_limit(struct ibv_qp *qp,
 	qp_attr.rate_limit = attr->rate_limit;
 
 	ret = ibv_cmd_modify_qp_ex(qp, &qp_attr, IBV_QP_RATE_LIMIT,
-				   &cmd.ibv_cmd,
-				   sizeof(cmd.ibv_cmd), sizeof(cmd),
-				   &resp,
-				   sizeof(resp), sizeof(resp));
+				   &cmd.ibv_cmd, sizeof(cmd), &resp,
+				   sizeof(resp));
 
 	return ret;
 }
@@ -2816,11 +2806,10 @@ int mlx5_query_device_ex(struct ibv_context *context,
 
 	memset(&cmd, 0, sizeof(cmd));
 	memset(&resp, 0, sizeof(resp));
-	err = ibv_cmd_query_device_ex(context, input, attr, attr_size,
-				      &raw_fw_ver,
-				      &cmd.ibv_cmd, sizeof(cmd.ibv_cmd), sizeof(cmd),
-				      &resp.ibv_resp, sizeof(resp.ibv_resp),
-				      cmd_supp_uhw ? sizeof(resp) : sizeof(resp.ibv_resp));
+	err = ibv_cmd_query_device_ex(
+		context, input, attr, attr_size, &raw_fw_ver, &cmd.ibv_cmd,
+		sizeof(cmd), &resp.ibv_resp,
+		cmd_supp_uhw ? sizeof(resp) : sizeof(resp.ibv_resp));
 	if (err)
 		return err;
 
@@ -3018,10 +3007,7 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 	}
 
 	err = ibv_cmd_create_wq(context, attr, &rwq->wq, &cmd.ibv_cmd,
-				sizeof(cmd.ibv_cmd),
-				sizeof(cmd),
-				&resp.ibv_resp, sizeof(resp.ibv_resp),
-				sizeof(resp));
+				sizeof(cmd), &resp.ibv_resp, sizeof(resp));
 	if (err)
 		goto err_create;
 
@@ -3077,7 +3063,7 @@ int mlx5_modify_wq(struct ibv_wq *wq, struct ibv_wq_attr *attr)
 		}
 	}
 
-	return ibv_cmd_modify_wq(wq, attr, &cmd.ibv_cmd,  sizeof(cmd.ibv_cmd), sizeof(cmd));
+	return ibv_cmd_modify_wq(wq, attr, &cmd.ibv_cmd, sizeof(cmd));
 }
 
 int mlx5_destroy_wq(struct ibv_wq *wq)

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3258,42 +3258,24 @@ int mlx5_destroy_flow(struct ibv_flow *flow_id)
 struct ibv_rwq_ind_table *mlx5_create_rwq_ind_table(struct ibv_context *context,
 						    struct ibv_rwq_ind_table_init_attr *init_attr)
 {
-	struct ibv_create_rwq_ind_table *cmd;
 	struct mlx5_create_rwq_ind_table_resp resp;
 	struct ibv_rwq_ind_table *ind_table;
-	uint32_t required_tbl_size;
-	int num_tbl_entries;
-	int cmd_size;
 	int err;
-
-	num_tbl_entries = 1 << init_attr->log_ind_tbl_size;
-	/* Data must be u64 aligned */
-	required_tbl_size = (num_tbl_entries * sizeof(uint32_t)) < sizeof(uint64_t) ?
-			sizeof(uint64_t) : (num_tbl_entries * sizeof(uint32_t));
-
-	cmd_size = required_tbl_size + sizeof(*cmd);
-	cmd = calloc(1, cmd_size);
-	if (!cmd)
-		return NULL;
 
 	memset(&resp, 0, sizeof(resp));
 	ind_table = calloc(1, sizeof(*ind_table));
 	if (!ind_table)
-		goto free_cmd;
+		return NULL;
 
-	err = ibv_cmd_create_rwq_ind_table(context, init_attr, ind_table, cmd,
-					   cmd_size, cmd_size, &resp.ibv_resp, sizeof(resp.ibv_resp),
-					   sizeof(resp));
+	err = ibv_cmd_create_rwq_ind_table(context, init_attr, ind_table,
+					   &resp.ibv_resp, sizeof(resp));
 	if (err)
 		goto err;
 
-	free(cmd);
 	return ind_table;
 
 err:
 	free(ind_table);
-free_cmd:
-	free(cmd);
 	return NULL;
 }
 


### PR DESCRIPTION
This series reworks all the places that execute commands to use a consistent set of helpers around write(). The helpers are designed to accept the location of all 5 buffers (hdr, cmd, drv_cmd, resp, drv_resp) involved with a command.

This cleanup removes a bunch of duplicated code and paves the way to add more options for delivering commands to the kernel.