### PR TITLE
hfi1verbs: Move the completion queue and receive work queues structs into kernel - headers

### DIFF
--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -25,6 +25,7 @@ publish_internal_headers(rdma
   rdma/rdma_user_rxe.h
   rdma/rvt-abi.h
   rdma/vmw_pvrdma-abi.h
+  rdma/rvt-abi.h
   )
 
 publish_internal_headers(rdma/hfi

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -23,6 +23,7 @@ publish_internal_headers(rdma
   rdma/rdma_user_ioctl.h
   rdma/rdma_user_ioctl_cmds.h
   rdma/rdma_user_rxe.h
+  rdma/rvt-abi.h
   rdma/vmw_pvrdma-abi.h
   )
 

--- a/kernel-headers/rdma/rvt-abi.h
+++ b/kernel-headers/rdma/rvt-abi.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause) */
+
+/*
+ * This file contains defines, structures, etc. that are used
+ * to communicate between kernel and user code.
+ */
+
+#ifndef RVT_ABI_USER_H
+#define RVT_ABI_USER_H
+
+#include <linux/types.h>
+#include <rdma/ib_user_verbs.h>
+#include <infiniband/verbs.h>
+#ifndef RDMA_ATOMIC_UAPI
+#define RDMA_ATOMIC_UAPI(_type, _name) _type _name
+#endif
+/*
+ * This structure is used to contain the head pointer, tail pointer,
+ * and completion queue entries as a single memory allocation so
+ * it can be mmap'ed into user space.
+ */
+struct rvt_cq_wc {
+	/* index of next entry to fill */
+	RDMA_ATOMIC_UAPI(__u32, head);
+	/* index of next ib_poll_cq() entry */
+	RDMA_ATOMIC_UAPI(__u32, tail);
+
+	/* these are actually size ibcq.cqe + 1 */
+	struct ib_uverbs_wc uqueue[0];
+};
+
+/*
+ * Receive work request queue entry.
+ * The size of the sg_list is determined when the QP (or SRQ) is created
+ * and stored in qp->r_rq.max_sge (or srq->rq.max_sge).
+ */
+struct rvt_rwqe {
+	__u64 wr_id;
+	__u8 num_sge;
+	__u8 padding[7];
+	struct ibv_sge sg_list[0];
+};
+
+/*
+ * This structure is used to contain the head pointer, tail pointer,
+ * and receive work queue entries as a single memory allocation so
+ * it can be mmap'ed into user space.
+ * Note that the wq array elements are variable size so you can't
+ * just index into the array to get the N'th element;
+ * use get_rwqe_ptr() instead.
+ */
+struct rvt_rwq {
+	/* new work requests posted to the head */
+	RDMA_ATOMIC_UAPI(__u32, head);
+	/* receives pull requests from here. */
+	RDMA_ATOMIC_UAPI(__u32, tail);
+	struct rvt_rwqe wq[0];
+};
+#endif /* RVT_ABI_USER_H */

--- a/providers/hfi1verbs/hfiverbs.h
+++ b/providers/hfi1verbs/hfiverbs.h
@@ -65,7 +65,8 @@
 
 #include <infiniband/driver.h>
 #include <infiniband/verbs.h>
