### PR TITLE
verbs: Introduce ibv_advise_mr() verb

### DIFF
--- a/kernel-headers/rdma/ib_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/ib_user_ioctl_cmds.h
@@ -65,6 +65,7 @@ enum {
 
 enum uverbs_methods_device {
 	UVERBS_METHOD_INVOKE_WRITE,
+	UVERBS_METHOD_INFO_HANDLES,
 };
 
 enum uverbs_attrs_invoke_write_cmd_attr_ids {
@@ -145,6 +146,19 @@ enum uverbs_attrs_reg_dm_mr_cmd_attr_ids {
 
 enum uverbs_methods_mr {
 	UVERBS_METHOD_DM_MR_REG,
+	UVERBS_METHOD_MR_DESTROY,
+	UVERBS_METHOD_ADVISE_MR,
+};
+
+enum uverbs_attrs_mr_destroy_ids {
+	UVERBS_ATTR_DESTROY_MR_HANDLE,
+};
+
+enum uverbs_attrs_advise_mr_cmd_attr_ids {
+	UVERBS_ATTR_ADVISE_MR_PD_HANDLE,
+	UVERBS_ATTR_ADVISE_MR_ADVICE,
+	UVERBS_ATTR_ADVISE_MR_FLAGS,
+	UVERBS_ATTR_ADVISE_MR_SGE_LIST,
 };
 
 enum uverbs_attrs_create_counters_cmd_attr_ids {
@@ -167,4 +181,57 @@ enum uverbs_methods_actions_counters_ops {
 	UVERBS_METHOD_COUNTERS_READ,
 };
 
+enum uverbs_attrs_info_handles_id {
+	UVERBS_ATTR_INFO_OBJECT_ID,
+	UVERBS_ATTR_INFO_TOTAL_HANDLES,
+	UVERBS_ATTR_INFO_HANDLES_LIST,
+};
+
+enum uverbs_methods_pd {
+	UVERBS_METHOD_PD_DESTROY,
+};
+
+enum uverbs_attrs_pd_destroy_ids {
+	UVERBS_ATTR_DESTROY_PD_HANDLE,
+};
+
+enum uverbs_methods_mw {
+	UVERBS_METHOD_MW_DESTROY,
+};
+
+enum uverbs_attrs_mw_destroy_ids {
+	UVERBS_ATTR_DESTROY_MW_HANDLE,
+};
+
+enum uverbs_methods_xrcd {
+	UVERBS_METHOD_XRCD_DESTROY,
+};
+
+enum uverbs_attrs_xrcd_destroy_ids {
+	UVERBS_ATTR_DESTROY_XRCD_HANDLE,
+};
+
+enum uverbs_methods_ah {
+	UVERBS_METHOD_AH_DESTROY,
+};
+
+enum uverbs_attrs_ah_destroy_ids {
+	UVERBS_ATTR_DESTROY_AH_HANDLE,
+};
+
+enum uverbs_methods_rwq_ind_tbl {
+	UVERBS_METHOD_RWQ_IND_TBL_DESTROY,
+};
+
+enum uverbs_attrs_rwq_ind_tbl_destroy_ids {
+	UVERBS_ATTR_DESTROY_RWQ_IND_TBL_HANDLE,
+};
+
+enum uverbs_methods_flow {
+	UVERBS_METHOD_FLOW_DESTROY,
+};
+
+enum uverbs_attrs_flow_destroy_ids {
+	UVERBS_ATTR_DESTROY_FLOW_HANDLE,
+};
 #endif

--- a/kernel-headers/rdma/ib_user_ioctl_verbs.h
+++ b/kernel-headers/rdma/ib_user_ioctl_verbs.h
@@ -157,4 +157,13 @@ enum ib_uverbs_read_counters_flags {
 	IB_UVERBS_READ_COUNTERS_PREFER_CACHED = 1 << 0,
 };
 
+enum ib_uverbs_advise_mr_advice {
+	IB_UVERBS_ADVISE_MR_ADVICE_PREFETCH,
+	IB_UVERBS_ADVISE_MR_ADVICE_PREFETCH_WRITE,
+};
+
+enum ib_uverbs_advise_mr_flag {
+	IB_UVERBS_ADVISE_MR_FLAG_FLUSH = 1 << 0,
+};
+
 #endif

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -36,6 +36,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   cmd_fallback.c
   cmd_flow_action.c
   cmd_ioctl.c
+  cmd_mr.c
   compat-1_0.c
   device.c
   dummy_ops.c

--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -376,6 +376,9 @@ static inline size_t _array_len(size_t size, size_t nelems)
 #define fill_attr_out_ptr_array(cmd, attr_id, ptr, nelems)                     \
 	fill_attr_out(cmd, attr_id, ptr, _array_len(sizeof(*ptr), nelems))
 
+#define fill_attr_in_ptr_array(cmd, attr_id, ptr, nelems)                       \
+	fill_attr_in(cmd, attr_id, ptr, _array_len(sizeof(*ptr), nelems))
+
 static inline size_t __check_divide(size_t val, unsigned int div)
 {
 	assert(val % div == 0);

--- a/libibverbs/cmd_mr.c
+++ b/libibverbs/cmd_mr.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 Mellanox Technologies, Ltd.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <infiniband/cmd_ioctl.h>
+#include <rdma/ib_user_ioctl_cmds.h>
+#include <infiniband/driver.h>
+
+int ibv_cmd_advise_mr(struct ibv_pd *pd,
+		      enum ibv_advise_mr_advice advice,
+		      uint32_t flags,
+		      struct ibv_sge *sg_list,
+		      uint32_t num_sge)
+{
+	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
+			       UVERBS_METHOD_ADVISE_MR,
+			       4);
+
+	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
+	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
+	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
+	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
+			       sg_list, num_sge);
+
+	return execute_ioctl(pd->context, cmd);
+}

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -218,6 +218,11 @@ struct verbs_counters {
  * Keep sorted.
  */
 struct verbs_context_ops {
+	int (*advise_mr)(struct ibv_pd *pd,
+			 enum ibv_advise_mr_advice advice,
+			 uint32_t flags,
+			 struct ibv_sge *sg_list,
+			 uint32_t num_sges);
 	struct ibv_dm *(*alloc_dm)(struct ibv_context *context,
 				   struct ibv_alloc_dm_attr *attr);
 	struct ibv_mw *(*alloc_mw)(struct ibv_pd *pd, enum ibv_mw_type type);
@@ -440,6 +445,11 @@ int ibv_cmd_rereg_mr(struct verbs_mr *vmr, uint32_t flags, void *addr,
 		     size_t cmd_sz, struct ib_uverbs_rereg_mr_resp *resp,
 		     size_t resp_sz);
 int ibv_cmd_dereg_mr(struct verbs_mr *vmr);
+int ibv_cmd_advise_mr(struct ibv_pd *pd,
+		      enum ibv_advise_mr_advice advice,
+		      uint32_t flags,
+		      struct ibv_sge *sg_list,
+		      uint32_t num_sge);
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -33,6 +33,15 @@
 #include "ibverbs.h"
 #include <errno.h>
 
+static int advise_mr(struct ibv_pd *pd,
+		     enum ibv_advise_mr_advice advice,
+		     uint32_t flags,
+		     struct ibv_sge *sg_list,
+		     uint32_t num_sges)
+{
+	return ENOSYS;
+}
+
 static struct ibv_dm *alloc_dm(struct ibv_context *context,
 			       struct ibv_alloc_dm_attr *attr)
 {
@@ -436,6 +445,7 @@ static int resize_cq(struct ibv_cq *cq, int cqe)
  * Keep sorted.
  */
 const struct verbs_context_ops verbs_dummy_ops = {
+	advise_mr,
 	alloc_dm,
 	alloc_mw,
 	alloc_null_mr,
@@ -550,6 +560,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 		}                                                              \
 	} while (0)
 
+	SET_OP(vctx, advise_mr);
 	SET_OP(vctx, alloc_dm);
 	SET_OP(ctx, alloc_mw);
 	SET_OP(vctx, alloc_null_mr);

--- a/libibverbs/examples/rc_pingpong.c
+++ b/libibverbs/examples/rc_pingpong.c
@@ -856,6 +856,11 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 
+	if (use_odp && use_dm) {
+		fprintf(stderr, "DM memory region can't be on demand\n");
+		return 1;
+	}
+
 	if (use_ts) {
 		ts.comp_recv_max_time_delta = 0;
 		ts.comp_recv_min_time_delta = 0xffffffff;

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -120,6 +120,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		__ioctl_final_num_attrs;
 		_verbs_init_and_alloc_context;
 		execute_ioctl;
+		ibv_cmd_advise_mr;
 		ibv_cmd_alloc_dm;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,4 +1,5 @@
 rdma_man_pages(
+  ibv_advise_mr.3.md
   ibv_alloc_dm.3
   ibv_alloc_mw.3
   ibv_alloc_null_mr.3.md

--- a/libibverbs/man/ibv_advise_mr.3.md
+++ b/libibverbs/man/ibv_advise_mr.3.md
@@ -1,0 +1,126 @@
+---
+date: 2018-10-19
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: IBV_ADVISE_MR
+---
+
+# NAME
+
+ibv_advise_mr - Gives advice or directions to the kernel about an
+		address range belongs to a memory region (MR).
+
+# SYNOPSIS
+
+```c
+#include <infiniband/verbs.h>
+
+int ibv_advise_mr(struct ibv_pd *pd,
+		  enum ibv_advise_mr_advice advice,
+		  uint32_t flags,
+		  struct ibv_sge *sg_list,
+		  uint32_t num_sge)
+```
+
+# DESCRIPTION
+
+**ibv_advise_mr()** Give advice or directions to the kernel about an
+address range belonging to a memory region (MR).
+Applications that are aware of future access patterns can use this verb
+in order to leverage this knowledge to improve system or
+application performance.
+
+**Conventional advice values**
+
+*IBV_ADVISE_MR_ADVICE_PREFETCH*
+:	Pre-fetch a range of an on-demand paging MR.
+	Make pages present with read-only permission before the actual IO is conducted.
+	This would provide a way to reduce latency by overlapping paging-in
+	and either compute time or IO to other ranges.
+
+*IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE*
+:	Like IBV_ADVISE_MR_ADVICE_PREFETCH but with read-access
+	and write-access permission to the fetched memory.
+
+# ARGUMENTS
+*pd*
+:	The protection domain (PD) associated with the MR.
+
+*advice*
+:	The requested advise value (as listed above).
+
+*flags*
+:	Describes the properties of the advise operation
+	**Conventional advice values**
+	*IBV_ADVISE_MR_FLAG_FLUSH*
+	:	Request to be a synchronized operation. Return to the caller
+		after the operation is completed.
+
+*sg_list*
+:	Pointer to the s/g array
+	When using IBV_ADVISE_OP_PREFETCH advise value, all the lkeys of all
+	the scatter gather elements (SGEs) must be associated with ODP MRs
+	(MRs that were registered with IBV_ACCESS_ON_DEMAND).
+
+*num_sge*
+:	Number of elements in the s/g array
+
+# RETURN VALUE
+
+**ibv_advise_mr()** returns 0 when the call was successful, or the value
+		    of errno on failure (which indicates the failure reason).
+
+*ENOSYS*
+:	libibverbs or provider driver doesn't support the ibv_advise_mr() verb.
+
+*ENOTSUP*
+:	The advise operation isn't supported.
+
+*EFAULT*
+:	In one of the following:
+	o When the range requested is out of the MR bounds, or when parts of
+	  it are not part of the process address space.
+	o One of the lkeys provided in the scatter gather list is invalid or
+	  with wrong write access.
+
+*EINVAL*
+:	In one of the following:
+	o The PD is invalid.
+	o The flags are invalid.
+
+# NOTES
+
+An application may pre-fetch any address range within an ODP MR when using the
+**IBV_ADVISE_MR_ADVICE_PREFETCH** or **IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE** advice.
+Semantically, this operation is best-effort. That means the kernel does not
+guarantee that underlying pages are updated in the HCA or the pre-fetched pages
+would remain resident.
+
+When using **IBV_ADVISE_MR_ADVICE_PREFETCH** or **IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE**
+advice, the operation will be done in the following stages:
+	o Page in the user pages to memory (pages aren't pinned).
+	o Get the dma mapping of these user pages.
+	o Post the underlying page translations to the HCA.
+
+If **IBV_ADVISE_MR_FLAG_FLUSH** is specified then the underlying pages are
+guaranteed to be updated in the HCA before returning SUCCESS.
+Otherwise the driver can choose to postpone the posting of the new translations
+to the HCA.
+When performing a local RDMA access operation it is recommended to use
+IBV_ADVISE_MR_FLAG_FLUSH flag with one of the pre-fetch advices to
+increase probability that the pages translations are valid in the HCA
+and avoid future page faults.
+
+# SEE ALSO
+
+**ibv_reg_mr**(3),
+**ibv_rereg_mr**(3),
+**ibv_dereg_mr**(3)
+
+# AUTHOR
+
+Aviad Yehezkel <aviadye@mellanox.com>
+

--- a/libibverbs/man/ibv_rc_pingpong.1
+++ b/libibverbs/man/ibv_rc_pingpong.1
@@ -8,12 +8,12 @@ ibv_rc_pingpong \- simple InfiniBand RC transport test
 .B ibv_rc_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
 [\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
-[\-o] [\-t] \fBHOSTNAME\fR
+[\-o] [\-P] [\-t] \fBHOSTNAME\fR
 
 .B ibv_rc_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
 [\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
-[\-o] [\-t]
+[\-o] [\-P] [\-t]
 
 .SH DESCRIPTION
 .PP
@@ -57,6 +57,9 @@ local port \fIGIDINDEX\fR
 .TP
 \fB\-o\fR, \fB\-\-odp\fR
 use on demand paging
+.TP
+\fB\-P\fR, \fB\-\-prefetch=\fR
+prefetch an ODP MR
 .TP
 \fB\-t\fR, \fB\-\-ts\fR
 get CQE with timestamp

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1786,6 +1786,11 @@ struct ibv_values_ex {
 
 struct verbs_context {
 	/*  "grows up" - new fields go here */
+	int (*advise_mr)(struct ibv_pd *pd,
+			 enum ibv_advise_mr_advice advice,
+			 uint32_t flags,
+			 struct ibv_sge *sg_list,
+			 uint32_t num_sges);
 	struct ibv_mr *(*alloc_null_mr)(struct ibv_pd *pd);
 	int (*read_counters)(struct ibv_counters *counters,
 			     uint64_t *counters_value,
@@ -2208,6 +2213,29 @@ struct ibv_comp_channel *ibv_create_comp_channel(struct ibv_context *context);
  * ibv_destroy_comp_channel - Destroy a completion event channel
  */
 int ibv_destroy_comp_channel(struct ibv_comp_channel *channel);
+
+/**
+ * ibv_advise_mr - Gives advice about an address range in MRs
+ * @pd - protection domain of all MRs for which the advice is for
+ * @advice - type of advice
+ * @flags - advice modifiers
+ * @sg_list - an array of memory ranges
+ * @num_sge - number of elements in the array
+ */
+static inline int ibv_advise_mr(struct ibv_pd *pd,
+				enum ibv_advise_mr_advice advice,
+				uint32_t flags,
+				struct ibv_sge *sg_list,
+				uint32_t num_sge)
+{
+	struct verbs_context *vctx;
+
+	vctx = verbs_get_ctx_op(pd->context, advise_mr);
+	if (!vctx)
+		return ENOSYS;
+
+	return vctx->advise_mr(pd, advice, flags, sg_list, num_sge);
+}
 
 /**
  * ibv_alloc_dm - Allocate device memory

--- a/libibverbs/verbs_api.h
+++ b/libibverbs/verbs_api.h
@@ -85,6 +85,12 @@
 #define ibv_flow_action_esp_encap                       ib_uverbs_flow_action_esp_encap
 #define ibv_flow_action_esp                             ib_uverbs_flow_action_esp
 
+#define ibv_advise_mr_advice                            ib_uverbs_advise_mr_advice
+#define IBV_ADVISE_MR_ADVICE_PREFETCH                   IB_UVERBS_ADVISE_MR_ADVICE_PREFETCH
+#define IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE             IB_UVERBS_ADVISE_MR_ADVICE_PREFETCH_WRITE
+
+#define IBV_ADVISE_MR_FLAG_FLUSH                        IB_UVERBS_ADVISE_MR_FLAG_FLUSH
+
 #define IBV_QPF_GRH_REQUIRED				IB_UVERBS_QPF_GRH_REQUIRED
 
 #endif

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -115,6 +115,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.attach_mcast  = mlx5_attach_mcast,
 	.detach_mcast  = mlx5_detach_mcast,
 
+	.advise_mr = mlx5_advise_mr,
 	.alloc_dm = mlx5_alloc_dm,
 	.alloc_parent_domain = mlx5_alloc_parent_domain,
 	.alloc_td = mlx5_alloc_td,

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -905,7 +905,11 @@ int mlx5_read_counters(struct ibv_counters *counters,
 		       uint64_t *counters_value,
 		       uint32_t ncounters,
 		       uint32_t flags);
-
+int mlx5_advise_mr(struct ibv_pd *pd,
+		   enum ibv_advise_mr_advice advice,
+		   uint32_t flags,
+		   struct ibv_sge *sg_list,
+		   uint32_t num_sges);
 static inline void *mlx5_find_uidx(struct mlx5_context *ctx, uint32_t uidx)
 {
 	int tind = uidx >> MLX5_UIDX_TABLE_SHIFT;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -493,6 +493,15 @@ free:
 	return 0;
 }
 
+int mlx5_advise_mr(struct ibv_pd *pd,
+		   enum ibv_advise_mr_advice advice,
+		   uint32_t flags,
+		   struct ibv_sge *sg_list,
+		   uint32_t num_sge)
+{
+	return ibv_cmd_advise_mr(pd, advice, flags, sg_list, num_sge);
+}
+
 struct ibv_mw *mlx5_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
 {
 	struct ibv_mw *mw;


### PR DESCRIPTION
This series Introduces a new verb named ibv_advise_mr(), it includes:
    - The application interface.
    - The command interface with the kernel.

The purpose of this verb is to give an advice to the kernel about an address range belongs to a memory region.

Performance - applications that are aware of future access patterns can use this verb in order to leverage this knowledge to improve system or application performance.
One example is for pre-fetching a range part of an on-demand paging MR which is implemented by this series.

The kernel part was already sent into rdma-next.