### PR TITLE
rdmacm:  Enable application control in some flows

### DIFF
--- a/debian/librdmacm-dev.install
+++ b/debian/librdmacm-dev.install
@@ -22,6 +22,7 @@ usr/share/man/man3/rdma_destroy_id.3
 usr/share/man/man3/rdma_destroy_qp.3
 usr/share/man/man3/rdma_destroy_srq.3
 usr/share/man/man3/rdma_disconnect.3
+usr/share/man/man3/rdma_establish.3
 usr/share/man/man3/rdma_event_str.3
 usr/share/man/man3/rdma_free_devices.3
 usr/share/man/man3/rdma_get_cm_event.3

--- a/debian/librdmacm-dev.install
+++ b/debian/librdmacm-dev.install
@@ -34,6 +34,7 @@ usr/share/man/man3/rdma_get_request.3
 usr/share/man/man3/rdma_get_send_comp.3
 usr/share/man/man3/rdma_get_src_port.3
 usr/share/man/man3/rdma_getaddrinfo.3
+usr/share/man/man3/rdma_init_qp_attr.3
 usr/share/man/man3/rdma_join_multicast.3
 usr/share/man/man3/rdma_join_multicast_ex.3
 usr/share/man/man3/rdma_leave_multicast.3

--- a/debian/librdmacm1.symbols
+++ b/debian/librdmacm1.symbols
@@ -25,6 +25,7 @@ librdmacm.so.1 librdmacm1 #MINVER#
  rdma_destroy_srq@RDMACM_1.0 1.0.15
  rdma_disconnect@RDMACM_1.0 1.0.15
  rdma_event_str@RDMACM_1.0 1.0.15
+ rdma_establish@RDMACM_1.2 23
  rdma_free_devices@RDMACM_1.0 1.0.15
  rdma_freeaddrinfo@RDMACM_1.0 1.0.15
  rdma_get_cm_event@RDMACM_1.0 1.0.15

--- a/debian/librdmacm1.symbols
+++ b/debian/librdmacm1.symbols
@@ -2,6 +2,7 @@ librdmacm.so.1 librdmacm1 #MINVER#
 * Build-Depends-Package: librdmacm-dev
  RDMACM_1.0@RDMACM_1.0 1.0.15
  RDMACM_1.1@RDMACM_1.1 16
+ RDMACM_1.2@RDMACM_1.2 23
  raccept@RDMACM_1.0 1.0.16
  rbind@RDMACM_1.0 1.0.16
  rclose@RDMACM_1.0 1.0.16
@@ -32,6 +33,7 @@ librdmacm.so.1 librdmacm1 #MINVER#
  rdma_get_request@RDMACM_1.0 1.0.15
  rdma_get_src_port@RDMACM_1.0 1.0.19
  rdma_getaddrinfo@RDMACM_1.0 1.0.15
