### PR TITLE
verbs:  Introduce a new post send API

### DIFF
--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -14,6 +14,7 @@ import copy
 import shlex
 import pipes
 from contextlib import contextmanager;
+from distutils.version import LooseVersion;
 
 def get_src_dir():
     """Get the source directory using git"""
@@ -106,7 +107,7 @@ def check_lib_symver(args,fn):
                 private,args.PACKAGE_VERSION));
 
     syms = list(syms - private);
-    syms.sort(key=lambda x:re.split('[._]',x));
+    syms.sort(key=LooseVersion)
     if newest_symver != syms[-1]:
         raise ValueError("Symbol version %r implied by filename %r not the newest in ELF (%r)"%(
             newest_symver,fn,syms));

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -17,6 +17,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.7@MLX5_1.7 21
  MLX5_1.8@MLX5_1.8 22
  MLX5_1.9@MLX5_1.9 23
+ MLX5_1.10@MLX5_1.10 24
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -57,3 +58,4 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_destroy_cmd_comp@MLX5_1.9 23
  mlx5dv_devx_get_async_cmd_comp@MLX5_1.9 23
  mlx5dv_devx_obj_query_async@MLX5_1.9 23
+ mlx5dv_qp_ex_from_ibv_qp_ex@MLX5_1.10 24

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -3,6 +3,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.0@IBVERBS_1.0 1.1.6
  IBVERBS_1.1@IBVERBS_1.1 1.1.6
  IBVERBS_1.5@IBVERBS_1.5 20
+ IBVERBS_1.6@IBVERBS_1.6 24
  (symver)IBVERBS_PRIVATE_22 22
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
@@ -70,6 +71,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_open_device@IBVERBS_1.0 1.1.6
  ibv_open_device@IBVERBS_1.1 1.1.6
  ibv_port_state_str@IBVERBS_1.1 1.1.6
