### PR TITLE
README.md: Fix incorrect package name in zypper install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ NOTE: Fedora Core uses the name 'ninja-build' for the 'ninja' command.
 ### openSUSE
 
 ```sh
-$ zypper install cmake gcc libnl3-devel libudev-devel ninja pkg-config valgrind-devel python3-deve python3-Cython
+$ zypper install cmake gcc libnl3-devel libudev-devel ninja pkg-config valgrind-devel python3-devel python3-Cython
 ```
 
 ## Building on CentOS 6/7


### PR DESCRIPTION
Fix 'python3-deve' -> 'python3-devel'.

Signed-off-by: Gal Pressman <galpress@amazon.com>