### PR TITLE
fixed the typo in ibv_uc_pingpong doc

### DIFF
--- a/libibverbs/man/ibv_uc_pingpong.1
+++ b/libibverbs/man/ibv_uc_pingpong.1
@@ -16,8 +16,8 @@ ibv_uc_pingpong \- simple InfiniBand UC transport test
 
 .SH DESCRIPTION
 .PP
-Run a simple ping-pong test over InfiniBand via the reliable
-connected (RC) transport.
+Run a simple ping-pong test over InfiniBand via the unreliable
+connected (UC) transport.
 
 .SH OPTIONS
 


### PR DESCRIPTION
This looks a simple typo in man doc.