### PR TITLE
mlx5: Add new device IDs

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -74,6 +74,8 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x101a),	/* ConnectX-5 Ex VF */
 	HCA(MELLANOX, 0x101b),    /* ConnectX-6 */
 	HCA(MELLANOX, 0x101c),	/* ConnectX-6 VF */
+	HCA(MELLANOX, 0x101d),	/* ConnectX-6 DX */
+	HCA(MELLANOX, 0x101e),	/* ConnectX family mlx5Gen Virtual Function */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
 	{}


### PR DESCRIPTION
Add ConnectX-6 DX HCA ID.

In addition, add "ConnectX family mlx5Gen Virtual Function" device ID.
Every new HCA VF will be identified with this device ID.