+ rdma_init_qp_attr@RDMACM_1.2 23
  rdma_join_multicast@RDMACM_1.0 1.0.15
  rdma_join_multicast_ex@RDMACM_1.1 16
  rdma_leave_multicast@RDMACM_1.0 1.0.15

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -10,7 +10,7 @@ publish_headers(infiniband
 
 rdma_library(rdmacm librdmacm.map
   # See Documentation/versioning.md
-  1 1.1.${PACKAGE_VERSION}
+  1 1.2.${PACKAGE_VERSION}
   acm.c
   addrinfo.c
   cma.c

--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -991,8 +991,8 @@ static int ucma_is_ud_qp(enum ibv_qp_type qp_type)
 	return (qp_type == IBV_QPT_UD);
 }
 
-static int rdma_init_qp_attr(struct rdma_cm_id *id, struct ibv_qp_attr *qp_attr,
-			     int *qp_attr_mask)
+int rdma_init_qp_attr(struct rdma_cm_id *id, struct ibv_qp_attr *qp_attr,
+		      int *qp_attr_mask)
 {
 	struct ucma_abi_init_qp_attr cmd;
 	struct ib_uverbs_qp_attr resp;

--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -2077,6 +2077,18 @@ static void ucma_copy_ud_event(struct cma_event *event,
 	dst->qkey = src->qkey;
 }
 
+int rdma_establish(struct rdma_cm_id *id)
+{
+	if (id->qp)
+		return ERR(EINVAL);
+
+	/* id->qp is NULL, so ucma_process_conn_resp() will only send ACCEPT to
+	 * the passive side, and will not attempt to modify the QP.
+	 */
+	return ucma_process_conn_resp(container_of(id, struct cma_id_private,
+						   id));
+}
+
 int rdma_get_cm_event(struct rdma_event_channel *channel,
 		      struct rdma_cm_event **event)
 {
@@ -2153,12 +2165,17 @@ retry:
 		break;
 	case RDMA_CM_EVENT_CONNECT_RESPONSE:
 		ucma_copy_conn_event(evt, &resp.param.conn);
-		evt->event.status = ucma_process_conn_resp(evt->id_priv);
-		if (!evt->event.status)
-			evt->event.event = RDMA_CM_EVENT_ESTABLISHED;
-		else {
-			evt->event.event = RDMA_CM_EVENT_CONNECT_ERROR;
-			evt->id_priv->connect_error = 1;
+		if (!evt->id_priv->id.qp) {
+			evt->event.event = RDMA_CM_EVENT_CONNECT_RESPONSE;
+		} else {
+			evt->event.status =
+				ucma_process_conn_resp(evt->id_priv);
+			if (!evt->event.status)
+				evt->event.event = RDMA_CM_EVENT_ESTABLISHED;
+			else {
+				evt->event.event = RDMA_CM_EVENT_CONNECT_ERROR;
+				evt->id_priv->connect_error = 1;
+			}
 		}
 		break;
 	case RDMA_CM_EVENT_ESTABLISHED:

--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -79,5 +79,6 @@ RDMACM_1.1 {
 
 RDMACM_1.2 {
 	global:
+		rdma_establish;
 		rdma_init_qp_attr;
 } RDMACM_1.1;

--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -76,3 +76,8 @@ RDMACM_1.1 {
 	global:
 		rdma_join_multicast_ex;
 } RDMACM_1.0;
+
+RDMACM_1.2 {
+	global:
+		rdma_init_qp_attr;
+} RDMACM_1.1;

--- a/librdmacm/man/CMakeLists.txt
+++ b/librdmacm/man/CMakeLists.txt
@@ -32,6 +32,7 @@ rdma_man_pages(
   rdma_get_send_comp.3
   rdma_get_src_port.3
   rdma_getaddrinfo.3
+  rdma_init_qp_attr.3.md
   rdma_join_multicast.3
   rdma_join_multicast_ex.3
   rdma_leave_multicast.3

--- a/librdmacm/man/CMakeLists.txt
+++ b/librdmacm/man/CMakeLists.txt
@@ -20,6 +20,7 @@ rdma_man_pages(
   rdma_destroy_qp.3
   rdma_destroy_srq.3
   rdma_disconnect.3
+  rdma_establish.3.md
   rdma_event_str.3
   rdma_free_devices.3
   rdma_get_cm_event.3

--- a/librdmacm/man/rdma_establish.3.md
+++ b/librdmacm/man/rdma_establish.3.md
@@ -1,0 +1,59 @@
+---
+date: 2019-01-16
+footer: librdmacm
+header: "Librdmacm Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: RDMA_ESTABLISH
+---
+
+# NAME
+
+rdma_establish - Complete an active connection request.
+
+# SYNOPSIS
+
+```c
+#include <rdma/rdma_cma.h>
+
+int rdma_establish(struct rdma_cm_id *id);
+```
+
+# DESCRIPTION
+
+**rdma_establish()** Acknowledge an incoming connection response event and complete the connection establishment.
+
+Notes:
+
+If a QP has not been created on the rdma_cm_id, this function should be called by the active side to complete the connection,
+
+after getting connect response event.
+
+This will trigger a connection established event on the passive side.
+
+This function should not be used on an rdma_cm_id on which a QP has been created.
+
+# ARGUMENTS
+
+*id*
+:    RDMA identifier.
+
+# RETURN VALUE
+
+**rdma_establish()** returns 0 on success, or -1 on error.  If an error occurs, errno will be set to indicate the failure reason.
+
+# SEE ALSO
+
+**rdma_connect**(3),
+**rdma_disconnect**(3)
+**rdma_get_cm_event**(3)
+
+# AUTHORS
+
+Danit Goldberg <danitg@mellanox.com>
+
+Yossi Itigin <yosefe@mellanox.com>
+
+
+

--- a/librdmacm/man/rdma_init_qp_attr.3.md
+++ b/librdmacm/man/rdma_init_qp_attr.3.md
@@ -1,0 +1,54 @@
+---
+date: 2018-12-31
+footer: librdmacm
+header: "Librdmacm Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: RDMA_INIT_QP_ATTR
+---
+
+# NAME
+
+rdma_init_qp_attr - Returns qp attributes of a rdma_cm_id.
+
+# SYNOPSIS
+
+```c
+#include <rdma/rdma_cma.h>
+
+int rdma_init_qp_attr(struct rdma_cm_id *id,
+		       struct ibv_qp_attr *qp_attr,
+		       int *qp_attr_mask);
+```
+# DESCRIPTION
+
+**rdma_init_qp_attr()** returns qp attributes of a rdma_cm_id.
+
+Information about qp attributes and qp attributes mask is returned through the *qp_attr* and *qp_attr_mask* parameters.
+
+For details on the qp_attr structure, see ibv_modify_qp.
+
+# ARGUMENTS
+
+*id*
+:    RDMA identifier.
+
+*qp_attr*
+:    A reference to a qp attributes struct containing response information.
+
+*qp_attr_mask*
+:    A reference to a qp attributes mask containing response information.
+
+# RETURN VALUE
+
+**rdma_init_qp_attr()** returns 0 on success, or -1 on error.  If an error occurs, errno will be set to indicate the failure reason.
+
+# SEE ALSO
+
+**rdma_cm**(7),
+**ibv_modify_qp**(3)
+
+# AUTHOR
+
+Danit Goldberg <danitg@mellanox.com>

--- a/librdmacm/man/rping.1
+++ b/librdmacm/man/rping.1
@@ -52,6 +52,9 @@ The size of each message transferred, in bytes.  (default 100)
 \-P
 Run the server in persistent mode.  This allows multiple rping clients
 to connect to a single server instance. The server will run until killed.
+.TP
+\-q
+Control QP Creation/Modification directly from the application, instead of rdma_cm.
 .SH "NOTES"
 Because this test maps RDMA resources to userspace, users must ensure
 that they have available system resources and permissions.  See the

--- a/librdmacm/rdma_cma.h
+++ b/librdmacm/rdma_cma.h
@@ -442,6 +442,24 @@ void rdma_destroy_qp(struct rdma_cm_id *id);
 int rdma_connect(struct rdma_cm_id *id, struct rdma_conn_param *conn_param);
 
 /**
+ * rdma_establish - Complete an active connection request.
+ * @id: RDMA identifier.
+ * Description:
+ *   Acknowledge an incoming connection response event and complete the
+ *   connection establishment.
+ * Notes:
+ *   If a QP has not been created on the rdma_cm_id, this function should be
+ *   called by the active side to complete the connection, after getting connect
+ *   response event. This will trigger a connection established event on the
+ *   passive side.
+ *   This function should not be used on an rdma_cm_id on which a QP has been
+ *   created.
+ * See also:
+ *   rdma_connect, rdma_disconnect, rdma_get_cm_event
+ */
+int rdma_establish(struct rdma_cm_id *id);
+
+/**
  * rdma_listen - Listen for incoming connection requests.
  * @id: RDMA identifier.
  * @backlog: backlog of incoming connection requests.

--- a/librdmacm/rdma_cma.h
+++ b/librdmacm/rdma_cma.h
@@ -721,6 +721,16 @@ int rdma_getaddrinfo(const char *node, const char *service,
 
 void rdma_freeaddrinfo(struct rdma_addrinfo *res);
 
+/**
+ * rdma_init_qp_attr - Returns QP attributes.
+ * @id: Communication identifier.
+ * @qp_attr: A reference to a QP attributes struct containing
+ * response information.
+ * @qp_attr_mask: A reference to a QP attributes mask containing
+ * response information.
+ */
+int rdma_init_qp_attr(struct rdma_cm_id *id, struct ibv_qp_attr *qp_attr,
+		      int *qp_attr_mask);
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This series enables application control in some flows as follows:

It exposes the internal function 'rdma_init_qp_attr' as an external librdmacm API.
As such an application can get the parameters for creating AH (needed for DC QP), or control QP attributes after its creation.

In addition,
It exposes CONNECT_RESPONSE event and rdma_establish() API.
Applications which do not create a QP through rdma_create_qp() may want to postpone the ESTABLISHED event on the passive side, to let the active side complete an application-specific connection establishment phase. For example, modify a QP created by the application to RTR, or make some preparations for receiving messages from the passive side.
