### PR TITLE
travis: Change SuSE package target due to Travis CI failures

### DIFF
--- a/buildlib/package-build-test
+++ b/buildlib/package-build-test
@@ -11,7 +11,7 @@ if [ -e "/.dockerenv" ] || (grep -q docker /proc/self/cgroup &>/dev/null); then
        exit 0
 fi
 
-for OS in centos7 tumbleweed
+for OS in centos7 leap
 do
 	echo
 	echo "Checking package build for ${OS} ...."


### PR DESCRIPTION
Change SuSE package target to leap due to random sigfaults while
running zypper command in tumbleweed under Travis CI environment.

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>