### PR TITLE
Device memory fixes

### DIFF
--- a/libibverbs/examples/rc_pingpong.c
+++ b/libibverbs/examples/rc_pingpong.c
@@ -488,9 +488,8 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
 		}
 
 		ibv_query_qp(ctx->qp, &attr, IBV_QP_CAP, &init_attr);
-		if (init_attr.cap.max_inline_data >= size) {
+		if (init_attr.cap.max_inline_data >= size && !use_dm)
 			ctx->send_flags |= IBV_SEND_INLINE;
-		}
 	}
 
 	{


### PR DESCRIPTION
This series includes few fixes for the device memory functionality as follows:
1) In mlx5 driver revises the flow of copying data from the device memory buffer to not use memcpy.
2) Avoid inline send when using device memory in rc_pingpong.
