### PR TITLE
verbs: Implicit ODP support

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -336,6 +336,16 @@ int ibv_cmd_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 
 	cmd->start 	  = (uintptr_t) addr;
 	cmd->length 	  = length;
+	/* On demand access and entire address space means implicit.
+	 * In that case set the value in the command to what kernel expects.
+	 */
+	if (access & IBV_ACCESS_ON_DEMAND) {
+		if (length == SIZE_MAX && addr)
+			return EINVAL;
+		if (length == SIZE_MAX)
+			cmd->length = UINT64_MAX;
+	}
+
 	cmd->hca_va 	  = hca_va;
 	cmd->pd_handle 	  = pd->handle;
 	cmd->access_flags = access;

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -314,13 +314,16 @@ static void print_odp_trans_caps(uint32_t trans)
 
 static void print_odp_caps(const struct ibv_device_attr_ex *device_attr)
 {
-	uint64_t unknown_general_caps = ~(IBV_ODP_SUPPORT);
+	uint64_t unknown_general_caps = ~(IBV_ODP_SUPPORT |
+					  IBV_ODP_SUPPORT_IMPLICIT);
 	const struct ibv_odp_caps *caps = &device_attr->odp_caps;
 
 	/* general odp caps */
 	printf("\tgeneral_odp_caps:\n");
 	if (caps->general_caps & IBV_ODP_SUPPORT)
 		printf("\t\t\t\t\tODP_SUPPORT\n");
+	if (caps->general_caps & IBV_ODP_SUPPORT_IMPLICIT)
+		printf("\t\t\t\t\tODP_SUPPORT_IMPLICIT\n");
 	if (caps->general_caps & unknown_general_caps)
 		printf("\t\t\t\t\tUnknown flags: 0x%" PRIX64 "\n",
 		       caps->general_caps & unknown_general_caps);

--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -52,6 +52,7 @@ struct ibv_odp_caps {
 
 enum ibv_odp_general_cap_bits {
         IBV_ODP_SUPPORT = 1 << 0, /* On demand paging is supported */
+        IBV_ODP_SUPPORT_IMPLICIT = 1 << 1, /* Implicit on demand paging is supported */
 };
 
 enum ibv_odp_transport_cap_bits {

--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -50,6 +50,8 @@ must be set too.
 .PP
 Local read access is always enabled for the MR.
 .PP
+To create an implicit ODP MR, IBV_ACCESS_ON_DEMAND should be set, addr should be 0 and length should be SIZE_MAX.
+.PP
 .B ibv_dereg_mr()
 deregisters the MR
 .I mr\fR.

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -218,6 +218,7 @@ struct ibv_odp_caps {
 
 enum ibv_odp_general_caps {
 	IBV_ODP_SUPPORT = 1 << 0,
+	IBV_ODP_SUPPORT_IMPLICIT = 1 << 1,
 };
 
 struct ibv_tso_caps {


### PR DESCRIPTION
This series exposes the option to register an implicit ODP MR by user space applications.

The matching kernel code was already accepted.