### PR TITLE
travis: Drop SuSE package test due to Travis CI failures

### DIFF
--- a/buildlib/package-build-test
+++ b/buildlib/package-build-test
@@ -11,7 +11,7 @@ if [ -e "/.dockerenv" ] || (grep -q docker /proc/self/cgroup &>/dev/null); then
        exit 0
 fi
 
-for OS in centos7 tumbleweed
+for OS in centos7
 do
 	echo
 	echo "Checking package build for ${OS} ...."


### PR DESCRIPTION
Remove SuSE from the list of tested packages due to random
sigfaults while running zypper command under Travis CI environment.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>