### PR TITLE
libqedr: Add support for doorbell overflow recovery in user space

### DIFF
--- a/kernel-headers/rdma/qedr-abi.h
+++ b/kernel-headers/rdma/qedr-abi.h
@@ -38,6 +38,15 @@
 #define QEDR_ABI_VERSION		(8)
 
 /* user kernel communication data structures. */
+enum qedr_alloc_ucontext_flags {
+	QEDR_ALLOC_UCTX_RESERVED	= 1 << 0,
+	QEDR_ALLOC_UCTX_DB_REC		= 1 << 1
+};
+
+struct qedr_alloc_ucontext_req {
+	__u32 context_flags;
+	__u32 reserved;
+};
 
 struct qedr_alloc_ucontext_resp {
 	__aligned_u64 db_pa;
@@ -74,6 +83,7 @@ struct qedr_create_cq_uresp {
 	__u32 db_offset;
 	__u16 icid;
 	__u16 reserved;
+	__aligned_u64 db_rec_addr;
 };
 
 struct qedr_create_qp_ureq {
@@ -109,6 +119,13 @@ struct qedr_create_qp_uresp {
 
 	__u32 rq_db2_offset;
 	__u32 reserved;
+
+	/* address of SQ doorbell recovery user entry */
+	__aligned_u64 sq_db_rec_addr;
+
+	/* address of RQ doorbell recovery user entry */
+	__aligned_u64 rq_db_rec_addr;
+
 };
 
 struct qedr_create_srq_ureq {
@@ -126,6 +143,14 @@ struct qedr_create_srq_uresp {
 	__u16 srq_id;
 	__u16 reserved0;
 	__u32 reserved1;
+};
+
+/* doorbell recovery entry allocated and populated by userspace doorbelling
+ * entities and mapped to kernel. Kernel uses this to register doorbell
+ * information with doorbell drop recovery mechanism.
+ */
+struct qedr_user_db_rec {
+	__aligned_u64 db_data; /* doorbell data */
 };
 
 #endif /* __QEDR_USER_H__ */

--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -46,6 +46,7 @@
 #define writel(b, p) (*(uint32_t *)(p) = (b))
 #define writeq(b, p) (*(uint64_t *)(p) = (b))
 
+#include "qelr_abi.h"
 #include "qelr_hsi.h"
 #include "qelr_chain.h"
 
@@ -123,6 +124,7 @@ struct qelr_devctx {
 	FILE			*dbg_fp;
 	void			*db_addr;
 	uint64_t		db_pa;
+	struct qedr_user_db_rec	db_rec_addr_dummy;
 	uint32_t		db_size;
 	uint8_t			disable_edpm;
 	uint32_t		kernel_page_size;
@@ -157,6 +159,9 @@ struct qelr_cq {
 
 	void			*db_addr;
 	union db_prod64		db;
+	/* Doorbell recovery entry address */
+	void			*db_rec_map;
+	struct qedr_user_db_rec *db_rec_addr;
 
 	uint8_t			chain_toggle;
 	union rdma_cqe		*latest_cqe;
@@ -195,6 +200,9 @@ struct qelr_qp_hwq_info {
 	void					*db;      /* Doorbell address */
 	void					*edpm_db;
 	union db_prod32				db_data;  /* Doorbell data */
+	/* Doorbell recovery entry address */
+	void					*db_rec_map;
+	struct qedr_user_db_rec			*db_rec_addr;
 	void					*iwarp_db2;
 	union db_prod32				iwarp_db2_data;
 

--- a/providers/qedr/qelr_abi.h
+++ b/providers/qedr/qelr_abi.h
@@ -45,8 +45,8 @@ DECLARE_DRV_CMD(qelr_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		qedr_create_cq_ureq, qedr_create_cq_uresp);
 DECLARE_DRV_CMD(qelr_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
 		qedr_create_qp_ureq, qedr_create_qp_uresp);
-DECLARE_DRV_CMD(qelr_get_context, IB_USER_VERBS_CMD_GET_CONTEXT,
-		empty, qedr_alloc_ucontext_resp);
+DECLARE_DRV_CMD(qelr_alloc_context, IB_USER_VERBS_CMD_GET_CONTEXT,
+		qedr_alloc_ucontext_req, qedr_alloc_ucontext_resp);
 DECLARE_DRV_CMD(qelr_reg_mr, IB_USER_VERBS_CMD_REG_MR,
 		empty, empty);
 DECLARE_DRV_CMD(qelr_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,

--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -42,7 +42,6 @@
 
 #include "qelr.h"
 #include "qelr_main.h"
-#include "qelr_abi.h"
 #include "qelr_chain.h"
 
 #include <sys/types.h>
@@ -165,8 +164,8 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 						void *private_data)
 {
 	struct qelr_devctx *ctx;
-	struct qelr_get_context cmd;
-	struct qelr_get_context_resp resp;
+	struct qelr_alloc_context cmd;
+	struct qelr_alloc_context_resp resp;
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_QEDR);
@@ -178,6 +177,7 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 	qelr_open_debug_file(ctx);
 	qelr_set_debug_mask();
 
+	cmd.context_flags |= QEDR_ALLOC_UCTX_DB_REC;
 	if (ibv_cmd_get_context(&ctx->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto cmd_err;


### PR DESCRIPTION
Sending a patch series to rdma-next: 
Use the doorbell overflow recovery mechanism for RDMA 
commit 36907cd5cd72 ("qed: Add doorbell overflow recovery mechanism")
for rdma ( RoCE and iWARP )

this is the user-side implementation for it. 