### PR TITLE
treewide: Don't cast malloc() output

### DIFF
--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -416,8 +416,8 @@ int ib_acm_enum_ep(int index, struct acm_ep_config_data **data, uint8_t port)
 	}
 
 	len = be16toh(hdr.length) - sizeof(hdr);
-	netw_edata = (struct acm_ep_config_data *)malloc(len);
-	host_edata = (struct acm_ep_config_data *)malloc(len);
+	netw_edata = malloc(len);
+	host_edata = malloc(len);
 	if (!netw_edata || !host_edata) {
 		ret = ACM_STATUS_ENOMEM;
 		goto out;

--- a/iwpmd/iwarp_pm_helper.c
+++ b/iwpmd/iwarp_pm_helper.c
@@ -579,7 +579,7 @@ void form_iwpm_send_msg(int pm_sock, struct sockaddr_storage *dest,
  */
 int add_iwpm_pending_msg(iwpm_send_msg *send_msg)
 {
-	iwpm_pending_msg *pending_msg = (iwpm_pending_msg *)malloc(sizeof(iwpm_pending_msg));
+	iwpm_pending_msg *pending_msg = malloc(sizeof(iwpm_pending_msg));
 	if (!pending_msg) {
 		syslog(LOG_WARNING, "add_iwpm_pending_msg: Unable to allocate message.\n");
 		return -ENOMEM;

--- a/iwpmd/iwarp_pm_server.c
+++ b/iwpmd/iwarp_pm_server.c
@@ -493,7 +493,7 @@ static int process_iwpm_query_mapping(struct nlmsghdr *req_nlh, int client_idx, 
 			"remote port = 0x%04X\n",
 			be16toh(msg_parms.cpport), be16toh(msg_parms.apport));
 	ret = -ENOMEM;
-        send_msg = (iwpm_send_msg *)malloc(sizeof(iwpm_send_msg));
+	send_msg = malloc(sizeof(iwpm_send_msg));
 	if (!send_msg) {
 		str_err = "Unable to allocate send msg buffer";
 		goto query_mapping_free_error;
@@ -683,7 +683,7 @@ static int process_iwpm_wire_request(iwpm_msg_parms *msg_parms, int nl_sock,
 		return 0;
 	}
 	/* allocate response message */
-        send_msg = (iwpm_send_msg *)malloc(sizeof(iwpm_send_msg));
+	send_msg = malloc(sizeof(iwpm_send_msg));
 	if (!send_msg) {
 		syslog(LOG_WARNING, "process_wire_request: Unable to allocate send msg.\n");
 		return -ENOMEM;
@@ -1138,7 +1138,7 @@ static int process_iwpm_netlink_msg(int nl_sock)
 	const char *str_err = "";
 	int ret = 0;
 
-	recv_buffer = (char *)malloc(NLMSG_SPACE(IWARP_PM_RECV_PAYLOAD));
+	recv_buffer = malloc(NLMSG_SPACE(IWARP_PM_RECV_PAYLOAD));
 	if (!recv_buffer) {
 		ret = -ENOMEM;
 		str_err = "Unable to allocate receive socket buffer";

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -91,7 +91,7 @@ struct ibv_pd *hns_roce_u_alloc_pd(struct ibv_context *context)
 	struct hns_roce_pd *pd;
 	struct hns_roce_alloc_pd_resp resp = {};
 
-	pd = (struct hns_roce_pd *)malloc(sizeof(*pd));
+	pd = malloc(sizeof(*pd));
 	if (!pd)
 		return NULL;
 


### PR DESCRIPTION
malloc() returns void* output which doesn't need to be casted.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>