### PR TITLE
kernel-boot: Reset buffer before refill

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -240,10 +240,11 @@ static int by_pci(struct data *d)
 		return -ENOMEM;
 
 	ret = readlink(subsystem, buf, sizeof(buf)-1);
-	if (ret == -1) {
+	if (ret == -1 || ret == sizeof(buf)) {
 		ret = -EINVAL;
 		goto out;
 	}
+	buf[ret] = 0;
 
 	subs = basename(buf);
 	if (strcmp(subs, "pci")) {
@@ -251,7 +252,6 @@ static int by_pci(struct data *d)
 		ret = -EINVAL;
 		goto out;
 	}
-
 	/* Real devices */
 	ret = asprintf(&devpath, "/sys/class/infiniband/%s/device", d->curr);
 	if (ret < 0) {
@@ -261,10 +261,12 @@ static int by_pci(struct data *d)
 	}
 
 	ret = readlink(devpath, buf, sizeof(buf)-1);
-	if (ret == -1) {
+	if (ret == -1 || ret == sizeof(buf)) {
 		ret = -EINVAL;
 		goto out;
 	}
+	buf[ret] = 0;
+
 	pci = basename(buf);
 	/*
 	 * pci = 0000:00:0c.0


### PR DESCRIPTION
In our flows, we fill buffer with larger number of literals than
in second run. It causes to situation where "junk" from previous
call is left in buffer and breaks second parsing.

Fixes: 6b4099d47be3 ("kernel-boot: Perform device rename to make stable names")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>