-
+#define RDMA_ATOMIC_UAPI(_type, _name)  _Atomic(_type) _name
+#include "rdma/rvt-abi.h"
 #define PFX		"hfi1: "
 
 struct hfi1_device {
@@ -77,39 +78,11 @@ struct hfi1_context {
 	struct verbs_context	ibv_ctx;
 };
 
-/*
- * This structure needs to have the same size and offsets as
- * the kernel's ib_wc structure since it is memory mapped.
- */
-struct hfi1_wc {
-	uint64_t		wr_id;
-	enum ibv_wc_status	status;
-	enum ibv_wc_opcode	opcode;
-	uint32_t		vendor_err;
-	uint32_t		byte_len;
-	uint32_t		imm_data;	/* in network byte order */
-	uint32_t		qp_num;
-	uint32_t		src_qp;
-	enum ibv_wc_flags	wc_flags;
-	uint16_t		pkey_index;
-	uint16_t		slid;
-	uint8_t			sl;
-	uint8_t			dlid_path_bits;
-	uint8_t			port_num;
-};
-
-struct hfi1_cq_wc {
-	_Atomic(uint32_t)	head;
-	_Atomic(uint32_t)	tail;
-	struct hfi1_wc		queue[1];
-};
-
 struct hfi1_cq {
-	struct ibv_cq		ibv_cq;
-	struct hfi1_cq_wc	*queue;
-	pthread_spinlock_t	lock;
+	struct ibv_cq           ibv_cq;
+	struct rvt_cq_wc       *queue;
+	pthread_spinlock_t      lock;
 };
-
 /*
  * Receive work request queue entry.
  * The size of the sg_list is determined when the QP is created and stored

--- a/providers/hfi1verbs/verbs.c
+++ b/providers/hfi1verbs/verbs.c
@@ -342,8 +342,8 @@ struct ibv_qp *hfi1_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr)
 	} else {
 		qp->rq.size = attr->cap.max_recv_wr + 1;
 		qp->rq.max_sge = attr->cap.max_recv_sge;
-		size = sizeof(struct hfi1_rwq) +
-			(sizeof(struct hfi1_rwqe) +
+		size = sizeof(struct rvt_rwq) +
+			(sizeof(struct rvt_rwqe) +
 			 (sizeof(struct ibv_sge) * qp->rq.max_sge)) *
 			qp->rq.size;
 		qp->rq.rwq = mmap(NULL, size,
@@ -412,8 +412,8 @@ int hfi1_destroy_qp(struct ibv_qp *ibqp)
 	if (qp->rq.rwq) {
 		size_t size;
 
-		size = sizeof(struct hfi1_rwq) +
-			(sizeof(struct hfi1_rwqe) +
+		size = sizeof(struct rvt_rwq) +
+			(sizeof(struct rvt_rwqe) +
 			 (sizeof(struct ibv_sge) * qp->rq.max_sge)) *
 			qp->rq.size;
 		(void) munmap(qp->rq.rwq, size);
@@ -470,8 +470,8 @@ static int post_recv(struct hfi1_rq *rq, struct ibv_recv_wr *wr,
 		     struct ibv_recv_wr **bad_wr)
 {
 	struct ibv_recv_wr *i;
-	struct hfi1_rwq *rwq;
-	struct hfi1_rwqe *wqe;
+	struct rvt_rwq *rwq;
+	struct rvt_rwqe *wqe;
 	uint32_t head;
 	int n, ret;
 
@@ -541,8 +541,8 @@ struct ibv_srq *hfi1_create_srq(struct ibv_pd *pd,
 
 	srq->rq.size = attr->attr.max_wr + 1;
 	srq->rq.max_sge = attr->attr.max_sge;
-	size = sizeof(struct hfi1_rwq) +
-		(sizeof(struct hfi1_rwqe) +
+	size = sizeof(struct rvt_rwq) +
+		(sizeof(struct rvt_rwqe) +
 		 (sizeof(struct ibv_sge) * srq->rq.max_sge)) * srq->rq.size;
 	srq->rq.rwq = mmap(NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED,
 			   pd->context->cmd_fd, resp.offset);
@@ -591,8 +591,8 @@ int hfi1_modify_srq(struct ibv_srq *ibsrq,
 	if (attr_mask & IBV_SRQ_MAX_WR) {
 		pthread_spin_lock(&srq->rq.lock);
 		/* Save the old size so we can unmmap the queue. */
-		size = sizeof(struct hfi1_rwq) +
-			(sizeof(struct hfi1_rwqe) +
+		size = sizeof(struct rvt_rwq) +
+			(sizeof(struct rvt_rwqe) +
 			 (sizeof(struct ibv_sge) * srq->rq.max_sge)) *
 			srq->rq.size;
 	}
@@ -607,8 +607,8 @@ int hfi1_modify_srq(struct ibv_srq *ibsrq,
 	if (attr_mask & IBV_SRQ_MAX_WR) {
 		(void) munmap(srq->rq.rwq, size);
 		srq->rq.size = attr->max_wr + 1;
-		size = sizeof(struct hfi1_rwq) +
-			(sizeof(struct hfi1_rwqe) +
+		size = sizeof(struct rvt_rwq) +
+			(sizeof(struct rvt_rwqe) +
 			 (sizeof(struct ibv_sge) * srq->rq.max_sge)) *
 			srq->rq.size;
 		srq->rq.rwq = mmap(NULL, size,
@@ -649,8 +649,8 @@ int hfi1_destroy_srq(struct ibv_srq *ibsrq)
 	if (ret)
 		return ret;
 
-	size = sizeof(struct hfi1_rwq) +
-		(sizeof(struct hfi1_rwqe) +
+	size = sizeof(struct rvt_rwq) +
+		(sizeof(struct rvt_rwqe) +
 		 (sizeof(struct ibv_sge) * srq->rq.max_sge)) * srq->rq.size;
 	(void) munmap(srq->rq.rwq, size);
 	free(srq);


### PR DESCRIPTION
 Move the completion queue and receive work queues structs into kernel - headers as these are shared between uapi and kernel. Below are the changes are done as part of these patches.

- Included a new header file (rvt-abi.h)  in kernel-headers. It contains structs that shared between uapi and kernel.
- Clean up structs that shared with uapi and kernel define in rdma-core hfi1 provider. Move those structs into rvt-abi.h

Signed-off-by: Kamenee Arumugam <kamenee.arumugam@intel.com>