### PR TITLE
ibacm: acme does not work if server_mode != unix

### DIFF
--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -64,8 +64,8 @@ static int ib_acm_connect_open(char *dest)
 	acm_set_server_port();
 	memset(&hint, 0, sizeof hint);
 
-	hint.ai_family = AF_INET;
 	hint.ai_family = AF_UNSPEC;
+	hint.ai_protocol = IPPROTO_TCP;
 
 	ret = getaddrinfo(dest, NULL, &hint, &res);
 	if (ret)

--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -74,20 +74,17 @@ static int ib_acm_connect_open(char *dest)
 	sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
 	if (sock == -1) {
 		ret = errno;
-		goto err1;
+		goto freeaddr;
 	}
 
 	((struct sockaddr_in *) res->ai_addr)->sin_port = htobe16(server_port);
 	ret = connect(sock, res->ai_addr, res->ai_addrlen);
-	if (ret)
-		goto err2;
+	if (ret) {
+		close(sock);
+		sock = -1;
+	}
 
-	freeaddrinfo(res);
-
-err2:
-	close(sock);
-	sock = -1;
-err1:
+freeaddr:
 	freeaddrinfo(res);
 	return ret;
 }

--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -56,7 +56,7 @@ static void acm_set_server_port(void)
 	}
 }
 
-int ib_acm_connect(char *dest)
+static int ib_acm_connect_open(char *dest)
 {
 	struct addrinfo hint, *res;
 	int ret;
@@ -64,65 +64,73 @@ int ib_acm_connect(char *dest)
 	acm_set_server_port();
 	memset(&hint, 0, sizeof hint);
 
-	if (dest && *dest != '/') {
-		hint.ai_family = AF_INET;
-		hint.ai_family = AF_UNSPEC;
+	hint.ai_family = AF_INET;
+	hint.ai_family = AF_UNSPEC;
 
-		ret = getaddrinfo(dest, NULL, &hint, &res);
-		if (ret)
-			return ret;
+	ret = getaddrinfo(dest, NULL, &hint, &res);
+	if (ret)
+		return ret;
 
-		sock = socket(res->ai_family, res->ai_socktype,
-			      res->ai_protocol);
-		if (sock == -1) {
-			ret = errno;
-			goto err1;
-		}
+	sock = socket(res->ai_family, res->ai_socktype, res->ai_protocol);
+	if (sock == -1) {
+		ret = errno;
+		goto err1;
+	}
 
-		((struct sockaddr_in *) res->ai_addr)->sin_port =
-			htobe16(server_port);
-		ret = connect(sock, res->ai_addr, res->ai_addrlen);
-		if (ret)
-			goto err2;
+	((struct sockaddr_in *) res->ai_addr)->sin_port = htobe16(server_port);
+	ret = connect(sock, res->ai_addr, res->ai_addrlen);
+	if (ret)
+		goto err2;
 
-		freeaddrinfo(res);
+	freeaddrinfo(res);
 
 err2:
+	close(sock);
+	sock = -1;
+err1:
+	freeaddrinfo(res);
+	return ret;
+}
+
+static int ib_acm_connect_unix(char *dest)
+{
+	struct sockaddr_un addr;
+	int ret;
+
+	addr.sun_family = AF_UNIX;
+	if (dest) {
+		if (snprintf(addr.sun_path, sizeof(addr.sun_path),
+			     "%s", dest) >= sizeof(addr.sun_path)) {
+			errno = ENAMETOOLONG;
+			return errno;
+		}
+	} else {
+		BUILD_ASSERT(sizeof(IBACM_IBACME_SERVER_PATH) <=
+			     sizeof(addr.sun_path));
+		strcpy(addr.sun_path, IBACM_IBACME_SERVER_PATH);
+	}
+
+	sock = socket(AF_UNIX, SOCK_STREAM, 0);
+	if (sock < 0)
+		return errno;
+
+	if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+		ret = errno;
 		close(sock);
 		sock = -1;
-err1:
-		freeaddrinfo(res);
-	} else {
-		struct sockaddr_un addr;
-
-		addr.sun_family = AF_UNIX;
-		if (dest) {
-			if (snprintf(addr.sun_path, sizeof(addr.sun_path),
-				     "%s", dest) >= sizeof(addr.sun_path)) {
-				errno = ENAMETOOLONG;
-				return errno;
-			}
-		} else {
-			BUILD_ASSERT(sizeof(IBACM_IBACME_SERVER_PATH) <=
-				     sizeof(addr.sun_path));
-			strcpy(addr.sun_path, IBACM_IBACME_SERVER_PATH);
-		}
-
-		sock = socket(AF_UNIX, SOCK_STREAM, 0);
-		if (sock < 0)
-			return errno;
-
-		if (connect(sock,
-			    (struct sockaddr *)&addr, sizeof(addr)) != 0) {
-			ret = errno;
-			close(sock);
-			sock = -1;
-			errno = ret;
-			return ret;
-		}
+		errno = ret;
+		return ret;
 	}
 
 	return 0;
+}
+
+int ib_acm_connect(char *dest)
+{
+	if (dest && *dest == '/')
+		return ib_acm_connect_unix(dest);
+
+	return ib_acm_connect_open(dest);
 }
 
 void ib_acm_disconnect(void)


### PR DESCRIPTION
This series of patches fixes a problem in ib_acm_connect() when the ibacm server mode is not
"unix". Decomposing ib_acm_connect() into two helper functions first is  done to be more inline with
coding conventions.

Running the ibacm server in mode loopback or open and then trying to run
ib_acme against it, fails:
    
$ ib_acme -S 127.0.0.1 -v -f i -s 10.196.100.60 -d 10.196.1.60
*** Error in `ib_acme': double free or corruption (fasttop): 0x000000000177c380 ***
======= Backtrace: =========
/lib64/libc.so.6(+0x7c619)[0x7f540121d619]
/lib64/libc.so.6(freeaddrinfo+0x28)[0x7f5401282fe8]
ib_acme[0x4049eb]
ib_acme[0x401841]
/lib64/libc.so.6(__libc_start_main+0xf5)[0x7f54011c2c05]
ib_acme[0x40315b]

After this series of patches:

$ ib_acme -S 127.0.0.1 -v -f i -s 10.196.100.60 -d 10.196.1.60
    Service: 127.0.0.1
    Destination: 10.196.1.60
    Source: 10.196.100.60
    Path information
      dgid: fe80::10:e000:128:d021
      sgid: fe80::10:e000:128:d021
      dlid: 19
      slid: 19
      flow label: 0x0
      hop limit: 0
      tclass: 0
      reversible: 1
      pkey: 0xffff
      sl: 0
      mtu: 4
      rate: 7
      packet lifetime: 0
    SA verification: success
    
return status 0x0
