### PR TITLE
mlx4:  Extend the DV API to control some internal resources 

### DIFF
--- a/providers/mlx4/cq.c
+++ b/providers/mlx4/cq.c
@@ -773,10 +773,10 @@ void mlx4_cq_resize_copy_cqes(struct mlx4_cq *cq, void *buf, int old_cqe)
 	++cq->cons_index;
 }
 
-int mlx4_alloc_cq_buf(struct mlx4_device *dev, struct mlx4_buf *buf, int nent,
-		      int entry_size)
+int mlx4_alloc_cq_buf(struct mlx4_device *dev, struct mlx4_context *ctx,
+		      struct mlx4_buf *buf, int nent, int entry_size)
 {
-	if (mlx4_alloc_buf(buf, align(nent * entry_size, dev->page_size),
+	if (mlx4_alloc_buf(ctx, buf, align(nent * entry_size, dev->page_size),
 			   dev->page_size))
 		return -1;
 	memset(buf->buf, 0, nent * entry_size);

--- a/providers/mlx4/dbrec.c
+++ b/providers/mlx4/dbrec.c
@@ -65,7 +65,7 @@ static struct mlx4_db_page *__add_page(struct mlx4_context *context,
 	if (!page)
 		return NULL;
 
-	if (mlx4_alloc_buf(&page->buf, ps, ps)) {
+	if (mlx4_alloc_buf(context, &page->buf, ps, ps)) {
 		free(page);
 		return NULL;
 	}
@@ -143,7 +143,7 @@ void mlx4_free_db(struct mlx4_context *context, enum mlx4_db_type type,
 		if (page->next)
 			page->next->prev = page->prev;
 
-		mlx4_free_buf(&page->buf);
+		mlx4_free_buf(context, &page->buf);
 		free(page);
 	}
 

--- a/providers/mlx4/man/CMakeLists.txt
+++ b/providers/mlx4/man/CMakeLists.txt
@@ -1,5 +1,6 @@
 rdma_man_pages(
   mlx4dv_init_obj.3
   mlx4dv_query_device.3
+  mlx4dv_set_context_attr.3.md
   mlx4dv.7
 )

--- a/providers/mlx4/man/mlx4dv_init_obj.3
+++ b/providers/mlx4/man/mlx4dv_init_obj.3
@@ -44,7 +44,8 @@ void            *buf;
 size_t          length;
 .in -8
 } buf;
-uint64_t        comp_mask;
+uint64_t        comp_mask; /* Use enum mlx4dv_qp_comp_mask */
+off_t           uar_mmap_offset; /* If MLX4DV_QP_MASK_UAR_MMAP_OFFSET is set in comp_mask, this will contain the mmap offset of *sdb* */
 .in -8
 };
 

--- a/providers/mlx4/man/mlx4dv_set_context_attr.3.md
+++ b/providers/mlx4/man/mlx4dv_set_context_attr.3.md
@@ -1,0 +1,73 @@
+---
+layout: page
+title: mlx4dv_set_context_attr
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx4dv_set_context_attr - Set context attributes
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx4dv.h>
+
+int mlx4dv_set_context_attr(struct ibv_context *context,
+                            enum mlx4dv_set_ctx_attr_type attr_type,
+                            void *attr);
+```
+
+# DESCRIPTION
+
+mlx4dv_set_context_attr gives the ability to set vendor specific attributes on
+the RDMA context.
+
+# ARGUMENTS
+*context*
+:	RDMA device context to work on.
+
+*attr_type*
+:	The type of the provided attribute.
+
+*attr*
+:	Pointer to the attribute to be set.
+## attr_type
+
+```c
+enum mlx4dv_set_ctx_attr_type {
+	/* Attribute type uint8_t */
+	MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ	= 0,
+	MLX4DV_SET_CTX_ATTR_BUF_ALLOCATORS	= 1,
+};
+```
+*MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ*
+:	Change the LOG WQs Range size for RSS
+
+*MLX4DV_SET_CTX_ATTR_BUF_ALLOCATORS*
+:	Provide an external buffer allocator
+
+```c
+struct mlx4dv_ctx_allocators {
+	void *(*alloc)(size_t size, void *priv_data);
+	void (*free)(void *ptr, void *priv_data);
+	void *data;
+};
+```
+*alloc*
+:	Function used for buffer allocation instead of libmlx4 internal method
+
+*free*
+:	Function used to free buffers allocated by alloc function
+
+*data*
+:	Metadata that can be used by alloc and free functions
+
+# RETURN VALUE
+Returns 0 on success, or the value of errno on failure
+(which indicates the failure reason).
+
+#AUTHOR
+
+Majd Dibbiny  <majd@mellanox.com>

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -430,6 +430,9 @@ int mlx4dv_set_context_attr(struct ibv_context *context,
 	case MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ:
 		ctx->log_wqs_range_sz = *((uint8_t *)attr);
 		break;
+	case MLX4DV_SET_CTX_ATTR_BUF_ALLOCATORS:
+		ctx->extern_alloc = *((struct mlx4dv_ctx_allocators *)attr);
+		break;
 	default:
 		return ENOTSUP;
 	}

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -136,6 +136,7 @@ struct mlx4_context {
 	void			       *hca_core_clock;
 	uint32_t			max_inl_recv_sz;
 	uint8_t				log_wqs_range_sz;
+	struct mlx4dv_ctx_allocators	extern_alloc;
 };
 
 struct mlx4_buf {
@@ -299,8 +300,9 @@ static inline void mlx4_update_cons_index(struct mlx4_cq *cq)
 	*cq->set_ci_db = htobe32(cq->cons_index & 0xffffff);
 }
 
-int mlx4_alloc_buf(struct mlx4_buf *buf, size_t size, int page_size);
-void mlx4_free_buf(struct mlx4_buf *buf);
+int mlx4_alloc_buf(struct mlx4_context *ctx, struct mlx4_buf *buf, size_t size,
+		   int page_size);
+void mlx4_free_buf(struct mlx4_context *ctx, struct mlx4_buf *buf);
 
 __be32 *mlx4_alloc_db(struct mlx4_context *context, enum mlx4_db_type type);
 void mlx4_free_db(struct mlx4_context *context, enum mlx4_db_type type,
@@ -339,8 +341,8 @@ struct ibv_cq *mlx4_create_cq(struct ibv_context *context, int cqe,
 struct ibv_cq_ex *mlx4_create_cq_ex(struct ibv_context *context,
 				    struct ibv_cq_init_attr_ex *cq_attr);
 void mlx4_cq_fill_pfns(struct mlx4_cq *cq, const struct ibv_cq_init_attr_ex *cq_attr);
-int mlx4_alloc_cq_buf(struct mlx4_device *dev, struct mlx4_buf *buf, int nent,
-		      int entry_size);
+int mlx4_alloc_cq_buf(struct mlx4_device *dev, struct mlx4_context *ctx,
+		      struct mlx4_buf *buf, int nent, int entry_size);
 int mlx4_resize_cq(struct ibv_cq *cq, int cqe);
 int mlx4_modify_cq(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
 int mlx4_destroy_cq(struct ibv_cq *cq);

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -102,6 +102,7 @@ struct mlx4_context {
 	struct verbs_context		ibv_ctx;
 
 	void			       *uar;
+	off_t				uar_mmap_offset;
 
 	void			       *bf_page;
 	int				bf_buf_size;

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -33,6 +33,7 @@
 #ifndef _MLX4DV_H_
 #define _MLX4DV_H_
 
+#include <stdio.h>
 #include <linux/types.h>
 #include <endian.h>
 #include <infiniband/verbs.h>
@@ -149,6 +150,10 @@ struct mlx4_cqe {
 	uint8_t		owner_sr_opcode;
 };
 
+enum mlx4dv_qp_comp_mask {
+	MLX4DV_QP_MASK_UAR_MMAP_OFFSET		= 1 << 0,
+};
+
 struct mlx4dv_qp {
 	__be32		       *rdb;
 	uint32_t		*sdb;
@@ -168,6 +173,7 @@ struct mlx4dv_qp {
 		size_t			length;
 	} buf;
 	uint64_t		comp_mask;
+	off_t			uar_mmap_offset;
 };
 
 enum mlx4dv_cq_comp_mask {

--- a/providers/mlx4/mlx4dv.h
+++ b/providers/mlx4/mlx4dv.h
@@ -533,8 +533,14 @@ int mlx4dv_query_device(struct ibv_context *ctx_in,
 enum mlx4dv_set_ctx_attr_type {
 	/* Attribute type uint8_t */
 	MLX4DV_SET_CTX_ATTR_LOG_WQS_RANGE_SZ	= 0,
+	MLX4DV_SET_CTX_ATTR_BUF_ALLOCATORS	= 1,
 };
 
+struct mlx4dv_ctx_allocators {
+	void *(*alloc)(size_t size, void *priv_data);
+	void (*free)(void *ptr, void *priv_data);
+	void *data;
+};
 /*
  * Returns 0 on success, or the value of errno on failure
  * (which indicates the failure reason).

--- a/providers/mlx4/qp.c
+++ b/providers/mlx4/qp.c
@@ -726,7 +726,7 @@ int mlx4_alloc_qp_buf(struct ibv_context *context, uint32_t max_recv_sge,
 	}
 
 	if (qp->buf_size) {
-		if (mlx4_alloc_buf(&qp->buf,
+		if (mlx4_alloc_buf(to_mctx(context), &qp->buf,
 				   align(qp->buf_size, to_mdev(context->device)->page_size),
 				   to_mdev(context->device)->page_size)) {
 			free(qp->sq.wrid);

--- a/providers/mlx4/srq.c
+++ b/providers/mlx4/srq.c
@@ -141,7 +141,7 @@ int mlx4_alloc_srq_buf(struct ibv_pd *pd, struct ibv_srq_attr *attr,
 
 	buf_size = srq->max << srq->wqe_shift;
 
-	if (mlx4_alloc_buf(&srq->buf, buf_size,
+	if (mlx4_alloc_buf(to_mctx(pd->context), &srq->buf, buf_size,
 			   to_mdev(pd->context->device)->page_size)) {
 		free(srq->wrid);
 		return -1;
@@ -287,7 +287,7 @@ err_db:
 	mlx4_free_db(to_mctx(context), MLX4_DB_TYPE_RQ, srq->db);
 err_free:
 	free(srq->wrid);
-	mlx4_free_buf(&srq->buf);
+	mlx4_free_buf(to_mctx(context), &srq->buf);
 err:
 	free(srq);
 	return NULL;
@@ -315,7 +315,7 @@ int mlx4_destroy_xrc_srq(struct ibv_srq *srq)
 	}
 
 	mlx4_free_db(mctx, MLX4_DB_TYPE_RQ, msrq->db);
-	mlx4_free_buf(&msrq->buf);
+	mlx4_free_buf(mctx, &msrq->buf);
 	free(msrq->wrid);
 	free(msrq);
 

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -507,7 +507,8 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 
 	cq_attr->cqe = align_queue_size(cq_attr->cqe + 1);
 
-	if (mlx4_alloc_cq_buf(to_mdev(context->device), &cq->buf, cq_attr->cqe, mctx->cqe_size))
+	if (mlx4_alloc_cq_buf(to_mdev(context->device), mctx, &cq->buf,
+			      cq_attr->cqe, mctx->cqe_size))
 		goto err;
 
 	cq->cqe_size = mctx->cqe_size;
@@ -544,7 +545,7 @@ err_db:
 	mlx4_free_db(to_mctx(context), MLX4_DB_TYPE_CQ, cq->set_ci_db);
 
 err_buf:
-	mlx4_free_buf(&cq->buf);
+	mlx4_free_buf(to_mctx(context), &cq->buf);
 
 err:
 	free(cq);
@@ -615,7 +616,9 @@ int mlx4_resize_cq(struct ibv_cq *ibcq, int cqe)
 		goto out;
 	}
 
-	ret = mlx4_alloc_cq_buf(to_mdev(ibcq->context->device), &buf, cqe, cq->cqe_size);
+	ret = mlx4_alloc_cq_buf(to_mdev(ibcq->context->device),
+				to_mctx(ibcq->context), &buf, cqe,
+				cq->cqe_size);
 	if (ret)
 		goto out;
 
@@ -625,13 +628,13 @@ int mlx4_resize_cq(struct ibv_cq *ibcq, int cqe)
 	ret = ibv_cmd_resize_cq(ibcq, cqe - 1, &cmd.ibv_cmd, sizeof cmd,
 				&resp, sizeof resp);
 	if (ret) {
-		mlx4_free_buf(&buf);
+		mlx4_free_buf(to_mctx(ibcq->context), &buf);
 		goto out;
 	}
 
 	mlx4_cq_resize_copy_cqes(cq, buf.buf, old_cqe);
 
-	mlx4_free_buf(&cq->buf);
+	mlx4_free_buf(to_mctx(ibcq->context), &cq->buf);
 	cq->buf = buf;
 	mlx4_update_cons_index(cq);
 
@@ -649,7 +652,7 @@ int mlx4_destroy_cq(struct ibv_cq *cq)
 		return ret;
 
 	mlx4_free_db(to_mctx(cq->context), MLX4_DB_TYPE_CQ, to_mcq(cq)->set_ci_db);
-	mlx4_free_buf(&to_mcq(cq)->buf);
+	mlx4_free_buf(to_mctx(cq->context), &to_mcq(cq)->buf);
 	free(to_mcq(cq));
 
 	return 0;
@@ -704,7 +707,7 @@ err_db:
 
 err_free:
 	free(srq->wrid);
-	mlx4_free_buf(&srq->buf);
+	mlx4_free_buf(to_mctx(pd->context), &srq->buf);
 
 err:
 	free(srq);
@@ -753,7 +756,7 @@ int mlx4_destroy_srq(struct ibv_srq *srq)
 		return ret;
 
 	mlx4_free_db(to_mctx(srq->context), MLX4_DB_TYPE_RQ, to_msrq(srq)->db);
-	mlx4_free_buf(&to_msrq(srq)->buf);
+	mlx4_free_buf(to_mctx(srq->context), &to_msrq(srq)->buf);
 	free(to_msrq(srq)->wrid);
 	free(to_msrq(srq));
 
@@ -1003,7 +1006,7 @@ err_free:
 	free(qp->sq.wrid);
 	if (qp->rq.wqe_cnt)
 		free(qp->rq.wrid);
-	mlx4_free_buf(&qp->buf);
+	mlx4_free_buf(ctx, &qp->buf);
 
 err:
 	free(qp);
@@ -1259,7 +1262,7 @@ int mlx4_destroy_qp(struct ibv_qp *ibqp)
 	}
 	if (qp->sq.wqe_cnt)
 		free(qp->sq.wrid);
-	mlx4_free_buf(&qp->buf);
+	mlx4_free_buf(to_mctx(ibqp->context), &qp->buf);
 	free(qp);
 
 	return 0;
@@ -1508,7 +1511,7 @@ err_rq_db:
 
 err_free:
 	free(qp->rq.wrid);
-	mlx4_free_buf(&qp->buf);
+	mlx4_free_buf(to_mctx(context), &qp->buf);
 
 err:
 	free(qp);
@@ -1595,7 +1598,7 @@ int mlx4_destroy_wq(struct ibv_wq *ibwq)
 	free(qp->rq.wrid);
 	free(qp->sq.wrid);
 
-	mlx4_free_buf(&qp->buf);
+	mlx4_free_buf(mcontext, &qp->buf);
 
 	free(qp);
 


### PR DESCRIPTION
This series extends the DV API to control some internal resources as of memory and UAR.
For that it enables setting an external memory allocator and returns the UAR mapping information.

