### PR TITLE
librxe: Resolve dmac in create AH

### DIFF
--- a/kernel-headers/rdma/ib_user_verbs.h
+++ b/kernel-headers/rdma/ib_user_verbs.h
@@ -270,6 +270,8 @@ struct ib_uverbs_ex_query_device_resp {
 	struct ib_uverbs_tm_caps tm_caps;
 	struct ib_uverbs_cq_moderation_caps cq_moderation_caps;
 	__aligned_u64 max_dm_size;
+	__u32 xrc_odp_caps;
+	__u32 reserved;
 };
 
 struct ib_uverbs_query_port {

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -58,8 +58,7 @@ struct rxe_global_route {
 struct rxe_av {
 	__u8			port_num;
 	__u8			network_type;
-	__u16			reserved1;
-	__u32			reserved2;
+	__u8			dmac[6];
 	struct rxe_global_route	grh;
 	union {
 		struct sockaddr_in	_sockaddr_in;

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -1021,10 +1021,12 @@ int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 	if (process_get_neigh(&neigh_handler))
 		goto free_resources;
 
-	ret_vid = neigh_get_vlan_id_from_dev(&neigh_handler);
+	if (vid) {
+		ret_vid = neigh_get_vlan_id_from_dev(&neigh_handler);
 
-	if (ret_vid <= 0xfff)
-		neigh_set_vlan_id(&neigh_handler, ret_vid);
+		if (ret_vid <= 0xfff)
+			neigh_set_vlan_id(&neigh_handler, ret_vid);
+	}
 
 	/* We are using only Ethernet here */
 	ether_len = neigh_get_ll(&neigh_handler,
@@ -1034,7 +1036,8 @@ int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 	if (ether_len <= 0)
 		goto free_resources;
 
-	*vid = ret_vid;
+	if (vid)
+		*vid = ret_vid;
 
 	ret = 0;
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2454,10 +2454,8 @@ struct ibv_ah *mlx5_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 			ah->kern_ah = true;
 			memcpy(ah->av.rmac, resp.dmac, ETHERNET_LL_SIZE);
 		} else {
-			uint16_t vid;
-
 			if (ibv_resolve_eth_l2_from_gid(pd->context, attr,
-							ah->av.rmac, &vid))
+							ah->av.rmac, NULL))
 				goto err;
 		}
 	}

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -802,6 +802,10 @@ static struct ibv_ah *rxe_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 
 	rdma_gid2ip(&av->sgid_addr, &sgid);
 	rdma_gid2ip(&av->dgid_addr, &attr->grh.dgid);
+	if (ibv_resolve_eth_l2_from_gid(pd->context, attr, av->dmac, NULL)) {
+		free(ah);
+		return NULL;
+	}
 
 	memset(&resp, 0, sizeof(resp));
 	if (ibv_cmd_create_ah(pd, &ah->ibv_ah, attr, &resp, sizeof(resp))) {

--- a/providers/vmw_pvrdma/verbs.c
+++ b/providers/vmw_pvrdma/verbs.c
@@ -190,7 +190,6 @@ struct ibv_ah *pvrdma_create_ah(struct ibv_pd *pd,
 	struct pvrdma_ah *ah;
 	struct pvrdma_av *av;
 	struct ibv_port_attr port_attr;
-	uint16_t vlan_id;
 
 	if (!attr->is_global)
 		return NULL;
@@ -224,7 +223,7 @@ struct ibv_ah *pvrdma_create_ah(struct ibv_pd *pd,
 
 	if (port_attr.port_cap_flags & IBV_PORT_IP_BASED_GIDS) {
 		if (!ibv_resolve_eth_l2_from_gid(pd->context, attr,
-						 av->dmac, &vlan_id))
+						 av->dmac, NULL))
 			return &ah->ibv_ah;
 	} else {
 		if (!set_mac_from_gid(&attr->grh.dgid, av->dmac))


### PR DESCRIPTION
Add support for resolving the destination MAC address when creating the AH.
The dmac will be used by the driver to mark loopback packets if the dmac and the smac are equal.