### PR TITLE
verbs: Provide native ioctl implementations for trivial destroy

### DIFF
--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -30,13 +30,19 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   1 1.5.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
+  cmd_ah.c
   cmd_counters.c
   cmd_cq.c
   cmd_dm.c
   cmd_fallback.c
+  cmd_flow.c
   cmd_flow_action.c
   cmd_ioctl.c
   cmd_mr.c
+  cmd_mw.c
+  cmd_pd.c
+  cmd_rwq_ind.c
+  cmd_xrcd.c
   compat-1_0.c
   device.c
   dummy_ops.c

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -326,22 +326,6 @@ int ibv_cmd_alloc_pd(struct ibv_context *context, struct ibv_pd *pd,
 	return 0;
 }
 
-int ibv_cmd_dealloc_pd(struct ibv_pd *pd)
-{
-	struct ibv_dealloc_pd req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_dealloc_pd){
-		.pd_handle = pd->handle,
-	};
-	ret = execute_cmd_write_req(pd->context, IB_USER_VERBS_CMD_DEALLOC_PD,
-				    &req, sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
-
-	return 0;
-}
-
 int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
 		      int vxrcd_size,
 		      struct ibv_xrcd_init_attr *attr,
@@ -370,23 +354,6 @@ int ibv_cmd_open_xrcd(struct ibv_context *context, struct verbs_xrcd *xrcd,
 		xrcd->comp_mask = VERBS_XRCD_HANDLE;
 		xrcd->handle  = resp->xrcd_handle;
 	}
-
-	return 0;
-}
-
-int ibv_cmd_close_xrcd(struct verbs_xrcd *xrcd)
-{
-	struct ibv_close_xrcd req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_close_xrcd){
-		.xrcd_handle = xrcd->handle,
-	};
-	ret = execute_cmd_write_req(xrcd->xrcd.context,
-				    IB_USER_VERBS_CMD_CLOSE_XRCD, &req,
-				    sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
 
 	return 0;
 }
@@ -448,23 +415,6 @@ int ibv_cmd_rereg_mr(struct verbs_mr *vmr, uint32_t flags, void *addr,
 	return 0;
 }
 
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	struct ibv_dereg_mr req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_dereg_mr){
-		.mr_handle = vmr->ibv_mr.handle,
-	};
-	ret = execute_cmd_write_req(vmr->ibv_mr.context,
-				    IB_USER_VERBS_CMD_DEREG_MR, &req,
-				    sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
-
-	return 0;
-}
-
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,
@@ -486,22 +436,6 @@ int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 	mw->rkey    = resp->rkey;
 	mw->handle  = resp->mw_handle;
 	mw->type    = type;
-
-	return 0;
-}
-
-int ibv_cmd_dealloc_mw(struct ibv_mw *mw)
-{
-	struct ibv_dealloc_mw req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_dealloc_mw) {
-		.mw_handle = mw->handle,
-	};
-	ret = execute_cmd_write_req(mw->context, IB_USER_VERBS_CMD_DEALLOC_MW,
-				    &req, sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
 
 	return 0;
 }
@@ -1529,22 +1463,6 @@ int ibv_cmd_create_ah(struct ibv_pd *pd, struct ibv_ah *ah,
 	return 0;
 }
 
