### PR TITLE
ibacm: Fix acm_log_once

### DIFF
--- a/ibacm/src/acm_util.h
+++ b/ibacm/src/acm_util.h
@@ -45,13 +45,13 @@
 #else /* !ACME_PRINTS */
 #define acm_log(level, format, ...) \
 	acm_write(level, "%s: "format, __func__, ## __VA_ARGS__)
-#define acm_log_once(level, format, ...) while (0) {                      \
+#define acm_log_once(level, format, ...) do {                             \
 	static bool once;                                                 \
 	if (!once) {                                                      \
 		acm_write(level, "%s: "format, __func__, ## __VA_ARGS__); \
 		once = true;                                              \
 	}                                                                 \
-}
+} while (0)
 #endif /* ACME_PRINTS */
 
 int acm_if_is_ib(char *ifname);


### PR DESCRIPTION
While do - do while, that's how the rhythm goes.

Fixes: 51c084b2a971 ("ibacm: Introduce acm_log_once()")
Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>