### PR TITLE
ibacm: ACM_ADDRESS_NAME names missing terminating NULL character

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2144,7 +2144,7 @@ static int acm_assign_ep_names(struct acmc_ep *ep)
 			type = ACM_ADDRESS_IP6;
 		} else {
 			type = ACM_ADDRESS_NAME;
-			memcpy(addr, name, strlen(name));
+			strncpy((char *)addr, name, sizeof(addr));
 		}
 
 		if (strcasecmp(pkey_str, "default")) {


### PR DESCRIPTION
The current ibacm.log file shows that there is a bug in
acm_assign_ep_names():

2018-12-21T07:49:26.410: acm_assign_ep_names: system1 mlx4_0 1 default
2018-12-21T07:49:26.410: acm_assign_ep_names: assigning system1
2018-12-21T07:49:26.410: acmp_add_addr:
2018-12-21T07:49:26.410: acmp_acquire_dest: type 1 addr system1????????
2018-12-21T07:49:26.410: acmp_get_dest: type 1 system1???????? not found
2018-12-21T07:49:26.410: acmp_alloc_dest: system1????????
2018-12-21T07:49:26.410: acmp_get_dest: system1????????
2018-12-21T07:49:26.410: acmp_put_dest: system1????????
2018-12-21T07:49:26.410: acmp_add_addr: added loopback dest system1????????

In acm_assign_ep_names(), ACM_ADDRESS_NAME type names are copied
into a buffer(which is eventually sent to the provider) without
the terminating NULL character. By modifying the copy to include
the terminating NULL character, the name is sent to the provider
correctly:

2018-12-20T18:52:35.627: acm_assign_ep_names: system1 mlx4_0 1 default
2018-12-20T18:52:35.627: acm_same_partition: pkey_a: 0xffff pkey_b: 0xffff
2018-12-20T18:52:35.627: acm_assign_ep_names: assigning system1
2018-12-20T18:52:35.627: acmp_add_addr:
2018-12-20T18:52:35.627: acmp_acquire_dest: type 1 addr system1
2018-12-20T18:52:35.627: acmp_get_dest: type 1 system1 not found
2018-12-20T18:52:35.627: acmp_alloc_dest: system1
2018-12-20T18:52:35.627: acmp_get_dest: system1
2018-12-20T18:52:35.627: acmp_put_dest: system1
2018-12-20T18:52:35.627: acmp_add_addr: added loopback dest system1

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>