### PR TITLE
debian: Limit cython version in pyverbs dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Uploaders: Benjamin Drung <benjamin.drung@cloud.ionos.com>,
 Section: net
 Priority: optional
 Build-Depends: cmake (>= 2.8.11),
-               cython3,
+               cython3 (>= 0.25),
                debhelper (>= 9),
                debhelper (>= 9.20160709) | dh-systemd,
                dpkg-dev (>= 1.17),
@@ -330,6 +330,7 @@ Package: python3-pyverbs
 Section: python
 Architecture: linux-any
 Depends: rdma-core (>= 21),
+         cython3 (>= 0.25),
          ${misc:Depends},
          ${python3:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
Despite that -DNO_PYVERBS was set correctly and pyverbs wasn't built,
dpkg-genchanges anyway tried to build changes list with pyverbs included
in it.

dpkg-genchanges: error: cannot fstat file ../python3-pyverbs_23.0~201903120844+git272bb55~ubuntu16.04.1_amd64.deb:
No such file or directory
dpkg-buildpackage: error: dpkg-genchanges gave error exit status 2

Ensure that pyverbs has proper dependency on cython version.

Link: https://launchpadlibrarian.net/414799420/buildlog_ubuntu-xenial-amd64.rdma-core_23.0~201903120844+git272bb55~ubuntu16.04.1_BUILDING.txt.gz
Fixes: ec5cdf32e801 ("build: Disable pyverbs build for older Cython versions")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>