### PR TITLE
cxgb4: remove update_qp_state()

### DIFF
--- a/providers/cxgb4/qp.c
+++ b/providers/cxgb4/qp.c
@@ -766,20 +766,6 @@ int c4iw_post_receive(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
 	return err;
 }
 
-static void update_qp_state(struct c4iw_qp *qhp)
-{
-	struct ibv_query_qp cmd;
-	struct ibv_qp_attr attr;
-	struct ibv_qp_init_attr iattr;
-	int ret;
-
-	ret = ibv_cmd_query_qp(&qhp->ibv_qp, &attr, IBV_QP_STATE, &iattr,
-			       &cmd, sizeof cmd);
-	assert(!ret);
-	if (!ret)
-		qhp->ibv_qp.state = attr.qp_state;
-}
-
 void c4iw_flush_qp(struct c4iw_qp *qhp)
 {
 	struct c4iw_cq *rchp, *schp;
@@ -815,7 +801,7 @@ void c4iw_flush_qp(struct c4iw_qp *qhp)
 	if (srqidx)
 		c4iw_flush_srqidx(qhp, srqidx);
 
-	update_qp_state(qhp);
+	qhp->ibv_qp.state = IBV_QPS_ERR;
 
 	c4iw_flush_hw_cq(rchp, qhp);
 	if (!qhp->srq) {


### PR DESCRIPTION
Remove it because it is not needed.  If we're flushing the qp, it is
because we've had a fatal error, so just set the user qp state to ERR
and continue on.

Signed-off-by: Steve Wise <swise@opengridcomputing.com>