### PR TITLE
mlx5: fix erroneous mlx5_qp and MLX5_QP* references

### DIFF
--- a/providers/mlx5/srq.c
+++ b/providers/mlx5/srq.c
@@ -345,20 +345,20 @@ int mlx5_store_srq(struct mlx5_context *ctx, uint32_t srqn,
 	int tind = srqn >> MLX5_SRQ_TABLE_SHIFT;
 
 	if (!ctx->srq_table[tind].refcnt) {
-		ctx->srq_table[tind].table = calloc(MLX5_QP_TABLE_MASK + 1,
-						   sizeof(struct mlx5_qp *));
+		ctx->srq_table[tind].table = calloc(MLX5_SRQ_TABLE_MASK + 1,
+						   sizeof(struct mlx5_srq *));
 		if (!ctx->srq_table[tind].table)
 			return -1;
 	}
 
 	++ctx->srq_table[tind].refcnt;
-	ctx->srq_table[tind].table[srqn & MLX5_QP_TABLE_MASK] = srq;
+	ctx->srq_table[tind].table[srqn & MLX5_SRQ_TABLE_MASK] = srq;
 	return 0;
 }
 
 void mlx5_clear_srq(struct mlx5_context *ctx, uint32_t srqn)
 {
-	int tind = srqn >> MLX5_QP_TABLE_SHIFT;
+	int tind = srqn >> MLX5_SRQ_TABLE_SHIFT;
 
 	if (!--ctx->srq_table[tind].refcnt)
 		free(ctx->srq_table[tind].table);


### PR DESCRIPTION
It looks likely some of the srq code was copied from qp.c and some
references to mlx5_qp and MLX5_QP* not properly replaced with their
mlx5_srq and MLX5_SRQ* equivalanets.

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>