-int ibv_cmd_destroy_ah(struct ibv_ah *ah)
-{
-	struct ibv_destroy_ah req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_destroy_ah){
-		.ah_handle = ah->handle,
-	};
-	ret = execute_cmd_write_req(ah->context, IB_USER_VERBS_CMD_DESTROY_AH,
-				    &req, sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
-
-	return 0;
-}
-
 int ibv_cmd_destroy_qp(struct ibv_qp *qp)
 {
 	struct ibv_destroy_qp req;
@@ -1851,23 +1769,6 @@ int ibv_cmd_create_flow(struct ibv_qp *qp,
 	return 0;
 }
 
-int ibv_cmd_destroy_flow(struct ibv_flow *flow_id)
-{
-	struct ibv_destroy_flow req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_destroy_flow){
-		.flow_handle = flow_id->handle,
-	};
-	ret = execute_cmd_write_ex_req(flow_id->context,
-				       IB_USER_VERBS_EX_CMD_DESTROY_FLOW, &req,
-				       sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
-
-	return 0;
-}
-
 int ibv_cmd_create_wq(struct ibv_context *context,
 		      struct ibv_wq_init_attr *wq_init_attr,
 		      struct ibv_wq *wq,
@@ -2016,24 +1917,6 @@ int ibv_cmd_create_rwq_ind_table(struct ibv_context *context,
 	rwq_ind_table->context = context;
 	return 0;
 }
-
-int ibv_cmd_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
-{
-	struct ibv_destroy_rwq_ind_table req;
-	int ret;
-
-	req.core_payload = (struct ib_uverbs_ex_destroy_rwq_ind_table){
-		.ind_tbl_handle = rwq_ind_table->ind_tbl_handle,
-	};
-	ret = execute_cmd_write_ex_req(rwq_ind_table->context,
-				       IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL,
-				       &req, sizeof(req));
-	if (verbs_is_destroy_err(&ret))
-		return ret;
-
-	return 0;
-}
-
 
 int ibv_cmd_modify_cq(struct ibv_cq *cq,
 		      struct ibv_modify_cq_attr *attr,

--- a/libibverbs/cmd_ah.c
+++ b/libibverbs/cmd_ah.c
@@ -30,49 +30,25 @@
  * SOFTWARE.
  */
 
-#include <infiniband/cmd_ioctl.h>
-#include <rdma/ib_user_ioctl_cmds.h>
-#include <infiniband/driver.h>
 #include <infiniband/cmd_write.h>
 
-int ibv_cmd_advise_mr(struct ibv_pd *pd,
-		      enum ibv_advise_mr_advice advice,
-		      uint32_t flags,
-		      struct ibv_sge *sg_list,
-		      uint32_t num_sge)
+int ibv_cmd_destroy_ah(struct ibv_ah *ah)
 {
-	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_ADVISE_MR,
-			       4);
-
-	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
-	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
-	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
-	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
-			       sg_list, num_sge);
-
-	return execute_ioctl(pd->context, cmd);
-}
-
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_MR_DESTROY,
-			     1, NULL);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_AH,
+			     UVERBS_METHOD_AH_DESTROY, 1, NULL);
 	int ret;
 
-	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MR_HANDLE,
-			 vmr->ibv_mr.handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_AH_HANDLE, ah->handle);
 
-	switch (execute_ioctl_fallback(vmr->ibv_mr.context, dereg_mr, cmdb,
-				       &ret)) {
+	switch (execute_ioctl_fallback(ah->context, destroy_ah, cmdb, &ret)) {
 	case TRY_WRITE: {
-		struct ibv_dereg_mr req;
+		struct ibv_destroy_ah req;
 
-		req.core_payload = (struct ib_uverbs_dereg_mr){
-			.mr_handle = vmr->ibv_mr.handle,
+		req.core_payload = (struct ib_uverbs_destroy_ah){
+			.ah_handle = ah->handle,
 		};
-		ret = execute_cmd_write_req(vmr->ibv_mr.context,
-					    IB_USER_VERBS_CMD_DEREG_MR, &req,
+		ret = execute_cmd_write_req(ah->context,
+					    IB_USER_VERBS_CMD_DESTROY_AH, &req,
 					    sizeof(req));
 		break;
 	}

--- a/libibverbs/cmd_fallback.c
+++ b/libibverbs/cmd_fallback.c
@@ -64,7 +64,7 @@ enum write_fallback _check_legacy(struct ibv_command_buffer *cmdb, int *ret)
 	}
 
 	if (fallback_ioctl_only)
-		return ERROR;
+		goto not_supp;
 
 	if (fallback_require_ex)
 		return TRY_WRITE_EX;

--- a/libibverbs/cmd_flow.c
+++ b/libibverbs/cmd_flow.c
@@ -30,50 +30,28 @@
  * SOFTWARE.
  */
 
-#include <infiniband/cmd_ioctl.h>
-#include <rdma/ib_user_ioctl_cmds.h>
-#include <infiniband/driver.h>
 #include <infiniband/cmd_write.h>
 
-int ibv_cmd_advise_mr(struct ibv_pd *pd,
-		      enum ibv_advise_mr_advice advice,
-		      uint32_t flags,
-		      struct ibv_sge *sg_list,
-		      uint32_t num_sge)
+int ibv_cmd_destroy_flow(struct ibv_flow *flow_id)
 {
-	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_ADVISE_MR,
-			       4);
-
-	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
-	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
-	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
-	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
-			       sg_list, num_sge);
-
-	return execute_ioctl(pd->context, cmd);
-}
-
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_MR_DESTROY,
-			     1, NULL);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_FLOW,
+			     UVERBS_METHOD_FLOW_DESTROY, 1, NULL);
 	int ret;
 
