### PR TITLE
Add traffic in pyverbs

### DIFF
--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -209,7 +209,7 @@ device's own memory rather than a user-allocated buffer.
 import random
 
 from pyverbs.device import DM, AllocDmAttr
-from pyverbs.mr import DmMr
+from pyverbs.mr import DMMR
 import pyverbs.device as d
 from pyverbs.pd import PD
 import pyverbs.enums as e
@@ -222,7 +222,7 @@ with d.Context(name='mlx5_0') as ctx:
         dm_mr_len = random.randint(4, dm_len)
         with DM(ctx, dm_attrs) as dm:
             with PD(ctx) as pd:
-                dm_mr = DmMr(pd, dm_mr_len, e.IBV_ACCESS_ZERO_BASED, dm=dm,
+                dm_mr = DMMR(pd, dm_mr_len, e.IBV_ACCESS_ZERO_BASED, dm=dm,
                              offset=0)
 ```
 
@@ -280,4 +280,30 @@ flags                 : 0
 Extended CQ:
 Handle                : 0
 CQEs                  : 15
+```
+
+##### Addressing related objects
+The following code demonstrates creation of GlobalRoute, AHAttr and AH objects.
+The example creates a global AH so it can also run on RoCE without
+modifications.
+```python
+
+from pyverbs.addr import GlobalRoute, AHAttr, AH
+import pyverbs.device as d
+from pyverbs.pd import PD
+
+with d.Context(name='mlx5_0') as ctx:
+    port_number = 1
+    gid_index = 0  # GID index 0 always exists and valid
+    gid = ctx.query_gid(port_number, gid_index)
+    gr = GlobalRoute(dgid=gid, sgid_index=gid_index)
+    ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_number)
+    print(ah_attr)
+    with PD(ctx) as pd:
+        ah = AH(pd, attr=ah_attr)
+DGID                  : fe80:0000:0000:0000:9a03:9bff:fe00:e4bf
+flow label            : 0
+sgid index            : 0
+hop limit             : 1
+traffic class         : 0
 ```

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -35,15 +35,6 @@ function(rdma_python_module PY_MODULE)
   endforeach()
 endfunction()
 
-function(rdma_python_test PY_MODULE)
-  foreach(PY_FILE ${ARGN})
-    get_filename_component(LINK "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" ABSOLUTE)
-    rdma_create_symlink("${LINK}" "${BUILD_PYTHON}/${PY_MODULE}/${PY_FILE}")
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}
-      DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
-  endforeach()
-endfunction()
-
 # Make a python script runnable from the build/bin directory with all the
 # correct paths filled in
 function(rdma_internal_binary)

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -12,9 +12,10 @@ rdma_cython_module(pyverbs
   )
 
 rdma_python_module(pyverbs
-  pyverbs_error.py
   __init__.py
+  pyverbs_error.py
   run_tests.py
+  utils.py
   )
 
 rdma_python_test(pyverbs/tests

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -9,6 +9,7 @@ rdma_cython_module(pyverbs
   enums.pyx
   mr.pyx
   pd.pyx
+  qp.pyx
   wr.pyx
   )
 

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -28,6 +28,7 @@ rdma_python_module(pyverbs/tests
   tests/device.py
   tests/mr.py
   tests/pd.py
+  tests/qp.py
   tests/utils.py
   )
 

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -9,6 +9,7 @@ rdma_cython_module(pyverbs
   enums.pyx
   mr.pyx
   pd.pyx
+  wr.pyx
   )
 
 rdma_python_module(pyverbs

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -18,8 +18,9 @@ rdma_python_module(pyverbs
   utils.py
   )
 
-rdma_python_test(pyverbs/tests
+rdma_python_module(pyverbs/tests
   tests/__init__.py
+  tests/addr.py
   tests/base.py
   tests/cq.py
   tests/device.py

--- a/pyverbs/addr.pxd
+++ b/pyverbs/addr.pxd
@@ -1,9 +1,23 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
 
-from .base cimport PyverbsObject
+from .base cimport PyverbsObject, PyverbsCM
 from pyverbs cimport libibverbs as v
 
 
 cdef class GID(PyverbsObject):
     cdef v.ibv_gid gid
+
+cdef class GRH(PyverbsObject):
+    cdef v.ibv_grh grh
+
+cdef class GlobalRoute(PyverbsObject):
+    cdef v.ibv_global_route gr
+
+cdef class AHAttr(PyverbsObject):
+    cdef v.ibv_ah_attr ah_attr
+
+cdef class AH(PyverbsCM):
+    cdef v.ibv_ah *ah
+    cdef object pd
+    cpdef close(self)

--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
 
-import sys
 from libc.stdint cimport uint8_t
+
+from pyverbs.utils import gid_str_to_array, gid_str
 from .pyverbs_error import PyverbsUserError
+from pyverbs.base import PyverbsRDMAErrno
+cimport pyverbs.libibverbs as v
+from pyverbs.pd cimport PD
+from pyverbs.cq cimport WC
 
 cdef extern from 'endian.h':
     unsigned long be64toh(unsigned long host_64bits)
@@ -13,6 +18,13 @@ cdef class GID(PyverbsObject):
     """
     GID class represents ibv_gid. It enables user to query for GIDs values.
     """
+    def __cinit__(self, val=None):
+        if val is not None:
+            vals = gid_str_to_array(val)
+
+            for i in range(16):
+                self.gid.raw[i] = <uint8_t>int(vals[i],16)
+
     @property
     def gid(self):
         """
@@ -29,23 +41,368 @@ cdef class GID(PyverbsObject):
         'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
         :return: None
         """
-        val = val.split(':')
-        if len(val) != 8:
-            raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
-        if any([len(v) != 4 for v in val]):
-            raise PyverbsUserError("Invalid GID value ({val})".format(val=val))
-        val_int = int("".join(val), 16)
-        vals = []
-        for i in range(8):
-            vals.append(val[i][0:2])
-            vals.append(val[i][2:4])
+        self._set_gid(val)
+
+    def _set_gid(self, val):
+        vals = gid_str_to_array(val)
 
         for i in range(16):
             self.gid.raw[i] = <uint8_t>int(vals[i],16)
 
     def __str__(self):
-        hex_values = '%016x%016x' % (be64toh(self.gid._global.subnet_prefix),
-                                   be64toh(self.gid._global.interface_id))
-        return ':'.join([hex_values[0:4], hex_values[4:8], hex_values[8:12],
-                         hex_values[12:16], hex_values[16:20], hex_values[20:24],
-                         hex_values[24:28],hex_values[28:32]])
+        return gid_str(self.gid._global.subnet_prefix,
+                       self.gid._global.interface_id)
+
+
+cdef class GRH(PyverbsObject):
+    """
+    Represents ibv_grh struct. Used when creating or initializing an
+    Address Handle from a Work Completion.
+    """
+    def __cinit__(self, GID sgid=None, GID dgid=None, version_tclass_flow=0,
+                  paylen=0, next_hdr=0, hop_limit=1):
+        """
+        Initializes a GRH object
+        :param sgid: Source GID
+        :param dgid: Destination GID
+        :param version_tclass_flow: A 32b big endian used to communicate
+                                    service level e.g. across subnets
+        :param paylen: A 16b big endian that is the packet length in bytes,
+                       starting from the first byte after the GRH up to and
+                       including the last byte of the ICRC
+        :param next_hdr: An 8b unsigned integer specifying the next header
+                         For non-raw packets: 0x1B
+                         For raw packets: According to IETF RFC 1700
+        :param hop_limit: An 8b unsigned integer specifying the number of hops
+                          (i.e. routers) that the packet is permitted to take
+                          prior to being discarded
+        :return: A GRH object
+        """
+        self.grh.dgid = dgid.gid
+        self.grh.sgid = sgid.gid
+        self.grh.version_tclass_flow = version_tclass_flow
+        self.grh.paylen = paylen
+        self.grh.next_hdr = next_hdr
+        self.grh.hop_limit = hop_limit
+
+    @property
+    def dgid(self):
+        return gid_str(self.grh.dgid._global.subnet_prefix,
+                       self.grh.dgid._global.interface_id)
+    @dgid.setter
+    def dgid(self, val):
+        vals = gid_str_to_array(val)
+        for i in range(16):
+            self.grh.dgid.raw[i] = <uint8_t>int(vals[i],16)
+
+    @property
+    def sgid(self):
+        return gid_str(self.grh.sgid._global.subnet_prefix,
+                       self.grh.sgid._global.interface_id)
+    @sgid.setter
+    def sgid(self, val):
+        vals = gid_str_to_array(val)
+        for i in range(16):
+            self.grh.sgid.raw[i] = <uint8_t>int(vals[i],16)
+
+    @property
+    def version_tclass_flow(self):
+        return self.grh.version_tclass_flow
+
+    @version_tclass_flow.setter
+    def version_tclass_flow(self, val):
+        self.grh.version_tclass_flow = val
+
+    @property
+    def paylen(self):
+        return self.grh.paylen
+    @paylen.setter
+    def paylen(self, val):
+        self.grh.paylen = val
+
+    @property
+    def next_hdr(self):
+        return self.grh.next_hdr
+    @next_hdr.setter
+    def next_hdr(self, val):
+        self.grh.next_hdr = val
+
+    @property
+    def hop_limit(self):
+        return self.grh.hop_limit
+    @hop_limit.setter
+    def hop_limit(self, val):
+        self.grh.hop_limit = val
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('DGID', self.dgid) +\
+               print_format.format('SGID', self.sgid) +\
+               print_format.format('version tclass flow', self.version_tclass_flow) +\
+               print_format.format('paylen', self.paylen) +\
+               print_format.format('next header', self.next_hdr) +\
+               print_format.format('hop limit', self.hop_limit)
+
+
+cdef class GlobalRoute(PyverbsObject):
+    """
+    Represents ibv_global_route. Used in Address Handle creation and describes
+    the values to be used in the GRH of the packets that will be sent using
+    this Address Handle.
+    """
+    def __cinit__(self, GID dgid=None, flow_label=0, sgid_index=0, hop_limit=1,
+                  traffic_class=0):
+        """
+        Initializes a GlobalRoute object with given parameters.
+        :param dgid: Destination GID
+        :param flow_label: A 20b value. If non-zero, gives a hint to switches
+                           and routers that this sequence of packets must be
+                           delivered in order
+        :param sgid_index: An index in the port's GID table that identifies the
+                           originator of the packet
+        :param hop_limit: An 8b unsigned integer specifying the number of hops
+                          (i.e. routers) that the packet is permitted to take
+                          prior to being discarded
+        :param traffic_class: An 8b unsigned integer specifying the required
+                              delivery priority for routers
+        :return: A GlobalRoute object
+        """
+        self.gr.dgid=dgid.gid
+        self.gr.flow_label = flow_label
+        self.gr.sgid_index = sgid_index
+        self.gr.hop_limit = hop_limit
+        self.gr.traffic_class = traffic_class
+
+    @property
+    def dgid(self):
+        return gid_str(self.gr.dgid._global.subnet_prefix,
+                       self.gr.dgid._global.interface_id)
+    @dgid.setter
+    def dgid(self, val):
+        vals = gid_str_to_array(val)
+        for i in range(16):
+            self.gr.dgid.raw[i] = <uint8_t>int(vals[i],16)
+
+    @property
+    def flow_label(self):
+        return self.gr.flow_label
+    @flow_label.setter
+    def flow_label(self, val):
+        self.gr.flow_label = val
+
+    @property
+    def sgid_index(self):
+        return self.gr.sgid_index
+    @sgid_index.setter
+    def sgid_index(self, val):
+        self.gr.sgid_index = val
+
+    @property
+    def hop_limit(self):
+        return self.gr.hop_limit
+    @hop_limit.setter
+    def hop_limit(self, val):
+        self.gr.hop_limit = val
+
+    @property
+    def traffic_class(self):
+        return self.gr.traffic_class
+    @traffic_class.setter
+    def traffic_class(self, val):
+        self.gr.traffic_class = val
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('DGID', self.dgid) +\
+               print_format.format('flow label', self.flow_label) +\
+               print_format.format('sgid index', self.sgid_index) +\
+               print_format.format('hop limit', self.hop_limit) +\
+               print_format.format('traffic class', self.traffic_class)
+
+
+cdef class AHAttr(PyverbsObject):
+    """ Represents ibv_ah_attr struct """
+    def __cinit__(self, dlid=0, sl=0, src_path_bits=0, static_rate=0,
+                  is_global=0, port_num=1, GlobalRoute gr=None):
+        """
+        Initializes an AHAttr object.
+        :param dlid: Destination LID, a 16b unsigned integer
+        :param sl: Service level, an 8b unsigned integer
+        :param src_path_bits: When LMC (LID mask count) is used in the port,
+                              packets are being sent with the port's base LID,
+                              bitwise ORed with the value of the src_path_bits.
+                              An 8b unsigned integer
+        :param static_rate: An 8b unsigned integer limiting the rate of packets
+                            that are being sent to the subnet
+        :param is_global: If non-zero, GRH information exists in the Address
+                          Handle
+        :param port_num: The local physical port from which the packets will be
+                         sent
+        :param grh: Attributes of a global routing header. Will only be used if
+                    is_global is non zero.
+        :return: An AHAttr object
+        """
+        self.ah_attr.port_num = port_num
+        self.ah_attr.sl = sl
+        self.ah_attr.src_path_bits = src_path_bits
+        self.ah_attr.dlid = dlid
+        self.ah_attr.static_rate = static_rate
+        self.ah_attr.is_global = is_global
+        # Do not set GRH fields for a non-global AH
+        if is_global:
+            if gr is None:
+                raise PyverbsUserError('Global AH Attr is created but gr parameter is None')
+            self.ah_attr.grh.dgid = gr.gr.dgid
+            self.ah_attr.grh.flow_label = gr.flow_label
+            self.ah_attr.grh.sgid_index = gr.sgid_index
+            self.ah_attr.grh.hop_limit = gr.hop_limit
+            self.ah_attr.grh.traffic_class = gr.traffic_class
+
+    @property
+    def port_num(self):
+        return self.ah_attr.port_num
+    @port_num.setter
+    def port_num(self, val):
+        self.ah_attr.port_num = val
+
+    @property
+    def sl(self):
+        return self.ah_attr.sl
+    @sl.setter
+    def sl(self, val):
+        self.ah_attr.sl = val
+
+    @property
+    def src_path_bits(self):
+        return self.ah_attr.src_path_bits
+    @src_path_bits.setter
+    def src_path_bits(self, val):
+        self.ah_attr.src_path_bits = val
+
+    @property
+    def dlid(self):
+        return self.ah_attr.dlid
+    @dlid.setter
+    def dlid(self, val):
+        self.ah_attr.dlid = val
+
+    @property
+    def static_rate(self):
+        return self.ah_attr.static_rate
+    @static_rate.setter
+    def static_rate(self, val):
+        self.ah_attr.static_rate = val
+
+    @property
+    def is_global(self):
+        return self.ah_attr.is_global
+    @is_global.setter
+    def is_global(self, val):
+        self.ah_attr.is_global = val
+
+    @property
+    def dgid(self):
+        if self.ah_attr.is_global:
+            return gid_str(self.ah_attr.grh.dgid._global.subnet_prefix,
+                           self.ah_attr.grh.dgid._global.interface_id)
+    @dgid.setter
+    def dgid(self, val):
+        if self.ah_attr.is_global:
+            vals = gid_str_to_array(val)
+            for i in range(16):
+                self.ah_attr.grh.dgid.raw[i] = <uint8_t>int(vals[i],16)
+
+    @property
+    def flow_label(self):
+        if self.ah_attr.is_global:
+            return self.ah_attr.grh.flow_label
+    @flow_label.setter
+    def flow_label(self, val):
+        self.ah_attr.grh.flow_label = val
+
+    @property
+    def sgid_index(self):
+        if self.ah_attr.is_global:
+            return self.ah_attr.grh.sgid_index
+    @sgid_index.setter
+    def sgid_index(self, val):
+        self.ah_attr.grh.sgid_index = val
+
+    @property
+    def hop_limit(self):
+        if self.ah_attr.is_global:
+            return self.ah_attr.grh.hop_limit
+    @hop_limit.setter
+    def hop_limit(self, val):
+        self.ah_attr.grh.hop_limit = val
+
+    @property
+    def traffic_class(self):
+        if self.ah_attr.is_global:
+            return self.ah_attr.grh.traffic_class
+    @traffic_class.setter
+    def traffic_class(self, val):
+        self.ah_attr.grh.traffic_class = val
+
+    def __str__(self):
+        print_format = '  {:22}: {:<20}\n'
+        if self.is_global:
+            global_format = print_format.format('dgid', self.dgid) +\
+                            print_format.format('flow label', self.flow_label) +\
+                            print_format.format('sgid index', self.sgid_index) +\
+                            print_format.format('hop limit', self.hop_limit) +\
+                            print_format.format('traffic_class', self.traffic_class)
+        else:
+            global_format = ''
+        return print_format.format('port num', self.port_num) +\
+               print_format.format('sl', self.sl) +\
+               print_format.format('source path bits', self.src_path_bits) +\
+               print_format.format('dlid', self.dlid) +\
+               print_format.format('static rate', self.static_rate) +\
+               print_format.format('is global', self.is_global) + global_format
+
+
+cdef class AH(PyverbsCM):
+    def __cinit__(self, PD pd, **kwargs):
+        """
+        Initializes an AH object with the given values.
+        Two creation methods are supported:
+        - Creation via AHAttr object (calls ibv_create_ah)
+        - Creation via a WC object (calls ibv_create_ah_from_wc)
+        :param pd: PD object this AH belongs to
+        :param kwargs: Arguments:
+           * *attr* (AHAttr)
+               An AHAttr object (represents ibv_ah_attr struct)
+            * *wc*
+               A WC object to use for AH initialization
+            * *grh*
+               A GRH object to use for AH initialization (when using wc)
+            * *port_num*
+               Port number to be used for this AH (when using wc)
+        :return: An AH object on success
+        """
+        if len(kwargs) == 1:
+            # Create AH via ib_create_ah
+            ah_attr = <AHAttr>kwargs['attr']
+            self.ah = v.ibv_create_ah(pd.pd, &ah_attr.ah_attr)
+        else:
+            # Create AH from WC
+            wc = <WC>kwargs['wc']
+            grh = <GRH>kwargs['grh']
+            port_num = kwargs['port_num']
+            self.ah = v.ibv_create_ah_from_wc(pd.pd, &wc.wc, &grh.grh, port_num)
+        if self.ah == NULL:
+            raise PyverbsRDMAErrno('Failed to create AH')
+        pd.add_ref(self)
+        self.pd = pd
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        self.logger.debug('Closing AH')
+        if self.ah != NULL:
+            if v.ibv_destroy_ah(self.ah):
+                raise PyverbsRDMAErrno('Failed to destroy AH')
+            self.ah = NULL
+            self.pd = None

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -14,6 +14,8 @@ cdef class CQ(PyverbsCM):
     cdef v.ibv_cq *cq
     cpdef close(self)
     cdef object context
+    cdef add_ref(self, obj)
+    cdef object qps
 
 cdef class CqInitAttrEx(PyverbsObject):
     cdef v.ibv_cq_init_attr_ex attr
@@ -24,6 +26,8 @@ cdef class CQEX(PyverbsCM):
     cdef v.ibv_cq *ibv_cq
     cpdef close(self)
     cdef object context
+    cdef add_ref(self, obj)
+    cdef object qps
 
 cdef class WC(PyverbsObject):
     cdef v.ibv_wc wc

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -13,6 +13,7 @@ cdef class Context(PyverbsCM):
     cdef object dms
     cdef object ccs
     cdef object cqs
+    cdef object qps
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -17,6 +17,7 @@ cimport pyverbs.libibverbs as v
 from pyverbs.addr cimport GID
 from pyverbs.mr import DMMR
 from pyverbs.pd cimport PD
+from pyverbs.qp cimport QP
 
 cdef extern from 'errno.h':
     int errno
@@ -88,6 +89,7 @@ cdef class Context(PyverbsCM):
         self.dms = weakref.WeakSet()
         self.ccs = weakref.WeakSet()
         self.cqs = weakref.WeakSet()
+        self.qps = weakref.WeakSet()
 
         dev_name = kwargs.get('name')
 
@@ -124,7 +126,7 @@ cdef class Context(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing Context')
-        self.close_weakrefs([self.ccs, self.cqs, self.dms, self.pds])
+        self.close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds])
         if self.context != NULL:
             rc = v.ibv_close_device(self.context)
             if rc != 0:
@@ -194,6 +196,8 @@ cdef class Context(PyverbsCM):
             self.ccs.add(obj)
         elif isinstance(obj, CQ) or isinstance(obj, CQEX):
             self.cqs.add(obj)
+        elif isinstance(obj, QP):
+            self.qps.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -325,6 +325,84 @@ cdef extern from 'infiniband/verbs.h':
         qp_type         qp_type
         unnamed         unnamed
 
+    cdef struct ibv_qp_cap:
+        unsigned int    max_send_wr
+        unsigned int    max_recv_wr
+        unsigned int    max_send_sge
+        unsigned int    max_recv_sge
+        unsigned int    max_inline_data
+
+    cdef struct ibv_qp_init_attr:
+        void            *qp_context
+        ibv_cq          *send_cq
+        ibv_cq          *recv_cq
+        ibv_srq         *srq
+        ibv_qp_cap      cap
+        ibv_qp_type     qp_type
+        int             sq_sig_all
+
+    cdef struct ibv_xrcd:
+        pass
+
+    cdef struct ibv_rwq_ind_table:
+        pass
+
+    cdef struct ibv_rx_hash_conf:
+        pass
+
+    cdef struct ibv_qp_init_attr_ex:
+        void                *qp_context
+        ibv_cq              *send_cq
+        ibv_cq              *recv_cq
+        ibv_srq             *srq
+        ibv_qp_cap          cap
+        ibv_qp_type         qp_type
+        int                 sq_sig_all
+        unsigned int        comp_mask
+        ibv_pd              *pd
+        ibv_xrcd            *xrcd
+        unsigned int        create_flags
+        unsigned short      max_tso_header
+        ibv_rwq_ind_table   *rwq_ind_tbl
+        ibv_rx_hash_conf    rx_hash_conf
+        unsigned int        source_qpn
+        unsigned long       send_ops_flags
+
+    cdef struct ibv_qp_attr:
+        ibv_qp_state    qp_state
+        ibv_qp_state    cur_qp_state
+        ibv_mtu         path_mtu
+        ibv_mig_state   path_mig_state
+        unsigned int    qkey
+        unsigned int    rq_psn
+        unsigned int    sq_psn
+        unsigned int    dest_qp_num
+        unsigned int    qp_access_flags
+        ibv_qp_cap      cap
+        ibv_ah_attr     ah_attr
+        ibv_ah_attr     alt_ah_attr
+        unsigned short  pkey_index
+        unsigned short  alt_pkey_index
+        unsigned char   en_sqd_async_notify
+        unsigned char   sq_draining
+        unsigned char   max_rd_atomic
+        unsigned char   max_dest_rd_atomic
+        unsigned char   min_rnr_timer
+        unsigned char   port_num
+        unsigned char   timeout
+        unsigned char   retry_cnt
+        unsigned char   rnr_retry
+        unsigned char   alt_port_num
+        unsigned char   alt_timeout
+        unsigned int    rate_limit
+
+    cdef struct ibv_srq:
+        ibv_context     *context
+        void            *srq_context
+        ibv_pd          *pd
+        unsigned int    handle
+        unsigned int    events_completed
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -228,6 +228,35 @@ cdef extern from 'infiniband/verbs.h':
         unsigned long   tag
         unsigned int    priv
 
+    cdef struct ibv_grh:
+        unsigned int    version_tclass_flow
+        unsigned short    paylen
+        unsigned char    next_hdr
+        unsigned char    hop_limit
+        ibv_gid         sgid
+        ibv_gid         dgid
+
+    cdef struct ibv_global_route:
+        ibv_gid         dgid
+        unsigned int    flow_label
+        unsigned char    sgid_index
+        unsigned char    hop_limit
+        unsigned char    traffic_class
+
+    cdef struct ibv_ah_attr:
+        ibv_global_route    grh
+        unsigned short        dlid
+        unsigned char        sl
+        unsigned char        src_path_bits
+        unsigned char        static_rate
+        unsigned char        is_global
+        unsigned char        port_num
+
+    cdef struct ibv_ah:
+        ibv_context         *context
+        ibv_pd              *pd
+        unsigned int        handle
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -287,3 +316,9 @@ cdef extern from 'infiniband/verbs.h':
     unsigned int ibv_wc_read_flow_tag(ibv_cq_ex *cq)
     void ibv_wc_read_tm_info(ibv_cq_ex *cq, ibv_wc_tm_info *tm_info)
     unsigned long ibv_wc_read_completion_wallclock_ns(ibv_cq_ex *cq)
+    ibv_ah *ibv_create_ah(ibv_pd *pd, ibv_ah_attr *attr)
+    int ibv_init_ah_from_wc(ibv_context *context, uint8_t port_num,
+                            ibv_wc *wc, ibv_grh *grh, ibv_ah_attr *ah_attr)
+    ibv_ah *ibv_create_ah_from_wc(ibv_pd *pd, ibv_wc *wc, ibv_grh *grh,
+                                  uint8_t port_num)
+    int ibv_destroy_ah(ibv_ah *ah)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -257,6 +257,74 @@ cdef extern from 'infiniband/verbs.h':
         ibv_pd              *pd
         unsigned int        handle
 
+    cdef struct ibv_sge:
+        unsigned long   addr
+        unsigned int    length
+        unsigned int    lkey
+
+    cdef struct ibv_recv_wr:
+        unsigned long   wr_id
+        ibv_recv_wr     *next
+        ibv_sge         *sg_list
+        int             num_sge
+
+    cdef struct rdma:
+        unsigned long   remote_addr
+        unsigned int    rkey
+
+    cdef struct atomic:
+        unsigned long   remote_addr
+        unsigned long   compare_add
+        unsigned long   swap
+        unsigned int    rkey
+
+    cdef struct ud:
+        ibv_ah          *ah
+        unsigned int    remote_qpn
+        unsigned int    remote_qkey
+
+    cdef union wr:
+        rdma            rdma
+        atomic          atomic
+        ud              ud
+
+    cdef struct ibv_mw_bind_info:
+        ibv_mr          *mr
+        unsigned long   addr
+        unsigned long   length
+        unsigned int    mw_access_flags
+
+    cdef struct bind_mw:
+        ibv_mw              *mw
+        unsigned int        rkey
+        ibv_mw_bind_info    bind_info
+
+    cdef struct tso:
+        void            *hdr
+        unsigned short  hdr_sz
+        unsigned short  mss
+
+    cdef union unnamed:
+        bind_mw         bind_mw
+        tso             tso
+
+    cdef struct xrc:
+        unsigned int    remote_srqn
+
+    cdef union qp_type:
+        xrc             xrc
+
+    cdef struct ibv_send_wr:
+        unsigned long   wr_id
+        ibv_send_wr     *next
+        ibv_sge         *sg_list
+        int             num_sge
+        ibv_wr_opcode   opcode
+        unsigned int    send_flags
+        wr              wr
+        qp_type         qp_type
+        unnamed         unnamed
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -403,6 +403,19 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    handle
         unsigned int    events_completed
 
+    cdef struct ibv_qp:
+        ibv_context     *context;
+        void            *qp_context;
+        ibv_pd          *pd;
+        ibv_cq          *send_cq;
+        ibv_cq          *recv_cq;
+        ibv_srq         *srq;
+        unsigned int    handle;
+        unsigned int    qp_num;
+        ibv_qp_state    state;
+        ibv_qp_type     qp_type;
+        unsigned int    events_completed;
+
     ibv_device **ibv_get_device_list(int *n)
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
@@ -468,3 +481,12 @@ cdef extern from 'infiniband/verbs.h':
     ibv_ah *ibv_create_ah_from_wc(ibv_pd *pd, ibv_wc *wc, ibv_grh *grh,
                                   uint8_t port_num)
     int ibv_destroy_ah(ibv_ah *ah)
+    ibv_qp *ibv_create_qp(ibv_pd *pd, ibv_qp_init_attr *qp_init_attr)
+    ibv_qp *ibv_create_qp_ex(ibv_context *context,
+                             ibv_qp_init_attr_ex *qp_init_attr_ex)
+    int ibv_modify_qp(ibv_qp *qp, ibv_qp_attr *qp_attr, int comp_mask)
+    int ibv_query_qp(ibv_qp *qp, ibv_qp_attr *attr, int attr_mask,
+                     ibv_qp_init_attr *init_attr)
+    int ibv_destroy_qp(ibv_qp *qp)
+    int ibv_post_recv(ibv_qp *qp, ibv_recv_wr *wr, ibv_recv_wr **bad_wr)
+    int ibv_post_send(ibv_qp *qp, ibv_send_wr *wr, ibv_send_wr **bad_wr)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -408,6 +408,9 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_RAW_PACKET_CAP_IP_CSUM          = 1 << 2
         IBV_RAW_PACKET_CAP_DELAY_DROP       = 1 << 3
 
+    cdef unsigned long long IBV_DEVICE_RAW_SCATTER_FCS
+    cdef unsigned long long IBV_DEVICE_PCI_WRITE_END_PADDING
+
 
 cdef extern from "<infiniband/tm_types.h>":
     cpdef enum ibv_tmh_op:
@@ -415,3 +418,6 @@ cdef extern from "<infiniband/tm_types.h>":
         IBV_TMH_RNDV          = 1
         IBV_TMH_FIN           = 2
         IBV_TMH_EAGER         = 3
+
+_IBV_DEVICE_RAW_SCATTER_FCS = IBV_DEVICE_RAW_SCATTER_FCS
+_IBV_DEVICE_PCI_WRITE_END_PADDING = IBV_DEVICE_PCI_WRITE_END_PADDING

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -12,3 +12,4 @@ cdef class PD(PyverbsCM):
     cdef object mrs
     cdef object mws
     cdef object ahs
+    cdef object qps

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -11,3 +11,4 @@ cdef class PD(PyverbsCM):
     cdef add_ref(self, obj)
     cdef object mrs
     cdef object mws
+    cdef object ahs

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -7,6 +7,7 @@ from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.device cimport Context, DM
 from .mr cimport MR, MW, DMMR
 from pyverbs.addr cimport AH
+from pyverbs.qp cimport QP
 
 cdef extern from 'errno.h':
     int errno
@@ -29,6 +30,7 @@ cdef class PD(PyverbsCM):
         self.mrs = weakref.WeakSet()
         self.mws = weakref.WeakSet()
         self.ahs = weakref.WeakSet()
+        self.qps = weakref.WeakSet()
 
     def __dealloc__(self):
         """
@@ -46,7 +48,7 @@ cdef class PD(PyverbsCM):
         :return: None
         """
         self.logger.debug('Closing PD')
-        self.close_weakrefs([self.ahs, self.mws, self.mrs])
+        self.close_weakrefs([self.qps, self.ahs, self.mws, self.mrs])
         if self.pd != NULL:
             rc = v.ibv_dealloc_pd(self.pd)
             if rc != 0:
@@ -61,6 +63,8 @@ cdef class PD(PyverbsCM):
             self.mws.add(obj)
         elif isinstance(obj, AH):
             self.ahs.add(obj)
+        elif isinstance(obj, QP):
+            self.qps.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -63,3 +63,7 @@ cdef class PD(PyverbsCM):
             self.ahs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
+
+    @property
+    def _pd(self):
+        return <object>self.pd

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -6,6 +6,7 @@ from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.device cimport Context, DM
 from .mr cimport MR, MW, DMMR
+from pyverbs.addr cimport AH
 
 cdef extern from 'errno.h':
     int errno
@@ -27,6 +28,7 @@ cdef class PD(PyverbsCM):
         self.logger.debug('PD: Allocated ibv_pd')
         self.mrs = weakref.WeakSet()
         self.mws = weakref.WeakSet()
+        self.ahs = weakref.WeakSet()
 
     def __dealloc__(self):
         """
@@ -44,7 +46,7 @@ cdef class PD(PyverbsCM):
         :return: None
         """
         self.logger.debug('Closing PD')
-        self.close_weakrefs([self.mws, self.mrs])
+        self.close_weakrefs([self.ahs, self.mws, self.mrs])
         if self.pd != NULL:
             rc = v.ibv_dealloc_pd(self.pd)
             if rc != 0:
@@ -57,5 +59,7 @@ cdef class PD(PyverbsCM):
             self.mrs.add(obj)
         elif isinstance(obj, MW):
             self.mws.add(obj)
+        elif isinstance(obj, AH):
+            self.ahs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -19,3 +19,14 @@ cdef class QPInitAttrEx(PyverbsObject):
 
 cdef class QPAttr(PyverbsObject):
     cdef v.ibv_qp_attr attr
+
+cdef class QP(PyverbsCM):
+    cdef v.ibv_qp *qp
+    cdef int type
+    cdef int state
+    cdef object pd
+    cdef object context
+    cpdef close(self)
+    cdef update_cqs(self, init_attr)
+    cdef object scq
+    cdef object rcq

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved.
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+cimport pyverbs.libibverbs as v
+
+cdef class QPCap(PyverbsObject):
+    cdef v.ibv_qp_cap cap
+
+cdef class QPInitAttr(PyverbsObject):
+    cdef v.ibv_qp_init_attr attr
+    cdef object scq
+    cdef object rcq
+
+cdef class QPInitAttrEx(PyverbsObject):
+    cdef v.ibv_qp_init_attr_ex attr
+    cdef object scq
+    cdef object rcq
+    cdef object pd
+
+cdef class QPAttr(PyverbsObject):
+    cdef v.ibv_qp_attr attr

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -1,0 +1,790 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved.
+from pyverbs.utils import gid_str, qp_type_to_str, qp_state_to_str, mtu_to_str
+from pyverbs.utils import access_flags_to_str, mig_state_to_str
+from pyverbs.pyverbs_error import PyverbsUserError
+cimport pyverbs.libibverbs_enums as e
+from pyverbs.addr cimport AHAttr, GID
+from pyverbs.addr cimport GlobalRoute
+from pyverbs.cq cimport CQ, CQEX
+cimport pyverbs.libibverbs as v
+from pyverbs.pd cimport PD
+
+
+cdef class QPCap(PyverbsObject):
+    def __cinit__(self, max_send_wr=1, max_recv_wr=10, max_send_sge=1,
+                      max_recv_sge=1, max_inline_data=0):
+        """
+        Initializes a QPCap object with user-provided or default values.
+        :param max_send_wr: max number of outstanding WRs in the SQ
+        :param max_recv_wr: max number of outstanding WRs in the RQ
+        :param max_send_sge: Requested max number of scatter-gather elements in
+                             a WR in the SQ
+        :param max_recv_sge: Requested max number of scatter-gather elements in
+                             a WR in the RQ
+        :param max_inline_data: max number of data (bytes) that can be posted
+                                inline to the SQ, otherwise 0
+        :return:
+        """
+        self.cap.max_send_wr = max_send_wr
+        self.cap.max_recv_wr = max_recv_wr
+        self.cap.max_send_sge = max_send_sge
+        self.cap.max_recv_sge = max_recv_sge
+        self.cap.max_inline_data = max_inline_data
+
+    @property
+    def max_send_wr(self):
+        return self.cap.max_send_wr
+    @max_send_wr.setter
+    def max_send_wr(self, val):
+        self.cap.max_send_wr = val
+
+    @property
+    def max_recv_wr(self):
+        return self.cap.max_recv_wr
+    @max_recv_wr.setter
+    def max_recv_wr(self, val):
+        self.cap.max_recv_wr = val
+
+    @property
+    def max_send_sge(self):
+        return self.cap.max_send_sge
+    @max_send_sge.setter
+    def max_send_sge(self, val):
+        self.cap.max_send_sge = val
+
+    @property
+    def max_recv_sge(self):
+        return self.cap.max_recv_sge
+    @max_recv_sge.setter
+    def max_recv_sge(self, val):
+        self.cap.max_recv_sge = val
+
+    @property
+    def max_inline_data(self):
+        return self.cap.max_inline_data
+    @max_inline_data.setter
+    def max_inline_data(self, val):
+        self.cap.max_inline_data = val
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return print_format.format('max send wrs', self.cap.max_send_wr) +\
+               print_format.format('max recv wrs', self.cap.max_recv_wr) +\
+               print_format.format('max send sges', self.cap.max_send_sge) +\
+               print_format.format('max recv sges', self.cap.max_recv_sge) +\
+               print_format.format('max inline data', self.cap.max_inline_data)
+
+
+cdef class QPInitAttr(PyverbsObject):
+    def __cinit__(self, qp_type=e.IBV_QPT_UD, qp_context=None,
+                  PyverbsObject scq=None, PyverbsObject rcq=None,
+                  object srq=None, QPCap cap=None, sq_sig_all=1):
+        """
+        Initializes a QpInitAttr object representing ibv_qp_init_attr struct.
+        Note that SRQ object is not yet supported in pyverbs so can't be passed
+        as a parameter. None should be used until such support is added.
+        :param qp_type: The desired QP type (see enum ibv_qp_type)
+        :param qp_context: Associated QP context
+        :param scq: Send CQ to be used for this QP
+        :param rcq: Receive CQ to be used for this QP
+        :param srq: Not yet supported
+        :param cap: A QPCap object
+        :param sq_sig_all: If set, each send WR will generate a completion
+                           entry
+        :return: A QpInitAttr object
+        """
+        _copy_caps(cap, self)
+        self.attr.qp_context = <void*>qp_context
+        if scq is not None:
+            if type(scq) is CQ:
+                self.attr.send_cq = <v.ibv_cq*>scq._cq
+            elif type(scq) is CQEX:
+                self.attr.send_cq = <v.ibv_cq*>scq._ibv_cq
+            else:
+                raise PyverbsUserError('Expected CQ/CQEX, got {t}'.\
+                                       format(t=type(scq)))
+        self.scq = scq
+
+        if rcq is not None:
+            if type(rcq) is CQ:
+                self.attr.recv_cq = <v.ibv_cq*>rcq._cq
+            elif type(rcq) is CQEX:
+                self.attr.recv_cq = <v.ibv_cq*>rcq._ibv_cq
+            else:
+                raise PyverbsUserError('Expected CQ/CQEX, got {t}'.\
+                                       format(t=type(rcq)))
+        self.rcq = rcq
+
+        self.attr.srq = NULL  # Until SRQ support is added
+        self.attr.qp_type = qp_type
+        self.attr.sq_sig_all = sq_sig_all
+
+    @property
+    def send_cq(self):
+        return self.scq
+    @send_cq.setter
+    def send_cq(self, val):
+        if type(val) is CQ:
+            self.attr.send_cq = <v.ibv_cq*>val._cq
+        elif type(val) is CQEX:
+            self.attr.send_cq = <v.ibv_cq*>val._ibv_cq
+        self.scq = val
+
+    @property
+    def recv_cq(self):
+        return self.rcq
+    @recv_cq.setter
+    def recv_cq(self, val):
+        if type(val) is CQ:
+            self.attr.recv_cq = <v.ibv_cq*>val._cq
+        elif type(val) is CQEX:
+            self.attr.recv_cq = <v.ibv_cq*>val._ibv_cq
+        self.rcq = val
+
+    @property
+    def cap(self):
+        return QPCap(max_send_wr=self.attr.cap.max_send_wr,
+                     max_recv_wr=self.attr.cap.max_recv_wr,
+                     max_send_sge=self.attr.cap.max_send_sge,
+                     max_recv_sge=self.attr.cap.max_recv_sge,
+                     max_inline_data=self.attr.cap.max_inline_data)
+    @cap.setter
+    def cap(self, val):
+        _copy_caps(val, self)
+
+    @property
+    def qp_type(self):
+        return self.attr.qp_type
+    @qp_type.setter
+    def qp_type(self, val):
+        self.attr.qp_type = val
+
+    @property
+    def sq_sig_all(self):
+        return self.attr.sq_sig_all
+    @sq_sig_all.setter
+    def sq_sig_all(self, val):
+        self.attr.sq_sig_all = val
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        ident_format = '    {:20}: {:<20}\n'
+        return print_format.format('QP type', qp_type_to_str(self.qp_type)) +\
+               print_format.format('SQ sig. all', self.sq_sig_all) +\
+               'QP caps:\n' +\
+               ident_format.format('max send WR', self.attr.cap.max_send_wr) +\
+               ident_format.format('max recv WR', self.attr.cap.max_recv_wr) +\
+               ident_format.format('max send SGE',
+                                   self.attr.cap.max_send_sge) +\
+               ident_format.format('max recv SGE',
+                                   self.attr.cap.max_recv_sge) +\
+               ident_format.format('max inline data',
+                                   self.attr.cap.max_inline_data)
+
+
+cdef class QPInitAttrEx(PyverbsObject):
+    def __cinit__(self, qp_type=e.IBV_QPT_UD, qp_context=None,
+                  PyverbsObject scq=None, PyverbsObject rcq=None,
+                  object srq=None, QPCap cap=None, sq_sig_all=0, comp_mask=0,
+                  PD pd=None, object xrcd=None, create_flags=0,
+                  max_tso_header=0, source_qpn=0, object hash_conf=None,
+                  object ind_table=None):
+        """
+        Initialize a QPInitAttrEx object with user-defined or default values.
+        :param qp_type: QP type to be created
+        :param qp_context: Associated user context
+        :param scq: Send CQ to be used for this QP
+        :param rcq: Recv CQ to be used for this QP
+        :param srq: Not yet supported
+        :param cap: A QPCap object
+        :param sq_sig_all: If set, each send WR will generate a completion
+                           entry
+        :param comp_mask: bit mask to determine which of the following fields
+                          are valid
+        :param pd: A PD object to be associated with this QP
+        :param xrcd: Not yet supported
+        :param create_flags: Creation flags for this QP
+        :param max_tso_header: Maximum TSO header size
+        :param source_qpn: Source QP number (requires IBV_QP_CREATE_SOURCE_QPN
+                           set in create_flags)
+        :param hash_conf: Not yet supported
+        :param ind_table: Not yet supported
+        :return: An initialized QPInitAttrEx object
+        """
+        _copy_caps(cap, self)
+        if scq is not None:
+            if type(scq) is CQ:
+                self.attr.send_cq = <v.ibv_cq*>scq._cq
+            elif type(scq) is CQEX:
+                self.attr.send_cq = <v.ibv_cq*>scq._ibv_cq
+            else:
+                raise PyverbsUserError('Expected CQ/CQEX, got {t}'.\
+                                       format(t=type(scq)))
+        self.scq = scq
+
+        if rcq is not None:
+            if type(rcq) is CQ:
+                self.attr.recv_cq = <v.ibv_cq*>rcq._cq
+            elif type(rcq) is CQEX:
+                self.attr.recv_cq = <v.ibv_cq*>rcq._ibv_cq
+            else:
+                raise PyverbsUserError('Expected CQ/CQEX, got {t}'.\
+                                       format(type(rcq)))
+        self.rcq = rcq
+
+        self.attr.srq = NULL  # Until SRQ support is added
+        self.attr.xrcd = NULL  # Until XRCD support is added
+        self.attr.rwq_ind_tbl = NULL  # Until RSS support is added
+        self.attr.qp_type = qp_type
+        self.attr.sq_sig_all = sq_sig_all
+        unsupp_flags = e.IBV_QP_INIT_ATTR_XRCD | e.IBV_QP_INIT_ATTR_IND_TABLE |\
+                       e.IBV_QP_INIT_ATTR_RX_HASH
+        if comp_mask & unsupp_flags:
+            raise PyverbsUserError('XRCD and RSS are not yet supported in pyverbs')
+        self.attr.comp_mask = comp_mask
+        if pd is not None:
+            self.attr.pd = <v.ibv_pd*>pd._pd
+            self.pd = pd
+        self.attr.create_flags = create_flags
+        self.attr.max_tso_header = max_tso_header
+        self.attr.source_qpn = source_qpn
+
+    @property
+    def send_cq(self):
+        return self.scq
+    @send_cq.setter
+    def send_cq(self, val):
+        if type(val) is CQ:
+            self.attr.send_cq = <v.ibv_cq*>val._cq
+        elif type(val) is CQEX:
+            self.attr.send_cq = <v.ibv_cq*>val._ibv_cq
+        self.scq = val
+
+    @property
+    def recv_cq(self):
+        return self.rcq
+    @recv_cq.setter
+    def recv_cq(self, val):
+        if type(val) is CQ:
+            self.attr.recv_cq = <v.ibv_cq*>val._cq
+        elif type(val) is CQEX:
+            self.attr.recv_cq = <v.ibv_cq*>val._ibv_cq
+        self.rcq = val
+
+    @property
+    def cap(self):
+        return QPCap(max_send_wr=self.attr.cap.max_send_wr,
+                     max_recv_wr=self.attr.cap.max_recv_wr,
+                     max_send_sge=self.attr.cap.max_send_sge,
+                     max_recv_sge=self.attr.cap.max_recv_sge,
+                     max_inline_data=self.attr.cap.max_inline_data)
+    @cap.setter
+    def cap(self, val):
+        _copy_caps(val, self)
+
+    @property
+    def qp_type(self):
+        return self.attr.qp_type
+    @qp_type.setter
+    def qp_type(self, val):
+        self.attr.qp_type = val
+
+    @property
+    def sq_sig_all(self):
+        return self.attr.sq_sig_all
+    @sq_sig_all.setter
+    def sq_sig_all(self, val):
+        self.attr.sq_sig_all = val
+
+    @property
+    def comp_mask(self):
+        return self.attr.comp_mask
+    @comp_mask.setter
+    def comp_mask(self, val):
+        self.attr.comp_mask = val
+
+    @property
+    def pd(self):
+        return self.pd
+    @pd.setter
+    def pd(self, val):
+        self.attr.pd = <v.ibv_pd*>val._pd
+        self.pd = val
+
+    @property
+    def create_flags(self):
+        return self.attr.create_flags
+    @create_flags.setter
+    def create_flags(self, val):
+        self.attr.create_flags = val
+
+    @property
+    def max_tso_header(self):
+        return self.attr.max_tso_header
+    @max_tso_header.setter
+    def max_tso_header(self, val):
+        self.attr.max_tso_header = val
+
+    @property
+    def source_qpn(self):
+        return self.attr.source_qpn
+    @source_qpn.setter
+    def source_qpn(self, val):
+        self.attr.source_qpn = val
+
+    def mask_to_str(self, mask):
+        comp_masks = {1: 'PD', 2: 'XRCD', 4: 'Create Flags',
+                      8: 'Max TSO header', 16: 'Indirection Table',
+                      32: 'RX hash'}
+        mask_str = ''
+        for f in comp_masks:
+            if mask & f:
+                mask_str += comp_masks[f]
+                mask_str += ' '
+        return mask_str
+
+    def flags_to_str(self, flags):
+        create_flags = {1: 'Block self mcast loopback', 2: 'Scatter FCS',
+                        4: 'CVLAN stripping', 8: 'Source QPN',
+                        16: 'PCI write end padding'}
+        create_str = ''
+        for f in create_flags:
+            if flags & f:
+                create_str += create_flags[f]
+                create_str += ' '
+        return create_str
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return print_format.format('QP type', qp_type_to_str(self.qp_type)) +\
+               print_format.format('SQ sig. all', self.sq_sig_all) +\
+               'QP caps:\n' +\
+               print_format.format('  max send WR',
+                                   self.attr.cap.max_send_wr) +\
+               print_format.format('  max recv WR',
+                                   self.attr.cap.max_recv_wr) +\
+               print_format.format('  max send SGE',
+                                   self.attr.cap.max_send_sge) +\
+               print_format.format('  max recv SGE',
+                                   self.attr.cap.max_recv_sge) +\
+               print_format.format('  max inline data',
+                                   self.attr.cap.max_inline_data) +\
+               print_format.format('comp mask',
+                                   self.mask_to_str(self.attr.comp_mask)) +\
+               print_format.format('create flags',
+                                   self.flags_to_str(self.attr.create_flags)) +\
+               print_format.format('max TSO header',
+                                   self.attr.max_tso_header) +\
+               print_format.format('Source QPN', self.attr.source_qpn)
+
+
+cdef class QPAttr(PyverbsObject):
+    def __cinit__(self, qp_state=e.IBV_QPS_INIT, cur_qp_state=e.IBV_QPS_RESET,
+                  port_num=1, path_mtu=e.IBV_MTU_1024):
+        """
+        Initializes a QPQttr object which represents ibv_qp_attr structs. It
+        can be used to modify a QP.
+        This function initializes default values for reset-to-init transition.
+        :param qp_state: Desired QP state
+        :param cur_qp_state: Current QP state
+        :return: An initialized QpAttr object
+        """
+        self.attr.qp_state = qp_state
+        self.attr.cur_qp_state = cur_qp_state
+        self.attr.port_num = port_num
+        self.attr.path_mtu = path_mtu
+
+    @property
+    def qp_state(self):
+        return self.attr.qp_state
+    @qp_state.setter
+    def qp_state(self, val):
+        self.attr.qp_state = val
+
+    @property
+    def cur_qp_state(self):
+        return self.attr.cur_qp_state
+    @cur_qp_state.setter
+    def cur_qp_state(self, val):
+        self.attr.cur_qp_state = val
+
+    @property
+    def path_mtu(self):
+        return self.attr.path_mtu
+    @path_mtu.setter
+    def path_mtu(self, val):
+        self.attr.path_mtu = val
+
+    @property
+    def path_mig_state(self):
+        return self.attr.path_mig_state
+    @path_mig_state.setter
+    def path_mig_state(self, val):
+        self.attr.path_mig_state = val
+
+    @property
+    def qkey(self):
+        return self.attr.qkey
+    @qkey.setter
+    def qkey(self, val):
+        self.attr.qkey = val
+
+    @property
+    def rq_psn(self):
+        return self.attr.rq_psn
+    @rq_psn.setter
+    def rq_psn(self, val):
+        self.attr.rq_psn = val
+
+    @property
+    def sq_psn(self):
+        return self.attr.sq_psn
+    @sq_psn.setter
+    def sq_psn(self, val):
+        self.attr.sq_psn = val
+
+    @property
+    def dest_qp_num(self):
+        return self.attr.dest_qp_num
+    @dest_qp_num.setter
+    def dest_qp_num(self, val):
+        self.attr.dest_qp_num = val
+
+    @property
+    def qp_access_flags(self):
+        return self.attr.qp_access_flags
+    @qp_access_flags.setter
+    def qp_access_flags(self, val):
+        self.attr.qp_access_flags = val
+
+    @property
+    def cap(self):
+        return QPCap(max_send_wr=self.attr.cap.max_send_wr,
+                     max_recv_wr=self.attr.cap.max_recv_wr,
+                     max_send_sge=self.attr.cap.max_send_sge,
+                     max_recv_sge=self.attr.cap.max_recv_sge,
+                     max_inline_data=self.attr.cap.max_inline_data)
+    @cap.setter
+    def cap(self, val):
+        _copy_caps(val, self)
+
+    @property
+    def ah_attr(self):
+        if self.attr.ah_attr.is_global:
+            gid = gid_str(self.attr.ah_attr.grh.dgid._global.subnet_prefix,
+                          self.attr.ah_attr.grh.dgid._global.interface_id)
+            g = GID(gid)
+            gr = GlobalRoute(flow_label=self.attr.ah_attr.grh.flow_label,
+                             sgid_index=self.attr.ah_attr.grh.sgid_index,
+                             hop_limit=self.attr.ah_attr.grh.hop_limit, dgid=g,
+                             traffic_class=self.attr.ah_attr.grh.traffic_class)
+        else:
+            gr = None
+        ah = AHAttr(dlid=self.attr.ah_attr.dlid, sl=self.attr.ah_attr.sl,
+                    src_path_bits=self.attr.ah_attr.src_path_bits,
+                    static_rate=self.attr.ah_attr.static_rate,
+                    is_global=self.attr.ah_attr.is_global, gr=gr)
+        return ah
+
+    @ah_attr.setter
+    def ah_attr(self, val):
+        self._copy_ah(val)
+
+    @property
+    def alt_ah_attr(self):
+        if self.attr.alt_ah_attr.is_global:
+            gid = gid_str(self.attr.alt_ah_attr.grh.dgid._global.subnet_prefix,
+                          self.attr.alt_ah_attr.grh.dgid._global.interface_id)
+            g = GID(gid)
+            gr = GlobalRoute(flow_label=self.attr.alt_ah_attr.grh.flow_label,
+                             sgid_index=self.attr.alt_ah_attr.grh.sgid_index,
+                             hop_limit=self.attr.alt_ah_attr.grh.hop_limit,
+                             dgid=g,
+                             traffic_class=self.attr.alt_ah_attr.grh.traffic_class)
+        else:
+            gr = None
+        ah = AHAttr(dlid=self.attr.alt_ah_attr.dlid,
+                    sl=self.attr.alt_ah_attr.sl,
+                    src_path_bits=self.attr.alt_ah_attr.src_path_bits,
+                    static_rate=self.attr.alt_ah_attr.static_rate,
+                    is_global=self.attr.alt_ah_attr.is_global, gr=gr)
+        return ah
+
+    @alt_ah_attr.setter
+    def alt_ah_attr(self, val):
+        self._copy_ah(val, True)
+
+    def _copy_ah(self, AHAttr ah_attr, is_alt=False):
+        if ah_attr is None:
+            return
+        if not is_alt:
+            for i in range(16):
+                self.attr.ah_attr.grh.dgid.raw[i] = \
+                    ah_attr.ah_attr.grh.dgid.raw[i]
+            self.attr.ah_attr.grh.flow_label = ah_attr.ah_attr.grh.flow_label
+            self.attr.ah_attr.grh.sgid_index = ah_attr.ah_attr.grh.sgid_index
+            self.attr.ah_attr.grh.hop_limit = ah_attr.ah_attr.grh.hop_limit
+            self.attr.ah_attr.grh.traffic_class = \
+                ah_attr.ah_attr.grh.traffic_class
+            self.attr.ah_attr.dlid = ah_attr.ah_attr.dlid
+            self.attr.ah_attr.sl = ah_attr.ah_attr.sl
+            self.attr.ah_attr.src_path_bits = ah_attr.ah_attr.src_path_bits
+            self.attr.ah_attr.static_rate = ah_attr.ah_attr.static_rate
+            self.attr.ah_attr.is_global = ah_attr.ah_attr.is_global
+            self.attr.ah_attr.port_num = ah_attr.ah_attr.port_num
+        else:
+            for i in range(16):
+                self.attr.alt_ah_attr.grh.dgid.raw[i] = \
+                    ah_attr.ah_attr.grh.dgid.raw[i]
+            self.attr.alt_ah_attr.grh.flow_label = \
+                ah_attr.ah_attr.grh.flow_label
+            self.attr.alt_ah_attr.grh.sgid_index = \
+                ah_attr.ah_attr.grh.sgid_index
+            self.attr.alt_ah_attr.grh.hop_limit = ah_attr.ah_attr.grh.hop_limit
+            self.attr.alt_ah_attr.grh.traffic_class = \
+                ah_attr.ah_attr.grh.traffic_class
+            self.attr.alt_ah_attr.dlid = ah_attr.ah_attr.dlid
+            self.attr.alt_ah_attr.sl = ah_attr.ah_attr.sl
+            self.attr.alt_ah_attr.src_path_bits = ah_attr.ah_attr.src_path_bits
+            self.attr.alt_ah_attr.static_rate = ah_attr.ah_attr.static_rate
+            self.attr.alt_ah_attr.is_global = ah_attr.ah_attr.is_global
+            self.attr.alt_ah_attr.port_num = ah_attr.ah_attr.port_num
+
+    @property
+    def pkey_index(self):
+        return self.attr.pkey_index
+    @pkey_index.setter
+    def pkey_index(self, val):
+        self.attr.pkey_index = val
+
+    @property
+    def alt_pkey_index(self):
+        return self.attr.alt_pkey_index
+    @alt_pkey_index.setter
+    def alt_pkey_index(self, val):
+        self.attr.alt_pkey_index = val
+
+    @property
+    def en_sqd_async_notify(self):
+        return self.attr.en_sqd_async_notify
+    @en_sqd_async_notify.setter
+    def en_sqd_async_notify(self, val):
+        self.attr.en_sqd_async_notify = val
+
+    @property
+    def sq_draining(self):
+        return self.attr.sq_draining
+    @sq_draining.setter
+    def sq_draining(self, val):
+        self.attr.sq_draining = val
+
+    @property
+    def max_rd_atomic(self):
+        return self.attr.max_rd_atomic
+    @max_rd_atomic.setter
+    def max_rd_atomic(self, val):
+        self.attr.max_rd_atomic = val
+
+    @property
+    def max_dest_rd_atomic(self):
+        return self.attr.max_dest_rd_atomic
+    @max_dest_rd_atomic.setter
+    def max_dest_rd_atomic(self, val):
+        self.attr.max_dest_rd_atomic = val
+
+    @property
+    def min_rnr_timer(self):
+        return self.attr.min_rnr_timer
+    @min_rnr_timer.setter
+    def min_rnr_timer(self, val):
+        self.attr.min_rnr_timer = val
+
+    @property
+    def port_num(self):
+        return self.attr.port_num
+    @port_num.setter
+    def port_num(self, val):
+        self.attr.port_num = val
+
+    @property
+    def timeout(self):
+        return self.attr.timeout
+    @timeout.setter
+    def timeout(self, val):
+        self.attr.timeout = val
+
+    @property
+    def retry_cnt(self):
+        return self.attr.retry_cnt
+    @retry_cnt.setter
+    def retry_cnt(self, val):
+        self.attr.retry_cnt = val
+
+    @property
+    def rnr_retry(self):
+        return self.attr.rnr_retry
+    @rnr_retry.setter
+    def rnr_retry(self, val):
+        self.attr.rnr_retry = val
+
+    @property
+    def alt_port_num(self):
+        return self.attr.alt_port_num
+    @alt_port_num.setter
+    def alt_port_num(self, val):
+        self.attr.alt_port_num = val
+
+    @property
+    def alt_timeout(self):
+        return self.attr.alt_timeout
+    @alt_timeout.setter
+    def alt_timeout(self, val):
+        self.attr.alt_timeout = val
+
+    @property
+    def rate_limit(self):
+        return self.attr.rate_limit
+    @rate_limit.setter
+    def rate_limit(self, val):
+        self.attr.rate_limit = val
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        ah_format = '    {:22}: {:<20}\n'
+        ident_format = '  {:22}: {:<20}\n'
+        if self.attr.ah_attr.is_global:
+            global_ah = ah_format.format('dgid',
+                                         gid_str(self.attr.ah_attr.grh.dgid._global.subnet_prefix,
+                                                 self.attr.ah_attr.grh.dgid._global.interface_id)) +\
+                        ah_format.format('flow label',
+                                         self.attr.ah_attr.grh.flow_label) +\
+                        ah_format.format('sgid index',
+                                         self.attr.ah_attr.grh.sgid_index) +\
+                        ah_format.format('hop limit',
+                                         self.attr.ah_attr.grh.hop_limit) +\
+                        ah_format.format('traffic_class',
+                                         self.attr.ah_attr.grh.traffic_class)
+        else:
+            global_ah = ''
+        if self.attr.alt_ah_attr.is_global:
+            alt_global_ah = ah_format.format('dgid',
+                                             gid_str(self.attr.alt_ah_attr.grh.dgid._global.subnet_prefix,
+                                                     self.attr.alt_ah_attr.grh.dgid._global.interface_id)) +\
+                            ah_format.format('flow label',
+                                             self.attr.alt_ah_attr.grh.flow_label) +\
+                            ah_format.format('sgid index',
+                                             self.attr.alt_ah_attr.grh.sgid_index) +\
+                            ah_format.format('hop limit',
+                                             self.attr.alt_ah_attr.grh.hop_limit) +\
+                            ah_format.format('traffic_class',
+                                             self.attr.alt_ah_attr.grh.traffic_class)
+        else:
+            alt_global_ah = ''
+        return print_format.format('QP state',
+                                   qp_state_to_str(self.attr.qp_state)) +\
+               print_format.format('QP current state',
+                            qp_state_to_str(self.attr.cur_qp_state)) +\
+               print_format.format('Path MTU',
+                                   mtu_to_str(self.attr.path_mtu)) +\
+               print_format.format('Path mig. state',
+                            mig_state_to_str(self.attr.path_mig_state)) +\
+               print_format.format('QKey', self.attr.qkey) +\
+               print_format.format('RQ PSN', self.attr.rq_psn) +\
+               print_format.format('SQ PSN', self.attr.sq_psn) +\
+               print_format.format('Dest QP number', self.attr.dest_qp_num) +\
+               print_format.format('QP access flags',
+                                   access_flags_to_str(self.attr.qp_access_flags)) +\
+               'QP caps:\n' +\
+               ident_format.format('max send WR',
+                                   self.attr.cap.max_send_wr) +\
+               ident_format.format('max recv WR',
+                                   self.attr.cap.max_recv_wr) +\
+               ident_format.format('max send SGE',
+                                   self.attr.cap.max_send_sge) +\
+               ident_format.format('max recv SGE',
+                                   self.attr.cap.max_recv_sge) +\
+               ident_format.format('max inline data',
+                                   self.attr.cap.max_inline_data) +\
+               'AH Attr:\n' +\
+               ident_format.format('port num', self.attr.ah_attr.port_num) +\
+               ident_format.format('sl', self.attr.ah_attr.sl) +\
+               ident_format.format('source path bits',
+                                   self.attr.ah_attr.src_path_bits) +\
+               ident_format.format('dlid', self.attr.ah_attr.dlid) +\
+               ident_format.format('port num', self.attr.ah_attr.port_num) +\
+               ident_format.format('static rate',
+                                   self.attr.ah_attr.static_rate) +\
+               ident_format.format('is global',
+                                   self.attr.ah_attr.is_global) +\
+               global_ah +\
+               'Alt. AH Attr:\n' +\
+               ident_format.format('port num', self.attr.alt_ah_attr.port_num) +\
+               ident_format.format('sl', self.attr.alt_ah_attr.sl) +\
+               ident_format.format('source path bits',
+                                   self.attr.alt_ah_attr.src_path_bits) +\
+               ident_format.format('dlid', self.attr.alt_ah_attr.dlid) +\
+               ident_format.format('port num', self.attr.alt_ah_attr.port_num) +\
+               ident_format.format('static rate',
+                                   self.attr.alt_ah_attr.static_rate) +\
+               ident_format.format('is global',
+                                   self.attr.alt_ah_attr.is_global) +\
+               alt_global_ah +\
+               print_format.format('PKey index', self.attr.pkey_index) +\
+               print_format.format('Alt. PKey index',
+                                   self.attr.alt_pkey_index) +\
+               print_format.format('En. SQD async notify',
+                                   self.attr.en_sqd_async_notify) +\
+               print_format.format('SQ draining', self.attr.sq_draining) +\
+               print_format.format('Max RD atomic', self.attr.max_rd_atomic) +\
+               print_format.format('Max dest. RD atomic',
+                                   self.attr.max_dest_rd_atomic) +\
+               print_format.format('Min RNR timer', self.attr.min_rnr_timer) +\
+               print_format.format('Port number', self.attr.port_num) +\
+               print_format.format('Timeout', self.attr.timeout) +\
+               print_format.format('Retry counter', self.attr.retry_cnt) +\
+               print_format.format('RNR retry', self.attr.rnr_retry) +\
+               print_format.format('Alt. port number',
+                                   self.attr.alt_port_num) +\
+               print_format.format('Alt. timeout', self.attr.alt_timeout) +\
+               print_format.format('Rate limit', self.attr.rate_limit)
+
+
+def _copy_caps(QPCap src, dst):
+    """
+    Copy the QPCaps values of src into the inner ibv_qp_cap struct of dst.
+    Since both ibv_qp_init_attr and ibv_qp_attr have an inner ibv_qp_cap inner
+    struct, they can both be used.
+    :param src: A QPCap object
+    :param dst: A QPInitAttr / QPInitAttrEx / QPAttr object
+    :return: None
+    """
+    # we're assigning to C structs here, we must have type-specific objects in
+    # order to do that. Instead of having this function smaller but in 3
+    # classes, it appears here once.
+    cdef QPInitAttr qia
+    cdef QPInitAttrEx qiae
+    cdef QPAttr qa
+    if src is None:
+        return
+    if type(dst) == QPInitAttr:
+        qia = <QPInitAttr>dst
+        qia.attr.cap.max_send_wr = src.cap.max_send_wr
+        qia.attr.cap.max_recv_wr = src.cap.max_recv_wr
+        qia.attr.cap.max_send_sge = src.cap.max_send_sge
+        qia.attr.cap.max_recv_sge = src.cap.max_recv_sge
+        qia.attr.cap.max_inline_data = src.cap.max_inline_data
+    elif type(dst) == QPInitAttrEx:
+        qiae = <QPInitAttrEx>dst
+        qiae.attr.cap.max_send_wr = src.cap.max_send_wr
+        qiae.attr.cap.max_recv_wr = src.cap.max_recv_wr
+        qiae.attr.cap.max_send_sge = src.cap.max_send_sge
+        qiae.attr.cap.max_recv_sge = src.cap.max_recv_sge
+        qiae.attr.cap.max_inline_data = src.cap.max_inline_data
+    else:
+        qa = <QPAttr>dst
+        qa.attr.cap.max_send_wr = src.cap.max_send_wr
+        qa.attr.cap.max_recv_wr = src.cap.max_recv_wr
+        qa.attr.cap.max_send_sge = src.cap.max_send_sge
+        qa.attr.cap.max_recv_sge = src.cap.max_recv_sge
+        qa.attr.cap.max_inline_data = src.cap.max_inline_data

--- a/pyverbs/tests/addr.py
+++ b/pyverbs/tests/addr.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved.  See COPYING file
+
+from pyverbs.addr import GlobalRoute, AHAttr, AH
+from pyverbs.pyverbs_error import PyverbsError
+from pyverbs.tests.base import PyverbsTestCase
+import pyverbs.device as d
+import pyverbs.enums as e
+from pyverbs.pd import PD
+from pyverbs.cq import WC
+
+class AHTest(PyverbsTestCase):
+    """
+    Test various functionalities of the AH class.
+    """
+    def test_create_ah(self):
+        """
+        Test ibv_create_ah.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            pd = PD(ctx)
+            for port_num in range(1, 1 + attr.phys_port_cnt):
+                gr = get_global_route(ctx, port_num=port_num)
+                ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
+                with AH(pd, attr=ah_attr):
+                    pass
+    # TODO: Test ibv_create_ah_from_wc once we have traffic
+
+    def test_create_ah_roce(self):
+        """
+        Verify that AH can't be created without GRH in RoCE
+        """
+        for ctx, attr, attr_ex in self.devices:
+            pd = PD(ctx)
+            for port_num in range(1, 1 + attr.phys_port_cnt):
+                port_attr = ctx.query_port(port_num)
+                if port_attr.link_layer == e.IBV_LINK_LAYER_INFINIBAND:
+                    return
+                ah_attr = AHAttr(is_global=0, port_num=port_num)
+                try:
+                    ah = AH(pd, attr=ah_attr)
+                except PyverbsError as err:
+                    assert 'Failed to create AH' in err.args[0]
+                else:
+                    raise PyverbsError('Created a non-global AH on RoCE')
+
+    def test_destroy_ah(self):
+        """
+        Test ibv_destroy_ah.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            pd = PD(ctx)
+            for port_num in range(1, 1 + attr.phys_port_cnt):
+                gr = get_global_route(ctx)
+                ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
+                with AH(pd, attr=ah_attr) as ah:
+                    ah.close()
+
+
+def get_global_route(ctx, gid_index=0, port_num=1):
+    """
+    Queries the provided Context's gid <gid_index> and creates a GlobalRoute
+    object with sgid_index <gid_index> and the queried GID as dgid.
+    :param ctx: Context object to query
+    :param gid_index: GID index to query and use. Default: 0, as it's always
+                      valid
+    :param port_num: Number of the port to query. Default: 1
+    :return: GlobalRoute object
+    """
+    gid = ctx.query_gid(port_num, gid_index)
+    gr = GlobalRoute(dgid=gid, sgid_index=gid_index)
+    return gr

--- a/pyverbs/tests/qp.py
+++ b/pyverbs/tests/qp.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
+"""
+Test module for pyverbs' qp module.
+"""
+import random
+
+from pyverbs.tests.base import PyverbsTestCase
+from pyverbs.qp import QPInitAttr, QPAttr, QP
+import pyverbs.tests.utils as u
+import pyverbs.enums as e
+from pyverbs.pd import PD
+from pyverbs.cq import CQ
+
+
+class QPTest(PyverbsTestCase):
+    """
+    Test various functionalities of the QP class.
+    """
+
+    def test_create_qp_no_attr_connected(self):
+        """
+        Test QP creation via ibv_create_qp without a QPAttr object proivded.
+        QP type can be either RC or UC.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    qia = get_qp_init_attr(cq, [e.IBV_QPT_RC, e.IBV_QPT_UC],
+                                           attr)
+                    with QP(pd, qia) as qp:
+                        assert qp.qp_state == e.IBV_QPS_RESET
+
+    def test_create_qp_no_attr(self):
+        """
+        Test QP creation via ibv_create_qp without a QPAttr object proivded.
+        QP type can be either Raw Packet or UD.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    for i in range(1, attr.phys_port_cnt + 1):
+                        qpts = [e.IBV_QPT_UD, e.IBV_QPT_RAW_PACKET] \
+                            if is_eth(ctx, i) else [e.IBV_QPT_UD]
+                        qia = get_qp_init_attr(cq, qpts, attr)
+                        with QP(pd, qia) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RESET
+
+    def test_create_qp_with_attr_connected(self):
+        """
+        Test QP creation via ibv_create_qp without a QPAttr object proivded.
+        QP type can be either RC or UC.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    qia = get_qp_init_attr(cq, [e.IBV_QPT_RC, e.IBV_QPT_UC],
+                                           attr)
+                    with QP(pd, qia, QPAttr()) as qp:
+                        assert qp.qp_state == e.IBV_QPS_INIT
+
+    def test_create_qp_with_attr(self):
+        """
+        Test QP creation via ibv_create_qp with a QPAttr object proivded.
+        QP type can be either Raw Packet or UD.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    for i in range(1, attr.phys_port_cnt + 1):
+                        qpts = [e.IBV_QPT_UD, e.IBV_QPT_RAW_PACKET] \
+                            if is_eth(ctx, i) else [e.IBV_QPT_UD]
+                        qia = get_qp_init_attr(cq, qpts, attr)
+                        with QP(pd, qia, QPAttr()) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RTS
+
+    def test_create_qp_ex_no_attr_connected(self):
+        """
+        Test QP creation via ibv_create_qp_ex without a QPAttr object proivded.
+        QP type can be either RC or UC.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    qia = get_qp_init_attr_ex(cq, pd, [e.IBV_QPT_RC,
+                                                       e.IBV_QPT_UC],
+                                              attr, attr_ex)
+                    with QP(ctx, qia) as qp:
+                        assert qp.qp_state == e.IBV_QPS_RESET
+
+    def test_create_qp_ex_no_attr(self):
+        """
+        Test QP creation via ibv_create_qp_ex without a QPAttr object proivded.
+        QP type can be either Raw Packet or UD.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    for i in range(1, attr.phys_port_cnt + 1):
+                        qpts = [e.IBV_QPT_UD, e.IBV_QPT_RAW_PACKET] \
+                            if is_eth(ctx, i) else [e.IBV_QPT_UD]
+                        qia = get_qp_init_attr_ex(cq, pd, qpts, attr,
+                                                  attr_ex)
+                        with QP(ctx, qia) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RESET
+
+    def test_create_qp_ex_with_attr_connected(self):
+        """
+        Test QP creation via ibv_create_qp_ex with a QPAttr object proivded.
+        QP type can be either RC or UC.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    qia = get_qp_init_attr_ex(cq, pd, [e.IBV_QPT_RC,
+                                                       e.IBV_QPT_UC],
+                                              attr, attr_ex)
+                    with QP(ctx, qia, QPAttr()) as qp:
+                        assert qp.qp_state == e.IBV_QPS_INIT
+
+    def test_create_qp_ex_with_attr(self):
+        """
+        Test QP creation via ibv_create_qp_ex with a QPAttr object proivded.
+        QP type can be either Raw Packet or UD.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    for i in range(1, attr.phys_port_cnt + 1):
+                        qpts = [e.IBV_QPT_UD, e.IBV_QPT_RAW_PACKET] \
+                            if is_eth(ctx, i) else [e.IBV_QPT_UD]
+                        qia = get_qp_init_attr_ex(cq, pd, qpts, attr,
+                                                  attr_ex)
+                        with QP(ctx, qia, QPAttr()) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RTS
+
+    def test_query_qp(self):
+        """
+        Queries a QP after creation. Verifies that its properties are as
+        expected.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    for i in range(1, attr.phys_port_cnt + 1):
+                        qpts = get_qp_types(ctx, i)
+                        is_ex = random.choice([True, False])
+                        if is_ex:
+                            qia = get_qp_init_attr_ex(cq, pd, qpts, attr,
+                                                      attr_ex)
+                        else:
+                            qia = get_qp_init_attr(cq, qpts, attr)
+                        caps = qia.cap  # Save them to verify values later
+                        qp = QP(ctx, qia) if is_ex else QP(pd, qia)
+                        attr, init_attr = qp.query(e.IBV_QP_CUR_STATE |
+                                                   e.IBV_QP_CAP)
+                        verify_qp_attrs(caps, e.IBV_QPS_RESET, init_attr,
+                                        attr)
+
+    def test_modify_qp(self):
+        """
+        Queries a QP after calling modify(). Verifies that its properties are
+        as expected.
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100, None, None, 0) as cq:
+                    is_ex = random.choice([True, False])
+                    if is_ex:
+                        qia = get_qp_init_attr_ex(cq, pd, [e.IBV_QPT_UD],
+                                                  attr, attr_ex)
+                    else:
+                        qia = get_qp_init_attr(cq, [e.IBV_QPT_UD], attr)
+                    qp = QP(ctx, qia) if is_ex \
+                        else QP(pd, qia)
+                    qa = QPAttr()
+                    qa.qkey = 0x123
+                    qp.to_init(qa)
+                    attr, iattr = qp.query(e.IBV_QP_QKEY)
+                    assert attr.qkey == qa.qkey
+                    qp.to_rtr(qa)
+                    qa.sq_psn = 0x45
+                    qp.to_rts(qa)
+                    attr, iattr = qp.query(e.IBV_QP_SQ_PSN)
+                    assert attr.sq_psn == qa.sq_psn
+                    qa.qp_state = e.IBV_QPS_RESET
+                    qp.modify(qa, e.IBV_QP_STATE)
+                    assert qp.qp_state == e.IBV_QPS_RESET
+
+
+def get_qp_types(ctx, port_num):
+    """
+    Returns a list of the commonly used QP types. Raw Packet QP will not be
+    included if link layer is not Ethernet.
+    :param ctx: The device's Context, to query the port's link layer
+    :param port_num: Port number to query
+    :return: An array of QP types that can be created on this port
+    """
+    qpts = [e.IBV_QPT_RC, e.IBV_QPT_UC, e.IBV_QPT_UD]
+    if is_eth(ctx, port_num):
+        qpts.append(e.IBV_QPT_RAW_PACKET)
+    return qpts
+
+
+def verify_qp_attrs(orig_cap, state, init_attr, attr):
+    assert state == attr.cur_qp_state
+    assert orig_cap.max_send_wr <= init_attr.cap.max_send_wr
+    assert orig_cap.max_recv_wr <= init_attr.cap.max_recv_wr
+    assert orig_cap.max_send_sge <= init_attr.cap.max_send_sge
+    assert orig_cap.max_recv_sge <= init_attr.cap.max_recv_sge
+    assert orig_cap.max_inline_data <= init_attr.cap.max_inline_data
+
+
+def get_qp_init_attr(cq, qpts, attr):
+    """
+    Creates a QPInitAttr object with a QP type of the provided <qpts> array and
+    other random values.
+    :param cq: CQ to be used as send and receive CQ
+    :param qpts: An array of possible QP types to use
+    :param attr: Device attributes for capability checks
+    :return: An initialized QPInitAttr object
+    """
+    qp_cap = u.random_qp_cap(attr)
+    qpt = random.choice(qpts)
+    sig = random.randint(0, 1)
+    return QPInitAttr(qp_type=qpt, scq=cq, rcq=cq, cap=qp_cap, sq_sig_all=sig)
+
+
+def get_qp_init_attr_ex(cq, pd, qpts, attr, attr_ex):
+    """
+    Creates a QPInitAttrEx object with a QP type of the provided <qpts> array
+    and other random values.
+    :param cq: CQ to be used as send and receive CQ
+    :param pd: A PD object to use
+    :param qpts: An array of possible QP types to use
+    :param attr: Device attributes for capability checks
+    :param attr_ex: Extended device attributes for capability checks
+    :return: An initialized QPInitAttrEx object
+    """
+    qpt = random.choice(qpts)
+    qia = u.random_qp_init_attr_ex(attr_ex, attr, qpt)
+    qia.send_cq = cq
+    qia.recv_cq = cq
+    qia.pd = pd  # Only XRCD can be created without a PD
+    return qia
+
+
+def is_eth(ctx, port_num):
+    """
+    Querires the device's context's <port_num> port for its link layer.
+    :param ctx: The Context to query
+    :param port_num: Which Context's port to query
+    :return: True if the port's link layer is Ethernet, else False
+    """
+    return ctx.query_port(port_num).link_layer == e.IBV_LINK_LAYER_ETHERNET

--- a/pyverbs/tests/utils.py
+++ b/pyverbs/tests/utils.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright (c) 2019, Mellanox Technologies. All rights reserved.  See COPYING file
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved.  See COPYING file
 """
 Provide some useful helper function for pyverbs' tests.
 """
@@ -7,9 +7,9 @@ from itertools import combinations as com
 from string import ascii_lowercase as al
 import random
 
+from pyverbs.qp import QPCap, QPInitAttrEx
 import pyverbs.device as d
 import pyverbs.enums as e
-
 
 MAX_MR_SIZE = 4194304
 # Some HWs limit DM address and length alignment to 4 for read and write
@@ -20,6 +20,8 @@ MIN_DM_SIZE = 4
 DM_ALIGNMENT = 4
 MIN_DM_LOG_ALIGN = 0
 MAX_DM_LOG_ALIGN = 6
+# Raw Packet QP supports TSO header, which creates a larger send WQE.
+MAX_RAW_PACKET_SEND_WR = 2500
 
 
 def get_mr_length():
@@ -97,3 +99,125 @@ def sample(coll):
     :return: A subset of <collection>
     """
     return random.sample(coll, int((len(coll) + 1) * random.random()))
+
+
+def random_qp_cap(attr):
+    """
+    Initializes a QPCap object with valid values based on the device's
+    attributes.
+    It doesn't check the max WR limits since they're reported for smaller WR
+    sizes.
+    :return: A QPCap object
+    """
+    # We use significantly smaller values than those in device attributes.
+    # The attributes reported by the device don't take into account possible
+    # larger WQEs that include e.g. memory window.
+    send_wr = random.randint(1, int(attr.max_qp_wr / 8))
+    recv_wr = random.randint(1, int(attr.max_qp_wr / 8))
+    send_sge = random.randint(1, int(attr.max_sge / 2))
+    recv_sge = random.randint(1, int(attr.max_sge / 2))
+    inline = random.randint(0, 16)
+    return QPCap(send_wr, recv_wr, send_sge, recv_sge, inline)
+
+
+def random_qp_create_mask(qpt, attr_ex):
+    """
+    Select a random sublist of ibv_qp_init_attr_mask. Some of the options are
+    not yet supported by pyverbs and will not be returned. TSO support is
+    checked for the device and the QP type. If it doesn't exist, TSO will not
+    be set.
+    :param qpt: Current QP type
+    :param attr_ex: Extended device attributes for capability checks
+    :return: A sublist of ibv_qp_init_attr_mask
+    """
+    has_tso = attr_ex.tso_caps.max_tso > 0 and \
+        attr_ex.tso_caps.supported_qpts & 1 << qpt
+    supp_flags = [e.IBV_QP_INIT_ATTR_CREATE_FLAGS,
+                  e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER]
+    # Either PD or XRCD flag is needed, XRCD is not supported yet
+    selected = sample(supp_flags)
+    selected.append(e.IBV_QP_INIT_ATTR_PD)
+    if e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER in selected and not has_tso:
+        selected.remove(e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER)
+    mask = 0
+    for s in selected:
+        mask += s.value
+    return mask
+
+
+def get_create_qp_flags_raw_packet(attr_ex):
+    """
+    Select random QP creation flags for Raw Packet QP. Filter out unsupported
+    flags prior to selection.
+    :param attr_ex: Device extended attributes to check capabilities
+    :return: A random combination of QP creation flags
+    """
+    has_fcs = attr_ex.device_cap_flags_ex & e._IBV_DEVICE_RAW_SCATTER_FCS
+    has_cvlan = attr_ex.raw_packet_caps & e.IBV_RAW_PACKET_CAP_CVLAN_STRIPPING
+    has_padding = attr_ex.device_cap_flags_ex & \
+        e._IBV_DEVICE_PCI_WRITE_END_PADDING
+    l = list(e.ibv_qp_create_flags)
+    l.remove(e.IBV_QP_CREATE_SOURCE_QPN)  # UD only
+    if not has_fcs:
+        l.remove(e.IBV_QP_CREATE_SCATTER_FCS)
+    if not has_cvlan:
+        l.remove(e.IBV_QP_CREATE_CVLAN_STRIPPING)
+    if not has_padding:
+        l.remove(e.IBV_QP_CREATE_PCI_WRITE_END_PADDING)
+    flags = sample(l)
+    val = 0
+    for i in flags:
+        val |= i.value
+    return val
+
+
+def random_qp_create_flags(qpt, attr_ex):
+    """
+    Select a random sublist of ibv_qp_create_flags according to the QP type.
+    :param qpt: Current QP type
+    :param attr_ex: Used for Raw Packet QP to check device capabilities
+    :return: A sublist of ibv_qp_create_flags
+    """
+    if qpt == e.IBV_QPT_RAW_PACKET:
+        return get_create_qp_flags_raw_packet(attr_ex)
+    elif qpt == e.IBV_QPT_UD:
+        # IBV_QP_CREATE_SOURCE_QPN is only supported by mlx5 driver and is not
+        # to be check in unittests.
+        return random.choice([0, 2])  # IBV_QP_CREATE_BLOCK_SELF_MCAST_LB
+    else:
+        return 0
+
+
+def random_qp_init_attr_ex(attr_ex, attr, qpt=None):
+    """
+    Create a random-valued QPInitAttrEX object with the given QP type.
+    QP type affects QP capabilities, so allow users to set it and still get
+    valid attributes.
+    :param attr_ex: Extended device attributes for capability checks
+    :param attr: Device attributes for capability checks
+    :param qpt: Requested QP type
+    :return: A valid initialized QPInitAttrEx object
+    """
+    max_tso = 0
+    if qpt is None:
+        qpt = random.choice([e.IBV_QPT_RC, e.IBV_QPT_UC, e.IBV_QPT_UD,
+                             e.IBV_QPT_RAW_PACKET])
+    qp_cap = random_qp_cap(attr)
+    if qpt == e.IBV_QPT_RAW_PACKET and \
+       qp_cap.max_send_wr > MAX_RAW_PACKET_SEND_WR:
+        qp_cap.max_send_wr = MAX_RAW_PACKET_SEND_WR
+    sig = random.randint(0, 1)
+    mask = random_qp_create_mask(qpt, attr_ex)
+    if mask & e.IBV_QP_INIT_ATTR_CREATE_FLAGS:
+        cflags = random_qp_create_flags(qpt, attr_ex)
+    else:
+        cflags = 0
+    if mask & e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER:
+        if qpt != e.IBV_QPT_RAW_PACKET:
+            mask -= e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER
+        else:
+            max_tso = \
+                random.randint(16, int(attr_ex.tso_caps.max_tso / 400))
+    qia = QPInitAttrEx(qp_type=qpt, cap=qp_cap, sq_sig_all=sig, comp_mask=mask,
+                       create_flags=cflags, max_tso_header=max_tso)
+    return qia

--- a/pyverbs/utils.py
+++ b/pyverbs/utils.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
+
+import struct
+
+from pyverbs.pyverbs_error import PyverbsUserError
+
+be64toh = lambda num: struct.unpack('Q', struct.pack('!Q', num))[0]
+
+def gid_str(subnet_prefix, interface_id):
+    hex_values = '%016x%016x' % (be64toh(subnet_prefix), be64toh(interface_id))
+    return ':'.join([hex_values[0:4], hex_values[4:8], hex_values[8:12],
+                     hex_values[12:16], hex_values[16:20], hex_values[20:24],
+                     hex_values[24:28],hex_values[28:32]])
+
+
+def gid_str_to_array(val):
+    """
+    Splits a GID to an array of u8 that can be easily assigned to a GID's raw
+    array.
+    :param val: GID value in 8 words format
+    'xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx'
+    :return: An array of format xx:xx etc.
+    """
+    val = val.split(':')
+    if len(val) != 8:
+        raise PyverbsUserError('Invalid GID value ({val})'.format(val=val))
+    if any([len(v) != 4 for v in val]):
+        raise PyverbsUserError('Invalid GID value ({val})'.format(val=val))
+    val_int = int(''.join(val), 16)
+    vals = []
+    for i in range(8):
+        vals.append(val[i][0:2])
+        vals.append(val[i][2:4])
+    return vals

--- a/pyverbs/utils.py
+++ b/pyverbs/utils.py
@@ -33,3 +33,49 @@ def gid_str_to_array(val):
         vals.append(val[i][0:2])
         vals.append(val[i][2:4])
     return vals
+
+
+def qp_type_to_str(qp_type):
+    types = {2: 'RC', 3: 'UC', 4: 'UD', 8: 'Raw Packet', 9: 'XRCD_SEND',
+             10: 'XRCD_RECV', 0xff:'Driver QP'}
+    try:
+        return types[qp_type]
+    except KeyError:
+        return 'Unknown ({qpt})'.format(qpt=qp_type)
+
+
+def qp_state_to_str(qp_state):
+    states = {0: 'Reset', 1: 'Init', 2: 'RTR', 3: 'RTS', 4: 'SQD',
+              5: 'SQE', 6: 'Error', 7: 'Unknown'}
+    try:
+        return states[qp_state]
+    except KeyError:
+        return 'Unknown ({qps})'.format(qps=qp_state_to_str)
+
+
+def mtu_to_str(mtu):
+    mtus = {1: 256, 2: 512, 3: 1024, 4: 2048, 5: 4096}
+    try:
+        return mtus[mtu]
+    except KeyError:
+        return 0
+
+
+def access_flags_to_str(flags):
+    access_flags = {1: 'Local write', 2: 'Remote write', 4: 'Remote read',
+                    8: 'Remote atomic', 16: 'MW bind', 32: 'Zero based',
+                    64: 'On demand'}
+    access_str = ''
+    for f in access_flags:
+        if flags & f:
+            access_str += access_flags[f]
+            access_str += ' '
+    return access_str
+
+
+def mig_state_to_str(mig):
+    mig_states = {0: 'Migrated', 1: 'Re-arm', 2: 'Armed'}
+    try:
+        return mig_states[mig]
+    except KeyError:
+        return 'Unknown ({m})'.format(m=mig)

--- a/pyverbs/wr.pxd
+++ b/pyverbs/wr.pxd
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
+
+from .base cimport PyverbsCM
+from pyverbs cimport libibverbs as v
+
+
+cdef class SGE(PyverbsCM):
+    cdef v.ibv_sge *sge
+    cpdef read(self, length, offset)
+
+cdef class RecvWR(PyverbsCM):
+    cdef v.ibv_recv_wr recv_wr
+
+cdef class SendWR(PyverbsCM):
+    cdef v.ibv_send_wr send_wr

--- a/pyverbs/wr.pyx
+++ b/pyverbs/wr.pyx
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies Inc. All rights reserved. See COPYING file
+
+from pyverbs.pyverbs_error import PyverbsUserError, PyverbsError
+from pyverbs.base import PyverbsRDMAErrno
+cimport pyverbs.libibverbs_enums as e
+from pyverbs.addr cimport AH
+
+cdef extern from 'stdlib.h':
+    void *malloc(size_t size)
+    void free(void *ptr)
+cdef extern from 'string.h':
+    void *memcpy(void *dest, const void *src, size_t n)
+
+
+cdef class SGE(PyverbsCM):
+    """
+    Represents ibv_sge struct. It has a read function to allow users to keep
+    track of data. Write function is not provided as a scatter-gather element
+    can be using a MR or a DMMR. In case direct (device's) memory is used,
+    write can't be done using memcpy that relies on CPU-specific optimizations.
+    A SGE has no way to tell which memory it is using.
+    """
+    def __cinit__(self, addr, length, lkey):
+        """
+        Initializes a SGE object.
+        :param addr: The address to be used for read/write
+        :param length: Available buffer size
+        :param lkey: Local key of the used MR/DMMR
+        :return: A SGE object
+        """
+        self.sge = <v.ibv_sge*>malloc(sizeof(v.ibv_sge))
+        if self.sge == NULL:
+            raise PyverbsError('Failed to allocate an SGE')
+        self.sge.addr = addr
+        self.sge.length = length
+        self.sge.lkey = lkey
+
+    def __dealloc(self):
+        self.close()
+
+    cpdef close(self):
+        free(self.sge)
+
+    cpdef read(self, length, offset):
+        """
+        Reads <length> bytes of data starting at <offset> bytes from the
+        SGE's address.
+        :param length: How many bytes to read
+        :param offset: Offset from the SGE's address in bytes
+        :return: The data written at the SGE's address + offset
+        """
+        cdef char *sg_data
+        cdef int off = offset
+        sg_data = <char*>(self.sge.addr + off)
+        return <object>sg_data[:length]
+
+    def _get_sge(self):
+        return <object>self.sge
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('Address', hex(self.sge.addr)) +\
+               print_format.format('Length', self.sge.length) +\
+               print_format.format('Key', hex(self.sge.lkey))
+
+    @property
+    def addr(self):
+        return self.sge.addr
+    @addr.setter
+    def addr(self, val):
+        self.sge.addr = val
+
+    @property
+    def length(self):
+        return self.sge.length
+    @length.setter
+    def length(self, val):
+        self.sge.length = val
+
+    @property
+    def lkey(self):
+        return self.sge.lkey
+    @lkey.setter
+    def lkey(self, val):
+        self.sge.lkey = val
+
+
+cdef class RecvWR(PyverbsCM):
+    def __cinit__(self, wr_id=0, num_sge=0, sg=None,
+                  RecvWR next_wr=None):
+        """
+        Initializes a RecvWR object.
+        :param wr_id: A user-defined WR ID
+        :param num_sge: Size of the scatter-gather array
+        :param sg: A scatter-gather array
+        :param: next_wr: The next WR in the list
+        :return: A RecvWR object
+        """
+        cdef v.ibv_sge *dst
+        if num_sge < 1 or sg is None:
+            raise PyverbsUserError('A WR needs at least one SGE')
+        self.recv_wr.sg_list = <v.ibv_sge*>malloc(num_sge * sizeof(v.ibv_sge))
+        if self.recv_wr.sg_list == NULL:
+            raise PyverbsRDMAErrno('Failed to malloc SG buffer')
+        dst = self.recv_wr.sg_list
+        copy_sg_array(<object>dst, sg, num_sge)
+        self.recv_wr.num_sge = num_sge
+        self.recv_wr.wr_id = wr_id
+        if next_wr is not None:
+            self.recv_wr.next = &next_wr.recv_wr
+
+    def __dealloc(self):
+        self.close()
+
+    cpdef close(self):
+        free(self.recv_wr.sg_list)
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('WR ID', self.recv_wr.wr_id) +\
+               print_format.format('Num SGE', self.recv_wr.num_sge)
+
+    @property
+    def next_wr(self):
+        if self.recv_wr.next == NULL:
+            return None
+        val = RecvWR()
+        val.recv_wr = self.recv_wr.next[0]
+        return val
+    @next_wr.setter
+    def next_wr(self, RecvWR val not None):
+        self.recv_wr.next = &val.recv_wr
+
+    @property
+    def wr_id(self):
+        return self.recv_wr.wr_id
+    @wr_id.setter
+    def wr_id(self, val):
+        self.recv_wr.wr_id = val
+
+    @property
+    def num_sge(self):
+        return self.recv_wr.num_sge
+    @num_sge.setter
+    def num_sge(self, val):
+        self.recv_wr.num_sge = val
+
+
+cdef class SendWR(PyverbsCM):
+    def __cinit__(self, wr_id=0, opcode=e.IBV_WR_SEND, num_sge=0, sg = None,
+                  send_flags=e.IBV_SEND_SIGNALED, SendWR next_wr = None):
+        """
+        Initialize a SendWR object with user-provided or default values.
+        :param wr_id: A user-defined WR ID
+        :param opcode: The WR's opcode
+        :param num_sge: Number of scatter-gather elements in the WR
+        :param send_flags: Send flags as define in ibv_send_flags enum
+        :param sg: A SGE element, head of the scatter-gather list
+        :return: An initialized SendWR object
+        """
+        cdef v.ibv_sge *dst
+        if num_sge < 1 or sg is None:
+            raise PyverbsUserError('A WR needs at least one SGE')
+        self.send_wr.sg_list = <v.ibv_sge*>malloc(num_sge * sizeof(v.ibv_sge))
+        if self.send_wr.sg_list == NULL:
+            raise PyverbsRDMAErrno('Failed to malloc SG buffer')
+        dst = self.send_wr.sg_list
+        copy_sg_array(<object>dst, sg, num_sge)
+        self.send_wr.num_sge = num_sge
+        self.send_wr.wr_id = wr_id
+        if next_wr is not None:
+            self.send_wr.next = &next_wr.send_wr
+        self.send_wr.opcode = opcode
+        self.send_wr.send_flags = send_flags
+
+    def __dealloc(self):
+        self.close()
+
+    cpdef close(self):
+        free(self.send_wr.sg_list)
+
+    def __str__(self):
+        print_format = '{:22}: {:<20}\n'
+        return print_format.format('WR ID', self.send_wr.wr_id) +\
+               print_format.format('Num SGE', self.send_wr.num_sge) +\
+               print_format.format('Opcode', self.send_wr.opcode) +\
+               print_format.format('Send flags',
+                                   send_flags_to_str(self.send_wr.send_flags))
+
+    @property
+    def next_wr(self):
+        if self.send_wr.next == NULL:
+            return None
+        val = SendWR()
+        val.send_wr = self.send_wr.next[0]
+        return val
+    @next_wr.setter
+    def next_wr(self, SendWR val not None):
+        self.send_wr.next = &val.send_wr
+
+    @property
+    def wr_id(self):
+        return self.send_wr.wr_id
+    @wr_id.setter
+    def wr_id(self, val):
+        self.send_wr.wr_id = val
+
+    @property
+    def num_sge(self):
+        return self.send_wr.num_sge
+    @num_sge.setter
+    def num_sge(self, val):
+        self.send_wr.num_sge = val
+
+    @property
+    def opcode(self):
+        return self.send_wr.opcode
+    @opcode.setter
+    def opcode(self, val):
+        self.send_wr.opcode = val
+
+    @property
+    def send_flags(self):
+        return self.send_wr.send_flags
+    @send_flags.setter
+    def send_flags(self, val):
+        self.send_wr.send_flags = val
+
+    property sg_list:
+        def __set__(self, SGE val not None):
+            self.send_wr.sg_list = val.sge
+
+    def set_wr_ud(self, AH ah not None, rqpn, rqkey):
+        """
+        Set the members of the ud struct in the send_wr's wr union.
+        :param ah: An address handle object
+        :param rqpn: The remote QP number
+        :param rqkey: The remote QKey, authorizing access to the destination QP
+        :return: None
+        """
+        self.send_wr.wr.ud.ah = ah.ah
+        self.send_wr.wr.ud.remote_qpn = rqpn
+        self.send_wr.wr.ud.remote_qkey = rqkey
+
+    def set_wr_rdma(self, rkey, addr):
+        """
+        Set the members of the rdma struct in the send_wr's wr union, used for
+        RDMA extended transport header creation.
+        :param rkey: Key to access the specified memory address.
+        :param addr: Start address of the buffer
+        :return: None
+        """
+        self.send_wr.wr.rdma.remote_addr = addr
+        self.send_wr.wr.rdma.rkey = rkey
+
+    def set_wr_atomic(self, rkey, addr, compare_add, swap=0):
+        """
+        Set the members of the atomic struct in the send_wr's wr union, used
+        for the atomic extended transport header.
+        :param rkey: Key to access the specified memory address.
+        :param addr: Start address of the buffer
+        :param compare_add: The data operand used in the compare portion of the
+                            compare and swap operation
+        :param swap: The data operand used in atomic operations:
+                     - In compare and swap this field is swapped into the
+                       addressed buffer
+                     - In fetch and add this field is added to the contents of
+                       the addressed buffer
+        :return: None
+        """
+        self.send_wr.wr.atomic.remote_addr = addr
+        self.send_wr.wr.atomic.rkey = rkey
+        self.send_wr.wr.atomic.compare_add = compare_add
+        self.send_wr.wr.atomic.swap = swap
+
+    def set_qp_type_xrc(self, remote_srqn):
+        """
+        Set the members of the xrc struct in the send_wr's qp_type union, used
+        for the XRC extended transport header.
+        :param remote_srqn: The XRC SRQ number to be used by the responder fot
+                            this packet
+        :return: None
+        """
+        self.send_wr.qp_type.xrc.remote_srqn = remote_srqn
+
+def send_flags_to_str(flags):
+    send_flags = {e.IBV_SEND_FENCE: 'IBV_SEND_FENCE',
+                  e.IBV_SEND_SIGNALED: 'IBV_SEND_SIGNALED',
+                  e.IBV_SEND_SOLICITED: 'IBV_SEND_SOLICITED',
+                  e.IBV_SEND_INLINE: 'IBV_SEND_INLINE',
+                  e.IBV_SEND_IP_CSUM: 'IBV_SEND_IP_CSUM'}
+    flags_str = ''
+    for f in send_flags:
+        if flags & f:
+            flags_str += send_flags[f]
+            flags_str += ' '
+    return flags_str
+
+
+cdef copy_sg_array(dst_obj, sg, num_sge):
+    cdef v.ibv_sge *dst = <v.ibv_sge*>dst_obj
+    cdef v.ibv_sge *src
+    for i in range(num_sge):
+        # Avoid 'storing unsafe C derivative of temporary Python' errors
+        # that will occur if we merge the two following lines.
+        tmp = sg[i]._get_sge()
+        src = <v.ibv_sge*>tmp
+        memcpy(dst, src, sizeof(v.ibv_sge))
+        dst += 1


### PR DESCRIPTION
This PR adds the support for RDMA traffic in pyverbs. It's
consisted roughly of three parts - Address handle support, QP
support and example (RC pingpong).