### PR TITLE
mlx: Fix few Ethernet related issues

### DIFF
--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -345,7 +345,11 @@ struct mlx4_wqe_ctrl_seg {
 	 * [1]   SE (solicited event)
 	 * [0]   FL (force loopback)
 	 */
-	__be32			srcrb_flags;
+	union {
+		__be32 srcrb_flags;
+		__be16 srcrb_flags16[2];
+	};
+
 	/*
 	 * imm is immediate data for send/RDMA write w/ immediate;
 	 * also invalidation key for send with invalidate; input

--- a/providers/mlx4/qp.c
+++ b/providers/mlx4/qp.c
@@ -358,6 +358,12 @@ int mlx4_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 				ctrl->srcrb_flags |= htobe32(MLX4_WQE_CTRL_IP_HDR_CSUM |
 							   MLX4_WQE_CTRL_TCP_UDP_CSUM);
 			}
+			/* Take the dmac from the payload - needed for loopback */
+			if (qp->link_layer == IBV_LINK_LAYER_ETHERNET) {
+				ctrl->srcrb_flags16[0] = *(__be16 *)(uintptr_t)wr->sg_list[0].addr;
+				ctrl->imm = *(__be32 *)((uintptr_t)(wr->sg_list[0].addr) + 2);
+			}
+
 			break;
 
 		default:

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2395,6 +2395,7 @@ struct ibv_ah *mlx5_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 	if (!ah)
 		return NULL;
 
+	static_rate = ah_attr_to_mlx5_rate(attr->static_rate);
 	if (is_eth) {
 		if (ibv_query_gid_type(pd->context, attr->port_num,
 				       attr->grh.sgid_index, &gid_type))
@@ -2408,13 +2409,13 @@ struct ibv_ah *mlx5_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 		 * for RoCE and shouldn't be set.
 		 */
 		grh = 0;
+		ah->av.stat_rate_sl = (static_rate << 4) | ((attr->sl & 0x7) << 1);
 	} else {
 		ah->av.fl_mlid = attr->src_path_bits & 0x7f;
 		ah->av.rlid = htobe16(attr->dlid);
 		grh = 1;
+		ah->av.stat_rate_sl = (static_rate << 4) | (attr->sl & 0x7);
 	}
-	static_rate = ah_attr_to_mlx5_rate(attr->static_rate);
-	ah->av.stat_rate_sl = (static_rate << 4) | attr->sl;
 	if (attr->is_global) {
 		ah->av.tclass = attr->grh.traffic_class;
 		ah->av.hop_limit = attr->grh.hop_limit;


### PR DESCRIPTION
This series handles 2 issues in mlx drivers:
- Fix SL to Ethernet priority conversion in mlx5
- Allow loopback when using raw Ethernet QP in mlx4