-	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MR_HANDLE,
-			 vmr->ibv_mr.handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_FLOW_HANDLE,
+			 flow_id->handle);
 
-	switch (execute_ioctl_fallback(vmr->ibv_mr.context, dereg_mr, cmdb,
+	switch (execute_ioctl_fallback(flow_id->context, destroy_ah, cmdb,
 				       &ret)) {
 	case TRY_WRITE: {
-		struct ibv_dereg_mr req;
+		struct ibv_destroy_flow req;
 
-		req.core_payload = (struct ib_uverbs_dereg_mr){
-			.mr_handle = vmr->ibv_mr.handle,
+		req.core_payload = (struct ib_uverbs_destroy_flow){
+			.flow_handle = flow_id->handle,
 		};
-		ret = execute_cmd_write_req(vmr->ibv_mr.context,
-					    IB_USER_VERBS_CMD_DEREG_MR, &req,
-					    sizeof(req));
+		ret = execute_cmd_write_ex_req(
+			flow_id->context, IB_USER_VERBS_EX_CMD_DESTROY_FLOW,
+			&req, sizeof(req));
 		break;
 	}
 

--- a/libibverbs/cmd_mw.c
+++ b/libibverbs/cmd_mw.c
@@ -30,49 +30,26 @@
  * SOFTWARE.
  */
 
-#include <infiniband/cmd_ioctl.h>
-#include <rdma/ib_user_ioctl_cmds.h>
-#include <infiniband/driver.h>
 #include <infiniband/cmd_write.h>
 
-int ibv_cmd_advise_mr(struct ibv_pd *pd,
-		      enum ibv_advise_mr_advice advice,
-		      uint32_t flags,
-		      struct ibv_sge *sg_list,
-		      uint32_t num_sge)
+int ibv_cmd_dealloc_mw(struct ibv_mw *mw)
 {
-	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_ADVISE_MR,
-			       4);
-
-	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
-	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
-	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
-	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
-			       sg_list, num_sge);
-
-	return execute_ioctl(pd->context, cmd);
-}
-
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_MR_DESTROY,
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MW, UVERBS_METHOD_MW_DESTROY,
 			     1, NULL);
 	int ret;
 
-	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MR_HANDLE,
-			 vmr->ibv_mr.handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MW_HANDLE,
+			 mw->handle);
 
-	switch (execute_ioctl_fallback(vmr->ibv_mr.context, dereg_mr, cmdb,
-				       &ret)) {
+	switch (execute_ioctl_fallback(mw->context, dealloc_mw, cmdb, &ret)) {
 	case TRY_WRITE: {
-		struct ibv_dereg_mr req;
+		struct ibv_dealloc_mw req;
 
-		req.core_payload = (struct ib_uverbs_dereg_mr){
-			.mr_handle = vmr->ibv_mr.handle,
+		req.core_payload = (struct ib_uverbs_dealloc_mw){
+			.mw_handle = mw->handle,
 		};
-		ret = execute_cmd_write_req(vmr->ibv_mr.context,
-					    IB_USER_VERBS_CMD_DEREG_MR, &req,
+		ret = execute_cmd_write_req(mw->context,
+					    IB_USER_VERBS_CMD_DEALLOC_MW, &req,
 					    sizeof(req));
 		break;
 	}

--- a/libibverbs/cmd_rwq_ind.c
+++ b/libibverbs/cmd_rwq_ind.c
@@ -30,50 +30,29 @@
  * SOFTWARE.
  */
 
-#include <infiniband/cmd_ioctl.h>
-#include <rdma/ib_user_ioctl_cmds.h>
-#include <infiniband/driver.h>
 #include <infiniband/cmd_write.h>
 
-int ibv_cmd_advise_mr(struct ibv_pd *pd,
-		      enum ibv_advise_mr_advice advice,
-		      uint32_t flags,
-		      struct ibv_sge *sg_list,
-		      uint32_t num_sge)
+int ibv_cmd_destroy_rwq_ind_table(struct ibv_rwq_ind_table *rwq_ind_table)
 {
-	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_ADVISE_MR,
-			       4);
-
-	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
-	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
-	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
-	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
-			       sg_list, num_sge);
-
-	return execute_ioctl(pd->context, cmd);
-}
-
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_MR_DESTROY,
-			     1, NULL);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_RWQ_IND_TBL,
+			     UVERBS_METHOD_RWQ_IND_TBL_DESTROY, 1, NULL);
 	int ret;
 
