### PR TITLE
Support for no port mapping requirements

### DIFF
--- a/iwpmd/iwarp_pm.h
+++ b/iwpmd/iwarp_pm.h
@@ -108,7 +108,8 @@ enum {
         IWPM_UNKNOWN_MAPPING_ERR,
         IWPM_CLIENT_DEV_INFO_ERR,
         IWPM_USER_LIB_INFO_ERR,
-        IWPM_REMOTE_QUERY_REJECT
+        IWPM_REMOTE_QUERY_REJECT,
+        IWPM_VERSION_MISMATCH_ERR,
 };
 
 /* iwpm param indexes */
@@ -236,9 +237,10 @@ int is_wcard_ipaddr(struct sockaddr_storage *);
 
 /* iwarp_pm_helper.c */
 
-iwpm_mapped_port *create_iwpm_mapped_port(struct sockaddr_storage *, int);
+iwpm_mapped_port *create_iwpm_mapped_port(struct sockaddr_storage *, int, __u32 flags);
 
-iwpm_mapped_port *reopen_iwpm_mapped_port(struct sockaddr_storage *, struct sockaddr_storage *, int);
+iwpm_mapped_port *reopen_iwpm_mapped_port(struct sockaddr_storage *, struct sockaddr_storage *, int,
+				__u32 flags);
 
 void add_iwpm_mapped_port(iwpm_mapped_port *);
 

--- a/iwpmd/iwarp_pm_helper.c
+++ b/iwpmd/iwarp_pm_helper.c
@@ -352,7 +352,7 @@ static iwpm_mapped_port *get_iwpm_port(int client_idx, struct sockaddr_storage *
  * @local_addr: local address to be mapped (IP address and TCP port)
  * @client_idx: the index of the client owner of the mapped port
  */
-iwpm_mapped_port *create_iwpm_mapped_port(struct sockaddr_storage *local_addr, int client_idx)
+iwpm_mapped_port *create_iwpm_mapped_port(struct sockaddr_storage *local_addr, int client_idx, __u32 flags)
 {
 	iwpm_mapped_port *iwpm_port;
 	struct sockaddr_storage mapped_addr;
@@ -362,8 +362,13 @@ iwpm_mapped_port *create_iwpm_mapped_port(struct sockaddr_storage *local_addr, i
 	if (get_iwpm_ip_addr(local_addr, &mapped_addr))
 		goto create_mapped_port_error;
 	/* get a tcp port from the host net stack */
-	if (get_iwpm_tcp_port(local_addr->ss_family, 0, &mapped_addr, &new_sd))
-		goto create_mapped_port_error;
+	if (flags & IWPM_FLAGS_NO_PORT_MAP) {
+		mapped_addr = *local_addr;
+		new_sd = -1;
+	} else {
+		if (get_iwpm_tcp_port(local_addr->ss_family, 0, &mapped_addr, &new_sd))
+			goto create_mapped_port_error;
+	}
 
 	iwpm_port = get_iwpm_port(client_idx, local_addr, &mapped_addr, new_sd);
 	return iwpm_port;
@@ -380,7 +385,8 @@ create_mapped_port_error:
  * @client_idx: the index of the client owner of the mapped port
  */
 iwpm_mapped_port *reopen_iwpm_mapped_port(struct sockaddr_storage *local_addr,
-						struct sockaddr_storage *mapped_addr, int client_idx)
+						struct sockaddr_storage *mapped_addr, int client_idx,
+						__u32 flags)
 {
 	iwpm_mapped_port *iwpm_port;
 	int new_sd;
@@ -395,9 +401,12 @@ iwpm_mapped_port *reopen_iwpm_mapped_port(struct sockaddr_storage *local_addr,
 		goto reopen_mapped_port_error;
 	}
 	/* get a tcp port from the host net stack */
-	if (get_iwpm_tcp_port(local_addr->ss_family, htobe16(1), mapped_addr, &new_sd))
-		goto reopen_mapped_port_error;
-
+	if (flags & IWPM_FLAGS_NO_PORT_MAP) {
+		new_sd = -1;
+	} else {
+		if (get_iwpm_tcp_port(local_addr->ss_family, htobe16(1), mapped_addr, &new_sd))
+			goto reopen_mapped_port_error;
+	}
 	iwpm_port = get_iwpm_port(client_idx, local_addr, mapped_addr, new_sd);
 	return iwpm_port;
 
@@ -520,7 +529,8 @@ find_same_mapping_exit:
  */
 void free_iwpm_port(iwpm_mapped_port *iwpm_port)
 {
-	close(iwpm_port->sd);
+	if (iwpm_port->sd != -1)
+		close(iwpm_port->sd);
 	free(iwpm_port);
 }
 


### PR DESCRIPTION
A soft iwarp driver that uses the host TCP stack via a kernel mode
socket does not need port mapping.  In fact, if the port map daemon,
iwpmd, is running, then iwpmd must not try and create/bind a socket to
the actual port for a soft iwarp connection, since the driver already
has that socket bound.

Yet if the soft iwarp driver wants to interoperate with hard iwarp
devices that -are- using port mapping, then the soft iwarp driver's
mappings still need to be maintained and advertised by the iwpm protocol.

This series updates iwpmd V4 of the IWPM ABI to support soft iwarp.

The ABI version define has been created in rdma_netlink.h so both kernel
and user code can share it.  The iwcm and iwpmd negotiate the ABI version
to use with a new HELLO netlink message.

The corresponding kernel changes are at:
https://github.com/larrystevenwise/linux/tree/topic/no-port-map-v2


