### PR TITLE
kernel-boot: Fix build failure with ancient libnl3 versions

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -47,9 +47,11 @@
 
 static struct nla_policy policy[RDMA_NLDEV_ATTR_MAX] = {
 	[RDMA_NLDEV_ATTR_DEV_INDEX] = { .type = NLA_U32 },
-	[RDMA_NLDEV_ATTR_DEV_NAME] = { .type = NLA_NUL_STRING },
 	[RDMA_NLDEV_ATTR_NODE_GUID] = { .type = NLA_U64 },
+#ifdef NLA_NUL_STRING
+	[RDMA_NLDEV_ATTR_DEV_NAME] = { .type = NLA_NUL_STRING },
 	[RDMA_NLDEV_ATTR_DEV_PROTOCOL] = { .type = NLA_NUL_STRING },
+#endif /* NLA_NUL_STRING */
 };
 
 struct data {


### PR DESCRIPTION
Debian jessie provides a very ancient libnl3 version without NLA_NUL_STRING.
In order to do not disable persistent naming on such systems, we prefer
to loose our netlink type validation.

Fixes: 6b4099d47be3 ("kernel-boot: Perform device rename to make stable names")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>