### PR TITLE
pyverbs: Remove RESERVED entries

### DIFF
--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -212,7 +212,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_SRQ_INIT_ATTR_XRCD      = 1 << 2
         IBV_SRQ_INIT_ATTR_CQ        = 1 << 3
         IBV_SRQ_INIT_ATTR_TM        = 1 << 4
-        IBV_SRQ_INIT_ATTR_RESERVED  = 1 << 5
 
     cpdef enum ibv_mig_state:
         IBV_MIG_MIGRATED
@@ -226,7 +225,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_QP_INIT_ATTR_MAX_TSO_HEADER = 1 << 3
         IBV_QP_INIT_ATTR_IND_TABLE      = 1 << 4
         IBV_QP_INIT_ATTR_RX_HASH        = 1 << 5
-        IBV_QP_INIT_ATTR_RESERVED       = 1 << 6
 
     cpdef enum ibv_qp_create_flags:
         IBV_QP_CREATE_BLOCK_SELF_MCAST_LB   = 1 << 1
@@ -264,14 +262,12 @@ cdef extern from '<infiniband/verbs.h>':
 
     cpdef enum ibv_wq_init_attr_mask:
         IBV_WQ_INIT_ATTR_FLAGS      = 1 << 0
-        IBV_WQ_INIT_ATTR_RESERVED   = 1 << 1
 
     cpdef enum ibv_wq_flags:
         IBV_WQ_FLAGS_CVLAN_STRIPPING        = 1 << 0
         IBV_WQ_FLAGS_SCATTER_FCS            = 1 << 1
         IBV_WQ_FLAGS_DELAY_DROP             = 1 << 2
         IBV_WQ_FLAGS_PCI_WRITE_END_PADDING  = 1 << 3
-        IBV_WQ_FLAGS_RESERVED               = 1 << 4
 
     cpdef enum ibv_wq_state:
         IBV_WQS_RESET
@@ -283,7 +279,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WQ_ATTR_STATE       = 1 << 0
         IBV_WQ_ATTR_CURR_STATE  = 1 << 1
         IBV_WQ_ATTR_FLAGS       = 1 << 2
-        IBV_WQ_ATTR_RESERVED    = 1 << 3
 
     cpdef enum ibv_rx_hash_function_flags:
         IBV_RX_HASH_FUNC_TOEPLITZ   = 1 << 0


### PR DESCRIPTION
Clean RESERVED enum members as we don't expect real applications to
use them.

Signed-off-by: Noa Osherovich <noaos@mellanox.com>
Reviewed-by: Maor Gottlieb <maorg@mellanox.com>