### PR TITLE
Pyverbs additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
 
       # pyverbs
       - python3-dev
-      - cython3
+      - python3-pip
 
 service:
     - docker
@@ -47,6 +47,7 @@ before_script:
   - wget -q http://releases.linaro.org/$LATEST_GCC_LINARO_URL
   - mkdir $HOME/aarch64 && tar xf $LATEST_GCC_LINARO_TAR -C $HOME/aarch64 --strip 1
   - rm $LATEST_GCC_LINARO_TAR
+  - http_proxy= pip3 install cython
 script:
   - buildlib/travis-build
   - buildlib/travis-checkpatch

--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -23,6 +23,7 @@ when needed (e.g. user buffer for memory region). The memory will be accessible
 to the users, but not allocated or freed by them.
 
 ## Usage Examples
+Note that all examples use a hard-coded device name ('mlx5_0').
 ##### Open an IB device
 
 Import the device module and open a device by name:
@@ -96,3 +97,131 @@ print(gid)
 ```
 
 'gid' is Pyverbs' equivalent to ibv_gid, provided to the user by Pyverbs.
+
+##### Query port
+The following code snippet provides an example of pyverbs' equivalent of
+querying a port. Context's query_port() command wraps ibv_query_port().
+The example below queries the first port of the device.
+```python
+import pyverbs.device as d
+ctx=d.Context(name='mlx5_0')
+port_attr = ctx.query_port(1)
+print(port_attr)
+Port state              : Active (4)
+Max MTU                 : 4096 (5)
+Active MTU              : 1024 (3)
+SM lid                  : 0
+Port lid                : 0
+lmc                     : 0x0
+Link layer              : Ethernet
+Max message size        : 0x40000000
+Port cap flags          : IBV_PORT_CM_SUP IBV_PORT_IP_BASED_GIDS
+Port cap flags 2        :
+max VL num              : 0
+Bad Pkey counter        : 0
+Qkey violations counter : 0
+Gid table len           : 256
+Pkey table len          : 1
+SM sl                   : 0
+Subnet timeout          : 0
+Init type reply         : 0
+Active width            : 4X (2)
+Ative speed             : 25.0 Gbps (32)
+Phys state              : Link up (5)
+Flags                   : 1
+```
+
+##### Extended query device
+The example below shows how to open a device using pyverbs and query the
+extended device's attributes.
+Context's query_device_ex() command wraps ibv_query_device_ex().
+```python
+import pyverbs.device as d
+
+ctx = d.Context(name='mlx5_0')
+attr = ctx.query_device_ex()
+attr.max_dm_size
+131072
+attr.rss_caps.max_rwq_indirection_table_size
+2048
+```
+
+#### Create RDMA objects
+##### PD
+The following example shows how to open a device and use its context to create
+a PD.
+```python
+import pyverbs.device as d
+from pyverbs.pd import PD
+
+with d.Context(name='mlx5_0') as ctx:
+    pd = PD(ctx)
+```
+##### MR
+The example below shows how to create a MR using pyverbs. Similar to C, a
+device must be opened prior to creation and a PD has to be allocated.
+```python
+import pyverbs.device as d
+from pyverbs.pd import PD
+from pyverbs.mr import MR
+import pyverbs.enums as e
+
+with d.Context(name='mlx5_0') as ctx:
+    with PD(ctx) as pd:
+        mr_len = 1000
+        flags = e.IBV_ACCESS_LOCAL_WRITE
+        mr = MR(pd, mr_len, flags)
+```
+##### Memory window
+The following example shows the equivalent of creating a type 1 memory window.
+It includes opening a device and allocating the necessary PD.
+```python
+import pyverbs.device as d
+from pyverbs.pd import PD
+from pyverbs.mr import MW
+import pyverbs.enums as e
+
+with d.Context(name='mlx5_0') as ctx:
+    with PD(ctx) as pd:
+        mw = MW(pd, e.IBV_MW_TYPE_1)
+```
+##### Device memory
+The following snippet shows how to allocate a DM - a direct memory object,
+using the device's memory.
+```python
+import random
+
+from pyverbs.device import DM, AllocDmAttr
+import pyverbs.device as d
+
+with d.Context(name='mlx5_0') as ctx:
+    attr = ctx.query_device_ex()
+    if attr.max_dm_size != 0:
+        dm_len = random.randint(4, attr.max_dm_size)
+        dm_attrs = AllocDmAttr(dm_len)
+        dm = DM(ctx, dm_attrs)
+```
+
+##### DM MR
+The example below shows how to open a DMMR - device memory MR, using the
+device's own memory rather than a user-allocated buffer.
+```python
+import random
+
+from pyverbs.device import DM, AllocDmAttr
+from pyverbs.mr import DmMr
+import pyverbs.device as d
+from pyverbs.pd import PD
+import pyverbs.enums as e
+
+with d.Context(name='mlx5_0') as ctx:
+    attr = ctx.query_device_ex()
+    if attr.max_dm_size != 0:
+        dm_len = random.randint(4, attr.max_dm_size)
+        dm_attrs = AllocDmAttr(dm_len)
+        dm_mr_len = random.randint(4, dm_len)
+        with DM(ctx, dm_attrs) as dm:
+            with PD(ctx) as pd:
+                dm_mr = DmMr(pd, dm_mr_len, e.IBV_ACCESS_ZERO_BASED, dm=dm,
+                             offset=0)
+```

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -177,3 +177,8 @@ M:	Adit Ranadive <aditr@vmware.com>
 L:	pv-drivers@vmware.com
 S:	Supported
 F:	providers/vmw_pvrdma/
+
+PYVERBS
+M:	Noa Osherovich <noaos@mellanox.com>
+S:	Supported
+F:	pyverbs/

--- a/buildlib/Findcython.cmake
+++ b/buildlib/Findcython.cmake
@@ -18,6 +18,14 @@ if(NOT _VERSION_RESULT)
 from Cython.Compiler.Main import main
 main(command_line = 1)")
   execute_process(COMMAND "chmod" "a+x" "${CYTHON_EXECUTABLE}")
+
+  # Dockers with older Cython versions fail to build pyverbs. Until we get to
+  # the bottom of this, disable pyverbs for older Cython versions.
+  if (CYTHON_VERSION_STRING VERSION_LESS "0.25")
+	message("Cython version < 0.25, disabling")
+	unset(CYTHON_EXECUTABLE)
+  endif()
+
 endif()
 unset(_VERSION_RESULT)
 unset(_VERSION)

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -297,6 +297,9 @@ class travis(APTEnvironment):
             (cd /usr/local/bin/ && ln -sf ../clang*/bin/clang-7 .)""".format(llvm_tar)];
         return cmds;
 
+    def get_cython(self):
+        return ["""RUN pip3 install cython"""]
+
     def get_docker_file(self):
         # First this to get apt-add-repository
         self.pkgs = {"software-properties-common"}
@@ -315,6 +318,7 @@ class travis(APTEnvironment):
         res.lines.extend(self.get_before_script())
 
         res.lines.extend(self.get_clang())
+        res.lines.extend(self.get_cython())
 
         return res;
 

--- a/buildlib/travis-build
+++ b/buildlib/travis-build
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+PATH=/home/`whoami`/.local/bin:$PATH
+
 # Stop on error
 set -e
 # Echo all commands to Travis log

--- a/debian/rules
+++ b/debian/rules
@@ -67,12 +67,13 @@ INST_EXCLUDE := "etc/init.d/srpd" \
 		"etc/init.d/ibacm" \
 		"usr/sbin/run_srp_daemon" \
 		"usr/sbin/srp_daemon.sh"
-ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
-	INST_EXCLUDE := $(INST_EXCLUDE) "usr/lib/python3/dist-packages/pyverbs"
-endif
 INST_EXCLUDE := $(addprefix -X,$(INST_EXCLUDE))
 override_dh_install:
+ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
+	dh_install -Npython3-pyverbs --fail-missing $(INST_EXCLUDE) --remaining-packages
+else
 	dh_install --fail-missing $(INST_EXCLUDE)
+endif
 
 # cmake installs the correct init scripts in the correct place, just setup the
 # pre-postrms

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved. See COPYING file
 
 rdma_cython_module(pyverbs
-  enums.pyx
+  addr.pyx
   base.pyx
   device.pyx
-  addr.pyx
+  enums.pyx
+  pd.pyx
   )
 
 rdma_python_module(pyverbs

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -18,6 +18,7 @@ rdma_python_module(pyverbs
 rdma_python_test(pyverbs/tests
   tests/__init__.py
   tests/device.py
+  tests/pd.py
   )
 
 rdma_internal_binary(

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -19,7 +19,9 @@ rdma_python_module(pyverbs
 rdma_python_test(pyverbs/tests
   tests/__init__.py
   tests/device.py
+  tests/mr.py
   tests/pd.py
+  tests/utils.py
   )
 
 rdma_internal_binary(

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -6,6 +6,7 @@ rdma_cython_module(pyverbs
   base.pyx
   device.pyx
   enums.pyx
+  mr.pyx
   pd.pyx
   )
 

--- a/pyverbs/addr.pxd
+++ b/pyverbs/addr.pxd
@@ -5,5 +5,5 @@ from .base cimport PyverbsObject
 from pyverbs cimport libibverbs as v
 
 
-cdef class Gid(PyverbsObject):
+cdef class GID(PyverbsObject):
     cdef v.ibv_gid gid

--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -9,7 +9,7 @@ cdef extern from 'endian.h':
     unsigned long be64toh(unsigned long host_64bits)
 
 
-cdef class Gid(PyverbsObject):
+cdef class GID(PyverbsObject):
     """
     GID class represents ibv_gid. It enables user to query for GIDs values.
     """

--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -13,34 +13,35 @@ cdef class GID(PyverbsObject):
     """
     GID class represents ibv_gid. It enables user to query for GIDs values.
     """
-    property gid:
-        def __get__(self):
-            """
-            Expose the inner GID
-            :return: A GID string in an 8 words format:
-            'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
-            """
-            return self.__str__()
-        def __set__(self, val):
-            """
-            Sets the inner GID
-            :param val: A GID string in an 8 words format:
-            'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
-            :return: None
-            """
-            val = val.split(':')
-            if len(val) != 8:
-                raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
-            if any([len(v) != 4 for v in val]):
-                raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
-            val_int = int("".join(val), 16)
-            vals = []
-            for i in range(8):
-                vals.append(val[i][0:2])
-                vals.append(val[i][2:4])
+    @property
+    def gid(self):
+        """
+        Expose the inner GID
+        :return: A GID string in an 8 words format:
+        'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
+        """
+        return self.__str__()
+    @gid.setter
+    def gid(self, val):
+        """
+        Sets the inner GID
+        :param val: A GID string in an 8 words format:
+        'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
+        :return: None
+        """
+        val = val.split(':')
+        if len(val) != 8:
+            raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
+        if any([len(v) != 4 for v in val]):
+            raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
+        val_int = int("".join(val), 16)
+        vals = []
+        for i in range(8):
+            vals.append(val[i][0:2])
+            vals.append(val[i][2:4])
 
-            for i in range(16):
-                self.gid.raw[i] = <uint8_t>int(vals[i],16)
+        for i in range(16):
+            self.gid.raw[i] = <uint8_t>int(vals[i],16)
 
     def __str__(self):
         hex_values = '%016x%016x' % (be64toh(self.gid._global.subnet_prefix),

--- a/pyverbs/base.pxd
+++ b/pyverbs/base.pxd
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright (c) 2018, Mellanox Technologies. All rights reserved.
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
 
 cdef class PyverbsObject(object):
+    cdef object __weakref__
     cdef object logger
+
+cdef class PyverbsCM(PyverbsObject):
+    cpdef close(self)

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -10,6 +10,7 @@ cdef class Context(PyverbsCM):
     cdef object name
     cdef add_ref(self, obj)
     cdef object pds
+    cdef object dms
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr
@@ -37,3 +38,12 @@ cdef class TSOCaps(PyverbsObject):
 
 cdef class DeviceAttrEx(PyverbsObject):
     cdef v.ibv_device_attr_ex dev_attr
+
+cdef class AllocDmAttr(PyverbsObject):
+    cdef v.ibv_alloc_dm_attr alloc_dm_attr
+
+cdef class DM(PyverbsCM):
+    cdef v.ibv_dm *dm
+    cdef object dm_mrs
+    cdef object context
+    cdef add_ref(self, obj)

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -13,3 +13,27 @@ cdef class Context(PyverbsCM):
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr
+
+cdef class QueryDeviceExInput(PyverbsObject):
+    cdef v.ibv_query_device_ex_input input
+
+cdef class ODPCaps(PyverbsObject):
+    cdef v.ibv_odp_caps odp_caps
+
+cdef class RSSCaps(PyverbsObject):
+    cdef v.ibv_rss_caps rss_caps
+
+cdef class PacketPacingCaps(PyverbsObject):
+    cdef v.ibv_packet_pacing_caps packet_pacing_caps
+
+cdef class TMCaps(PyverbsObject):
+    cdef v.ibv_tm_caps tm_caps
+
+cdef class CQModerationCaps(PyverbsObject):
+    cdef v.ibv_cq_moderation_caps cq_mod_caps
+
+cdef class TSOCaps(PyverbsObject):
+    cdef v.ibv_tso_caps tso_caps
+
+cdef class DeviceAttrEx(PyverbsObject):
+    cdef v.ibv_device_attr_ex dev_attr

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
 
-from .base cimport PyverbsObject
+from .base cimport PyverbsObject, PyverbsCM
 cimport pyverbs.libibverbs as v
 
 
-cdef class Context(PyverbsObject):
+cdef class Context(PyverbsCM):
     cdef v.ibv_context *context
     cdef object name
-    cpdef close(self)
+    cdef add_ref(self, obj)
+    cdef object pds
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -47,3 +47,6 @@ cdef class DM(PyverbsCM):
     cdef object dm_mrs
     cdef object context
     cdef add_ref(self, obj)
+
+cdef class PortAttr(PyverbsObject):
+    cdef v.ibv_port_attr attr

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -8,7 +8,7 @@ cimport pyverbs.libibverbs as v
 cdef class Context(PyverbsObject):
     cdef v.ibv_context *context
     cdef object name
-    cdef _close(self)
+    cpdef close(self)
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -141,123 +141,123 @@ cdef class DeviceAttr(PyverbsObject):
     properties (read only) and also provides an __str__() function for
     readability.
     """
-    property fw_version:
-        def __get__(self):
-            return self.dev_attr.fw_ver.decode()
-    property node_guid:
-        def __get__(self):
-            return self.dev_attr.node_guid
-    property sys_image_guid:
-        def __get__(self):
-            return self.dev_attr.sys_image_guid
-    property max_mr_size:
-        def __get__(self):
-            return self.dev_attr.max_mr_size
-    property page_size_cap:
-        def __get__(self):
-            return self.dev_attr.page_size_cap
-    property vendor_id:
-        def __get__(self):
-            return self.dev_attr.vendor_id
-    property vendor_part_id:
-        def __get__(self):
-            return self.dev_attr.vendor_part_id
-    property hw_ver:
-        def __get__(self):
-            return self.dev_attr.hw_ver
-    property max_qp:
-        def __get__(self):
-            return self.dev_attr.max_qp
-    property max_qp_wr:
-        def __get__(self):
-            return self.dev_attr.max_qp_wr
-    property device_cap_flags:
-        def __get__(self):
-            return self.dev_attr.device_cap_flags
-    property max_sge:
-        def __get__(self):
-            return self.dev_attr.max_sge
-    property max_sge_rd:
-        def __get__(self):
-            return self.dev_attr.max_sge_rd
-    property max_cq:
-        def __get__(self):
-            return self.dev_attr.max_cq
-    property max_cqe:
-        def __get__(self):
-            return self.dev_attr.max_cqe
-    property max_mr:
-        def __get__(self):
-            return self.dev_attr.max_mr
-    property max_pd:
-        def __get__(self):
-            return self.dev_attr.max_pd
-    property max_qp_rd_atom:
-        def __get__(self):
-            return self.dev_attr.max_qp_rd_atom
-    property max_ee_rd_atom:
-        def __get__(self):
-            return self.dev_attr.max_ee_rd_atom
-    property max_res_rd_atom:
-        def __get__(self):
-            return self.dev_attr.max_res_rd_atom
-    property max_qp_init_rd_atom:
-        def __get__(self):
-            return self.dev_attr.max_qp_init_rd_atom
-    property max_ee_init_rd_atom:
-        def __get__(self):
-            return self.dev_attr.max_ee_init_rd_atom
-    property atomic_caps:
-        def __get__(self):
-            return self.dev_attr.atomic_cap
-    property max_ee:
-        def __get__(self):
-            return self.dev_attr.max_ee
-    property max_rdd:
-        def __get__(self):
-            return self.dev_attr.max_rdd
-    property max_mw:
-        def __get__(self):
-            return self.dev_attr.max_mw
-    property max_raw_ipv6_qps:
-        def __get__(self):
-            return self.dev_attr.max_raw_ipv6_qp
-    property max_raw_ethy_qp:
-        def __get__(self):
-            return self.dev_attr.max_raw_ethy_qp
-    property max_mcast_grp:
-        def __get__(self):
-            return self.dev_attr.max_mcast_grp
-    property max_mcast_qp_attach:
-        def __get__(self):
-            return self.dev_attr.max_mcast_qp_attach
-    property max_ah:
-        def __get__(self):
-            return self.dev_attr.max_ah
-    property max_fmr:
-        def __get__(self):
-            return self.dev_attr.max_fmr
-    property max_map_per_fmr:
-        def __get__(self):
-            return self.dev_attr.max_map_per_fmr
-    property max_srq:
-        def __get__(self):
-            return self.dev_attr.max_srq
-    property max_srq_wr:
-        def __get__(self):
-            return self.dev_attr.max_srq_wr
-    property max_srq_sge:
-        def __get__(self):
-            return self.dev_attr.max_srq_sge
-    property max_pkeys:
-        def __get__(self):
-            return self.dev_attr.max_pkeys
-    property local_ca_ack_delay:
-        def __get__(self):
-            return self.dev_attr.local_ca_ack_delay
-    property phys_port_cnt:
-        def __get__(self):
-            return self.dev_attr.phys_port_cnt
+    @property
+    def fw_version(self):
+        return self.dev_attr.fw_ver.decode()
+    @property
+    def node_guid(self):
+        return self.dev_attr.node_guid
+    @property
+    def sys_image_guid(self):
+        return self.dev_attr.sys_image_guid
+    @property
+    def max_mr_size(self):
+        return self.dev_attr.max_mr_size
+    @property
+    def page_size_cap(self):
+        return self.dev_attr.page_size_cap
+    @property
+    def vendor_id(self):
+        return self.dev_attr.vendor_id
+    @property
+    def vendor_part_id(self):
+        return self.dev_attr.vendor_part_id
+    @property
+    def hw_ver(self):
+        return self.dev_attr.hw_ver
+    @property
+    def max_qp(self):
+        return self.dev_attr.max_qp
+    @property
+    def max_qp_wr(self):
+        return self.dev_attr.max_qp_wr
+    @property
+    def device_cap_flags(self):
+        return self.dev_attr.device_cap_flags
+    @property
+    def max_sge(self):
+        return self.dev_attr.max_sge
+    @property
+    def max_sge_rd(self):
+        return self.dev_attr.max_sge_rd
+    @property
+    def max_cq(self):
+        return self.dev_attr.max_cq
+    @property
+    def max_cqe(self):
+        return self.dev_attr.max_cqe
+    @property
+    def max_mr(self):
+        return self.dev_attr.max_mr
+    @property
+    def max_pd(self):
+        return self.dev_attr.max_pd
+    @property
+    def max_qp_rd_atom(self):
+        return self.dev_attr.max_qp_rd_atom
+    @property
+    def max_ee_rd_atom(self):
+        return self.dev_attr.max_ee_rd_atom
+    @property
+    def max_res_rd_atom(self):
+        return self.dev_attr.max_res_rd_atom
+    @property
+    def max_qp_init_rd_atom(self):
+        return self.dev_attr.max_qp_init_rd_atom
+    @property
+    def max_ee_init_rd_atom(self):
+        return self.dev_attr.max_ee_init_rd_atom
+    @property
+    def atomic_caps(self):
+        return self.dev_attr.atomic_cap
+    @property
+    def max_ee(self):
+        return self.dev_attr.max_ee
+    @property
+    def max_rdd(self):
+        return self.dev_attr.max_rdd
+    @property
+    def max_mw(self):
+        return self.dev_attr.max_mw
+    @property
+    def max_raw_ipv6_qps(self):
+        return self.dev_attr.max_raw_ipv6_qp
+    @property
+    def max_raw_ethy_qp(self):
+        return self.dev_attr.max_raw_ethy_qp
+    @property
+    def max_mcast_grp(self):
+        return self.dev_attr.max_mcast_grp
+    @property
+    def max_mcast_qp_attach(self):
+        return self.dev_attr.max_mcast_qp_attach
+    @property
+    def max_ah(self):
+        return self.dev_attr.max_ah
+    @property
+    def max_fmr(self):
+        return self.dev_attr.max_fmr
+    @property
+    def max_map_per_fmr(self):
+        return self.dev_attr.max_map_per_fmr
+    @property
+    def max_srq(self):
+        return self.dev_attr.max_srq
+    @property
+    def max_srq_wr(self):
+        return self.dev_attr.max_srq_wr
+    @property
+    def max_srq_sge(self):
+        return self.dev_attr.max_srq_sge
+    @property
+    def max_pkeys(self):
+        return self.dev_attr.max_pkeys
+    @property
+    def local_ca_ack_delay(self):
+        return self.dev_attr.local_ca_ack_delay
+    @property
+    def phys_port_cnt(self):
+        return self.dev_attr.phys_port_cnt
 
     def __str__(self):
         print_format = '{:<22}: {:<20}\n'

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -102,16 +102,9 @@ cdef class Context(PyverbsObject):
         Closes the inner IB device.
         :return: None
         """
-        self._close()
+        self.close()
 
-    def close(self):
-        """
-        Closes the inner IB device.
-        :return: None
-        """
-        self._close()
-
-    cdef _close(self):
+    cpdef close(self):
         self.logger.debug('Closing Context')
         if self.context != NULL:
             rc = v.ibv_close_device(self.context)

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -10,7 +10,7 @@ from .pyverbs_error import PyverbsRDMAError
 from .pyverbs_error import PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
 cimport pyverbs.libibverbs as v
-from pyverbs.addr cimport Gid
+from pyverbs.addr cimport GID
 
 cdef extern from 'errno.h':
     int errno
@@ -134,7 +134,7 @@ cdef class Context(PyverbsObject):
         return dev_attr
 
     def query_gid(self, unsigned int port_num, int index):
-        gid = Gid()
+        gid = GID()
         rc = v.ibv_query_gid(self.context, port_num, index, &gid.gid)
         if rc != 0:
             raise PyverbsRDMAError('Failed to query gid {idx} of port {port}'.

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -24,13 +24,13 @@ cdef extern from 'infiniband/verbs.h':
 
     cdef struct ibv_device_attr:
         char            *fw_ver
-        unsigned long   node_guid;
-        unsigned long   sys_image_guid;
-        unsigned long   max_mr_size;
-        unsigned long   page_size_cap;
-        unsigned int    vendor_id;
-        unsigned int    vendor_part_id;
-        unsigned int    hw_ver;
+        unsigned long   node_guid
+        unsigned long   sys_image_guid
+        unsigned long   max_mr_size
+        unsigned long   page_size_cap
+        unsigned int    vendor_id
+        unsigned int    vendor_part_id
+        unsigned int    hw_ver
         unsigned int    max_qp
         unsigned int    max_qp_wr
         unsigned int    device_cap_flags
@@ -46,29 +46,35 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    max_qp_init_rd_atom
         unsigned int    max_ee_init_rd_atom
         ibv_atomic_cap  atomic_cap
-        unsigned int    max_ee;
-        unsigned int    max_rdd;
-        unsigned int    max_mw;
-        unsigned int    max_raw_ipv6_qp;
-        unsigned int    max_raw_ethy_qp;
-        unsigned int    max_mcast_grp;
-        unsigned int    max_mcast_qp_attach;
-        unsigned int    max_total_mcast_qp_attach;
-        unsigned int    max_ah;
-        unsigned int    max_fmr;
-        unsigned int    max_map_per_fmr;
-        unsigned int    max_srq;
-        unsigned int    max_srq_wr;
-        unsigned int    max_srq_sge;
-        unsigned int    max_pkeys;
-        unsigned int    local_ca_ack_delay;
-        unsigned int    phys_port_cnt;
+        unsigned int    max_ee
+        unsigned int    max_rdd
+        unsigned int    max_mw
+        unsigned int    max_raw_ipv6_qp
+        unsigned int    max_raw_ethy_qp
+        unsigned int    max_mcast_grp
+        unsigned int    max_mcast_qp_attach
+        unsigned int    max_total_mcast_qp_attach
+        unsigned int    max_ah
+        unsigned int    max_fmr
+        unsigned int    max_map_per_fmr
+        unsigned int    max_srq
+        unsigned int    max_srq_wr
+        unsigned int    max_srq_sge
+        unsigned int    max_pkeys
+        unsigned int    local_ca_ack_delay
+        unsigned int    phys_port_cnt
+
+    struct ibv_pd:
+        ibv_context     *context
+        unsigned int    handle
 
     ibv_device **ibv_get_device_list(int *n)
-    void ibv_free_device_list(ibv_device **list);
-    ibv_context *ibv_open_device(ibv_device *device);
+    void ibv_free_device_list(ibv_device **list)
+    ibv_context *ibv_open_device(ibv_device *device)
     int ibv_close_device(ibv_context *context)
     int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)
     unsigned long ibv_get_device_guid(ibv_device *device)
     int ibv_query_gid(ibv_context *context, unsigned int port_num,
                       int index, ibv_gid *gid)
+    ibv_pd *ibv_alloc_pd(ibv_context *context)
+    int ibv_dealloc_pd(ibv_pd *pd)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -68,6 +68,15 @@ cdef extern from 'infiniband/verbs.h':
         ibv_context     *context
         unsigned int    handle
 
+    cdef struct ibv_mr:
+        ibv_context     *context
+        ibv_pd          *pd
+        void            *addr
+        size_t          length
+        unsigned int    handle
+        unsigned int    lkey
+        unsigned int    rkey
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -78,3 +87,5 @@ cdef extern from 'infiniband/verbs.h':
                       int index, ibv_gid *gid)
     ibv_pd *ibv_alloc_pd(ibv_context *context)
     int ibv_dealloc_pd(ibv_pd *pd)
+    ibv_mr *ibv_reg_mr(ibv_pd *pd, void *addr, size_t length, int access)
+    int ibv_dereg_mr(ibv_mr *mr)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -148,6 +148,30 @@ cdef extern from 'infiniband/verbs.h':
         ibv_context     *context
         unsigned int    comp_mask
 
+    cdef struct ibv_port_attr:
+        ibv_port_state     state
+        ibv_mtu            max_mtu
+        ibv_mtu            active_mtu
+        int                     gid_tbl_len
+        unsigned int            port_cap_flags
+        unsigned int            max_msg_sz
+        unsigned int            bad_pkey_cntr
+        unsigned int            qkey_viol_cntr
+        unsigned short          pkey_tbl_len
+        unsigned short          lid
+        unsigned short          sm_lid
+        unsigned char           lmc
+        unsigned char           max_vl_num
+        unsigned char           sm_sl
+        unsigned char           subnet_timeout
+        unsigned char           init_type_reply
+        unsigned char           active_width
+        unsigned char           active_speed
+        unsigned char           phys_state
+        unsigned char           link_layer
+        unsigned char           flags
+        unsigned short          port_cap_flags2
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -173,3 +197,5 @@ cdef extern from 'infiniband/verbs.h':
                          size_t length)
     int ibv_memcpy_from_dm(void *host_addr,  ibv_dm *dm, unsigned long dm_offset,
                            size_t length)
+    int ibv_query_port(ibv_context *context, uint8_t port_num,
+                       ibv_port_attr *port_attr)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -139,6 +139,15 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    handle
         ibv_mw_type     mw_type
 
+    cdef struct ibv_alloc_dm_attr:
+        size_t          length
+        unsigned int    log_align_req
+        unsigned int    comp_mask
+
+    cdef struct ibv_dm:
+        ibv_context     *context
+        unsigned int    comp_mask
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -156,3 +165,11 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_dereg_mr(ibv_mr *mr)
     ibv_mw *ibv_alloc_mw(ibv_pd *pd, ibv_mw_type type)
     int ibv_dealloc_mw(ibv_mw *mw)
+    ibv_dm *ibv_alloc_dm(ibv_context *context, ibv_alloc_dm_attr *attr)
+    int ibv_free_dm(ibv_dm *dm)
+    ibv_mr *ibv_reg_dm_mr(ibv_pd *pd, ibv_dm *dm, unsigned long dm_offset,
+                          size_t length, unsigned int access)
+    int ibv_memcpy_to_dm(ibv_dm *dm, unsigned long dm_offset, void *host_addr,
+                         size_t length)
+    int ibv_memcpy_from_dm(void *host_addr,  ibv_dm *dm, unsigned long dm_offset,
+                           size_t length)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -132,6 +132,13 @@ cdef extern from 'infiniband/verbs.h':
         ibv_cq_moderation_caps  cq_mod_caps
         unsigned long           max_dm_size
 
+    cdef struct ibv_mw:
+        ibv_context     *context
+        ibv_pd          *pd
+        unsigned int    rkey
+        unsigned int    handle
+        ibv_mw_type     mw_type
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -147,3 +154,5 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_dealloc_pd(ibv_pd *pd)
     ibv_mr *ibv_reg_mr(ibv_pd *pd, void *addr, size_t length, int access)
     int ibv_dereg_mr(ibv_mr *mr)
+    ibv_mw *ibv_alloc_mw(ibv_pd *pd, ibv_mw_type type)
+    int ibv_dealloc_mw(ibv_mw *mw)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
 
 include 'libibverbs_enums.pxd'
-from libc.stdint cimport uint8_t, uint64_t
+from libc.stdint cimport uint8_t, uint32_t, uint64_t
 
 cdef extern from 'infiniband/verbs.h':
 
@@ -77,11 +77,69 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    lkey
         unsigned int    rkey
 
+    cdef struct ibv_query_device_ex_input:
+        unsigned int    comp_mask
+
+    cdef struct per_transport_caps:
+        uint32_t rc_odp_caps
+        uint32_t uc_odp_caps
+        uint32_t ud_odp_caps
+
+    cdef struct ibv_odp_caps:
+        uint64_t general_caps
+        per_transport_caps per_transport_caps
+
+    cdef struct ibv_tso_caps:
+        unsigned int    max_tso
+        unsigned int    supported_qpts
+
+    cdef struct ibv_rss_caps:
+        unsigned int    supported_qpts
+        unsigned int    max_rwq_indirection_tables
+        unsigned int    max_rwq_indirection_table_size
+        unsigned long   rx_hash_fields_mask
+        unsigned int    rx_hash_function
+
+    cdef struct ibv_packet_pacing_caps:
+        unsigned int    qp_rate_limit_min
+        unsigned int    qp_rate_limit_max
+        unsigned int    supported_qpts
+
+    cdef struct ibv_tm_caps:
+        unsigned int    max_rndv_hdr_size
+        unsigned int    max_num_tags
+        unsigned int    flags
+        unsigned int    max_ops
+        unsigned int    max_sge
+
+    cdef struct ibv_cq_moderation_caps:
+        unsigned int    max_cq_count
+        unsigned int    max_cq_period
+
+    cdef struct ibv_device_attr_ex:
+        ibv_device_attr         orig_attr
+        unsigned int            comp_mask
+        ibv_odp_caps            odp_caps
+        unsigned long           completion_timestamp_mask
+        unsigned long           hca_core_clock
+        unsigned long           device_cap_flags_ex
+        ibv_tso_caps            tso_caps
+        ibv_rss_caps            rss_caps
+        unsigned int            max_wq_type_rq
+        ibv_packet_pacing_caps  packet_pacing_caps
+        unsigned int            raw_packet_caps
+        ibv_tm_caps             tm_caps
+        ibv_cq_moderation_caps  cq_mod_caps
+        unsigned long           max_dm_size
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
     int ibv_close_device(ibv_context *context)
     int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)
+    int ibv_query_device_ex(ibv_context *context,
+                            ibv_query_device_ex_input *input,
+                            ibv_device_attr_ex *attr)
     unsigned long ibv_get_device_guid(ibv_device *device)
     int ibv_query_gid(ibv_context *context, unsigned int port_num,
                       int index, ibv_gid *gid)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -3,6 +3,11 @@
 
 cdef extern from '<infiniband/verbs.h>':
 
+    cpdef enum:
+        IBV_LINK_LAYER_UNSPECIFIED
+        IBV_LINK_LAYER_INFINIBAND
+        IBV_LINK_LAYER_ETHERNET
+
     cpdef enum ibv_atomic_cap:
         IBV_ATOMIC_NONE
         IBV_ATOMIC_HCA
@@ -29,6 +34,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_PORT_SYS_IMAGE_GUID_SUP         = 1 << 11
         IBV_PORT_PKEY_SW_EXT_PORT_TRAP_SUP  = 1 << 12
         IBV_PORT_EXTENDED_SPEEDS_SUP        = 1 << 14
+        IBV_PORT_CAP_MASK2_SUP              = 1 << 15,
         IBV_PORT_CM_SUP                     = 1 << 16
         IBV_PORT_SNMP_TUNNEL_SUP            = 1 << 17
         IBV_PORT_REINIT_SUP                 = 1 << 18
@@ -40,6 +46,14 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_PORT_LINK_LATENCY_SUP           = 1 << 24
         IBV_PORT_CLIENT_REG_SUP             = 1 << 25
         IBV_PORT_IP_BASED_GIDS              = 1 << 26
+
+    cpdef enum ibv_port_cap_flags2:
+        IBV_PORT_SET_NODE_DESC_SUP              = 1 << 0
+        IBV_PORT_INFO_EXT_SUP                   = 1 << 1
+        IBV_PORT_VIRT_SUP                       = 1 << 2
+        IBV_PORT_SWITCH_PORT_STATE_TABLE_SUP    = 1 << 3
+        IBV_PORT_LINK_WIDTH_2X_SUP              = 1 << 4
+        IBV_PORT_LINK_SPEED_HDR_SUP             = 1 << 5
 
     cpdef enum ibv_mtu:
         IBV_MTU_256     = 1

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved. See COPYING file
+
+from pyverbs.base cimport PyverbsCM
+from . cimport libibverbs as v
+
+
+cdef class MR(PyverbsCM):
+    cdef object pd
+    cdef v.ibv_mr *mr
+    cdef void *buf
+    cpdef read(self, length, offset)

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -14,3 +14,6 @@ cdef class MR(PyverbsCM):
 cdef class MW(PyverbsCM):
     cdef object pd
     cdef v.ibv_mw *mw
+
+cdef class DMMR(MR):
+    cdef object dm

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -10,3 +10,7 @@ cdef class MR(PyverbsCM):
     cdef v.ibv_mr *mr
     cdef void *buf
     cpdef read(self, length, offset)
+
+cdef class MW(PyverbsCM):
+    cdef object pd
+    cdef v.ibv_mw *mw

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+from pyverbs.device cimport Context
+cimport pyverbs.libibverbs as v
+from .base cimport PyverbsCM
+
+
+cdef class PD(PyverbsCM):
+    cdef v.ibv_pd *pd
+    cdef Context ctx

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -10,3 +10,4 @@ cdef class PD(PyverbsCM):
     cdef Context ctx
     cdef add_ref(self, obj)
     cdef object mrs
+    cdef object mws

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -8,3 +8,5 @@ from .base cimport PyverbsCM
 cdef class PD(PyverbsCM):
     cdef v.ibv_pd *pd
     cdef Context ctx
+    cdef add_ref(self, obj)
+    cdef object mrs

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.base import PyverbsRDMAErrno
+
+cdef extern from 'errno.h':
+    int errno
+
+
+cdef class PD(PyverbsCM):
+    def __cinit__(self, Context context not None):
+        """
+        Initializes a PD object. A reference for the creating Context is kept
+        so that Python's GC will destroy the objects in the right order.
+        :param context: The Context object creating the PD
+        :return: The newly created PD on success
+        """
+        self.pd = v.ibv_alloc_pd(<v.ibv_context*>context.context)
+        if self.pd == NULL:
+            raise PyverbsRDMAErrno('Failed to allocate PD', errno)
+        self.ctx = context
+        context.add_ref(self)
+        self.logger.debug('PD: Allocated ibv_pd')
+
+    def __dealloc__(self):
+        """
+        Closes the inner PD.
+        :return: None
+        """
+        self.close()
+
+    cpdef close(self):
+        """
+        Closes the underlying C object of the PD.
+        PD may be deleted directly or indirectly by closing its context, which
+        leaves the Python PD object without the underlying C object, so during
+        destruction, need to check whether or not the C object exists.
+        :return: None
+        """
+        self.logger.debug('Closing PD')
+        if self.pd != NULL:
+            rc = v.ibv_dealloc_pd(self.pd)
+            if rc != 0:
+                raise PyverbsRDMAErrno('Failed to dealloc PD')
+            self.pd = NULL
+            self.ctx = None

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -4,7 +4,8 @@ import weakref
 
 from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
-from .mr cimport MR, MW
+from pyverbs.device cimport Context, DM
+from .mr cimport MR, MW, DMMR
 
 cdef extern from 'errno.h':
     int errno
@@ -52,7 +53,7 @@ cdef class PD(PyverbsCM):
             self.ctx = None
 
     cdef add_ref(self, obj):
-        if isinstance(obj, MR):
+        if isinstance(obj, MR) or isinstance(obj, DMMR):
             self.mrs.add(obj)
         elif isinstance(obj, MW):
             self.mws.add(obj)

--- a/pyverbs/tests/device.py
+++ b/pyverbs/tests/device.py
@@ -2,9 +2,11 @@
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
 import unittest
 import resource
+import random
 
+from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
+import pyverbs.tests.utils as u
 import pyverbs.device as d
-
 
 PAGE_SIZE = resource.getpagesize()
 
@@ -73,3 +75,146 @@ class device_test(unittest.TestCase):
             with d.Context(name=dev.name.decode()) as ctx:
                 attr_ex = ctx.query_device_ex()
                 self.verify_device_attr(attr_ex.orig_attr)
+
+
+class dm_test(unittest.TestCase):
+    """
+    Test various functionalities of the DM class.
+    """
+    def test_create_dm(self):
+        """
+        test ibv_alloc_dm()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                with d.DM(ctx, dm_attrs):
+                    pass
+
+    def test_destroy_dm(self):
+        """
+        test ibv_free_dm()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                dm = d.DM(ctx, dm_attrs)
+                dm.close()
+
+    def test_create_dm_bad_flow(self):
+        """
+        test ibv_alloc_dm() with an illegal size and comp mask
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = attr.max_dm_size + 1
+                dm_attrs = u.get_dm_attrs(dm_len)
+                try:
+                    dm = d.DM(ctx, dm_attrs)
+                except PyverbsRDMAError as e:
+                    assert 'Failed to allocate device memory of size' in e.args[0]
+                    assert 'Max available size' in e.args[0]
+                else:
+                    raise PyverbsError('Created a DM with size larger than max reported')
+                dm_attrs.comp_mask = random.randint(1, 100)
+                try:
+                    dm = d.DM(ctx, dm_attrs)
+                except PyverbsRDMAError as e:
+                    assert 'Failed to allocate device memory of size' in e.args[0]
+                else:
+                    raise PyverbsError('Created a DM with illegal comp mask {c}'.\
+                                       format(c=dm_attrs.comp_mask))
+
+    def test_destroy_dm_bad_flow(self):
+        """
+        test calling ibv_free_dm() twice
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                dm = d.DM(ctx, dm_attrs)
+                dm.close()
+                dm.close()
+
+    def test_dm_write(self):
+        """
+        Test writing to the device memory
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                with d.DM(ctx, dm_attrs) as dm:
+                    data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
+                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
+                    data = u.get_data(data_length)
+                    dm.copy_to_dm(data_offset, data.encode(), data_length)
+
+    def test_dm_write_bad_flow(self):
+        """
+        Test writing to the device memory with bad offset and length
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                with d.DM(ctx, dm_attrs) as dm:
+                    data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
+                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
+                    data_offset += 1 # offset needs to be a multiple of 4
+                    data = u.get_data(data_length)
+                    try:
+                        dm.copy_to_dm(data_offset, data.encode(), data_length)
+                    except PyverbsRDMAError as e:
+                            assert 'Failed to copy to dm' in e.args[0]
+                    else:
+                        raise PyverbsError('Wrote to device memory with a bad offset')
+
+    def test_dm_read(self):
+        """
+        Test reading from the device memory
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device_ex()
+                if attr.max_dm_size == 0:
+                    return
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_attrs = u.get_dm_attrs(dm_len)
+                with d.DM(ctx, dm_attrs) as dm:
+                    data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
+                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
+                    data = u.get_data(data_length)
+                    dm.copy_to_dm(data_offset, data.encode(), data_length)
+                    read_str = dm.copy_from_dm(data_offset, data_length)
+                    assert read_str.decode() == data

--- a/pyverbs/tests/device.py
+++ b/pyverbs/tests/device.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
 import unittest
+import resource
+
 import pyverbs.device as d
+
+
+PAGE_SIZE = resource.getpagesize()
+
 
 class device_test(unittest.TestCase):
     """
@@ -27,8 +33,9 @@ class device_test(unittest.TestCase):
         """
         lst = d.get_device_list()
         for dev in lst:
-            ctx = d.Context(name=dev.name.decode())
-            ctx.query_device()
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr = ctx.query_device()
+                self.verify_device_attr(attr)
 
     def test_query_gid(self):
         """
@@ -36,6 +43,33 @@ class device_test(unittest.TestCase):
         """
         lst = d.get_device_list()
         for dev in lst:
-            ctx = d.Context(name=dev.name.decode())
-            ctx.query_gid(port_num=1, index=0)
+            with d.Context(name=dev.name.decode()) as ctx:
+                ctx.query_gid(port_num=1, index=0)
 
+    @staticmethod
+    def verify_device_attr(attr):
+        assert attr.node_guid != 0
+        assert attr.sys_image_guid != 0
+        assert attr.max_mr_size > PAGE_SIZE
+        assert attr.page_size_cap > PAGE_SIZE
+        assert attr.vendor_id != 0
+        assert attr.vendor_part_id != 0
+        assert attr.max_qp > 0
+        assert attr.max_qp_wr > 0
+        assert attr.max_sge > 0
+        assert attr.max_sge_rd > 0
+        assert attr.max_cq > 0
+        assert attr.max_cqe > 0
+        assert attr.max_mr > 0
+        assert attr.max_pd > 0
+        assert attr.max_pkeys > 0
+
+    def test_query_device_ex(self):
+        """
+        Test ibv_query_device_ex()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr_ex = ctx.query_device_ex()
+                self.verify_device_attr(attr_ex.orig_attr)

--- a/pyverbs/tests/mr.py
+++ b/pyverbs/tests/mr.py
@@ -3,11 +3,11 @@
 import unittest
 import random
 
-from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
 import pyverbs.tests.utils as u
+from pyverbs.mr import MR, MW
 import pyverbs.device as d
-from pyverbs.mr import MR
 from pyverbs.pd import PD
 import pyverbs.enums as e
 
@@ -144,3 +144,40 @@ class mr_test(unittest.TestCase):
                     with MR(pd, length, u.get_access_flags()) as mr:
                         buf = mr.buf
 
+
+class mw_test(unittest.TestCase):
+    """
+    Test various functionalities of the MW class.
+    """
+    def test_reg_mw(self):
+        """ Test ibv_alloc_mw() """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    with MW(pd, random.choice([e.IBV_MW_TYPE_1, e.IBV_MW_TYPE_2])) as mw:
+                        pass
+
+    def test_dereg_mw(self):
+        """ Test ibv_dealloc_mw() """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    with MW(pd, random.choice([e.IBV_MW_TYPE_1, e.IBV_MW_TYPE_2])) as mw:
+                        mw.close()
+
+    def test_reg_mw_wrong_type(self):
+        """ Test ibv_alloc_mw() """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    try:
+                        mw_type =random.randint(3, 100)
+                        mw = MW(pd, mw_type)
+                    except PyverbsRDMAError as e:
+                        pass
+                    else:
+                        raise PyverbsError('Created a MW with type {t}'.\
+                                           format(t=mw_type))

--- a/pyverbs/tests/mr.py
+++ b/pyverbs/tests/mr.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+import unittest
+import random
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.base import PyverbsRDMAErrno
+import pyverbs.tests.utils as u
+import pyverbs.device as d
+from pyverbs.mr import MR
+from pyverbs.pd import PD
+import pyverbs.enums as e
+
+MAX_IO_LEN = 1048576
+
+
+class mr_test(unittest.TestCase):
+    """
+    Test various functionalities of the MR class.
+    """
+    def test_reg_mr(self):
+        """ Test ibv_reg_mr() """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    with MR(pd, u.get_mr_length(), u.get_access_flags()) as mr:
+                        pass
+
+    def test_dereg_mr(self):
+        """ Test ibv_dereg_mr() """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    with MR(pd, u.get_mr_length(), u.get_access_flags()) as mr:
+                        mr.close()
+
+    def test_reg_mr_bad_flow(self):
+        """ Verify that trying to register a MR with None PD fails """
+        try:
+            mr = MR(None, random.randint(0, 10000), u.get_access_flags())
+        except TypeError as te:
+            assert 'expected pyverbs.pd.PD' in te.args[0]
+            assert 'got NoneType' in te.args[0]
+        else:
+            raise PyverbsRDMAErrno('Created a MR with None PD')
+
+    def test_dereg_mr_twice(self):
+        """ Verify that explicit call to MR's close() doesn't fails """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    with MR(pd, u.get_mr_length(), u.get_access_flags()) as mr:
+                        # Pyverbs supports multiple destruction of objects, we are
+                        # not expecting an exception here.
+                        mr.close()
+                        mr.close()
+
+    def test_reg_mr_bad_flags(self):
+        """ Verify that illegal flags combination fails as expected """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    flags = random.sample([e.IBV_ACCESS_REMOTE_WRITE,
+                                          e.IBV_ACCESS_REMOTE_ATOMIC],
+                                          random.randint(1, 2))
+                    mr_flags = 0
+                    for i in flags:
+                        mr_flags += i.value
+                    try:
+                        mr = MR(pd, u.get_mr_length(), mr_flags)
+                    except PyverbsRDMAError as err:
+                        assert 'Failed to register a MR' in err.args[0]
+                    else:
+                        raise PyverbsRDMAError('Registered a MR with illegal falgs')
+
+    def test_write(self):
+        """
+        Test writing to MR's buffer
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    mr_len = u.get_mr_length()
+                    with MR(pd, mr_len, u.get_access_flags()) as mr:
+                        write_len = min(random.randint(1, MAX_IO_LEN), mr_len)
+                        mr.write(u.get_data(write_len), write_len)
+
+    def test_read(self):
+        """
+        Test reading from MR's buffer
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    mr_len = u.get_mr_length()
+                    with MR(pd, mr_len, u.get_access_flags()) as mr:
+                        write_len = min(random.randint(1, MAX_IO_LEN), mr_len)
+                        write_str = u.get_data(write_len)
+                        mr.write(write_str, write_len)
+                        read_len = random.randint(1, write_len)
+                        offset = random.randint(0, write_len-read_len)
+                        read_str = mr.read(read_len, offset).decode()
+                        assert read_str in write_str
+
+    def test_lkey(self):
+        """
+        Test reading lkey property
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    length = u.get_mr_length()
+                    with MR(pd, length, u.get_access_flags()) as mr:
+                        lkey = mr.lkey
+
+    def test_rkey(self):
+        """
+        Test reading rkey property
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    length = u.get_mr_length()
+                    with MR(pd, length, u.get_access_flags()) as mr:
+                        rkey = mr.rkey
+
+    def test_buffer(self):
+        """
+        Test reading buf property
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    length = u.get_mr_length()
+                    with MR(pd, length, u.get_access_flags()) as mr:
+                        buf = mr.buf
+

--- a/pyverbs/tests/pd.py
+++ b/pyverbs/tests/pd.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+
+import unittest
+import random
+
+from pyverbs.base import PyverbsRDMAErrno
+import pyverbs.device as d
+from pyverbs.pd import PD
+
+
+class pd_test(unittest.TestCase):
+    """
+    Test various functionalities of the PD class.
+    """
+    def test_alloc_pd(self):
+        """
+        Test ibv_alloc_pd()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx):
+                    pass
+
+    def test_dealloc_pd(self):
+        """
+        Test ibv_dealloc_pd()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    pd.close()
+
+    def test_multiple_pd_creation(self):
+        """
+        Test multiple creations and destructions of a PD object
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                for i in range(random.randint(1, 200)):
+                    with PD(ctx) as pd:
+                        pd.close()
+
+    def test_create_pd_none_ctx(self):
+        """
+        Verify that PD can't be created with a None context
+        """
+        try:
+            pd = PD(None)
+        except TypeError as te:
+            assert 'expected pyverbs.device.Context' in te.args[0]
+            assert 'got NoneType' in te.args[0]
+        else:
+            raise PyverbsRDMAErrno('Created a PD with None context')
+
+    def test_destroy_pd_twice(self):
+        """
+        Test bad flow cases in destruction of a PD object
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with PD(ctx) as pd:
+                    # Pyverbs supports multiple destruction of objects, we are
+                    # not expecting an exception here.
+                    pd.close()
+                    pd.close()

--- a/pyverbs/tests/utils.py
+++ b/pyverbs/tests/utils.py
@@ -2,9 +2,19 @@
 # Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
 from string import ascii_lowercase as al
 import random
+
+import pyverbs.device as d
 import pyverbs.enums as e
 
 MAX_MR_SIZE = 4194304
+# Some HWs limit DM address and length alignment to 4 for read and write
+# operations. Use a minimal length and alignment that respect that.
+# For creation purposes use random alignments. As this is log2 of address
+# alignment, no need for large numbers.
+MIN_DM_SIZE = 4
+DM_ALIGNMENT = 4
+MIN_DM_LOG_ALIGN = 0
+MAX_DM_LOG_ALIGN = 6
 
 def get_mr_length():
     # Allocating large buffers typically fails
@@ -26,3 +36,9 @@ def get_access_flags():
 
 def get_data(length):
     return ''.join(random.choice(al) for i in range(length))
+
+
+def get_dm_attrs(dm_len):
+    align = random.randint(MIN_DM_LOG_ALIGN, MAX_DM_LOG_ALIGN)
+    # Comp mask != 0 is not supported
+    return d.AllocDmAttr(dm_len, align, 0)

--- a/pyverbs/tests/utils.py
+++ b/pyverbs/tests/utils.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+from string import ascii_lowercase as al
+import random
+import pyverbs.enums as e
+
+MAX_MR_SIZE = 4194304
+
+def get_mr_length():
+    # Allocating large buffers typically fails
+    return random.randint(0, MAX_MR_SIZE)
+
+
+def get_access_flags():
+    vals = list(e.ibv_access_flags)
+    selected = random.sample(vals, random.randint(1, 7))
+    # Remote write / remote atomic are not allowed without local write
+    if e.IBV_ACCESS_REMOTE_WRITE in selected or e.IBV_ACCESS_REMOTE_ATOMIC in selected:
+        if not e.IBV_ACCESS_LOCAL_WRITE in selected:
+            selected.append(e.IBV_ACCESS_LOCAL_WRITE)
+    flags = 0
+    for i in selected:
+        flags += i.value
+    return flags
+
+
+def get_data(length):
+    return ''.join(random.choice(al) for i in range(length))


### PR DESCRIPTION
This pull requeset adds pyverbs support for PD and MR related classes,
divided as follows:
- General fixes prior to addition of new classes:
  - Rename Gid class to GID and use as will be done from now on for all
    acronyms.
  - Unify close() functions of pyverbs objects to a single cpdef
    function.
  - Switch to Python-style properties, replacing the deprecated legacy
    syntax.
- Add PD and MR related classes: PD, MR, MW, DM and DMMR. This part also
  adds support for ibv_query_device_ex(), as it is needed for new
  capabilities checks. Those patches also include unittests (for path
  only).
- Add support for ibv_query_port() in Context class. This is a very
  basic capability that doesn't depend on any missing infrastructure.
- Some technical/build-related commits: update MAINTAINERS file and fix
  build issues.
