### PR TITLE
verbs: Fix pingpong buffer validation

### DIFF
--- a/libibverbs/examples/srq_pingpong.c
+++ b/libibverbs/examples/srq_pingpong.c
@@ -669,7 +669,7 @@ int main(int argc, char *argv[])
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:q:r:n:l:eg:c:",
+		c = getopt_long(argc, argv, "p:d:i:s:m:q:r:n:l:eg:c",
 				long_options, NULL);
 		if (c == -1)
 			break;

--- a/libibverbs/examples/uc_pingpong.c
+++ b/libibverbs/examples/uc_pingpong.c
@@ -572,7 +572,7 @@ int main(int argc, char *argv[])
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:l:eg:c:",
+		c = getopt_long(argc, argv, "p:d:i:s:m:r:n:l:eg:c",
 				long_options, NULL);
 		if (c == -1)
 			break;

--- a/libibverbs/examples/ud_pingpong.c
+++ b/libibverbs/examples/ud_pingpong.c
@@ -593,7 +593,7 @@ int main(int argc, char *argv[])
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:c:", long_options,
+		c = getopt_long(argc, argv, "p:d:i:s:r:n:l:eg:c", long_options,
 				NULL);
 		if (c == -1)
 			break;
@@ -747,7 +747,7 @@ int main(int argc, char *argv[])
 	if (servername) {
 		if (validate_buf)
 			for (int i = 0; i < size; i += page_size)
-				ctx->buf[i] = i / page_size % sizeof(char);
+				ctx->buf[i + 40] = i / page_size % sizeof(char);
 
 		if (pp_post_send(ctx, rem_dest->qpn)) {
 			fprintf(stderr, "Couldn't post send\n");
@@ -860,7 +860,8 @@ int main(int argc, char *argv[])
 
 		if ((!servername) && (validate_buf)) {
 			for (int i = 0; i < size; i += page_size)
-				if (ctx->buf[i] != i / page_size % sizeof(char))
+				if (ctx->buf[i + 40] !=
+				    i / page_size % sizeof(char))
 					printf("invalid data in page %d\n",
 					       i / page_size);
 		}

--- a/libibverbs/examples/xsrq_pingpong.c
+++ b/libibverbs/examples/xsrq_pingpong.c
@@ -876,7 +876,7 @@ int main(int argc, char *argv[])
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:c:n:l:eg:", long_options,
+		c = getopt_long(argc, argv, "p:d:i:s:m:n:l:eg:c", long_options,
 				NULL);
 		if (c == -1)
 			break;


### PR DESCRIPTION
The buffer allocated in the UD test has extra 40 bytes reserved for
GRH for both the client and the server, while the actual payload starts
at offset 40.

Since the buffer validation applies to the payload only, we should take
this offset into account:
As the sender, make sure to fill the payload starting at offset 40 as
all data before that will not be sent on ibv_post_send.
As the receiver, make sure to validate the payload starting at offset 40
as all data before that is not part of the actual payload (GRH/not
valid).

Also, The buffer validation option doesn't require an extra parameter,
remove the extra ':' from all ibv_*_pingpong examples.

Fixes: 099c5aa50bc8 ("libibverb/examples: Add command line option to enable buffer validation")
Cc: Yuval Shaia <yuval.shaia@oracle.com>
Signed-off-by: Gal Pressman <galpress@amazon.com>
Reviewed-by: Yishai Hadas <yishaih@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>