+ ibv_qp_to_qp_ex@IBVERBS_1.6 24
  ibv_query_device@IBVERBS_1.0 1.1.6
  ibv_query_device@IBVERBS_1.1 1.1.6
  ibv_query_gid@IBVERBS_1.0 1.1.6

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -27,7 +27,7 @@ configure_file("libibverbs.map.in"
 
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
-  1 1.5.${PACKAGE_VERSION}
+  1 1.6.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
   cmd_ah.c

--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -806,7 +806,14 @@ int ibv_cmd_create_qp_ex2(struct ibv_context *context,
 	struct verbs_xrcd *vxrcd = NULL;
 	int err;
 
-	if (qp_attr->comp_mask >= IBV_QP_INIT_ATTR_RESERVED)
+	if (!check_comp_mask(qp_attr->comp_mask,
+			     IBV_QP_INIT_ATTR_PD |
+			     IBV_QP_INIT_ATTR_XRCD |
+			     IBV_QP_INIT_ATTR_CREATE_FLAGS |
+			     IBV_QP_INIT_ATTR_MAX_TSO_HEADER |
+			     IBV_QP_INIT_ATTR_IND_TABLE |
+			     IBV_QP_INIT_ATTR_RX_HASH |
+			     IBV_QP_INIT_ATTR_SEND_OPS_FLAGS))
 		return EINVAL;
 
 	memset(&cmd->core_payload, 0, sizeof(cmd->core_payload));
@@ -850,7 +857,10 @@ int ibv_cmd_create_qp_ex(struct ibv_context *context,
 	struct verbs_xrcd *vxrcd = NULL;
 	int err;
 
-	if (attr_ex->comp_mask > (IBV_QP_INIT_ATTR_XRCD | IBV_QP_INIT_ATTR_PD))
+	if (!check_comp_mask(attr_ex->comp_mask,
+			     IBV_QP_INIT_ATTR_PD |
+			     IBV_QP_INIT_ATTR_XRCD |
+			     IBV_QP_INIT_ATTR_SEND_OPS_FLAGS))
 		return ENOSYS;
 
 	err = create_qp_ex_common(qp, attr_ex, vxrcd,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -77,7 +77,7 @@ struct verbs_srq {
 
 enum verbs_qp_mask {
 	VERBS_QP_XRCD		= 1 << 0,
-	VERBS_QP_RESERVED	= 1 << 1
+	VERBS_QP_EX		= 1 << 1,
 };
 
 enum ibv_gid_type {
@@ -101,10 +101,14 @@ static inline struct verbs_mr *verbs_get_mr(struct ibv_mr *mr)
 }
 
 struct verbs_qp {
-	struct ibv_qp		qp;
+	union {
+		struct ibv_qp qp;
+		struct ibv_qp_ex qp_ex;
+	};
 	uint32_t		comp_mask;
 	struct verbs_xrcd       *xrcd;
 };
+static_assert(offsetof(struct ibv_qp_ex, qp_base) == 0, "Invalid qp layout");
 
 enum ibv_flow_action_type {
 	IBV_FLOW_ACTION_UNSPECIFIED,

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -111,6 +111,11 @@ IBVERBS_1.5 {
 		ibv_get_pkey_index;
 } IBVERBS_1.1;
 
+IBVERBS_1.6 {
+	global:
+		ibv_qp_to_qp_ex;
+} IBVERBS_1.5;
+
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
    version. See the top level CMakeLists.txt for this setting. */
 

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -68,6 +68,7 @@ rdma_man_pages(
   ibv_srq_pingpong.1
   ibv_uc_pingpong.1
   ibv_ud_pingpong.1
+  ibv_wr_post.3.md
   ibv_xsrq_pingpong.1
   )
 rdma_alias_man_pages(
@@ -101,4 +102,24 @@ rdma_alias_man_pages(
   ibv_rate_to_mbps.3 mbps_to_ibv_rate.3
   ibv_rate_to_mult.3 mult_to_ibv_rate.3
   ibv_reg_mr.3 ibv_dereg_mr.3
+  ibv_wr_post.3 ibv_wr_abort.3
+  ibv_wr_post.3 ibv_wr_complete.3
+  ibv_wr_post.3 ibv_wr_start.3
+  ibv_wr_post.3 ibv_wr_atomic_cmp_swp.3
+  ibv_wr_post.3 ibv_wr_atomic_fetch_add.3
+  ibv_wr_post.3 ibv_wr_bind_mw.3
+  ibv_wr_post.3 ibv_wr_local_inv.3
+  ibv_wr_post.3 ibv_wr_rdma_read.3
+  ibv_wr_post.3 ibv_wr_rdma_write.3
+  ibv_wr_post.3 ibv_wr_rdma_write_imm.3
+  ibv_wr_post.3 ibv_wr_send.3
+  ibv_wr_post.3 ibv_wr_send_imm.3
+  ibv_wr_post.3 ibv_wr_send_inv.3
+  ibv_wr_post.3 ibv_wr_send_tso.3
+  ibv_wr_post.3 ibv_wr_set_inline_data.3
+  ibv_wr_post.3 ibv_wr_set_inline_data_list.3
+  ibv_wr_post.3 ibv_wr_set_sge.3
+  ibv_wr_post.3 ibv_wr_set_sge_list.3
+  ibv_wr_post.3 ibv_wr_set_ud_addr.3
+  ibv_wr_post.3 ibv_wr_set_xrc_srqn.3
   )

--- a/libibverbs/man/ibv_create_qp_ex.3
+++ b/libibverbs/man/ibv_create_qp_ex.3
@@ -39,6 +39,7 @@ uint16_t                max_tso_header; /* Maximum TSO header size */
 struct ibv_rwq_ind_table *rwq_ind_tbl;  /* Indirection table to be associated with the QP */
 struct ibv_rx_hash_conf  rx_hash_conf;  /* RX hash configuration to be used */
 uint32_t                source_qpn;     /* Source QP number, creation flag IBV_QP_CREATE_SOURCE_QPN should be set, few NOTEs below */
+uint64_t                send_ops_flags; /* Select which QP send ops will be defined in struct ibv_qp_ex. Use enum ibv_qp_create_send_ops_flags */
 .in -8
 };
 .sp
@@ -62,6 +63,7 @@ IBV_QP_CREATE_SOURCE_QPN                = 1 << 10, /* The created QP will use th
 IBV_QP_CREATE_PCI_WRITE_END_PADDING     = 1 << 11, /* Incoming packets will be padded to cacheline size */
 .in -8
 };
+.fi
 .nf
 struct ibv_rx_hash_conf {
 .in +8
@@ -72,7 +74,6 @@ uint64_t               rx_hash_fields_mask;    /* RX fields that should particip
 .in -8
 };
 .fi
-
 .nf
 enum ibv_rx_hash_fields {
 .in +8
@@ -89,6 +90,23 @@ IBV_RX_HASH_IPSEC_SPI           = 1 << 8,
  * For applying RSS on the inner packet, then the following field should be set with one of the L3/L4 fields.
 */
 IBV_RX_HASH_INNER		= (1UL << 31),
+.in -8
+};
+.fi
+.nf
+struct ibv_qp_create_send_ops_flags {
+.in +8
+IBV_QP_EX_WITH_RDMA_WRITE		= 1 << 0,
+IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM	= 1 << 1,
+IBV_QP_EX_WITH_SEND			= 1 << 2,
+IBV_QP_EX_WITH_SEND_WITH_IMM		= 1 << 3,
+IBV_QP_EX_WITH_RDMA_READ		= 1 << 4,
+IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP	= 1 << 5,
+IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD	= 1 << 6,
+IBV_QP_EX_WITH_LOCAL_INV		= 1 << 7,
+IBV_QP_EX_WITH_BIND_MW			= 1 << 8,
+IBV_QP_EX_WITH_SEND_WITH_INV		= 1 << 9,
+IBV_QP_EX_WITH_TSO			= 1 << 10,
 .in -8
 };
 .fi
@@ -118,6 +136,12 @@ The attributes max_recv_wr and max_recv_sge are ignored by
 if the QP is to be associated with an SRQ.
 .PP
 The attribute source_qpn is supported only on UD QP, without flow steering RX should not be possible.
+.PP
+Use
+.B ibv_qp_to_qp_ex()
+to get the
+.I ibv_qp_ex
+for accessing the send ops iterator interface, when QP create attr IBV_QP_INIT_ATTR_SEND_OPS_FLAGS is used.
 .PP
 .B ibv_destroy_qp()
 fails if the QP is attached to a multicast group.

--- a/libibverbs/man/ibv_rc_pingpong.1
+++ b/libibverbs/man/ibv_rc_pingpong.1
@@ -8,12 +8,12 @@ ibv_rc_pingpong \- simple InfiniBand RC transport test
 .B ibv_rc_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
 [\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
-[\-o] [\-P] [\-t] \fBHOSTNAME\fR
+[\-o] [\-P] [\-t] [\-j] [\-N] \fBHOSTNAME\fR
 
 .B ibv_rc_pingpong
 [\-p port] [\-d device] [\-i ib port] [\-s size] [\-m size]
 [\-r rx depth] [\-n iters] [\-l sl] [\-e] [\-g gid index]
-[\-o] [\-P] [\-t]
+[\-o] [\-P] [\-t] [\-j] [\-N]
 
 .SH DESCRIPTION
 .PP
@@ -66,6 +66,12 @@ get CQE with timestamp
 .TP
 \fB\-c\fR, \fB\-\-chk\fR
 validate received buffer
+.TP
+\fB\-j\fR, \fB\-\-dm\fR
+use device memory
+.TP
+\fB\-N\fR, \fB\-\-new_send\fR
+use new post send WR API
 
 .SH SEE ALSO
 .BR ibv_uc_pingpong (1),

--- a/libibverbs/man/ibv_wr_post.3.md
+++ b/libibverbs/man/ibv_wr_post.3.md
@@ -1,0 +1,333 @@
+---
+date: 2018-11-27
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: IBV_WR API
+---
+
+# NAME
+
+ibv_wr_abort, ibv_wr_complete, ibv_wr_start - Manage regions allowed to post work
+
+ibv_wr_atomic_cmp_swp, ibv_wr_atomic_fetch_add - Post remote atomic operation work requests
+
+ibv_wr_bind_mw, ibv_wr_local_inv - Post work requests for memory windows
+
+ibv_wr_rdma_read, ibv_wr_rdma_write, ibv_wr_rdma_write_imm - Post RDMA work requests
+
+ibv_wr_send, ibv_wr_send_imm, ibv_wr_send_inv - Post send work requests
+
+ibv_wr_send_tso - Post segmentation offload work requests
+
+ibv_wr_set_inline_data, ibv_wr_set_inline_data_list - Attach inline data to the last work request
+
+ibv_wr_set_sge, ibv_wr_set_sge_list - Attach data to the last work request
+
+ibv_wr_set_ud_addr - Attach UD addressing info to the last work request
+
+ibv_wr_set_xrc_srqn - Attach an XRC SRQN to the last work request
+
+# SYNOPSIS
+
+```c
+#include <infiniband/verbs.h>
+
+void ibv_wr_abort(struct ibv_qp_ex *qp);
+int ibv_wr_complete(struct ibv_qp_ex *qp);
+void ibv_wr_start(struct ibv_qp_ex *qp);
+
+void ibv_wr_atomic_cmp_swp(struct ibv_qp_ex *qp, uint32_t rkey,
+                           uint64_t remote_addr, uint64_t compare,
+                           uint64_t swap);
+void ibv_wr_atomic_fetch_add(struct ibv_qp_ex *qp, uint32_t rkey,
+                             uint64_t remote_addr, uint64_t add);
+
+void ibv_wr_bind_mw(struct ibv_qp_ex *qp, struct ibv_mw *mw, uint32_t rkey,
+                    const struct ibv_mw_bind_info *bind_info);
+void ibv_wr_local_inv(struct ibv_qp_ex *qp, uint32_t invalidate_rkey);
+
+void ibv_wr_rdma_read(struct ibv_qp_ex *qp, uint32_t rkey,
+                      uint64_t remote_addr);
+void ibv_wr_rdma_write(struct ibv_qp_ex *qp, uint32_t rkey,
+                       uint64_t remote_addr);
+void ibv_wr_rdma_write_imm(struct ibv_qp_ex *qp, uint32_t rkey,
+                           uint64_t remote_addr, __be32 imm_data);
+
+void ibv_wr_send(struct ibv_qp_ex *qp);
+void ibv_wr_send_imm(struct ibv_qp_ex *qp, __be32 imm_data);
+void ibv_wr_send_inv(struct ibv_qp_ex *qp, uint32_t invalidate_rkey);
+void ibv_wr_send_tso(struct ibv_qp_ex *qp, void *hdr, uint16_t hdr_sz,
+                     uint16_t mss);
+
+void ibv_wr_set_inline_data(struct ibv_qp_ex *qp, void *addr, size_t length);
+void ibv_wr_set_inline_data_list(struct ibv_qp_ex *qp, size_t num_buf,
+                                 const struct ibv_data_buf *buf_list);
+void ibv_wr_set_sge(struct ibv_qp_ex *qp, uint32_t lkey, uint64_t addr,
+                    uint32_t length);
+void ibv_wr_set_sge_list(struct ibv_qp_ex *qp, size_t num_sge,
+                         const struct ibv_sge *sg_list);
+
+void ibv_wr_set_ud_addr(struct ibv_qp_ex *qp, struct ibv_ah *ah,
+                        uint32_t remote_qpn, uint32_t remote_qkey);
+void ibv_wr_set_xrc_srqn(struct ibv_qp_ex *qp, uint32_t remote_srqn);
+```
+
+# DESCRIPTION
+
+The verbs work request API (ibv_wr_\*) allows efficient posting of work to a send
+queue using function calls instead of the struct based *ibv_post_send()*
+scheme. This approach is designed to minimize CPU branching and locking during
+the posting process.
+
+This API is intended to be used to access additional functionality beyond
+what is provided by *ibv_post_send()*.
+
+WRs batches of *ibv_post_send()* and this API WRs batches can interleave
+together just if they are not posted within the critical region of each other.
+(A critical region in this API formed by *ibv_wr_start()* and
+*ibv_wr_complete()*/*ibv_wr_abort()*)
+
+# USAGE
+
+To use these APIs the QP must be created using ibv_create_qp_ex() which allows
+setting the **IBV_QP_INIT_ATTR_SEND_OPS_FLAGS** in *comp_mask*. The
+*send_ops_flags* should be set to the OR of the work request types that will
+be posted to the QP.
+
+If the QP does not support all the requested work request types then QP
+creation will fail.
+
+Posting work requests to the QP is done within the critical region formed by
+*ibv_wr_start()* and *ibv_wr_complete()*/*ibv_wr_abort()* (see CONCURRENCY below).
+
+Each work request is created by calling a WR builder function (see the table
+column WR builder below) to start creating the work request, followed by
+allowed/required setter functions described below.
+
+The WR builder and setter combination can be called multiple times to
+efficiently post multiple work requests within a single critical region.
+
+Each WR builder will use the *wr_id* member of *struct ibv_qp_ex* to set the
+value to be returned in the completion. Some operations will also use the
+*wr_flags* member to influence operation (see Flags below). These values
+should be set before invoking the WR builder function.
+
+For example a simple send could be formed as follows:
+
+```C
+qpx->wr_id = 1;
+ibv_wr_send(qpx);
+ibv_wr_set_sge(qpx, lkey, &data, sizeof(data));
+```
+
+The section WORK REQUESTS describes the various WR builders and setters in
+details.
+
+Posting work is completed by calling *ibv_wr_complete()* or *ibv_wr_abort()*.
+No work is executed to the queue until *ibv_wr_complete()* returns
+success. *ibv_wr_abort()* will discard all work prepared since *ibv_wr_start()*.
+
+# WORK REQUESTS
+
+Many of the operations match the opcodes available for *ibv_post_send()*. Each
+operation has a WR builder function, a list of allowed setters, and a flag bit
+to request the operation with *send_ops_flags* in *struct
+ibv_qp_init_attr_ex* (see the EXAMPLE below).
+
+| Operation            | WR builder                | QP Type Supported                | setters  |
+|----------------------|---------------------------|----------------------------------|----------|
+| ATOMIC_CMP_AND_SWP   | ibv_wr_atomic_cmp_swp()   | RC, XRC_SEND                     | DATA, QP |
+| ATOMIC_FETCH_AND_ADD | ibv_wr_atomic_fetch_add() | RC, XRC_SEND                     | DATA, QP |
+| BIND_MW              | ibv_wr_bind_mw()          | UC, RC, XRC_SEND                 | NONE     |
+| LOCAL_INV            | ibv_wr_local_inv()        | UC, RC, XRC_SEND                 | NONE     |
+| RDMA_READ            | ibv_wr_rdma_read()        | RC, XRC_SEND                     | DATA, QP |
+| RDMA_WRITE           | ibv_wr_rdma_write()       | UC, RC, XRC_SEND                 | DATA, QP |
+| RDMA_WRITE_WITH_IMM  | ibv_wr_rdma_write_imm()   | UC, RC, XRC_SEND                 | DATA, QP |
+| SEND                 | ibv_wr_send()             | UD, UC, RC, XRC_SEND, RAW_PACKET | DATA, QP |
+| SEND_WITH_IMM        | ibv_wr_send_imm()         | UD, UC, RC, SRC SEND             | DATA, QP |
+| SEND_WITH_INV        | ibv_wr_send_inv()         | UC, RC, XRC_SEND                 | DATA, QP |
+| TSO                  | ibv_wr_send_tso()         | UD, RAW_PACKET                   | DATA, QP |
+
+
+## Atomic operations
+
+Atomic operations are only atomic so long as all writes to memory go only
+through the same RDMA hardware. It is not atomic with writes performed by the
+CPU, or by other RDMA hardware in the system.
+
+*ibv_wr_atomic_cmp_swp()*
+:   If the remote 64 bit memory location specified by *rkey* and *remote_addr*
+    equals *compare* then set it to *swap*.
+
+*ibv_wr_atomic_fetch_add()*
+:   Add *add* to the 64 bit memory location specified *rkey* and *remote_addr*.
+
+## Memory Windows
+
+Memory window type 2 operations (See man page for ibv_alloc_mw).
+
+*ibv_wr_bind_mw()*
+:   Bind a MW type 2 specified by **mw**, set a new **rkey** and set its
+    properties by **bind_info**.
+
+*ibv_wr_local_inv()*
+:   Invalidate a MW type 2 which is associated with **rkey**.
+
+## RDMA
+
+*ibv_wr_rdma_read()*
+:   Read from the remote memory location specified *rkey* and
+    *remote_addr*. The number of bytes to read, and the local location to
+    store the data, is determined by the DATA buffers set after this call.
+
+*ibv_wr_rdma_write()*, *ibv_wr_rdma_write_imm()*
+:   Write to the remote memory location specified *rkey* and
+    *remote_addr*. The number of bytes to read, and the local location to get
+    the data, is determined by the DATA buffers set after this call.
+
+    The _imm version causes the remote side to get a IBV_WC_RECV_RDMA_WITH_IMM
+    containing the 32 bits of immediate data.
+
+## Message Send
+
+*ibv_wr_send()*, *ibv_wr_send_imm()*
+:   Send a message. The number of bytes to send, and the local location to get
+    the data, is determined by the DATA buffers set after this call.
+
+    The _imm version causes the remote side to get a IBV_WC_RECV_RDMA_WITH_IMM
+    containing the 32 bits of immediate data.
+
+*ibv_wr_send_inv()*
+:   The data transfer is the same as for *ibv_wr_send()*, however the remote
+    side will invalidate the MR specified by *invalidate_rkey* before
+    delivering a completion.
+
+*ibv_wr_send_tso()*
+:   Produce multiple SEND messages using TCP Segmentation Offload. The SGE
+    points to a TCP Stream buffer which will be segmented into
+    MSS size SENDs. The hdr includes the entire network headers up to and
+    including the TCP header and is prefixed before each segment.
+
+## QP Specific setters
+
+Certain QP types require each post to be accompanied by additional setters,
+these setters are mandatory for any operation listing a QP setter in the above
+table.
+
+*UD* QPs
+:   *ibv_wr_set_ud_addr()* must be called to set the destination address of
+    the work.
+
+*XRC_SEND* QPs
+:   *ibv_wr_set_xrc_srqn()* must be called to set the destination SRQN field.
+
+## DATA transfer setters
+
+For work that requires to transfer data one of the following setters should
+be called once after the WR builder:
+
+*ibv_wr_set_sge()*
+:   Transfer data to/from a single buffer given by the lkey, addr and
+    length. This is equivalent to *ibv_wr_set_sge_list()* with a single
+    element.
+
+*ibv_wr_set_sge_list()*
+:   Transfer data to/from a list of buffers, logically concatenated
+    together. Each buffer is specified by an element in an array of *struct
+    ibv_sge*.
+
+Inline setters will copy the send data during the setter and allows the caller
+to immediately re-use the buffer. This behavior is identical to the
+IBV_SEND_INLINE flag. Generally this copy is done in a way that optimizes
+SEND latency and is suitable for small messages. The provider will limit the
+amount of data it can support in a single operation. This limit is requested
+in the *max_inline_data* member of *struct ibv_qp_init_attr*. Valid only
+for SEND and RDMA_WRITE.
+
+*ibv_wr_set_inline_data()*
+:   Copy send data from a single buffer given by the addr and length.
+    This is equivalent to *ibv_wr_set_inline_data_list()* with a single
+    element.
+
+*ibv_wr_set_inline_data_list()*
+:   Copy send data from a list of buffers, logically concatenated
+    together. Each buffer is specified by an element in an array of *struct
+    ibv_inl_data*.
+
+## Flags
+
+A bit mask of flags may be specified in *wr_flags* to control the behavior of
+the work request.
+
+**IBV_SEND_FENCE**
+:   Do not start this work request until prior work has completed.
+
+**IBV_SEND_IP_CSUM**
+:   Offload the IPv4 and TCP/UDP checksum calculation
+
+**IBV_SEND_SIGNALED**
+:   A completion will be generated in the completion queue for the operation.
+
+**IBV_SEND_SOLICTED**
+:   Set the solicted bit in the RDMA packet. This informs the other side to
+    generate a completion event upon receiving the RDMA operation.
+
+# CONCURRENCY
+
+The provider will provide locking to ensure that *ibv_wr_start()* and
+*ibv_wr_complete()/abort()* form a per-QP critical section where no other
+threads can enter.
+
+If an *ibv_td* is provided during QP creation then no locking will be perfomed
+and it is up to the caller to ensure that only one thread can be within the
+critical region at a time.
+
+# RETURN VALUE
+
+Applications should use this API in a way that does not create failures. The
+individual APIs do not return a failure indication to avoid branching.
+
+If a failure is detected during operation, for instance due to an invalid
+argument, then *ibv_wr_complete()* will return failure and the entire posting
+will be aborted.
+
+# EXAMPLE
+
+```c
+/* create RC QP type and specify the required send opcodes */
+qp_init_attr_ex.qp_type = IBV_QPT_RC;
+qp_init_attr_ex.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+qp_init_attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_WRITE;
+qp_init_attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM;
+
+ibv_qp *qp = ibv_create_qp_ex(ctx, qp_init_attr_ex);
+ibv_qp_ex *qpx = ibv_qp_to_qp_ex(qp);
+
+ibv_wr_start(qpx);
+
+/* create 1st WRITE WR entry */
+qpx->wr_id = my_wr_id_1;
+ibv_wr_rdma_write(qpx, rkey, remote_addr_1);
+ibv_wr_set_sge(qpx, lkey, local_addr_1, length_1);
+
+/* create 2nd WRITE_WITH_IMM WR entry */
+qpx->wr_id = my_wr_id_2;
+qpx->send_flags = IBV_SEND_SIGNALED;
+ibv_wr_rdma_write_imm(qpx, rkey, remote_addr_2, htonl(0x1234));
+ibv_set_wr_sge(qpx, lkey, local_addr_2, length_2);
+
+/* Begin processing WRs */
+ret = ibv_wr_complete(qpx);
+```
+
+# SEE ALSO
+
+**ibv_post_send**(3), **ibv_create_qp_ex(3)**.
+
+# AUTHOR
+
+Jason Gunthorpe <jgg@mellanox.com>
+Guy Levi <guyle@mellanox.com>

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -589,6 +589,15 @@ LATEST_SYMVER_FUNC(ibv_create_qp, 1_1, "IBVERBS_1.1",
 	return qp;
 }
 
+struct ibv_qp_ex *ibv_qp_to_qp_ex(struct ibv_qp *qp)
+{
+	struct verbs_qp *vqp = (struct verbs_qp *)qp;
+
+	if (vqp->comp_mask & VERBS_QP_EX)
+		return &vqp->qp_ex;
+	return NULL;
+}
+
 LATEST_SYMVER_FUNC(ibv_query_qp, 1_1, "IBVERBS_1.1",
 		   int,
 		   struct ibv_qp *qp, struct ibv_qp_attr *attr,

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -889,7 +889,7 @@ enum ibv_qp_init_attr_mask {
 	IBV_QP_INIT_ATTR_MAX_TSO_HEADER = 1 << 3,
 	IBV_QP_INIT_ATTR_IND_TABLE	= 1 << 4,
 	IBV_QP_INIT_ATTR_RX_HASH	= 1 << 5,
-	IBV_QP_INIT_ATTR_RESERVED	= 1 << 6
+	IBV_QP_INIT_ATTR_SEND_OPS_FLAGS = 1 << 6,
 };
 
 enum ibv_qp_create_flags {
@@ -898,6 +898,20 @@ enum ibv_qp_create_flags {
 	IBV_QP_CREATE_CVLAN_STRIPPING		= 1 << 9,
 	IBV_QP_CREATE_SOURCE_QPN		= 1 << 10,
 	IBV_QP_CREATE_PCI_WRITE_END_PADDING	= 1 << 11,
+};
+
+enum ibv_qp_create_send_ops_flags {
+	IBV_QP_EX_WITH_RDMA_WRITE		= 1 << 0,
+	IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM	= 1 << 1,
+	IBV_QP_EX_WITH_SEND			= 1 << 2,
+	IBV_QP_EX_WITH_SEND_WITH_IMM		= 1 << 3,
+	IBV_QP_EX_WITH_RDMA_READ		= 1 << 4,
+	IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP	= 1 << 5,
+	IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD	= 1 << 6,
+	IBV_QP_EX_WITH_LOCAL_INV		= 1 << 7,
+	IBV_QP_EX_WITH_BIND_MW			= 1 << 8,
+	IBV_QP_EX_WITH_SEND_WITH_INV		= 1 << 9,
+	IBV_QP_EX_WITH_TSO			= 1 << 10,
 };
 
 struct ibv_rx_hash_conf {
@@ -926,6 +940,8 @@ struct ibv_qp_init_attr_ex {
 	struct ibv_rwq_ind_table       *rwq_ind_tbl;
 	struct ibv_rx_hash_conf	rx_hash_conf;
 	uint32_t		source_qpn;
+	/* See enum ibv_qp_create_send_ops_flags */
+	uint64_t send_ops_flags;
 };
 
 enum ibv_qp_open_attr_mask {
@@ -1049,6 +1065,11 @@ enum ibv_send_flags {
 	IBV_SEND_SOLICITED	= 1 << 2,
 	IBV_SEND_INLINE		= 1 << 3,
 	IBV_SEND_IP_CSUM	= 1 << 4
+};
+
+struct ibv_data_buf {
+	void *addr;
+	size_t length;
 };
 
 struct ibv_sge {
@@ -1205,6 +1226,174 @@ struct ibv_qp {
 	pthread_cond_t		cond;
 	uint32_t		events_completed;
 };
+
+struct ibv_qp_ex {
+	struct ibv_qp qp_base;
+	uint64_t comp_mask;
+
+	uint64_t wr_id;
+	/* bitmask from enum ibv_send_flags */
+	unsigned int wr_flags;
+
+	void (*wr_atomic_cmp_swp)(struct ibv_qp_ex *qp, uint32_t rkey,
+				  uint64_t remote_addr, uint64_t compare,
+				  uint64_t swap);
+	void (*wr_atomic_fetch_add)(struct ibv_qp_ex *qp, uint32_t rkey,
+				    uint64_t remote_addr, uint64_t add);
+	void (*wr_bind_mw)(struct ibv_qp_ex *qp, struct ibv_mw *mw,
+			   uint32_t rkey,
+			   const struct ibv_mw_bind_info *bind_info);
+	void (*wr_local_inv)(struct ibv_qp_ex *qp, uint32_t invalidate_rkey);
+	void (*wr_rdma_read)(struct ibv_qp_ex *qp, uint32_t rkey,
+			     uint64_t remote_addr);
+	void (*wr_rdma_write)(struct ibv_qp_ex *qp, uint32_t rkey,
+			      uint64_t remote_addr);
+	void (*wr_rdma_write_imm)(struct ibv_qp_ex *qp, uint32_t rkey,
+				  uint64_t remote_addr, __be32 imm_data);
+
+	void (*wr_send)(struct ibv_qp_ex *qp);
+	void (*wr_send_imm)(struct ibv_qp_ex *qp, __be32 imm_data);
+	void (*wr_send_inv)(struct ibv_qp_ex *qp, uint32_t invalidate_rkey);
+	void (*wr_send_tso)(struct ibv_qp_ex *qp, void *hdr, uint16_t hdr_sz,
+			    uint16_t mss);
+
+	void (*wr_set_ud_addr)(struct ibv_qp_ex *qp, struct ibv_ah *ah,
+			       uint32_t remote_qpn, uint32_t remote_qkey);
+	void (*wr_set_xrc_srqn)(struct ibv_qp_ex *qp, uint32_t remote_srqn);
+
+	void (*wr_set_inline_data)(struct ibv_qp_ex *qp, void *addr,
+				   size_t length);
+	void (*wr_set_inline_data_list)(struct ibv_qp_ex *qp, size_t num_buf,
+					const struct ibv_data_buf *buf_list);
+	void (*wr_set_sge)(struct ibv_qp_ex *qp, uint32_t lkey, uint64_t addr,
+			   uint32_t length);
+	void (*wr_set_sge_list)(struct ibv_qp_ex *qp, size_t num_sge,
+				const struct ibv_sge *sg_list);
+
+	void (*wr_start)(struct ibv_qp_ex *qp);
+	int (*wr_complete)(struct ibv_qp_ex *qp);
+	void (*wr_abort)(struct ibv_qp_ex *qp);
+};
+
+struct ibv_qp_ex *ibv_qp_to_qp_ex(struct ibv_qp *qp);
+
+static inline void ibv_wr_atomic_cmp_swp(struct ibv_qp_ex *qp, uint32_t rkey,
+					 uint64_t remote_addr, uint64_t compare,
+					 uint64_t swap)
+{
+	qp->wr_atomic_cmp_swp(qp, rkey, remote_addr, compare, swap);
+}
+
+static inline void ibv_wr_atomic_fetch_add(struct ibv_qp_ex *qp, uint32_t rkey,
+					   uint64_t remote_addr, uint64_t add)
+{
+	qp->wr_atomic_fetch_add(qp, rkey, remote_addr, add);
+}
+
+static inline void ibv_wr_bind_mw(struct ibv_qp_ex *qp, struct ibv_mw *mw,
+				  uint32_t rkey,
+				  const struct ibv_mw_bind_info *bind_info)
+{
+	qp->wr_bind_mw(qp, mw, rkey, bind_info);
+}
+
+static inline void ibv_wr_local_inv(struct ibv_qp_ex *qp,
+				    uint32_t invalidate_rkey)
+{
+	qp->wr_local_inv(qp, invalidate_rkey);
+}
+
+static inline void ibv_wr_rdma_read(struct ibv_qp_ex *qp, uint32_t rkey,
+				    uint64_t remote_addr)
+{
+	qp->wr_rdma_read(qp, rkey, remote_addr);
+}
+
+static inline void ibv_wr_rdma_write(struct ibv_qp_ex *qp, uint32_t rkey,
+				     uint64_t remote_addr)
+{
+	qp->wr_rdma_write(qp, rkey, remote_addr);
+}
+
+static inline void ibv_wr_rdma_write_imm(struct ibv_qp_ex *qp, uint32_t rkey,
+					 uint64_t remote_addr, __be32 imm_data)
+{
+	qp->wr_rdma_write_imm(qp, rkey, remote_addr, imm_data);
+}
+
+static inline void ibv_wr_send(struct ibv_qp_ex *qp)
+{
+	qp->wr_send(qp);
+}
+
+static inline void ibv_wr_send_imm(struct ibv_qp_ex *qp, __be32 imm_data)
+{
+	qp->wr_send_imm(qp, imm_data);
+}
+
+static inline void ibv_wr_send_inv(struct ibv_qp_ex *qp,
+				   uint32_t invalidate_rkey)
+{
+	qp->wr_send_inv(qp, invalidate_rkey);
+}
+
+static inline void ibv_wr_send_tso(struct ibv_qp_ex *qp, void *hdr,
+				   uint16_t hdr_sz, uint16_t mss)
+{
+	qp->wr_send_tso(qp, hdr, hdr_sz, mss);
+}
+
+static inline void ibv_wr_set_ud_addr(struct ibv_qp_ex *qp, struct ibv_ah *ah,
+				      uint32_t remote_qpn, uint32_t remote_qkey)
+{
+	qp->wr_set_ud_addr(qp, ah, remote_qpn, remote_qkey);
+}
+
+static inline void ibv_wr_set_xrc_srqn(struct ibv_qp_ex *qp,
+				       uint32_t remote_srqn)
+{
+	qp->wr_set_xrc_srqn(qp, remote_srqn);
+}
+
+static inline void ibv_wr_set_inline_data(struct ibv_qp_ex *qp, void *addr,
+					  size_t length)
+{
+	qp->wr_set_inline_data(qp, addr, length);
+}
+
+static inline void ibv_wr_set_inline_data_list(struct ibv_qp_ex *qp,
+					       size_t num_buf,
+					       const struct ibv_data_buf *buf_list)
+{
+	qp->wr_set_inline_data_list(qp, num_buf, buf_list);
+}
+
+static inline void ibv_wr_set_sge(struct ibv_qp_ex *qp, uint32_t lkey,
+				  uint64_t addr, uint32_t length)
+{
+	qp->wr_set_sge(qp, lkey, addr, length);
+}
+
+static inline void ibv_wr_set_sge_list(struct ibv_qp_ex *qp, size_t num_sge,
+				       const struct ibv_sge *sg_list)
+{
+	qp->wr_set_sge_list(qp, num_sge, sg_list);
+}
+
+static inline void ibv_wr_start(struct ibv_qp_ex *qp)
+{
+	qp->wr_start(qp);
+}
+
+static inline int ibv_wr_complete(struct ibv_qp_ex *qp)
+{
+	return qp->wr_complete(qp);
+}
+
+static inline void ibv_wr_abort(struct ibv_qp_ex *qp)
+{
+	qp->wr_abort(qp);
+}
 
 struct ibv_comp_channel {
 	struct ibv_context     *context;

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.9.${PACKAGE_VERSION}
+  1 1.10.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -80,3 +80,8 @@ MLX5_1.9 {
 		mlx5dv_devx_get_async_cmd_comp;
 		mlx5dv_devx_obj_query_async;
 } MLX5_1.8;
+
+MLX5_1.10 {
+	global:
+		mlx5dv_qp_ex_from_ibv_qp_ex;
+} MLX5_1.9;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -18,6 +18,7 @@ rdma_man_pages(
   mlx5dv_open_device.3.md
   mlx5dv_query_device.3
   mlx5dv_ts_to_ns.3
+  mlx5dv_wr_post.3.md
   mlx5dv.7
 )
 rdma_alias_man_pages(
@@ -39,4 +40,6 @@ rdma_alias_man_pages(
  mlx5dv_devx_qp_modify.3 mlx5dv_devx_ind_tbl_modify.3
  mlx5dv_devx_qp_modify.3 mlx5dv_devx_ind_tbl_query.3
  mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_dereg.3
+ mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
+ mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
 )

--- a/providers/mlx5/man/mlx5dv_create_qp.3.md
+++ b/providers/mlx5/man/mlx5dv_create_qp.3.md
@@ -95,6 +95,11 @@ struct mlx5dv_dc_init_attr {
 :	used to create a DCT QP.
 
 
+# NOTES
+
+**mlx5dv_qp_ex_from_ibv_qp_ex()** is used to get *struct mlx5dv_qp_ex* for
+accessing the send ops interfaces when IBV_QP_INIT_ATTR_SEND_OPS_FLAGS is used.
+
 # RETURN VALUE
 
 **mlx5dv_create_qp()**

--- a/providers/mlx5/man/mlx5dv_wr_post.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_post.3.md
@@ -1,0 +1,94 @@
+---
+date: 2019-02-24
+footer: mlx5
+header: "mlx5 Programmer's Manual"
+tagline: Verbs
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: MLX5DV_WR
+---
+
+# NAME
+
+mlx5dv_wr_set_dc_addr - Attach a DC info to the last work request
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+static inline void mlx5dv_wr_set_dc_addr(struct mlx5dv_qp_ex *mqp,
+                                         struct ibv_ah *ah,
+                                         uint32_t remote_dctn,
+                                         uint64_t remote_dc_key);
+```
+
+# DESCRIPTION
+
+The MLX5DV work request APIs (mlx5dv_wr_\*) is an extension for IBV work
+request API (ibv_wr_\*) with mlx5 specific features for send work request.
+This may be used together with or without ibv_wr_* calls.
+
+# USAGE
+
+To use these APIs a QP must be created using mlx5dv_create_qp() with
+*send_ops_flags* of struct ibv_qp_init_attr_ex set.
+
+If the QP does not support all the requested work request types then QP
+creation will fail.
+
+The mlx5dv_qp_ex is extracted from the IBV_QP by ibv_qp_to_qp_ex() and
+mlx5dv_qp_ex_from_ibv_qp_ex(). This should be used to apply the mlx5 specific
+features on the posted WR.
+
+A work request creation requires to use the ibv_qp_ex as described in the
+man for ibv_wr_post and mlx5dv_qp with its available builders and setters.
+
+## QP Specific setters
+
+*DCI* QPs
+:   *mlx5dv_wr_set_dc_addr()* must be called to set the DCI WR properties. The
+    destination address of the work is specified by *ah*, the remote DCT
+    number is specified by *remote_dctn* and the DC key is specified by
+    *remote_dc_key*.
+    This setter is available when the QP transport is DCI and send_ops_flags
+    in struct ibv_qp_init_attr_ex is set.
+    The available builders and setters for DCI QP are the same as RC QP.
+
+# EXAMPLE
+
+```c
+/* create DC QP type and specify the required send opcodes */
+attr_ex.qp_type = IBV_QPT_DRIVER;
+attr_ex.comp_mask |= IBV_QP_INIT_ATTR_SEND_OPS_FLAGS;
+attr_ex.send_ops_flags |= IBV_QP_EX_WITH_RDMA_WRITE;
+
+attr_dv.comp_mask |= MLX5DV_QP_INIT_ATTR_MASK_DC;
+attr_dv.dc_init_attr.dc_type = MLX5DV_DCTYPE_DCI;
+
+ibv_qp *qp = mlx5dv_create_qp(ctx, attr_ex, attr_dv);
+ibv_qp_ex *qpx = ibv_qp_to_qp_ex(qp);
+mlx5dv_qp_ex *mqpx = mlx5dv_qp_ex_from_ibv_qp_ex(qpx);
+
+ibv_wr_start(qpx);
+
+/* Use ibv_qp_ex object to set WR generic attributes */
+qpx->wr_id = my_wr_id_1;
+qpx->wr_flags = IBV_SEND_SIGNALED;
+ibv_wr_rdma_write(qpx, rkey, remote_addr_1);
+ibv_wr_set_sge(qpx, lkey, local_addr_1, length_1);
+
+/* Use mlx5 DC setter using mlx5dv_qp_ex object */
+mlx5dv_wr_set_wr_dc_addr(mqpx, ah, remote_dctn, remote_dc_key);
+
+ret = ibv_wr_complete(qpx);
+```
+
+# SEE ALSO
+
+**ibv_post_send**(3), **ibv_create_qp_ex(3)**, **ibv_wr_post(3)**.
+
+# AUTHOR
+
+Guy Levi <guyle@mellanox.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -503,6 +503,7 @@ enum mlx5_qp_flags {
 struct mlx5_qp {
 	struct mlx5_resource            rsc; /* This struct must be first */
 	struct verbs_qp			verbs_qp;
+	struct mlx5dv_qp_ex		dv_qp;
 	struct ibv_qp		       *ibv_qp;
 	struct mlx5_buf                 buf;
 	int                             max_inline_data;
@@ -688,6 +689,11 @@ static inline struct mlx5_qp *to_mqp(struct ibv_qp *ibqp)
 	struct verbs_qp *vqp = (struct verbs_qp *)ibqp;
 
 	return container_of(vqp, struct mlx5_qp, verbs_qp);
+}
+
+static inline struct mlx5_qp *mqp_from_mlx5dv_qp_ex(struct mlx5dv_qp_ex *dv_qp)
+{
+	return container_of(dv_qp, struct mlx5_qp, dv_qp);
 }
 
 static inline struct mlx5_rwq *to_mrwq(struct ibv_wq *ibwq)
@@ -930,7 +936,8 @@ int mlx5_advise_mr(struct ibv_pd *pd,
 		   struct ibv_sge *sg_list,
 		   uint32_t num_sges);
 int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
-			 const struct ibv_qp_init_attr_ex *attr);
+			 const struct ibv_qp_init_attr_ex *attr,
+			 const struct mlx5dv_qp_init_attr *mlx5_attr);
 
 static inline void *mlx5_find_uidx(struct mlx5_context *ctx, uint32_t uidx)
 {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -513,6 +513,7 @@ struct mlx5_qp {
 	struct mlx5_bf		       *bf;
 
 	/* Start of new post send API specific fields */
+	bool				inl_wqe;
 	uint8_t				cur_setters_cnt;
 	uint8_t				fm_cache_rb;
 	int				err;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -505,7 +505,6 @@ struct mlx5_qp {
 	struct verbs_qp			verbs_qp;
 	struct ibv_qp		       *ibv_qp;
 	struct mlx5_buf                 buf;
-	void				*sq_start;
 	int                             max_inline_data;
 	int                             buf_size;
 	/* For Raw Packet QP, use different buffers for the SQ and RQ */
@@ -513,8 +512,20 @@ struct mlx5_qp {
 	int				sq_buf_size;
 	struct mlx5_bf		       *bf;
 
+	/* Start of new post send API specific fields */
+	uint8_t				cur_setters_cnt;
+	uint8_t				fm_cache_rb;
+	int				err;
+	int				nreq;
+	uint32_t			cur_size;
+	uint32_t			cur_post_rb;
+	void				*cur_data;
+	struct mlx5_wqe_ctrl_seg	*cur_ctrl;
+	/* End of new post send API specific fields */
+
 	uint8_t				fm_cache;
 	uint8_t	                        sq_signal_bits;
+	void				*sq_start;
 	struct mlx5_wq                  sq;
 
 	__be32                         *db;
@@ -916,6 +927,9 @@ int mlx5_advise_mr(struct ibv_pd *pd,
 		   uint32_t flags,
 		   struct ibv_sge *sg_list,
 		   uint32_t num_sges);
+int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
+			 const struct ibv_qp_init_attr_ex *attr);
+
 static inline void *mlx5_find_uidx(struct mlx5_context *ctx, uint32_t uidx)
 {
 	int tind = uidx >> MLX5_UIDX_TABLE_SHIFT;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -520,6 +520,7 @@ struct mlx5_qp {
 	int				nreq;
 	uint32_t			cur_size;
 	uint32_t			cur_post_rb;
+	void				*cur_eth;
 	void				*cur_data;
 	struct mlx5_wqe_ctrl_seg	*cur_ctrl;
 	/* End of new post send API specific fields */

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -193,6 +193,26 @@ struct ibv_qp *mlx5dv_create_qp(struct ibv_context *context,
 				struct ibv_qp_init_attr_ex *qp_attr,
 				struct mlx5dv_qp_init_attr *mlx5_qp_attr);
 
+struct mlx5dv_qp_ex {
+	uint64_t comp_mask;
+	/*
+	 * Available just for the MLX5 DC QP type with send opcodes of type:
+	 * rdma, atomic and send.
+	 */
+	void (*wr_set_dc_addr)(struct mlx5dv_qp_ex *mqp, struct ibv_ah *ah,
+			       uint32_t remote_dctn, uint64_t remote_dc_key);
+};
+
+struct mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex *qp);
+
+static inline void mlx5dv_wr_set_dc_addr(struct mlx5dv_qp_ex *mqp,
+					 struct ibv_ah *ah,
+					 uint32_t remote_dctn,
+					 uint64_t remote_dc_key)
+{
+	mqp->wr_set_dc_addr(mqp, ah, remote_dctn, remote_dc_key);
+}
+
 enum mlx5dv_flow_action_esp_mask {
 	MLX5DV_FLOW_ACTION_ESP_MASK_FLAGS	= 1 << 0,
 };

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1129,56 +1129,63 @@ int mlx5_destroy_srq(struct ibv_srq *srq)
 	return 0;
 }
 
-static int sq_overhead(struct mlx5_qp *qp, enum ibv_qp_type qp_type)
+static int _sq_overhead(struct mlx5_qp *qp,
+			enum ibv_qp_type qp_type,
+			uint64_t ops)
 {
-	size_t size = 0;
-	size_t mw_bind_size =
-	    sizeof(struct mlx5_wqe_umr_ctrl_seg) +
-	    sizeof(struct mlx5_wqe_mkey_context_seg) +
-	    max_t(size_t, sizeof(struct mlx5_wqe_umr_klm_seg), 64);
+	size_t size = sizeof(struct mlx5_wqe_ctrl_seg);
+	size_t rdma_size = 0;
+	size_t atomic_size = 0;
+	size_t mw_size = 0;
 
+	/* Operation overhead */
+	if (ops & (IBV_QP_EX_WITH_RDMA_WRITE |
+		   IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM |
+		   IBV_QP_EX_WITH_RDMA_READ))
+		rdma_size = sizeof(struct mlx5_wqe_ctrl_seg) +
+			    sizeof(struct mlx5_wqe_raddr_seg);
+
+	if (ops & (IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP |
+		   IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD))
+		atomic_size = sizeof(struct mlx5_wqe_ctrl_seg) +
+			      sizeof(struct mlx5_wqe_raddr_seg) +
+			      sizeof(struct mlx5_wqe_atomic_seg);
+
+	if (ops & (IBV_QP_EX_WITH_BIND_MW | IBV_QP_EX_WITH_LOCAL_INV))
+		mw_size = sizeof(struct mlx5_wqe_ctrl_seg) +
+			  sizeof(struct mlx5_wqe_umr_ctrl_seg) +
+			  sizeof(struct mlx5_wqe_mkey_context_seg) +
+			  max_t(size_t, sizeof(struct mlx5_wqe_umr_klm_seg), 64);
+
+	size = max_t(size_t, size, rdma_size);
+	size = max_t(size_t, size, atomic_size);
+	size = max_t(size_t, size, mw_size);
+
+	/* Transport overhead */
 	switch (qp_type) {
 	case IBV_QPT_DRIVER:
 		if (qp->dc_type != MLX5DV_DCTYPE_DCI)
 			return -EINVAL;
-		size += sizeof(struct mlx5_wqe_datagram_seg);
 		SWITCH_FALLTHROUGH;
-
-	case IBV_QPT_RC:
-		size += sizeof(struct mlx5_wqe_ctrl_seg) +
-			max(sizeof(struct mlx5_wqe_atomic_seg) +
-			    sizeof(struct mlx5_wqe_raddr_seg),
-			    mw_bind_size);
-		break;
-
-	case IBV_QPT_UC:
-		size = sizeof(struct mlx5_wqe_ctrl_seg) +
-			max(sizeof(struct mlx5_wqe_raddr_seg),
-			    mw_bind_size);
-		break;
 
 	case IBV_QPT_UD:
-		size = sizeof(struct mlx5_wqe_ctrl_seg) +
-			sizeof(struct mlx5_wqe_datagram_seg);
-
+		size += sizeof(struct mlx5_wqe_datagram_seg);
 		if (qp->flags & MLX5_QP_FLAGS_USE_UNDERLAY)
-			size += (sizeof(struct mlx5_wqe_eth_seg) + sizeof(struct mlx5_wqe_eth_pad));
-
+			size += sizeof(struct mlx5_wqe_eth_seg) +
+				sizeof(struct mlx5_wqe_eth_pad);
 		break;
 
-	case IBV_QPT_XRC_SEND:
-		size = sizeof(struct mlx5_wqe_ctrl_seg) + mw_bind_size;
-		SWITCH_FALLTHROUGH;
-
 	case IBV_QPT_XRC_RECV:
-		size = max(size, sizeof(struct mlx5_wqe_ctrl_seg) +
-			   sizeof(struct mlx5_wqe_xrc_seg) +
-			   sizeof(struct mlx5_wqe_raddr_seg));
+	case IBV_QPT_XRC_SEND:
+		size += sizeof(struct mlx5_wqe_xrc_seg);
 		break;
 
 	case IBV_QPT_RAW_PACKET:
-		size = sizeof(struct mlx5_wqe_ctrl_seg) +
-			sizeof(struct mlx5_wqe_eth_seg);
+		size += sizeof(struct mlx5_wqe_eth_seg);
+		break;
+
+	case IBV_QPT_RC:
+	case IBV_QPT_UC:
 		break;
 
 	default:
@@ -1186,6 +1193,50 @@ static int sq_overhead(struct mlx5_qp *qp, enum ibv_qp_type qp_type)
 	}
 
 	return size;
+}
+
+static int sq_overhead(struct mlx5_qp *qp, struct ibv_qp_init_attr_ex *attr)
+{
+	uint64_t ops;
+
+	if (attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS) {
+		ops = attr->send_ops_flags;
+	} else {
+		switch (attr->qp_type) {
+		case IBV_QPT_RC:
+		case IBV_QPT_UC:
+		case IBV_QPT_DRIVER:
+		case IBV_QPT_XRC_RECV:
+		case IBV_QPT_XRC_SEND:
+			ops = IBV_QP_EX_WITH_SEND |
+			      IBV_QP_EX_WITH_SEND_WITH_INV |
+			      IBV_QP_EX_WITH_SEND_WITH_IMM |
+			      IBV_QP_EX_WITH_RDMA_WRITE |
+			      IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM |
+			      IBV_QP_EX_WITH_RDMA_READ |
+			      IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP |
+			      IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD |
+			      IBV_QP_EX_WITH_LOCAL_INV |
+			      IBV_QP_EX_WITH_BIND_MW;
+			break;
+
+		case IBV_QPT_UD:
+			ops = IBV_QP_EX_WITH_SEND |
+			      IBV_QP_EX_WITH_SEND_WITH_IMM |
+			      IBV_QP_EX_WITH_TSO;
+			break;
+
+		case IBV_QPT_RAW_PACKET:
+			ops = IBV_QP_EX_WITH_SEND |
+			      IBV_QP_EX_WITH_TSO;
+			break;
+
+		default:
+			return -EINVAL;
+		}
+	}
+
+	return _sq_overhead(qp, attr->qp_type, ops);
 }
 
 static int mlx5_calc_send_wqe(struct mlx5_context *ctx,
@@ -1197,7 +1248,7 @@ static int mlx5_calc_send_wqe(struct mlx5_context *ctx,
 	int max_gather;
 	int tot_size;
 
-	size = sq_overhead(qp, attr->qp_type);
+	size = sq_overhead(qp, attr);
 	if (size < 0)
 		return size;
 
@@ -1270,7 +1321,7 @@ static int mlx5_calc_sq_size(struct mlx5_context *ctx,
 		return -EINVAL;
 	}
 
-	qp->max_inline_data = wqe_size - sq_overhead(qp, attr->qp_type) -
+	qp->max_inline_data = wqe_size - sq_overhead(qp, attr) -
 		sizeof(struct mlx5_wqe_inl_data_seg);
 	attr->cap.max_inline_data = qp->max_inline_data;
 
@@ -1620,7 +1671,8 @@ enum {
 					IBV_QP_INIT_ATTR_CREATE_FLAGS |
 					IBV_QP_INIT_ATTR_MAX_TSO_HEADER |
 					IBV_QP_INIT_ATTR_IND_TABLE |
-					IBV_QP_INIT_ATTR_RX_HASH),
+					IBV_QP_INIT_ATTR_RX_HASH |
+					IBV_QP_INIT_ATTR_SEND_OPS_FLAGS),
 };
 
 enum {
@@ -1727,13 +1779,23 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 	    (attr->qp_type != IBV_QPT_RAW_PACKET))
 		return NULL;
 
+	if (attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS &&
+	    (attr->comp_mask & IBV_QP_INIT_ATTR_RX_HASH ||
+	     (attr->qp_type == IBV_QPT_DRIVER &&
+	      mlx5_qp_attr &&
+	      mlx5_qp_attr->comp_mask & MLX5DV_QP_INIT_ATTR_MASK_DC &&
+	      mlx5_qp_attr->dc_init_attr.dc_type == MLX5DV_DCTYPE_DCT))) {
+		errno = EINVAL;
+		return NULL;
+	}
+
 	qp = calloc(1, sizeof(*qp));
 	if (!qp) {
 		mlx5_dbg(fp, MLX5_DBG_QP, "\n");
 		return NULL;
 	}
 
-	ibqp = (struct ibv_qp *)&qp->verbs_qp;
+	ibqp = &qp->verbs_qp.qp;
 	qp->ibv_qp = ibqp;
 
 	if ((attr->comp_mask & IBV_QP_INIT_ATTR_CREATE_FLAGS) &&
@@ -1847,6 +1909,18 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 		return ibqp;
 	}
 
+	if (ctx->atomic_cap == IBV_ATOMIC_HCA)
+		qp->atomics_enabled = 1;
+
+	if (attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS) {
+		ret = mlx5_qp_fill_wr_pfns(qp, attr);
+		if (ret) {
+			errno = ret;
+			mlx5_dbg(fp, MLX5_DBG_QP, "Failed to handle operations flags (errno %d)\n", errno);
+			goto err;
+		}
+	}
+
 	cmd.flags = mlx5_create_flags;
 	qp->wq_sig = qp_sig_enabled();
 	if (qp->wq_sig)
@@ -1910,9 +1984,6 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 	cmd.sq_wqe_count = qp->sq.wqe_cnt;
 	cmd.rq_wqe_count = qp->rq.wqe_cnt;
 	cmd.rq_wqe_shift = qp->rq.wqe_shift;
-
-	if (ctx->atomic_cap == IBV_ATOMIC_HCA)
-		qp->atomics_enabled = 1;
 
 	if (!ctx->cqe_version) {
 		cmd.uidx = 0xffffff;
@@ -1991,6 +2062,9 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 
 	if (resp_drv->comp_mask & MLX5_IB_CREATE_QP_RESP_MASK_SQN)
 		qp->sqn = resp_drv->sqn;
+
+	if (attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS)
+		qp->verbs_qp.comp_mask |= VERBS_QP_EX;
 
 	return ibqp;
 


### PR DESCRIPTION
Introduce a new set of QP send operations which allow extensibility for new send opcodes.

This concept lets to add vendor specific send opcodes, users can also require a set of supported QP send ops specified during QP creation.

This new API was implemented by the mlx5 driver for the general send opcodes, in addition a driver specific opcode for DC was implemented over the DV API.