### PR TITLE
mlx5: Fix incorrect error handling when SQ wqe count is 0

### DIFF
--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1453,13 +1453,13 @@ static int mlx5_alloc_qp_buf(struct ibv_context *context,
 			err = -1;
 			goto ex_wrid;
 		}
-	}
 
-	qp->sq.wqe_head = malloc(qp->sq.wqe_cnt * sizeof(*qp->sq.wqe_head));
-	if (!qp->sq.wqe_head) {
-		errno = ENOMEM;
-		err = -1;
+		qp->sq.wqe_head = malloc(qp->sq.wqe_cnt * sizeof(*qp->sq.wqe_head));
+		if (!qp->sq.wqe_head) {
+			errno = ENOMEM;
+			err = -1;
 			goto ex_wrid;
+		}
 	}
 
 	if (qp->rq.wqe_cnt) {


### PR DESCRIPTION
Driver allocates memory based on wqe count and checks whether the memory
allocation succeeded. However, this memory check should not be performed
when wqe count is 0.