### PR TITLE
cmake: Explicitly convert build type to be STRING

### DIFF
--- a/buildlib/RDMA_BuildType.cmake
+++ b/buildlib/RDMA_BuildType.cmake
@@ -8,7 +8,7 @@ function(RDMA_BuildType)
   # in performance contexts it doesn't make much sense to have the default build
   # turn off the optimizer.
   if(NOT CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE String
+	  set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
       "Options are ${build_types}"
       FORCE
       )


### PR DESCRIPTION
The build type was declared As "String" instead of "STRING" and it
produced the following warning while rdma-core was built.

CMake Warning (dev) at buildlib/RDMA_BuildType.cmake:11 (set):
  implicitly converting 'String' to 'STRING' type.
Call Stack (most recent call first):
  CMakeLists.txt:170 (RDMA_BuildType)
This warning is for project developers.  Use -Wno-dev to suppress it.

Fixes: 7cb1daa8d9e6 ("Be consistent about defining NDEBUG")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>