### PR TITLE
pyverbs: Add completions support

### DIFF
--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -225,3 +225,59 @@ with d.Context(name='mlx5_0') as ctx:
                 dm_mr = DmMr(pd, dm_mr_len, e.IBV_ACCESS_ZERO_BASED, dm=dm,
                              offset=0)
 ```
+
+##### CQ
+The following snippets show how to create CQs using pyverbs. Pyverbs supports
+both CQ and extended CQ (CQEX).
+As in C, a completion queue can be created with or without a completion
+channel, the snippets show that.
+CQ's 3rd parameter is cq_context, a user-defined context. We're using None in
+our snippets.
+```python
+import random
+
+from pyverbs.cq import CompChannel, CQ
+import pyverbs.device as d
+
+with d.Context(name='mlx5_0') as ctx:
+    num_cqes = random.randint(0, 200) # Just arbitrary values. Max value can be
+                                      # found in device attributes
+    comp_vector = 0 # An arbitrary value. comp_vector is limited by the
+                    # context's num_comp_vectors
+    if random.choice([True, False]):
+        with CompChannel(ctx) as cc:
+            cq = CQ(ctx, num_cqes, None, cc, comp_vector)
+    else:
+        cq = CQ(ctx, num_cqes, None, None, comp_vector)
+    print(cq)
+CQ
+Handle                : 0
+CQEs                  : 63
+```
+
+```python
+import random
+
+from pyverbs.cq import CqInitAttrEx, CQEX
+import pyverbs.device as d
+import pyverbs.enums as e
+
+with d.Context(name='mlx5_0') as ctx:
+    num_cqe = random.randint(0, 200)
+    wc_flags = e.IBV_WC_EX_WITH_CVLAN
+    comp_mask = 0 # Not using flags in this example
+    # completion channel is not used in this example
+    attrs = CqInitAttrEx(cqe=num_cqe, wc_flags=wc_flags, comp_mask=comp_mask,
+                         flags=0)
+    print(attrs)
+    cq_ex = CQEX(ctx, attrs)
+    print(cq_ex)
+    Number of CQEs        : 10
+WC flags              : IBV_WC_EX_WITH_CVLAN
+comp mask             : 0
+flags                 : 0
+
+Extended CQ:
+Handle                : 0
+CQEs                  : 15
+```

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -4,6 +4,7 @@
 rdma_cython_module(pyverbs
   addr.pyx
   base.pyx
+  cq.pyx
   device.pyx
   enums.pyx
   mr.pyx

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -19,6 +19,7 @@ rdma_python_module(pyverbs
 
 rdma_python_test(pyverbs/tests
   tests/__init__.py
+  tests/cq.py
   tests/device.py
   tests/mr.py
   tests/pd.py

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -13,5 +13,20 @@ cdef class CQ(PyverbsCM):
     cpdef close(self)
     cdef object context
 
+cdef class CqInitAttrEx(PyverbsObject):
+    cdef v.ibv_cq_init_attr_ex attr
+
+cdef class CQEX(PyverbsCM):
+    cdef v.ibv_cq_ex *cq
+    cdef v.ibv_cq *ibv_cq
+    cpdef close(self)
+    cdef object context
+
 cdef class WC(PyverbsObject):
     cdef v.ibv_wc wc
+
+cdef class PollCqAttr(PyverbsObject):
+    cdef v.ibv_poll_cq_attr attr
+
+cdef class WcTmInfo(PyverbsObject):
+    cdef v.ibv_wc_tm_info info

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+cimport pyverbs.libibverbs as v
+
+cdef class CompChannel(PyverbsCM):
+    cdef v.ibv_comp_channel *cc
+    cpdef close(self)
+    cdef object context
+
+cdef class CQ(PyverbsCM):
+    cdef v.ibv_cq *cq
+    cpdef close(self)
+    cdef object context
+
+cdef class WC(PyverbsObject):
+    cdef v.ibv_wc wc

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -1,0 +1,295 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+from pyverbs.base import PyverbsRDMAErrno
+cimport pyverbs.libibverbs_enums as e
+from pyverbs.device cimport Context
+
+cdef class CompChannel(PyverbsCM):
+    """
+    A completion channel is a file descriptor used to deliver completion
+    notifications to a userspace process. When a completion event is generated
+    for a CQ, the event is delivered via the completion channel attached to the
+    CQ.
+    """
+    def __cinit__(self, Context context not None):
+        """
+        Initializes a completion channel object on the given device.
+        :param context: The device's context to use
+        :return: A CompChannel object on success
+        """
+        self.cc = v.ibv_create_comp_channel(context.context)
+        if self.cc == NULL:
+            raise PyverbsRDMAErrno('Failed to create a completion channel')
+        self.context = context
+        context.add_ref(self)
+        self.logger.debug('Created a Completion Channel')
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        self.logger.debug('Closing completion channel')
+        if self.cc != NULL:
+            rc = v.ibv_destroy_comp_channel(self.cc)
+            if rc != 0:
+                raise PyverbsRDMAErrno('Failed to destroy a completion channel')
+            self.cc = NULL
+
+    def get_cq_event(self, CQ expected_cq):
+        """
+        Waits for the next completion event in the completion event channel
+        :param expected_cq: The CQ that got the event
+        :return: None
+        """
+        cdef v.ibv_cq *cq
+        cdef void *ctx
+
+        rc = v.ibv_get_cq_event(self.cc, &cq, &ctx)
+        if rc != 0:
+            raise PyverbsRDMAErrno('Failed to get CQ event')
+        if cq != expected_cq.cq:
+            raise PyverbsRDMAErrno('Received event on an unexpected CQ')
+
+
+cdef class CQ(PyverbsCM):
+    """
+    A Completion Queue is the notification mechanism for work request
+    completions. A CQ can have 0 or more associated QPs.
+    """
+    def __cinit__(self, Context context not None, cqe, cq_context,
+                  CompChannel channel, comp_vector):
+        """
+        Initializes a CQ object with the given parameters.
+        :param context: The device's context on which to open the CQ
+        :param cqe: CQ's capacity
+        :param cq_context: User context's pointer
+        :param channel: If set, will be used to return completion events
+        :param comp_vector: Will be used for signaling completion events.
+                            Must be larger than 0 and smaller than the
+                            context's num_comp_vectors
+        :return: The newly created CQ
+        """
+        self.cq = v.ibv_create_cq(context.context, cqe, <void*>cq_context,
+                                  NULL, comp_vector)
+        if self.cq == NULL:
+            raise PyverbsRDMAErrno('Failed to create a CQ')
+        self.context = context
+        context.add_ref(self)
+        self.logger.debug('Created a CQ')
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        self.logger.debug('Closing CQ')
+        if self.cq != NULL:
+            rc = v.ibv_destroy_cq(self.cq)
+            if rc != 0:
+                raise PyverbsRDMAErrno('Failed to close CQ')
+            self.cq = NULL
+            self.context = None
+
+    def poll(self, num_entries=1):
+        """
+        Polls the CQ for completions.
+        :param num_entries: number of completions to pull
+        :return: (npolled, wcs): The number of polled completions and an array
+                 of the polled completions
+        """
+        cdef v.ibv_wc wc
+        wcs = []
+        npolled = 0
+
+        while npolled < num_entries:
+            rc = v.ibv_poll_cq(self.cq, 1, &wc)
+            if rc < 0:
+                raise PyverbsRDMAErrno('Failed to poll CQ')
+            if rc == 0:
+                break;
+            npolled += 1
+            wcs.append(WC(wr_id=wc.wr_id, status=wc.status, opcode=wc.opcode,
+                          vendor_err=wc.vendor_err, byte_len=wc.byte_len,
+                          qp_num=wc.qp_num, src_qp=wc.src_qp,
+                          imm_data=wc.imm_data, wc_flags=wc.wc_flags,
+                          pkey_index=wc.pkey_index, slid=wc.slid, sl=wc.sl,
+                          dlid_path_bits=wc.dlid_path_bits))
+        return npolled, wcs
+
+    @property
+    def _cq(self):
+        return <object>self.cq
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return 'CQ\n' +\
+               print_format.format('Handle', self.cq.handle) +\
+               print_format.format('CQEs', self.cq.cqe)
+
+
+cdef class WC(PyverbsObject):
+    def __cinit__(self, wr_id=0, status=0, opcode=0, vendor_err=0, byte_len=0,
+                  qp_num=0, src_qp=0, imm_data=0, wc_flags=0, pkey_index=0,
+                  slid=0, sl=0, dlid_path_bits=0):
+        self.wr_id = wr_id
+        self.status = status
+        self.opcode = opcode
+        self.vendor_err = vendor_err
+        self.byte_len = byte_len
+        self.qp_num = qp_num
+        self.src_qp = src_qp
+        self.wc_flags = wc_flags
+        self.pkey_index = pkey_index
+        self.slid = slid
+        self.sl = sl
+        self.dlid_path_bits = dlid_path_bits
+
+    @property
+    def wr_id(self):
+        return self.wc.wr_id
+    @wr_id.setter
+    def wr_id(self, val):
+        self.wc.wr_id = val
+
+    @property
+    def status(self):
+        return self.wc.status
+    @status.setter
+    def status(self, val):
+        self.wc.status = val
+
+    @property
+    def opcode(self):
+        return self.wc.opcode
+    @opcode.setter
+    def opcode(self, val):
+        self.wc.opcode = val
+
+    @property
+    def vendor_err(self):
+        return self.wc.vendor_err
+    @vendor_err.setter
+    def vendor_err(self, val):
+        self.wc.vendor_err = val
+
+    @property
+    def byte_len(self):
+        return self.wc.byte_len
+    @byte_len.setter
+    def byte_len(self, val):
+        self.wc.byte_len = val
+
+    @property
+    def qp_num(self):
+        return self.wc.qp_num
+    @qp_num.setter
+    def qp_num(self, val):
+        self.wc.qp_num = val
+
+    @property
+    def src_qp(self):
+        return self.wc.src_qp
+    @src_qp.setter
+    def src_qp(self, val):
+        self.wc.src_qp = val
+
+    @property
+    def wc_flags(self):
+        return self.wc.wc_flags
+    @wc_flags.setter
+    def wc_flags(self, val):
+        self.wc.wc_flags = val
+
+    @property
+    def pkey_index(self):
+        return self.wc.pkey_index
+    @pkey_index.setter
+    def pkey_index(self, val):
+        self.wc.pkey_index = val
+
+    @property
+    def slid(self):
+        return self.wc.slid
+    @slid.setter
+    def slid(self, val):
+        self.wc.slid = val
+
+    @property
+    def sl(self):
+        return self.wc.sl
+    @sl.setter
+    def sl(self, val):
+        self.wc.sl = val
+
+    @property
+    def dlid_path_bits(self):
+        return self.wc.dlid_path_bits
+    @dlid_path_bits.setter
+    def dlid_path_bits(self, val):
+        self.wc.dlid_path_bits = val
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('WR ID', self.wr_id) +\
+            print_format.format('status', cqe_status_to_str(self.status)) +\
+            print_format.format('opcode', cqe_opcode_to_str(self.opcode)) +\
+            print_format.format('vendor error', self.vendor_err) +\
+            print_format.format('byte length', self.byte_len) +\
+            print_format.format('QP num', self.qp_num) +\
+            print_format.format('source QP', self.src_qp) +\
+            print_format.format('WC flags', cqe_flags_to_str(self.wc_flags)) +\
+            print_format.format('pkey index', self.pkey_index) +\
+            print_format.format('slid', self.slid) +\
+            print_format.format('sl', self.sl) +\
+            print_format.format('dlid path bits', self.dlid_path_bits)
+
+
+def cqe_status_to_str(status):
+    try:
+        return {e.IBV_WC_SUCCESS: "success",
+                e.IBV_WC_LOC_LEN_ERR: "local length error",
+                e.IBV_WC_LOC_QP_OP_ERR: "local QP op error",
+                e.IBV_WC_LOC_EEC_OP_ERR: "local EEC op error",
+                e.IBV_WC_LOC_PROT_ERR: "local protection error",
+                e.IBV_WC_WR_FLUSH_ERR: "WR flush error",
+                e.IBV_WC_MW_BIND_ERR: "memory window bind error",
+                e.IBV_WC_BAD_RESP_ERR: "bad response error",
+                e.IBV_WC_LOC_ACCESS_ERR: "local access error",
+                e.IBV_WC_REM_INV_REQ_ERR: "remote invalidate request error",
+                e.IBV_WC_REM_ACCESS_ERR: "remote access error",
+                e.IBV_WC_REM_OP_ERR: "remote op error",
+                e.IBV_WC_RETRY_EXC_ERR: "retry exceeded error",
+                e.IBV_WC_RNR_RETRY_EXC_ERR: "RNR retry exceeded",
+                e.IBV_WC_LOC_RDD_VIOL_ERR: "local RDD violation error",
+                e.IBV_WC_REM_INV_RD_REQ_ERR: "remote invalidate RD request error",
+                e.IBV_WC_REM_ABORT_ERR: "remote abort error",
+                e.IBV_WC_INV_EECN_ERR: "invalidate EECN error",
+                e.IBV_WC_INV_EEC_STATE_ERR: "invalidate EEC state error",
+                e.IBV_WC_FATAL_ERR: "WC fatal error",
+                e.IBV_WC_RESP_TIMEOUT_ERR: "response timeout error",
+                e.IBV_WC_GENERAL_ERR: "general error"}[status]
+    except KeyError:
+        return "Unknown CQE status"
+
+def cqe_opcode_to_str(opcode):
+    try:
+        return {0x0: "Send", 0x1:"RDMA write", 0x2: "RDMA read",
+                0x3: "Compare and swap", 0x4: "Fetch and add",
+                0x5: "Bind Memory window", 0x6: "Local invalidate",
+                0x7: "TSO", 0x80: "Receive",
+                0x81: "Receive RDMA with immediate",
+                0x82: "Tag matching - add", 0x83: "Tag matching - delete",
+                0x84: "Tag matching - sync", 0x85: "Tag matching - receive",
+                0x86: "Tag matching - no tag"}[opcode]
+    except KeyError:
+        return "Unknown CQE opcode {op}".format(op=opcode)
+
+def cqe_flags_to_str(flags):
+    cqe_flags = {1: "GRH", 2: "With immediate", 4: "IP csum OK",
+                 8: "With invalidate", 16: "TM sync request", 32: "TM match",
+                 64: "TM data valid"}
+    flags_str = ""
+    for f in cqe_flags:
+        if flags & f:
+            flags_str += cqe_flags[f]
+            flags_str += " "
+    return flags_str

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -11,6 +11,8 @@ cdef class Context(PyverbsCM):
     cdef add_ref(self, obj)
     cdef object pds
     cdef object dms
+    cdef object ccs
+    cdef object cqs
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -9,9 +9,9 @@ which returns a DeviceAttr object.
 import weakref
 
 from .pyverbs_error import PyverbsRDMAError, PyverbsError
+from pyverbs.cq cimport CQEX, CQ, CompChannel
 from .pyverbs_error import PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
-from pyverbs.cq cimport CQ, CompChannel
 cimport pyverbs.libibverbs_enums as e
 cimport pyverbs.libibverbs as v
 from pyverbs.addr cimport GID
@@ -192,7 +192,7 @@ cdef class Context(PyverbsCM):
             self.dms.add(obj)
         elif isinstance(obj, CompChannel):
             self.ccs.add(obj)
-        elif isinstance(obj, CQ):
+        elif isinstance(obj, CQ) or isinstance(obj, CQEX):
             self.cqs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -200,6 +200,34 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    sl
         unsigned int    dlid_path_bits
 
+    cdef struct ibv_cq_init_attr_ex:
+        unsigned int        cqe
+        void                *cq_context
+        ibv_comp_channel    *channel
+        unsigned int        comp_vector
+        unsigned long       wc_flags
+        unsigned int        comp_mask
+        unsigned int        flags
+
+    cdef struct ibv_cq_ex:
+        ibv_context         *context
+        ibv_comp_channel    *channel
+        void                *cq_context
+        unsigned int        handle
+        int                 cqe
+        unsigned int        comp_events_completed
+        unsigned int        async_events_completed
+        unsigned int        comp_mask
+        ibv_wc_status       status
+        unsigned long       wr_id
+
+    cdef struct ibv_poll_cq_attr:
+        unsigned int    comp_mask
+
+    cdef struct ibv_wc_tm_info:
+        unsigned long   tag
+        unsigned int    priv
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -235,3 +263,25 @@ cdef extern from 'infiniband/verbs.h':
                           ibv_comp_channel *channel, int comp_vector)
     int ibv_destroy_cq(ibv_cq *cq)
     int ibv_poll_cq(ibv_cq *cq, int num_entries, ibv_wc *wc)
+    ibv_cq_ex *ibv_create_cq_ex(ibv_context *context,
+                                ibv_cq_init_attr_ex *cq_attr)
+    ibv_cq *ibv_cq_ex_to_cq(ibv_cq_ex *cq)
+    int ibv_start_poll(ibv_cq_ex *cq, ibv_poll_cq_attr *attr)
+    int ibv_next_poll(ibv_cq_ex *cq)
+    void ibv_end_poll(ibv_cq_ex *cq)
+    ibv_wc_opcode ibv_wc_read_opcode(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_vendor_err(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_byte_len(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_imm_data(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_invalidated_rkey(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_qp_num(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_src_qp(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_wc_flags(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_slid(ibv_cq_ex *cq)
+    unsigned char ibv_wc_read_sl(ibv_cq_ex *cq)
+    unsigned char ibv_wc_read_dlid_path_bits(ibv_cq_ex *cq)
+    unsigned long ibv_wc_read_completion_ts(ibv_cq_ex *cq)
+    unsigned short ibv_wc_read_cvlan(ibv_cq_ex *cq)
+    unsigned int ibv_wc_read_flow_tag(ibv_cq_ex *cq)
+    void ibv_wc_read_tm_info(ibv_cq_ex *cq, ibv_wc_tm_info *tm_info)
+    unsigned long ibv_wc_read_completion_wallclock_ns(ibv_cq_ex *cq)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -21,6 +21,7 @@ cdef extern from 'infiniband/verbs.h':
 
     cdef struct ibv_context:
         ibv_device *device
+        int num_comp_vectors
 
     cdef struct ibv_device_attr:
         char            *fw_ver
@@ -172,6 +173,33 @@ cdef extern from 'infiniband/verbs.h':
         unsigned char           flags
         unsigned short          port_cap_flags2
 
+    cdef struct ibv_comp_channel:
+        ibv_context     *context
+        unsigned int    fd
+        unsigned int    refcnt
+
+    cdef struct ibv_cq:
+        ibv_context         *context
+        ibv_comp_channel    *channel
+        void                *cq_context
+        int                 handle
+        int                 cqe
+
+    cdef struct ibv_wc:
+        unsigned long   wr_id
+        ibv_wc_status   status
+        ibv_wc_opcode   opcode
+        unsigned int    vendor_err
+        unsigned int    byte_len
+        unsigned int    qp_num
+        unsigned int    imm_data
+        unsigned int    src_qp
+        int             wc_flags
+        unsigned int    pkey_index
+        unsigned int    slid
+        unsigned int    sl
+        unsigned int    dlid_path_bits
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -199,3 +227,11 @@ cdef extern from 'infiniband/verbs.h':
                            size_t length)
     int ibv_query_port(ibv_context *context, uint8_t port_num,
                        ibv_port_attr *port_attr)
+    ibv_comp_channel *ibv_create_comp_channel(ibv_context *context)
+    int ibv_destroy_comp_channel(ibv_comp_channel *channel)
+    int ibv_get_cq_event(ibv_comp_channel *channel, ibv_cq **cq,
+                         void **cq_context)
+    ibv_cq *ibv_create_cq(ibv_context *context, int cqe, void *cq_context,
+                          ibv_comp_channel *channel, int comp_vector)
+    int ibv_destroy_cq(ibv_cq *cq)
+    int ibv_poll_cq(ibv_cq *cq, int num_entries, ibv_wc *wc)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -173,17 +173,18 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_RECV_RDMA_WITH_IMM
 
     cpdef enum ibv_create_cq_wc_flags:
-        IBV_WC_EX_WITH_BYTE_LEN                 = 1 << 0
-        IBV_WC_EX_WITH_IMM                      = 1 << 1
-        IBV_WC_EX_WITH_QP_NUM                   = 1 << 2
-        IBV_WC_EX_WITH_SRC_QP                   = 1 << 3
-        IBV_WC_EX_WITH_SLID                     = 1 << 4
-        IBV_WC_EX_WITH_SL                       = 1 << 5
-        IBV_WC_EX_WITH_DLID_PATH_BITS           = 1 << 6
-        IBV_WC_EX_WITH_COMPLETION_TIMESTAMP     = 1 << 7
-        IBV_WC_EX_WITH_CVLAN                    = 1 << 8
-        IBV_WC_EX_WITH_FLOW_TAG                 = 1 << 9
-        IBV_WC_EX_WITH_TM_INFO                  = 1 << 10
+        IBV_WC_EX_WITH_BYTE_LEN                         = 1 << 0
+        IBV_WC_EX_WITH_IMM                              = 1 << 1
+        IBV_WC_EX_WITH_QP_NUM                           = 1 << 2
+        IBV_WC_EX_WITH_SRC_QP                           = 1 << 3
+        IBV_WC_EX_WITH_SLID                             = 1 << 4
+        IBV_WC_EX_WITH_SL                               = 1 << 5
+        IBV_WC_EX_WITH_DLID_PATH_BITS                   = 1 << 6
+        IBV_WC_EX_WITH_COMPLETION_TIMESTAMP             = 1 << 7
+        IBV_WC_EX_WITH_CVLAN                            = 1 << 8
+        IBV_WC_EX_WITH_FLOW_TAG                         = 1 << 9
+        IBV_WC_EX_WITH_TM_INFO                          = 1 << 10
+        IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK   = 1 << 11
 
     cpdef enum ibv_wc_flags:
         IBV_WC_GRH              = 1 << 0
@@ -339,6 +340,14 @@ cdef extern from '<infiniband/verbs.h>':
 
     cpdef enum ibv_read_counters_flags:
         IBV_READ_COUNTERS_ATTR_PREFER_CACHED = 1 << 0
+
+    cpdef enum ibv_cq_init_attr_mask:
+        IBV_CQ_INIT_ATTR_MASK_FLAGS = 1 << 0
+
+    cpdef enum ibv_create_cq_attr_flags:
+        IBV_CREATE_CQ_ATTR_SINGLE_THREADED = 1 << 0
+        IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN  = 1 << 1
+
 
 cdef extern from "<infiniband/tm_types.h>":
     cpdef enum ibv_tmh_op:

--- a/pyverbs/tests/cq.py
+++ b/pyverbs/tests/cq.py
@@ -6,8 +6,8 @@ Test module for pyverbs' cq module.
 import unittest
 import random
 
+from pyverbs.cq import CompChannel, CQ, CqInitAttrEx, CQEX
 from pyverbs.pyverbs_error import PyverbsError
-from pyverbs.cq import CompChannel, CQ
 import pyverbs.device as d
 import pyverbs.enums as e
 
@@ -124,7 +124,86 @@ class CCTest(unittest.TestCase):
                 cc.close()
 
 
+class CQEXTest(unittest.TestCase):
+    """
+    Test various functionalities of the CQEX class.
+    """
+
+    @staticmethod
+    def test_create_cq_ex():
+        """
+        Test ibv_create_cq_ex()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with CQEX(ctx, get_attrs_ex(ctx)):
+                    pass
+
+    @staticmethod
+    def test_create_cq_ex_bad_flow():
+        """
+        Test ibv_create_cq_ex() with wrong comp_vector / number of cqes
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                attrs_ex = get_attrs_ex(ctx)
+                max_cqe = ctx.query_device().max_cqe
+                attrs_ex.cqe = max_cqe + random.randint(1, 100)
+                try:
+                    CQEX(ctx, attrs_ex)
+                except PyverbsError as e:
+                    assert 'Failed to create extended CQ' in e.args[0]
+                    assert ' Errno: 22' in e.args[0]
+                else:
+                    raise PyverbsError(
+                        'Created a CQEX with {c} CQEs while device\'s max CQE={dc}'.
+                        format(c=attrs_ex.cqe, dc=max_cqe))
+                comp_channel = random.randint(ctx.num_comp_vectors, 100)
+                attrs_ex.comp_vector = comp_channel
+                attrs_ex.cqe = get_num_cqes(ctx)
+                try:
+                    CQEX(ctx, attrs_ex)
+                except PyverbsError as e:
+                    assert 'Failed to create extended CQ' in e.args[0]
+                    assert ' Errno: 22' in e.args[0]
+                else:
+                    raise PyverbsError(
+                        'Created a CQEX with comp_vector={c} while device\'s num_comp_vectors={dc}'.
+                        format(c=comp_channel, dc=ctx.num_comp_vectors))
+
+    @staticmethod
+    def test_destroy_cq_ex():
+        """
+        Test ibv_destroy_cq() for extended CQs
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with CQEX(ctx, get_attrs_ex(ctx)) as cq:
+                    cq.close()
+
+
 def get_num_cqes(ctx):
     attr = ctx.query_device()
     max_cqe = attr.max_cqe
     return random.randint(0, max_cqe)
+
+
+def get_attrs_ex(ctx):
+    cqe = get_num_cqes(ctx)
+    sample = random.sample(list(e.ibv_create_cq_wc_flags),
+                           random.randint(0, 11))
+    wc_flags = 0
+    for flag in sample:
+        wc_flags |= flag
+    comp_mask = random.choice([0, e.IBV_CQ_INIT_ATTR_MASK_FLAGS])
+    flags = 0
+    if comp_mask is not 0:
+        sample = random.sample(list(e.ibv_create_cq_attr_flags),
+                               random.randint(0, 2))
+        for flag in sample:
+            flags |= flag
+    return CqInitAttrEx(cqe=cqe, wc_flags=wc_flags, comp_mask=comp_mask,
+                        flags=flags)

--- a/pyverbs/tests/cq.py
+++ b/pyverbs/tests/cq.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+"""
+Test module for pyverbs' cq module.
+"""
+import unittest
+import random
+
+from pyverbs.pyverbs_error import PyverbsError
+from pyverbs.cq import CompChannel, CQ
+import pyverbs.device as d
+import pyverbs.enums as e
+
+
+class CQTest(unittest.TestCase):
+    """
+    Test various functionalities of the CQ class.
+    """
+
+    @staticmethod
+    def test_create_cq():
+        """
+        Test ibv_create_cq()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                cqes = get_num_cqes(ctx)
+                comp_vector = random.randint(0, ctx.num_comp_vectors - 1)
+                if random.choice([True, False]):
+                    with CompChannel(ctx) as cc:
+                        with CQ(ctx, cqes, None, cc, comp_vector):
+                            pass
+                else:
+                    with CQ(ctx, cqes, None, None, comp_vector):
+                        pass
+
+    @staticmethod
+    def test_create_cq_bad_flow():
+        """
+        Test ibv_create_cq() with a wrong comp_vector / cqe number
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                cqes = get_num_cqes(ctx)
+                comp_vector = random.randint(ctx.num_comp_vectors, 100)
+                try:
+                    if random.choice([True, False]):
+                        with CompChannel(ctx) as cc:
+                            with CQ(ctx, cqes, None, cc, comp_vector):
+                                pass
+                    else:
+                        with CQ(ctx, cqes, None, None, comp_vector):
+                            pass
+                except PyverbsError as e:
+                    assert 'Failed to create a CQ' in e.args[0]
+                    assert 'Invalid argument' in e.args[0]
+                else:
+                    raise PyverbsError(
+                        'Created a CQ with comp_vector={n} while device\'s num_comp_vectors={nc}'.
+                        format(n=comp_vector, nc=ctx.num_comp_vectors))
+                max_cqe = ctx.query_device().max_cqe
+                cqes = random.randint(max_cqe + 1, max_cqe + 100)
+                try:
+                    if random.choice([True, False]):
+                        with CompChannel(ctx) as cc:
+                            with CQ(ctx, cqes, None, cc, 0):
+                                pass
+                    else:
+                        with CQ(ctx, cqes, None, None, 0):
+                            pass
+                except PyverbsError as err:
+                    assert 'Failed to create a CQ' in err.args[0]
+                    assert 'Invalid argument' in err.args[0]
+                else:
+                    raise PyverbsError(
+                        'Created a CQ with cqe={n} while device\'s max_cqe={nc}'.
+                        format(n=cqes, nc=max_cqe))
+
+    @staticmethod
+    def test_destroy_cq():
+        """
+        Test ibv_destroy_cq()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                cqes = get_num_cqes(ctx)
+                comp_vector = random.randint(0, ctx.num_comp_vectors - 1)
+                if random.choice([True, False]):
+                    with CompChannel(ctx) as cc:
+                        cq = CQ(ctx, cqes, None, cc, comp_vector)
+                else:
+                    cq = CQ(ctx, cqes, None, None, comp_vector)
+                cq.close()
+
+
+class CCTest(unittest.TestCase):
+    """
+    Test various functionalities of the Completion Channel class.
+    """
+
+    @staticmethod
+    def test_create_comp_channel():
+        """
+        Test ibv_create_comp_channel()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                with CompChannel(ctx):
+                    pass
+
+    @staticmethod
+    def test_destroy_comp_channel():
+        """
+        Test ibv_destroy_comp_channel()
+        """
+        lst = d.get_device_list()
+        for dev in lst:
+            with d.Context(name=dev.name.decode()) as ctx:
+                cc = CompChannel(ctx)
+                cc.close()
+
+
+def get_num_cqes(ctx):
+    attr = ctx.query_device()
+    max_cqe = attr.max_cqe
+    return random.randint(0, max_cqe)

--- a/pyverbs/tests/device.py
+++ b/pyverbs/tests/device.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
+"""
+Test module for pyverbs' device module.
+"""
 import unittest
 import resource
 import random
@@ -11,23 +14,26 @@ import pyverbs.device as d
 PAGE_SIZE = resource.getpagesize()
 
 
-class device_test(unittest.TestCase):
+class DeviceTest(unittest.TestCase):
     """
     Test various functionalities of the Device class.
     """
-    def test_dev_list(self):
+
+    @staticmethod
+    def test_dev_list():
         """
         Verify that it's possible to get IB devices list.
         """
-        lst = d.get_device_list()
+        d.get_device_list()
 
-    def test_open_dev(self):
+    @staticmethod
+    def test_open_dev():
         """
         Test ibv_open_device()
         """
         lst = d.get_device_list()
         for dev in lst:
-            ctx = d.Context(name=dev.name.decode())
+            d.Context(name=dev.name.decode())
 
     def test_query_device(self):
         """
@@ -39,7 +45,8 @@ class device_test(unittest.TestCase):
                 attr = ctx.query_device()
                 self.verify_device_attr(attr)
 
-    def test_query_gid(self):
+    @staticmethod
+    def test_query_gid():
         """
         Test ibv_query_gid()
         """
@@ -50,6 +57,12 @@ class device_test(unittest.TestCase):
 
     @staticmethod
     def verify_device_attr(attr):
+        """
+        Helper method that verifies correctness of some members of DeviceAttr
+        object.
+        :param attr: A DeviceAttr object
+        :return: None
+        """
         assert attr.node_guid != 0
         assert attr.sys_image_guid != 0
         assert attr.max_mr_size > PAGE_SIZE
@@ -78,6 +91,12 @@ class device_test(unittest.TestCase):
 
     @staticmethod
     def verify_port_attr(attr):
+        """
+        Helper method that verifies correctness of some members of PortAttr
+        object.
+        :param attr: A PortAttr object
+        :return: None
+        """
         assert 'Invalid' not in d.phys_state_to_str(attr.state)
         assert 'Invalid' not in d.translate_mtu(attr.max_mtu)
         assert 'Invalid' not in d.translate_mtu(attr.active_mtu)
@@ -98,7 +117,8 @@ class device_test(unittest.TestCase):
                     port_attr = ctx.query_port(p + 1)
                     self.verify_port_attr(port_attr)
 
-    def test_query_port_bad_flow(self):
+    @staticmethod
+    def test_query_port_bad_flow():
         """ Verify that querying non-existing ports fails as expected """
         lst = d.get_device_list()
         for dev in lst:
@@ -111,14 +131,18 @@ class device_test(unittest.TestCase):
                     assert 'Failed to query port' in e.args[0]
                     assert 'Invalid argument' in e.args[0]
                 else:
-                    raise PyverbsRDMAError('Successfully queried non-existing port {p}'.\
-                                           format(p=port))
+                    raise PyverbsRDMAError(
+                        'Successfully queried non-existing port {p}'. \
+                        format(p=port))
 
-class dm_test(unittest.TestCase):
+
+class DMTest(unittest.TestCase):
     """
     Test various functionalities of the DM class.
     """
-    def test_create_dm(self):
+
+    @staticmethod
+    def test_create_dm():
         """
         test ibv_alloc_dm()
         """
@@ -134,7 +158,8 @@ class dm_test(unittest.TestCase):
                 with d.DM(ctx, dm_attrs):
                     pass
 
-    def test_destroy_dm(self):
+    @staticmethod
+    def test_destroy_dm():
         """
         test ibv_free_dm()
         """
@@ -150,7 +175,8 @@ class dm_test(unittest.TestCase):
                 dm = d.DM(ctx, dm_attrs)
                 dm.close()
 
-    def test_create_dm_bad_flow(self):
+    @staticmethod
+    def test_create_dm_bad_flow():
         """
         test ibv_alloc_dm() with an illegal size and comp mask
         """
@@ -163,22 +189,27 @@ class dm_test(unittest.TestCase):
                 dm_len = attr.max_dm_size + 1
                 dm_attrs = u.get_dm_attrs(dm_len)
                 try:
-                    dm = d.DM(ctx, dm_attrs)
+                    d.DM(ctx, dm_attrs)
                 except PyverbsRDMAError as e:
-                    assert 'Failed to allocate device memory of size' in e.args[0]
+                    assert 'Failed to allocate device memory of size' in \
+                           e.args[0]
                     assert 'Max available size' in e.args[0]
                 else:
-                    raise PyverbsError('Created a DM with size larger than max reported')
+                    raise PyverbsError(
+                        'Created a DM with size larger than max reported')
                 dm_attrs.comp_mask = random.randint(1, 100)
                 try:
-                    dm = d.DM(ctx, dm_attrs)
+                    d.DM(ctx, dm_attrs)
                 except PyverbsRDMAError as e:
-                    assert 'Failed to allocate device memory of size' in e.args[0]
+                    assert 'Failed to allocate device memory of size' in \
+                           e.args[0]
                 else:
-                    raise PyverbsError('Created a DM with illegal comp mask {c}'.\
-                                       format(c=dm_attrs.comp_mask))
+                    raise PyverbsError(
+                        'Created a DM with illegal comp mask {c}'. \
+                        format(c=dm_attrs.comp_mask))
 
-    def test_destroy_dm_bad_flow(self):
+    @staticmethod
+    def test_destroy_dm_bad_flow():
         """
         test calling ibv_free_dm() twice
         """
@@ -188,13 +219,15 @@ class dm_test(unittest.TestCase):
                 attr = ctx.query_device_ex()
                 if attr.max_dm_size == 0:
                     return
-                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
                 dm_attrs = u.get_dm_attrs(dm_len)
                 dm = d.DM(ctx, dm_attrs)
                 dm.close()
                 dm.close()
 
-    def test_dm_write(self):
+    @staticmethod
+    def test_dm_write():
         """
         Test writing to the device memory
         """
@@ -204,15 +237,18 @@ class dm_test(unittest.TestCase):
                 attr = ctx.query_device_ex()
                 if attr.max_dm_size == 0:
                     return
-                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
                 dm_attrs = u.get_dm_attrs(dm_len)
                 with d.DM(ctx, dm_attrs) as dm:
                     data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
-                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
+                    data_offset = random.randrange(0, dm_len - data_length,
+                                                   u.DM_ALIGNMENT)
                     data = u.get_data(data_length)
                     dm.copy_to_dm(data_offset, data.encode(), data_length)
 
-    def test_dm_write_bad_flow(self):
+    @staticmethod
+    def test_dm_write_bad_flow():
         """
         Test writing to the device memory with bad offset and length
         """
@@ -222,21 +258,25 @@ class dm_test(unittest.TestCase):
                 attr = ctx.query_device_ex()
                 if attr.max_dm_size == 0:
                     return
-                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
                 dm_attrs = u.get_dm_attrs(dm_len)
                 with d.DM(ctx, dm_attrs) as dm:
                     data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
-                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
-                    data_offset += 1 # offset needs to be a multiple of 4
+                    data_offset = random.randrange(0, dm_len - data_length,
+                                                   u.DM_ALIGNMENT)
+                    data_offset += 1  # offset needs to be a multiple of 4
                     data = u.get_data(data_length)
                     try:
                         dm.copy_to_dm(data_offset, data.encode(), data_length)
                     except PyverbsRDMAError as e:
-                            assert 'Failed to copy to dm' in e.args[0]
+                        assert 'Failed to copy to dm' in e.args[0]
                     else:
-                        raise PyverbsError('Wrote to device memory with a bad offset')
+                        raise PyverbsError(
+                            'Wrote to device memory with a bad offset')
 
-    def test_dm_read(self):
+    @staticmethod
+    def test_dm_read():
         """
         Test reading from the device memory
         """
@@ -246,11 +286,13 @@ class dm_test(unittest.TestCase):
                 attr = ctx.query_device_ex()
                 if attr.max_dm_size == 0:
                     return
-                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size, u.DM_ALIGNMENT)
+                dm_len = random.randrange(u.MIN_DM_SIZE, attr.max_dm_size,
+                                          u.DM_ALIGNMENT)
                 dm_attrs = u.get_dm_attrs(dm_len)
                 with d.DM(ctx, dm_attrs) as dm:
                     data_length = random.randrange(4, dm_len, u.DM_ALIGNMENT)
-                    data_offset = random.randrange(0, dm_len - data_length, u.DM_ALIGNMENT)
+                    data_offset = random.randrange(0, dm_len - data_length,
+                                                   u.DM_ALIGNMENT)
                     data = u.get_data(data_length)
                     dm.copy_to_dm(data_offset, data.encode(), data_length)
                     read_str = dm.copy_from_dm(data_offset, data_length)

--- a/pyverbs/tests/pd.py
+++ b/pyverbs/tests/pd.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
-
+"""
+Test module for pyverbs' pd module.
+"""
 import unittest
 import random
 
@@ -9,11 +11,12 @@ import pyverbs.device as d
 from pyverbs.pd import PD
 
 
-class pd_test(unittest.TestCase):
+class PDTest(unittest.TestCase):
     """
     Test various functionalities of the PD class.
     """
-    def test_alloc_pd(self):
+    @staticmethod
+    def test_alloc_pd():
         """
         Test ibv_alloc_pd()
         """
@@ -23,7 +26,8 @@ class pd_test(unittest.TestCase):
                 with PD(ctx):
                     pass
 
-    def test_dealloc_pd(self):
+    @staticmethod
+    def test_dealloc_pd():
         """
         Test ibv_dealloc_pd()
         """
@@ -33,7 +37,8 @@ class pd_test(unittest.TestCase):
                 with PD(ctx) as pd:
                     pd.close()
 
-    def test_multiple_pd_creation(self):
+    @staticmethod
+    def test_multiple_pd_creation():
         """
         Test multiple creations and destructions of a PD object
         """
@@ -44,19 +49,21 @@ class pd_test(unittest.TestCase):
                     with PD(ctx) as pd:
                         pd.close()
 
-    def test_create_pd_none_ctx(self):
+    @staticmethod
+    def test_create_pd_none_ctx():
         """
         Verify that PD can't be created with a None context
         """
         try:
-            pd = PD(None)
+            PD(None)
         except TypeError as te:
             assert 'expected pyverbs.device.Context' in te.args[0]
             assert 'got NoneType' in te.args[0]
         else:
             raise PyverbsRDMAErrno('Created a PD with None context')
 
-    def test_destroy_pd_twice(self):
+    @staticmethod
+    def test_destroy_pd_twice():
         """
         Test bad flow cases in destruction of a PD object
         """

--- a/pyverbs/tests/utils.py
+++ b/pyverbs/tests/utils.py
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+"""
+Provide some useful helper function for pyverbs' tests.
+"""
 from string import ascii_lowercase as al
 import random
 
 import pyverbs.device as d
 import pyverbs.enums as e
+
 
 MAX_MR_SIZE = 4194304
 # Some HWs limit DM address and length alignment to 4 for read and write
@@ -16,15 +20,26 @@ DM_ALIGNMENT = 4
 MIN_DM_LOG_ALIGN = 0
 MAX_DM_LOG_ALIGN = 6
 
+
 def get_mr_length():
-    # Allocating large buffers typically fails
+    """
+    Provide a random value for MR length. We avoid large buffers as these
+    allocations typically fails.
+    :return: A random MR length
+    """
     return random.randint(0, MAX_MR_SIZE)
 
 
 def get_access_flags():
+    """
+    Provide random legal access flags for an MR.
+    Since remote write and remote atomic require local write permission, if
+    one of them is randomly selected without local write, local write will be
+    added as well.
+    :return: A random legal value for MR flags
+    """
     vals = list(e.ibv_access_flags)
     selected = random.sample(vals, random.randint(1, 7))
-    # Remote write / remote atomic are not allowed without local write
     if e.IBV_ACCESS_REMOTE_WRITE in selected or e.IBV_ACCESS_REMOTE_ATOMIC in selected:
         if not e.IBV_ACCESS_LOCAL_WRITE in selected:
             selected.append(e.IBV_ACCESS_LOCAL_WRITE)
@@ -35,10 +50,21 @@ def get_access_flags():
 
 
 def get_data(length):
+    """
+    Randomizes data of a given length.
+    :param length: Length of the data
+    :return: A random data of the given length
+    """
     return ''.join(random.choice(al) for i in range(length))
 
 
 def get_dm_attrs(dm_len):
+    """
+    Initializes an AllocDmAttr member with the given length and random
+    alignment. It currently sets comp_mask = 0 since other comp_mask values
+    are not supported.
+    :param dm_len:
+    :return: An initialized AllocDmAttr object
+    """
     align = random.randint(MIN_DM_LOG_ALIGN, MAX_DM_LOG_ALIGN)
-    # Comp mask != 0 is not supported
     return d.AllocDmAttr(dm_len, align, 0)


### PR DESCRIPTION
The following patches enable creating completions queues and related
objects such as completion channel in pyverbs. These patches have
matching unit-tests patches.
The series also includes an update to pyverbs' documentation and a patch
to fix pylint issues.