### PR TITLE
libibverbs: Expose the get neighbor timeout for dmac resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@
 #   -DNO_PYVERBS=1 (default, build pyverbs)
 #      Invoke cython to build pyverbs. Usually you will run with this option
 #      is set, but it will be disabled for travis runs.
+#   -DNEIGH_GET_DEFAULT_TIMEOUT_MS=3000 (default)
+#      Set the default timeout for lookup of neighbor for mac address.
 
 cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
 project(rdma-core C)
@@ -82,6 +84,10 @@ if (IN_PLACE)
   set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
   set(CMAKE_INSTALL_LIBDIR "lib")
   set(CMAKE_INSTALL_INCLUDEDIR "include")
+endif()
+
+if ("${NEIGH_GET_DEFAULT_TIMEOUT_MS}" STREQUAL "")
+  set(NEIGH_GET_DEFAULT_TIMEOUT_MS 3000)
 endif()
 
 include(GNUInstallDirs)

--- a/buildlib/config.h.in
+++ b/buildlib/config.h.in
@@ -61,6 +61,8 @@
 # define VERBS_WRITE_ONLY 0
 #endif
 
+# define NEIGH_GET_DEFAULT_TIMEOUT_MS @NEIGH_GET_DEFAULT_TIMEOUT_MS@
+
 // Configuration defaults
 
 #define IBACM_SERVER_MODE_UNIX 0

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -967,7 +967,6 @@ static inline int create_peer_from_gid(int family, void *raw_gid,
 	return 0;
 }
 
-#define NEIGH_GET_DEFAULT_TIMEOUT_MS 3000
 int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 				struct ibv_ah_attr *attr,
 				uint8_t eth_mac[ETHERNET_LL_SIZE],


### PR DESCRIPTION
This allows the neighbor timeout to be configured while building
rdma-core using the extra cmake flags.

Reviewed-by: Jorgen Hansen <jhansen@vmware.com>
Reviewed-by: Vishnu Dasa <vdasa@vmware.com>
Signed-off-by: Adit Ranadive <aditr@vmware.com>