### PR TITLE
verbs: Don't check IBV_ODP_SUPPORT_RECV in ibv_{xsrq,srq}_pingpong

### DIFF
--- a/libibverbs/examples/srq_pingpong.c
+++ b/libibverbs/examples/srq_pingpong.c
@@ -381,7 +381,6 @@ static struct pingpong_context *pp_init_ctx(struct ibv_device *ib_dev, int size,
 	if (use_odp) {
 		struct ibv_device_attr_ex attrx;
 		const uint32_t rc_caps_mask = IBV_ODP_SUPPORT_SEND |
-					      IBV_ODP_SUPPORT_RECV |
 					      IBV_ODP_SUPPORT_SRQ_RECV;
 
 		if (ibv_query_device_ex(ctx->context, NULL, &attrx)) {

--- a/libibverbs/examples/xsrq_pingpong.c
+++ b/libibverbs/examples/xsrq_pingpong.c
@@ -219,7 +219,6 @@ static int pp_init_ctx(char *ib_devname)
 	if (use_odp) {
 		struct ibv_device_attr_ex attrx;
 		const uint32_t xrc_caps_mask = IBV_ODP_SUPPORT_SEND |
-					       IBV_ODP_SUPPORT_RECV |
 					       IBV_ODP_SUPPORT_SRQ_RECV;
 
 		if (ibv_query_device_ex(ctx.context, NULL, &attrx)) {


### PR DESCRIPTION
ibv_{xsrq,srq}_pingpong use SRQ, no need to check for IB_ODP_SUPPORT_RECV device capability to use ODP, IBV_ODP_SUPPORT_SRQ_RECV is enough.
