### PR TITLE
ibacm: acme does not work if server_mode != unix

### DIFF
--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -76,22 +76,19 @@ int ib_acm_connect(char *dest)
 			      res->ai_protocol);
 		if (sock == -1) {
 			ret = errno;
-			goto err1;
+			goto freeaddr;
 		}
 
 		((struct sockaddr_in *) res->ai_addr)->sin_port =
 			htobe16(server_port);
 		ret = connect(sock, res->ai_addr, res->ai_addrlen);
-		if (ret)
-			goto err2;
-
+		if (ret) {
+			close(sock);
+			sock = -1;
+		}
+freeaddr:
 		freeaddrinfo(res);
-
-err2:
-		close(sock);
-		sock = -1;
-err1:
-		freeaddrinfo(res);
+		return ret;
 	} else {
 		struct sockaddr_un addr;
 


### PR DESCRIPTION
Running the ibacm server in mode loopback or open and then trying to run
ib_acme against it, fails:

$ ib_acme -S 127.0.0.1 -v -f i -s 10.196.100.60 -d 10.196.1.60
*** Error in `ib_acme': double free or corruption (fasttop): 0x000000000177c380 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x7c619)[0x7f540121d619]
/lib64/libc.so.6(freeaddrinfo+0x28)[0x7f5401282fe8]
ib_acme[0x4049eb]
ib_acme[0x401841]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f54011c2c05]
ib_acme[0x40315b]

There are several errors in ib_acm_connect() that need to be fixed.

Afterwards:

$ ib_acme -S 127.0.0.1 -v -f i -s 10.196.100.60 -d 10.196.1.60
Service: 127.0.0.1
Destination: 10.196.1.60
Source: 10.196.100.60
Path information
  dgid: fe80::10:e000:128:d021
  sgid: fe80::10:e000:128:d021
  dlid: 19
  slid: 19
  flow label: 0x0
  hop limit: 0
  tclass: 0
  reversible: 1
  pkey: 0xffff
  sl: 0
  mtu: 4
  rate: 7
  packet lifetime: 0
SA verification: success

return status 0x0

Fixes: 579b6bf8 ("ibacm: Adding new configuration option 'server_mode'")

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>