### PR TITLE
ibdiags: Fix linkage error on PPC platform due to typo

### DIFF
--- a/infiniband-diags/CMakeLists.txt
+++ b/infiniband-diags/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(ibdiags_tools STATIC
 function(ibdiag_programs)
   foreach(I ${ARGN})
     rdma_sbin_executable(${I} "${I}.c")
-    target_link_libraries(${I} PRIVATE ${RT_LIBRARIES} ibumad ibmad ibdiags_tools ibnetdisc)
+    target_link_libraries(${I} LINK_PRIVATE ${RT_LIBRARIES} ibumad ibmad ibdiags_tools ibnetdisc)
   endforeach()
 endfunction()
 
@@ -44,6 +44,6 @@ ibdiag_programs(
   )
 
 rdma_test_executable(ibsendtrap "ibsendtrap.c")
-target_link_libraries(ibsendtrap PRIVATE ibumad ibmad ibdiags_tools)
+target_link_libraries(ibsendtrap LINK_PRIVATE ibumad ibmad ibdiags_tools)
 rdma_test_executable(mcm_rereg_test "mcm_rereg_test.c")
-target_link_libraries(mcm_rereg_test PRIVATE ibumad ibmad ibdiags_tools)
+target_link_libraries(mcm_rereg_test LINK_PRIVATE ibumad ibmad ibdiags_tools)


### PR DESCRIPTION
Incorrect linkage type causes to linkage errors on PPC platform.

[267/395] Linking C executable bin/mcm_rereg_test
FAILED: bin/mcm_rereg_test
: && /usr/bin/cc  -std=gnu11 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter -Wmissing-prototypes -Wmissing-declarations
-Wwrite-strings -Wformat=2 -Wformat-nonliteral -Wredundant-decls -Wnested-externs -Wshadow -Wno-missing-field-i
nitializers -Wstrict-prototypes -Wold-style-definition -Wredundant-decls -O2 -g  -Wl,--as-needed -Wl,--no-undefined
infiniband-diags/CMakeFiles/mcm_rereg_test.dir/mcm_rereg_test.c.o  -o bin/mcm_rereg_test  ccan/libccan.a util/librdma_util
.a -lPRIVATE lib/libibumad.so.3.0.25.0 lib/libibmad.so.5.3.25.0 infiniband-diags/libibdiags_tools.a lib/libibumad.so.3.0.25.0
-Wl,-rpath,/tmp/rdma-core/build/lib &&
: /usr/bin/ld: cannot find -lPRIVATE
collect2: error: ld returned 1 exit status

Fixes: 58670e0a17ba ("ibdiags: Add cmake files for ibdiags components")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>