### PR TITLE
Ibacm log wrong client

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -1766,8 +1766,10 @@ static void acm_nl_receive(struct acmc_client *client)
 	/* Currently we handle only request from the local service client */
 	client_inx = RDMA_NL_GET_CLIENT(acmnlmsg->nlmsg_header.nlmsg_type);
 	op = RDMA_NL_GET_OP(acmnlmsg->nlmsg_header.nlmsg_type);
-	if (client_inx != RDMA_NL_LS)
+	if (client_inx != RDMA_NL_LS) {
+		acm_log_once(0, "ERROR - Unknown NL client ID (%d)\n", client_inx);
 		goto rcv_cleanup;
+	}
 
 	switch (op) {
 	case RDMA_NL_LS_OP_RESOLVE:
@@ -1778,7 +1780,7 @@ static void acm_nl_receive(struct acmc_client *client)
 		break;
 	default:
 		/* Not supported*/
-		acm_log(1, "WARN - invalid opcode %x\n", op);
+		acm_log_once(0, "WARN - invalid opcode %x\n", op);
 		acm_nl_process_invalid_request(client, acmnlmsg);
 		break;
 	}

--- a/ibacm/src/acm_util.h
+++ b/ibacm/src/acm_util.h
@@ -38,10 +38,19 @@
 #undef acm_log
 #define acm_log(level, format, ...) \
 	printf(format, ## __VA_ARGS__)
+#define acm_log_once(level, format, ...) \
+	printf(format, ## __VA_ARGS__)
 
 #else /* !ACME_PRINTS */
 #define acm_log(level, format, ...) \
 	acm_write(level, "%s: "format, __func__, ## __VA_ARGS__)
+#define acm_log_once(level, format, ...) while (0) {                      \
+	static bool once;                                                 \
+	if (!once) {                                                      \
+		acm_write(level, "%s: "format, __func__, ## __VA_ARGS__); \
+		once = true;                                              \
+	}                                                                 \
+}
 #endif /* ACME_PRINTS */
 
 int acm_if_is_ib(char *ifname);


### PR DESCRIPTION
This is a small fix enabling logging of an unknown netlink client ID, and also introduces a log once functionality.