### PR TITLE
travis: Explicitly set debug as cmake build type

### DIFF
--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -54,7 +54,7 @@ cp ../util/udma_barrier.h.old ../util/udma_barrier.h
 # instead force it on by changing the CMakeLists.txt
 cd ..
 echo 'set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror")' >> buildlib/RDMA_EnableCStd.cmake
-sed -i -e 's/-DCMAKE_BUILD_TYPE=Release//g' debian/rules
+sed -i -e 's/-DCMAKE_BUILD_TYPE=Release/-DCMAKE_BUILD_TYPE=Debug/g' debian/rules
 sed -i -e 's/ninja \(.*\)-v/ninja \1/g' debian/rules
 
 CC=gcc-8 debian/rules build


### PR DESCRIPTION
CMAKE_BUILD_TYPE can be one of five types: empty, Debug, Release,
RelWithDebInfo and MinSizeRel. Unfortunately, the cmake documentation
is not clear what will be set in "empty" type.

We remove the ambiguity by setting Debug mode.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>