### PR TITLE
rsockets: Align rsocket behavior with socket behavior

### DIFF
--- a/librdmacm/man/rsocket.7.in
+++ b/librdmacm/man/rsocket.7.in
@@ -1,5 +1,5 @@
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
-.TH "RSOCKET" 7 "2013-01-21" "librdmacm" "Librdmacm Programmer's Manual" librdmacm
+.TH "RSOCKET" 7 "2019-04-16" "librdmacm" "Librdmacm Programmer's Manual" librdmacm
 .SH NAME
 rsocket \- RDMA socket API
 .SH SYNOPSIS
@@ -146,6 +146,10 @@ inline_default - default size of inline data
 iomap_size - default size of remote iomapping table
 .P
 polling_time - default number of microseconds to poll for data before waiting
+.P
+wake_up_interval - maximum number of milliseconds to block in poll.
+This value is used to safe guard against potential application hangs
+in rpoll().
 .P
 All configuration files should contain a single integer value.  Values may
 be set by issuing a command similar to the following example.

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -1339,6 +1339,7 @@ static int rs_do_connect(struct rsocket *rs)
 	struct rs_conn_data *creq, *cresp;
 	int to, ret;
 
+	fastlock_acquire(&rs->slock);
 	switch (rs->state) {
 	case rs_init:
 	case rs_bound:
@@ -1449,6 +1450,7 @@ connected:
 			rs->err = errno;
 		}
 	}
+	fastlock_release(&rs->slock);
 	return ret;
 }
 


### PR DESCRIPTION
This series adjusts the behavior or rsockets to align with sockets.  Specifically, it adds a service thread to processing connection requests and accept them without using the application thread to drive the CM states.  This allows a single-threaded application to connect to itself, and fixes an issue in rsockets where newly accepted sockets were forced to inherit the nonblocking semantics of the listening socket.  This conflicted with normal socket behavior.

The last patch fixes the behavior of rpoll() in multi-threaded use cases.  It uses a signaling mechanism to wake up blocked threads whenever the state of an rsocket might have changed, so that the polling threads can re-check the rsocket states.

An email thread for the issues should be available here:

http://mail.openjdk.java.net/pipermail/nio-dev/2018-December/005632.html
