### PR TITLE
vmw_pvrdma: Use resource ids from physical device if available

### DIFF
--- a/kernel-headers/rdma/vmw_pvrdma-abi.h
+++ b/kernel-headers/rdma/vmw_pvrdma-abi.h
@@ -49,7 +49,11 @@
 
 #include <linux/types.h>
 
-#define PVRDMA_UVERBS_ABI_VERSION	3		/* ABI Version. */
+#define PVRDMA_UVERBS_MIN_ABI_VERSION		3
+#define PVRDMA_UVERBS_MAX_ABI_VERSION		4
+
+#define PVRDMA_UVERBS_NO_QP_HANDLE_ABI_VERSION	3
+
 #define PVRDMA_UAR_HANDLE_MASK		0x00FFFFFF	/* Bottom 24 bits. */
 #define PVRDMA_UAR_QP_OFFSET		0		/* QP doorbell. */
 #define PVRDMA_UAR_QP_SEND		(1 << 30)	/* Send bit. */
@@ -177,6 +181,11 @@ struct pvrdma_create_qp {
 	__u32 rbuf_size;
 	__u32 sbuf_size;
 	__aligned_u64 qp_addr;
+};
+
+struct pvrdma_create_qp_resp {
+	__u32 qpn;
+	__u32 qp_handle;
 };
 
 /* PVRDMA masked atomic compare and swap */

--- a/providers/vmw_pvrdma/pvrdma-abi.h
+++ b/providers/vmw_pvrdma/pvrdma-abi.h
@@ -54,8 +54,10 @@ DECLARE_DRV_CMD(user_pvrdma_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
 		empty, pvrdma_alloc_pd_resp);
 DECLARE_DRV_CMD(user_pvrdma_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		pvrdma_create_cq, pvrdma_create_cq_resp);
-DECLARE_DRV_CMD(user_pvrdma_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+DECLARE_DRV_CMD(user_pvrdma_create_qp_v3, IB_USER_VERBS_CMD_CREATE_QP,
 		pvrdma_create_qp, empty);
+DECLARE_DRV_CMD(user_pvrdma_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
+		pvrdma_create_qp, pvrdma_create_qp_resp);
 DECLARE_DRV_CMD(user_pvrdma_create_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
 		pvrdma_create_srq, pvrdma_create_srq_resp);
 DECLARE_DRV_CMD(user_pvrdma_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -170,6 +170,7 @@ struct pvrdma_qp {
 	struct pvrdma_wq		sq;
 	struct pvrdma_wq		rq;
 	int				is_srq;
+	uint32_t			qp_handle;
 };
 
 struct pvrdma_ah {

--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -201,8 +201,8 @@ static const struct verbs_match_ent hca_table[] = {
 
 static const struct verbs_device_ops pvrdma_dev_ops = {
 	.name = "pvrdma",
-	.match_min_abi_version = PVRDMA_UVERBS_ABI_VERSION,
-	.match_max_abi_version = PVRDMA_UVERBS_ABI_VERSION,
+	.match_min_abi_version = PVRDMA_UVERBS_MIN_ABI_VERSION,
+	.match_max_abi_version = PVRDMA_UVERBS_MAX_ABI_VERSION,
 	.match_table = hca_table,
 	.alloc_device = pvrdma_device_alloc,
 	.uninit_device = pvrdma_uninit_device,


### PR DESCRIPTION
This change allows user-space to use physical resource numbers if
they are passed up from the driver. Doing so allows communication with
physical non-ESX endpoints (such as a bare-metal Linux machine or a
SR-IOV-enabled VM).

This is accomplished by separating the concept of the QP number from
the QP handle. Previously, the two were the same, as the QP number
was exposed to the guest and also used to reference  a virtual QP in
the device backend. With physical resource numbers exposed, the QP
number given to the guest is the QP number assigned to the physical
HCA's QP, while the QP handle is still the internal handle used to
reference a virtual QP. Regardless of whether the device is exposing
physical ids, the driver will still try to pick up the QP handle from
the backend if possible.

The MR keys exposed to the guest when the physical resource ids feature
is turned on are likewise now the MR keys created by the physical HCA,
instead of virtual MR keys.

The ABI has been updated to allow the return of the QP handle to the
guest library. The ABI version has been bumped up because of this
non-compatible change.

Reviewed-by: Jorgen Hansen <jhansen@vmware.com>
Signed-off-by: Adit Ranadive <aditr@vmware.com>
Signed-off-by: Bryan Tan <bryantan@vmware.com>