### PR TITLE
ibacm: remove include of net/if.h due to conflict

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -360,23 +360,23 @@ else()
   set(HAVE_FULL_SYMBOL_VERSIONS 1)
 endif()
 
-if (${NO_PYVERBS})
-  set(CYTHON_EXECUTABLE "")
-else ()
-  # Look for Python. We prefer some variant of python 3 if the system has it.
-  FIND_PACKAGE(PythonInterp 3 QUIET)
-  if (NOT ${PythonInterp_FOUND})
-    FIND_PACKAGE(PythonInterp REQUIRED)
-  endif()
-  FIND_PACKAGE(cython)
-endif()
-
 # Look for Python. We prefer some variant of python 3 if the system has it.
 FIND_PACKAGE(PythonInterp 3 QUIET)
-if (NOT ${PythonInterp_FOUND})
+if (PythonInterp_FOUND)
+  # pyverbs can only use python3:
+  if (NO_PYVERBS)
+    set(CYTHON_EXECUTABLE "")
+  else()
+    FIND_PACKAGE(cython)
+  endif()
+else()
+  # But we still must have python (be it 2) for the build process:
   FIND_PACKAGE(PythonInterp REQUIRED)
+  set(CYTHON_EXECUTABLE "")
 endif()
+
 # A cython & python-devel installation that matches our selected interpreter.
+
 if (CYTHON_EXECUTABLE)
  # cmake has really bad logic here, if PythonIterp has been run it tries to
  # find a matching -devel installation but will happily return a non-matching

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -645,10 +645,6 @@ def run_deb_build(args,env):
             "-e","DEB_BUILD_OPTIONS=parallel=%u"%(multiprocessing.cpu_count()),
         ];
 
-        if not env.build_pyverbs:
-            opts.append("-e");
-            opts.append("EXTRA_CMAKE_FLAGS=%s"%(' '.join(["-DNO_PYVERBS=1"])));
-
         # Create a go.py that will let us run the compilation as the user and
         # then switch to root only for the packaging step.
         with open(os.path.join(tmpdir,"go.py"),"w") as F:

--- a/debian/rules
+++ b/debian/rules
@@ -37,14 +37,15 @@ DH_AUTO_CONFIGURE := "--" \
 		     $(EXTRA_CMAKE_FLAGS)
 
 override_dh_auto_configure:
-ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
-	dh_auto_configure $(DH_AUTO_CONFIGURE)
-else
-	dh_auto_configure $(DH_AUTO_CONFIGURE) \
-		        -DNO_PYVERBS=0 \
-			-DPYTHON_EXECUTABLE:PATH=/usr/bin/python3 \
-			-DCMAKE_INSTALL_PYTHON_ARCH_LIB:PATH=/usr/lib/python3/dist-packages
-endif
+	if [ -e /usr/bin/python3 ]; then \
+		dh_auto_configure $(DH_AUTO_CONFIGURE) \
+				-DPYTHON_EXECUTABLE:PATH=/usr/bin/python3 \
+				-DCMAKE_INSTALL_PYTHON_ARCH_LIB:PATH=/usr/lib/python3/dist-packages; \
+	else \
+		dh_auto_configure $(DH_AUTO_CONFIGURE) \
+			        -DNO_PYVERBS=1; \
+	fi
+
 
 override_dh_auto_build:
 	ninja -C build-deb -v
@@ -69,11 +70,11 @@ INST_EXCLUDE := "etc/init.d/srpd" \
 		"usr/sbin/srp_daemon.sh"
 INST_EXCLUDE := $(addprefix -X,$(INST_EXCLUDE))
 override_dh_install:
-ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
-	dh_install -Npython3-pyverbs --fail-missing $(INST_EXCLUDE) --remaining-packages
-else
-	dh_install --fail-missing $(INST_EXCLUDE)
-endif
+	if [ -e build-deb/python/pyverbs/__init__.py ]; then \
+		dh_install --fail-missing $(INST_EXCLUDE); \
+	else \
+		dh_install -Npython3-pyverbs --fail-missing $(INST_EXCLUDE) --remaining-packages; \
+	fi
 
 # cmake installs the correct init scripts in the correct place, just setup the
 # pre-postrms
@@ -101,11 +102,12 @@ override_dh_strip:
 	dh_strip --remaining-packages
 
 override_dh_builddeb:
-ifeq ($(EXTRA_CMAKE_FLAGS), -DNO_PYVERBS=1)
-	dh_builddeb -Npython3-pyverbs --remaining-packages
-else
-	dh_builddeb --remaining-package
-endif
+	if [ -e build-deb/python/pyverbs/__init__.py ]; then \
+		dh_builddeb --remaining-package; \
+	else \
+		dh_builddeb -Npython3-pyverbs --remaining-packages; \
+	fi
+
 
 # Upstream encourages the use of 'build' as the developer build output
 # directory, allow that directory to be present and still allow dh to work.

--- a/ibacm/src/acm_util.c
+++ b/ibacm/src/acm_util.c
@@ -33,7 +33,6 @@
 #include <string.h>
 #include <unistd.h>
 #include <arpa/inet.h>
-#include <net/if.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <errno.h>


### PR DESCRIPTION
Certain versions of linux-headers nad glibc-headers had both an enum with
identifiers name IFF_* (e.g.: IFF_UP). See e.g.:
https://bugzilla.redhat.com/show_bug.cgi?id=1300256 .

Remove inclusion if <net/if.h> (<linux/if.h> is included through the
netlink3 headers).

Fixes: db109a15 ('ibacm: Replace ioctl with netlink')
Signed-off-by: Tzafrir Cohen <tzafrirc@mellanox.com>
Signed-off-by: Noa Osherovich <noaos@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>