### PR TITLE
specs: Disable package python3-pyverbs if no python_provide macro

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -217,6 +217,7 @@ Requires: %{name}%{?_isa} = %{version}-%{release}
 In conjunction with the kernel ib_srp driver, srp_daemon allows you to
 discover and use SCSI devices via the SCSI RDMA Protocol over InfiniBand.
 
+%if %{with_pyverbs}
 %package -n python3-pyverbs
 Summary: Python3 API over IB verbs
 %{?python_provide:%python_provide python3-pyverbs}
@@ -224,6 +225,7 @@ Summary: Python3 API over IB verbs
 %description -n python3-pyverbs
 Pyverbs is a Cython-based Python API over libibverbs, providing an
 easy, object-oriented access to IB verbs.
+%endif
 
 %prep
 %setup

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -330,6 +330,7 @@ rdma-ndd is a system daemon which watches for rdma device changes and/or
 hostname changes and updates the Node Description of the rdma devices based
 on those changes.
 
+%if %{with_pyverbs}
 %package -n python3-pyverbs
 Summary:        Python3 API over IB verbs
 Group:          Development/Languages/Python
@@ -337,6 +338,7 @@ Group:          Development/Languages/Python
 %description -n python3-pyverbs
 Pyverbs is a Cython-based Python API over libibverbs, providing an
 easy, object-oriented access to IB verbs.
+%endif
 
 %prep
 %setup -q -n  %{name}-%{version}%{git_ver}


### PR DESCRIPTION
The RH systems before 7.6 didn't have %python_provide macro and it
caused to rpmbuild failures on such platforms. Don't ever check
python_provide if pyverbs is not build.

Signed-off-by: Tzafrir Cohen <tzafrir@debian.org>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>