### PR TITLE
ibacm: lower level of log message

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2259,7 +2259,7 @@ static void acm_ep_up(struct acmc_port *port, uint16_t pkey)
 
 	ret = acm_assign_ep_names(ep);
 	if (ret) {
-		acm_log(0, "ERROR - unable to assign EP name for pkey 0x%x\n", pkey);
+		acm_log(1, "unable to assign EP name for pkey 0x%x\n", pkey);
 		goto ep_close;
 	}
 


### PR DESCRIPTION
When using partitioning in a virtualized system, the Physical Function
(PF) is assigned all pkeys used by the PF and the VFs assigned to the
VMs. Typically, there will be no IPoIB interfaces plumbed, which use
the pkeys assigned to the VMs.

This is logged as errors using log level zero by the ibacm running on
the KVM server or in Xen's Dom0:

acm_ep_up: ERROR - unable to assign EP name for pkey 0x7fff
acm_ep_up: ERROR - unable to assign EP name for pkey 0x2a00
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa001
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa002
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa003
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa004
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa005
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa006
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa007
acm_ep_up: ERROR - unable to assign EP name for pkey 0xa008

It would be better to log these instances at a lower log level and not
label them as errors.

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>