### PR TITLE
verbs: Expose PCI atomic capabilities

### DIFF
--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -36,6 +36,7 @@ uint32_t               raw_packet_caps;            /* Raw packet capabilities, u
 struct ibv_tm_caps     tm_caps;                    /* Tag matching capabilities */
 struct ibv_cq_moderation_caps  cq_mod_caps;        /* CQ moderation max capabilities */
 uint64_t     	       max_dm_size;		   /* Max Device Memory size (in bytes) available for allocation */
+struct ibv_pci_atomic_caps atomic_caps;            /* PCI atomic operations capabilities, use enum ibv_pci_atomic_op_size */
 .in -8
 };
 
@@ -106,6 +107,22 @@ uint32_t        max_sge;             /* Max number of SGEs in a tagged buffer */
 struct ibv_cq_moderation_caps {
 	uint16_t max_cq_count;
 	uint16_t max_cq_period;
+};
+
+enum ibv_pci_atomic_op_size {
+.in +8
+IBV_PCI_ATOMIC_OPERATION_4_BYTE_SIZE_SUP = 1 << 0,
+IBV_PCI_ATOMIC_OPERATION_8_BYTE_SIZE_SUP = 1 << 1,
+IBV_PCI_ATOMIC_OPERATION_16_BYTE_SIZE_SUP = 1 << 2,
+.in -8
+};
+
+struct ibv_pci_atomic_caps {
+.in +8
+uint16_t fetch_add;	/* Supported sizes for an atomic fetch and add operation, use enum ibv_pci_atomic_op_size */
+uint16_t swap;		/* Supported sizes for an atomic unconditional swap operation, use enum ibv_pci_atomic_op_size */
+uint16_t compare_swap;	/* Supported sizes for an atomic compare and swap operation, use enum ibv_pci_atomic_op_size */
+.in -8
 };
 .fi
 

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -293,6 +293,22 @@ struct ibv_cq_moderation_caps {
 	uint16_t max_cq_period; /* in micro seconds */
 };
 
+enum ibv_pci_atomic_op_size {
+	IBV_PCI_ATOMIC_OPERATION_4_BYTE_SIZE_SUP = 1 << 0,
+	IBV_PCI_ATOMIC_OPERATION_8_BYTE_SIZE_SUP = 1 << 1,
+	IBV_PCI_ATOMIC_OPERATION_16_BYTE_SIZE_SUP = 1 << 2,
+};
+
+/*
+ * Bitmask for supported operation sizes
+ * Use enum ibv_pci_atomic_op_size
+ */
+struct ibv_pci_atomic_caps {
+	uint16_t fetch_add;
+	uint16_t swap;
+	uint16_t compare_swap;
+};
+
 struct ibv_device_attr_ex {
 	struct ibv_device_attr	orig_attr;
 	uint32_t		comp_mask;
@@ -308,6 +324,7 @@ struct ibv_device_attr_ex {
 	struct ibv_tm_caps	tm_caps;
 	struct ibv_cq_moderation_caps  cq_mod_caps;
 	uint64_t max_dm_size;
+	struct ibv_pci_atomic_caps pci_atomic_caps;
 };
 
 enum ibv_mtu {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2019 Mellanox Technologies, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#define u8 uint8_t
+
+enum mlx5_cap_mode {
+	HCA_CAP_OPMOD_GET_CUR	= 1,
+};
+
+enum {
+	MLX5_CMD_OP_QUERY_HCA_CAP = 0x100,
+};
+
+struct mlx5_ifc_atomic_caps_bits {
+	u8         reserved_at_0[0x40];
+
+	u8         atomic_req_8B_endianness_mode[0x2];
+	u8         reserved_at_42[0x4];
+	u8         supported_atomic_req_8B_endianness_mode_1[0x1];
+
+	u8         reserved_at_47[0x19];
+
+	u8         reserved_at_60[0x20];
+
+	u8         reserved_at_80[0x10];
+	u8         atomic_operations[0x10];
+
+	u8         reserved_at_a0[0x10];
+	u8         atomic_size_qp[0x10];
+
+	u8         reserved_at_c0[0x10];
+	u8         atomic_size_dc[0x10];
+
+	u8         reserved_at_e0[0x1a0];
+
+	u8         fetch_add_pci_atomic[0x10];
+	u8         swap_pci_atomic[0x10];
+	u8         compare_swap_pci_atomic[0x10];
+
+	u8         reserved_at_2b0[0x550];
+};
+
+union mlx5_ifc_hca_cap_union_bits {
+	struct mlx5_ifc_atomic_caps_bits atomic_caps;
+	u8         reserved_at_0[0x8000];
+};
+
+struct mlx5_ifc_query_hca_cap_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+
+	union mlx5_ifc_hca_cap_union_bits capability;
+};
+
+struct mlx5_ifc_query_hca_cap_in_bits {
+	u8         opcode[0x10];
+	u8         reserved_at_10[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x40];
+};
+
+enum mlx5_cap_type {
+	MLX5_CAP_ATOMIC = 3,
+};


### PR DESCRIPTION
This series exposes PCI atomic operations capabilities to user space applications
	
PCI atomic operations were first introduced in PCIe Base Specification
2.1. The supported operations are swap, fetch & add and compare & swap.

Each operation can be supported in a few different operation sizes therefore we expose the capabilities in a bitmask of supported operation
sizes per operation type.
	
Each device needs to enable the above PCI capabilities and report on to let applications use them.
The mlx5 driver exposes the capabilities by using the DEVX interface.