-	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MR_HANDLE,
-			 vmr->ibv_mr.handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_RWQ_IND_TBL_HANDLE,
+			 rwq_ind_table->ind_tbl_handle);
 
-	switch (execute_ioctl_fallback(vmr->ibv_mr.context, dereg_mr, cmdb,
+	switch (execute_ioctl_fallback(rwq_ind_table->context, destroy_ah, cmdb,
 				       &ret)) {
 	case TRY_WRITE: {
-		struct ibv_dereg_mr req;
+		struct ibv_destroy_rwq_ind_table req;
 
-		req.core_payload = (struct ib_uverbs_dereg_mr){
-			.mr_handle = vmr->ibv_mr.handle,
+		req.core_payload = (struct ib_uverbs_ex_destroy_rwq_ind_table){
+			.ind_tbl_handle = rwq_ind_table->ind_tbl_handle,
 		};
-		ret = execute_cmd_write_req(vmr->ibv_mr.context,
-					    IB_USER_VERBS_CMD_DEREG_MR, &req,
-					    sizeof(req));
+		ret = execute_cmd_write_ex_req(
+			rwq_ind_table->context,
+			IB_USER_VERBS_EX_CMD_DESTROY_RWQ_IND_TBL, &req,
+			sizeof(req));
 		break;
 	}
 

--- a/libibverbs/cmd_xrcd.c
+++ b/libibverbs/cmd_xrcd.c
@@ -30,49 +30,26 @@
  * SOFTWARE.
  */
 
-#include <infiniband/cmd_ioctl.h>
-#include <rdma/ib_user_ioctl_cmds.h>
-#include <infiniband/driver.h>
 #include <infiniband/cmd_write.h>
 
-int ibv_cmd_advise_mr(struct ibv_pd *pd,
-		      enum ibv_advise_mr_advice advice,
-		      uint32_t flags,
-		      struct ibv_sge *sg_list,
-		      uint32_t num_sge)
+int ibv_cmd_close_xrcd(struct verbs_xrcd *xrcd)
 {
-	DECLARE_COMMAND_BUFFER(cmd, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_ADVISE_MR,
-			       4);
-
-	fill_attr_in_obj(cmd, UVERBS_ATTR_ADVISE_MR_PD_HANDLE, pd->handle);
-	fill_attr_const_in(cmd, UVERBS_ATTR_ADVISE_MR_ADVICE, advice);
-	fill_attr_in_uint32(cmd, UVERBS_ATTR_ADVISE_MR_FLAGS, flags);
-	fill_attr_in_ptr_array(cmd, UVERBS_ATTR_ADVISE_MR_SGE_LIST,
-			       sg_list, num_sge);
-
-	return execute_ioctl(pd->context, cmd);
-}
-
-int ibv_cmd_dereg_mr(struct verbs_mr *vmr)
-{
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_MR, UVERBS_METHOD_MR_DESTROY,
-			     1, NULL);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_XRCD,
+			     UVERBS_METHOD_XRCD_DESTROY, 1, NULL);
 	int ret;
 
-	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_MR_HANDLE,
-			 vmr->ibv_mr.handle);
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_DESTROY_XRCD_HANDLE, xrcd->handle);
 
-	switch (execute_ioctl_fallback(vmr->ibv_mr.context, dereg_mr, cmdb,
+	switch (execute_ioctl_fallback(xrcd->xrcd.context, close_xrcd, cmdb,
 				       &ret)) {
 	case TRY_WRITE: {
-		struct ibv_dereg_mr req;
+		struct ibv_close_xrcd req;
 
-		req.core_payload = (struct ib_uverbs_dereg_mr){
-			.mr_handle = vmr->ibv_mr.handle,
+		req.core_payload = (struct ib_uverbs_close_xrcd){
+			.xrcd_handle = xrcd->handle,
 		};
-		ret = execute_cmd_write_req(vmr->ibv_mr.context,
-					    IB_USER_VERBS_CMD_DEREG_MR, &req,
+		ret = execute_cmd_write_req(xrcd->xrcd.context,
+					    IB_USER_VERBS_CMD_CLOSE_XRCD, &req,
 					    sizeof(req));
 		break;
 	}


### PR DESCRIPTION
This series provides native ioctl implementations for trivial destroy, in case the kernel doesn't support it a fallback to the write mode will take place.

The first patch fixes a bad flow to set the error code upon execute_ioctl_fallback().