### PR TITLE
verbs: The ibv_xsrq_pingpong "-c" option is broken

### DIFF
--- a/libibverbs/examples/xsrq_pingpong.c
+++ b/libibverbs/examples/xsrq_pingpong.c
@@ -897,7 +897,7 @@ int main(int argc, char *argv[])
 			{}
 		};
 
-		c = getopt_long(argc, argv, "p:d:i:s:m:n:l:eog:c", long_options,
+		c = getopt_long(argc, argv, "p:d:i:s:m:n:l:eog:c:", long_options,
 				NULL);
 		if (c == -1)
 			break;


### PR DESCRIPTION
$ ibv_xsrq_pingpong -c 2
Segmentation fault

The getopt_long() optstring was modifed by 257470c2 to remove ':' from
the string leaving an optstring of "p:d:i:s:m:q:r:n:l:eg:c". The
explanation for this change in 257470c2 is:

"Also, The buffer validation option doesn't require an extra parameter,
remove the extra ':' from all ibv_*_pingpong examples."

In other ibv_*_pingpong examples, the "-c" option refers to the chk
(buffer validation) option. So, it made sense to make the change in
those example programs, but not in ibv_xsrq_pingpong.

Fixes: 257470c2 ("verbs: Fix pingpong buffer validation")

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>