### PR TITLE
suse: fix dracut support

### DIFF
--- a/suse/module-setup.sh
+++ b/suse/module-setup.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+check() {
+	[ -n "$hostonly" -a -c /sys/class/infiniband_verbs/uverbs0 ] && return 0
+	[ -n "$hostonly" ] && return 255
+	return 0
+}
+
+depends() {
+	return 0
+}
+
+install() {
+	inst /etc/rdma/mlx4.conf
+	inst /etc/rdma/modules/infiniband.conf
+	inst /etc/rdma/modules/iwarp.conf
+	inst /etc/rdma/modules/opa.conf
+	inst /etc/rdma/modules/rdma.conf
+	inst /etc/rdma/modules/roce.conf
+	inst /usr/lib/mlx4-setup.sh
+	inst_multiple lspci setpci awk sleep
+	inst_rules 60-rdma-persistent-naming.rules 70-persistent-ipoib.rules 75-rdma-description.rules 90-rdma-hw-modules.rules 90-rdma-ulp-modules.rules
+	inst_multiple -o \
+                  $systemdsystemunitdir/rdma-hw.target \
+                  $systemdsystemunitdir/rdma-load-modules@.service
+}
+
+installkernel() {
+	hostonly='' instmods =drivers/infiniband =drivers/net/ethernet/mellanox =drivers/net/ethernet/chelsio =drivers/net/ethernet/cisco =drivers/net/ethernet/emulex =drivers/target
+	hostonly='' instmods crc-t10dif crct10dif_common
+}

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -392,7 +392,7 @@ cd build
 cd ..
 mkdir -p %{buildroot}/%{_sysconfdir}/rdma
 
-%global dracutlibdir %%{_sysconfdir}/dracut.conf.d
+%global dracutlibdir %%{_libexecdir}/dracut/
 %global sysmodprobedir %%{_sysconfdir}/modprobe.d
 
 mkdir -p %{buildroot}%{_udevrulesdir}
@@ -413,8 +413,7 @@ chmod 0644 %{buildroot}%{sysmodprobedir}/50-libmlx4.conf
 install -D -m0755 redhat/rdma.mlx4-setup.sh %{buildroot}%{_libexecdir}/mlx4-setup.sh
 
 # Dracut file for IB support during boot
-sed 's%/usr/libexec%/usr/lib%g' redhat/rdma.modules-setup.sh > %{buildroot}%{dracutlibdir}/modules.d/05rdma/module-setup.sh
-chmod 0755 %{buildroot}%{dracutlibdir}/modules.d/05rdma/module-setup.sh
+install -D -m0644 suse/module-setup.sh %{buildroot}%{dracutlibdir}/modules.d/05rdma/module-setup.sh
 
 # ibacm
 cd build


### PR DESCRIPTION
SUSE dracut does not support /etc/dracut.conf.d but /usr/lib/dracut/modules.d
Replace redhat script by a simpler one that reuses the standard
udev/systemd scripts

Cc: stable@linux-rdma.org #v15
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>