### PR TITLE
Enhance build system to allow separate installation

### DIFF
--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -1,4 +1,6 @@
-install(FILES
+rdma_component()
+
+rdma_install(FILES
   ibacm.md
   ibsrpdm.md
   libibverbs.md

--- a/buildlib/publish_headers.cmake
+++ b/buildlib/publish_headers.cmake
@@ -25,6 +25,6 @@ function(publish_headers DEST)
 
   foreach(SFIL ${ARGN})
     get_filename_component(FIL ${SFIL} NAME)
-    install(FILES "${SFIL}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DEST}/" RENAME "${FIL}")
+    rdma_install(FILES "${SFIL}" DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/${DEST}/" RENAME "${FIL}")
   endforeach()
 endfunction()

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -21,7 +21,7 @@ function(rdma_cython_module PY_MODULE)
       LIBRARY_OUTPUT_DIRECTORY "${BUILD_PYTHON}/${PY_MODULE}"
       PREFIX "")
     target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs)
-    install(TARGETS ${SONAME}
+    rdma_install(TARGETS ${SONAME}
       DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
   endforeach()
 endfunction()
@@ -30,7 +30,7 @@ function(rdma_python_module PY_MODULE)
   foreach(PY_FILE ${ARGN})
     get_filename_component(LINK "${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}" ABSOLUTE)
     rdma_create_symlink("${LINK}" "${BUILD_PYTHON}/${PY_MODULE}/${PY_FILE}")
-    install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}
+    rdma_install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/${PY_FILE}
       DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
   endforeach()
 endfunction()

--- a/buildlib/rdma_man.cmake
+++ b/buildlib/rdma_man.cmake
@@ -37,7 +37,7 @@ function(rdma_md_man_page SRC MAN_SECT MANFN)
     rdma_man_get_prebuilt(${SRC} OBJ)
   endif()
 
-  install(FILES "${OBJ}"
+  rdma_install(FILES "${OBJ}"
     RENAME "${MANFN}"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man${MAN_SECT}/")
 endfunction()
@@ -59,7 +59,7 @@ function(rdma_rst_man_page SRC MAN_SECT MANFN)
     rdma_man_get_prebuilt(${SRC} OBJ)
   endif()
 
-  install(FILES "${OBJ}"
+  rdma_install(FILES "${OBJ}"
     RENAME "${MANFN}"
     DESTINATION "${CMAKE_INSTALL_MANDIR}/man${MAN_SECT}/")
 endfunction()
@@ -97,7 +97,7 @@ function(rdma_man_pages)
 	RENAME "${BASE_NAME}")
     else()
       string(REGEX REPLACE "^.+[.](.+)$" "\\1" MAN_SECT "${I}")
-      install(FILES "${I}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man${MAN_SECT}/")
+      rdma_install(FILES "${I}" DESTINATION "${CMAKE_INSTALL_MANDIR}/man${MAN_SECT}/")
     endif()
   endforeach()
 endfunction()

--- a/ccan/CMakeLists.txt
+++ b/ccan/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_internal_headers(ccan
   array_size.h
   bitmap.h

--- a/ibacm/CMakeLists.txt
+++ b/ibacm/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(infiniband
   include/infiniband/acm.h
   include/infiniband/acm_prov.h
@@ -38,7 +40,7 @@ target_link_libraries(ibacmp LINK_PRIVATE
   )
 set_target_properties(ibacmp PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")
-install(TARGETS ibacmp DESTINATION "${ACM_PROVIDER_DIR}")
+rdma_install(TARGETS ibacmp DESTINATION "${ACM_PROVIDER_DIR}")
 # ACM providers are linked into a subdir so that IN_PLACE can work.
 file(MAKE_DIRECTORY "${BUILD_LIB}/ibacm/")
 rdma_create_symlink("../libibacmp.so" "${BUILD_LIB}/ibacm/libibacmp.so")
@@ -71,7 +73,7 @@ rdma_subst_install(FILES "ibacm.service.in"
   RENAME ibacm.service
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install(FILES "ibacm.socket"
+rdma_install(FILES "ibacm.socket"
   DESTINATION "${CMAKE_INSTALL_SYSTEMD_SERVICEDIR}"
   RENAME ibacm.socket
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)

--- a/infiniband-diags/CMakeLists.txt
+++ b/infiniband-diags/CMakeLists.txt
@@ -1,9 +1,11 @@
+rdma_component()
+
 publish_internal_headers(""
   ibdiag_common.h
   ibdiag_sa.h
   )
 
-install(FILES
+rdma_install(FILES
   etc/error_thresholds
   etc/ibdiag.conf
   DESTINATION "${IBDIAG_CONFIG_PATH}")

--- a/infiniband-diags/man/CMakeLists.txt
+++ b/infiniband-diags/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 # rst2man has no way to set the include search path and we need to substitute
 # into the common files, so subst/link them all into the build directory
 function(rdma_rst_common)

--- a/infiniband-diags/scripts/CMakeLists.txt
+++ b/infiniband-diags/scripts/CMakeLists.txt
@@ -1,9 +1,11 @@
+rdma_component()
+
 function(_rdma_sbin_interp INTERP IFN OFN)
   configure_file("${IFN}" "${CMAKE_CURRENT_BINARY_DIR}/${OFN}" @ONLY)
   file(WRITE "${BUILD_BIN}/${OFN}" "#!${INTERP}\nexec ${INTERP} ${CMAKE_CURRENT_BINARY_DIR}/${OFN} \"$@\"\n")
   execute_process(COMMAND "chmod" "a+x" "${BUILD_BIN}/${OFN}")
 
-  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${OFN}"
+  rdma_install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${OFN}"
     DESTINATION "${CMAKE_INSTALL_SBINDIR}"
     PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 endfunction()
@@ -12,7 +14,7 @@ function(_rdma_sbin_interp_link INTERP IFN OFN)
   file(WRITE "${BUILD_BIN}/${OFN}" "#!${INTERP}\nexec ${INTERP} ${CMAKE_CURRENT_SOURCE_DIR}/${IFN} \"$@\"\n")
   execute_process(COMMAND "chmod" "a+x" "${BUILD_BIN}/${OFN}")
 
-  install(FILES "${IFN}"
+  rdma_install(FILES "${IFN}"
     DESTINATION "${CMAKE_INSTALL_SBINDIR}"
     RENAME "${OFN}"
     PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
@@ -81,7 +83,7 @@ rdma_sbin_perl_program(
   ibidsverify.pl
   )
 
-install(FILES "IBswcountlimits.pm"
+rdma_install(FILES "IBswcountlimits.pm"
   DESTINATION "${CMAKE_INSTALL_PERLDIR}")
 
 if (ENABLE_IBDIAGS_COMPAT)

--- a/iwpmd/CMakeLists.txt
+++ b/iwpmd/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_sbin_executable(iwpmd
   iwarp_pm_common.c
   iwarp_pm_helper.c
@@ -21,12 +23,12 @@ rdma_subst_install(FILES "iwpmd_init.in"
   DESTINATION "${CMAKE_INSTALL_INITDDIR}"
   RENAME "iwpmd"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
-install(FILES "iwpmd.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
+rdma_install(FILES "iwpmd.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 
-install(FILES "iwpmd.rules"
+rdma_install(FILES "iwpmd.rules"
   RENAME "90-iwpmd.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES modules-iwpmd.conf
+rdma_install(FILES modules-iwpmd.conf
   RENAME "iwpmd.conf"
   DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rdma/modules")

--- a/kernel-boot/CMakeLists.txt
+++ b/kernel-boot/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_subst_install(FILES rdma-load-modules@.service.in
   DESTINATION "${CMAKE_INSTALL_SYSTEMD_SERVICEDIR}"
   RENAME rdma-load-modules@.service
@@ -8,7 +10,7 @@ rdma_subst_install(FILES "rdma-hw.target.in"
   DESTINATION "${CMAKE_INSTALL_SYSTEMD_SERVICEDIR}"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install(FILES
+rdma_install(FILES
   modules/infiniband.conf
   modules/iwarp.conf
   modules/opa.conf
@@ -16,29 +18,29 @@ install(FILES
   modules/roce.conf
   DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rdma/modules")
 
-install(FILES "rdma-persistent-naming.rules"
+rdma_install(FILES "rdma-persistent-naming.rules"
   RENAME "60-rdma-persistent-naming.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES "rdma-description.rules"
+rdma_install(FILES "rdma-description.rules"
   RENAME "75-rdma-description.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES "rdma-hw-modules.rules"
+rdma_install(FILES "rdma-hw-modules.rules"
   RENAME "90-rdma-hw-modules.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES "rdma-ulp-modules.rules"
+rdma_install(FILES "rdma-ulp-modules.rules"
   RENAME "90-rdma-ulp-modules.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES "rdma-umad.rules"
+rdma_install(FILES "rdma-umad.rules"
   RENAME "90-rdma-umad.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
 # This file is intended to be customized by the user, so it is installed in
 # /etc/
-install(FILES "persistent-ipoib.rules"
+rdma_install(FILES "persistent-ipoib.rules"
   RENAME "70-persistent-ipoib.rules"
   DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d")
 
@@ -49,7 +51,7 @@ function(rdma_udev_executable EXEC)
   add_executable(${EXEC} ${ARGN})
   target_link_libraries(${EXEC} LINK_PRIVATE ${COMMON_LIBS})
   set_target_properties(${EXEC} PROPERTIES RUNTIME_OUTPUT_DIRECTORY "${BUILD_BIN}")
-  install(TARGETS ${EXEC} DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}/../")
+  rdma_install(TARGETS ${EXEC} DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}/../")
 endfunction()
 
 if (NOT NL_KIND EQUAL 0)

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_internal_headers(rdma
   rdma/bnxt_re-abi.h
   rdma/cxgb3-abi.h

--- a/libibmad/CMakeLists.txt
+++ b/libibmad/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(infiniband
   mad.h
   mad_osd.h

--- a/libibnetdisc/CMakeLists.txt
+++ b/libibnetdisc/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(infiniband
   ibnetdisc.h
   ibnetdisc_osd.h

--- a/libibnetdisc/man/CMakeLists.txt
+++ b/libibnetdisc/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   ibnd_discover_fabric.3
   ibnd_find_node_guid.3

--- a/libibumad/CMakeLists.txt
+++ b/libibumad/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(infiniband
   umad.h
   umad_cm.h

--- a/libibumad/man/CMakeLists.txt
+++ b/libibumad/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   umad_addr_dump.3
   umad_alloc.3

--- a/libibumad/tests/CMakeLists.txt
+++ b/libibumad/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_test_executable(umad_reg2 umad_reg2_compat.c)
 target_link_libraries(umad_reg2 LINK_PRIVATE ibumad)
 

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(infiniband
   arch.h
   opcode.h
@@ -65,6 +67,8 @@ target_link_libraries(ibverbs LINK_PRIVATE
   )
 
 function(ibverbs_finalize)
+  rdma_component(libibverbs)
+
   if (ENABLE_STATIC)
     # In static mode the .pc file lists all of the providers for static
     # linking. The user should set RDMA_STATIC_PROVIDERS to select which ones

--- a/libibverbs/examples/CMakeLists.txt
+++ b/libibverbs/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 # Shared example files
 add_library(ibverbs_tools STATIC
   pingpong.c

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   ibv_advise_mr.3.md
   ibv_alloc_dm.3

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_headers(rdma
   rdma_cma.h
   rdma_cma_abi.h
@@ -35,7 +37,7 @@ target_link_libraries(rspreload LINK_PRIVATE
   ${CMAKE_THREAD_LIBS_INIT}
   ${CMAKE_DL_LIBS}
 )
-install(TARGETS rspreload DESTINATION "${CMAKE_INSTALL_LIBDIR}/rsocket/")
+rdma_install(TARGETS rspreload DESTINATION "${CMAKE_INSTALL_LIBDIR}/rsocket/")
 
 # These are for compat with old packaging, these name should not be used.
 # FIXME: Maybe we can get rid of them?

--- a/librdmacm/examples/CMakeLists.txt
+++ b/librdmacm/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 # Shared example files
 add_library(rdmacm_tools STATIC
   common.c

--- a/librdmacm/man/CMakeLists.txt
+++ b/librdmacm/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   cmtime.1
   mckey.1

--- a/providers/bnxt_re/CMakeLists.txt
+++ b/providers/bnxt_re/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(bnxt_re
 	db.c
 	main.c

--- a/providers/cxgb3/CMakeLists.txt
+++ b/providers/cxgb3/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(cxgb3
   cq.c
   iwch.c

--- a/providers/cxgb4/CMakeLists.txt
+++ b/providers/cxgb4/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NO_STRICT_ALIASING_FLAGS}")
 
 rdma_provider(cxgb4

--- a/providers/efa/CMakeLists.txt
+++ b/providers/efa/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_shared_provider(efa libefa.map
 	1 1.0.${PACKAGE_VERSION}
 	efa.c

--- a/providers/efa/man/CMakeLists.txt
+++ b/providers/efa/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   efadv_create_driver_qp.3.md
   efadv.7.md

--- a/providers/hfi1verbs/CMakeLists.txt
+++ b/providers/hfi1verbs/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(hfi1verbs
   hfiverbs.c
   verbs.c

--- a/providers/hns/CMakeLists.txt
+++ b/providers/hns/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(hns
   hns_roce_u.c
   hns_roce_u_buf.c

--- a/providers/i40iw/CMakeLists.txt
+++ b/providers/i40iw/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(i40iw
   i40iw_uk.c
   i40iw_umain.c

--- a/providers/ipathverbs/CMakeLists.txt
+++ b/providers/ipathverbs/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(ipathverbs
   ipathverbs.c
   verbs.c
@@ -6,6 +8,6 @@ rdma_provider(ipathverbs
 rdma_subst_install(FILES "truescale.conf.in"
   DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/modprobe.d/"
   RENAME "truescale.conf")
-install(FILES truescale-serdes.cmds
+rdma_install(FILES truescale-serdes.cmds
   DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)

--- a/providers/mlx4/CMakeLists.txt
+++ b/providers/mlx4/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_shared_provider(mlx4 libmlx4.map
   1 1.0.${PACKAGE_VERSION}
   buf.c
@@ -13,6 +15,6 @@ publish_headers(infiniband
   mlx4dv.h
 )
 
-install(FILES "mlx4.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/modprobe.d/")
+rdma_install(FILES "mlx4.conf" DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/modprobe.d/")
 
 rdma_pkg_config("mlx4" "libibverbs" "${CMAKE_THREAD_LIBS_INIT}")

--- a/providers/mlx4/man/CMakeLists.txt
+++ b/providers/mlx4/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   mlx4dv_init_obj.3
   mlx4dv_query_device.3

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 set(MLX5_DEBUG "FALSE" CACHE BOOL
   "Enable expensive runtime logging options for the mlx5 verbs provider")
 if (MLX5_DEBUG)

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   mlx5dv_alloc_dm.3.md
   mlx5dv_create_cq.3.md

--- a/providers/mthca/CMakeLists.txt
+++ b/providers/mthca/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(mthca
   ah.c
   buf.c

--- a/providers/nes/CMakeLists.txt
+++ b/providers/nes/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(nes
   nes_umain.c
   nes_uverbs.c

--- a/providers/ocrdma/CMakeLists.txt
+++ b/providers/ocrdma/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(ocrdma
   ocrdma_main.c
   ocrdma_verbs.c

--- a/providers/qedr/CMakeLists.txt
+++ b/providers/qedr/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(qedr
   qelr_main.c
   qelr_verbs.c

--- a/providers/rxe/CMakeLists.txt
+++ b/providers/rxe/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(rxe
   rxe.c
   )

--- a/providers/rxe/man/CMakeLists.txt
+++ b/providers/rxe/man/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_man_pages(
   rxe.7
   rxe_cfg.8

--- a/providers/vmw_pvrdma/CMakeLists.txt
+++ b/providers/vmw_pvrdma/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 rdma_provider(vmw_pvrdma
   cq.c
   pvrdma_main.c

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019, Mellanox Technologies. All rights reserved. See COPYING file
 
+rdma_component()
+
 rdma_cython_module(pyverbs
   addr.pyx
   base.pyx

--- a/rdma-ndd/CMakeLists.txt
+++ b/rdma-ndd/CMakeLists.txt
@@ -1,6 +1,8 @@
 # COPYRIGHT (c) 2016 Intel Corporation.
 # Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
+rdma_component()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 
 rdma_sbin_executable(rdma-ndd
@@ -17,7 +19,7 @@ rdma_man_pages(
   rdma-ndd.8.in
   )
 
-install(FILES "rdma-ndd.rules"
+rdma_install(FILES "rdma-ndd.rules"
   RENAME "60-rdma-ndd.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 

--- a/srp_daemon/CMakeLists.txt
+++ b/srp_daemon/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NO_STRICT_ALIASING_FLAGS}")
 
 rdma_man_pages(
@@ -27,7 +29,7 @@ rdma_subst_install(FILES "srp_daemon.sh.in"
   RENAME "srp_daemon.sh"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 
-install(FILES start_on_all_ports
+rdma_install(FILES start_on_all_ports
   DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/srp_daemon"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 
@@ -41,13 +43,13 @@ rdma_subst_install(FILES srp_daemon_port@.service.in
   RENAME srp_daemon_port@.service
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
-install(FILES srp_daemon.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
+rdma_install(FILES srp_daemon.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 
-install(FILES "srp_daemon.rules"
+rdma_install(FILES "srp_daemon.rules"
   RENAME "60-srp_daemon.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-install(FILES modules-srp_daemon.conf
+rdma_install(FILES modules-srp_daemon.conf
   RENAME "srp_daemon.conf"
   DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rdma/modules")
 
@@ -57,6 +59,6 @@ set(RDMA_SERVICE "openibd" CACHE STRING "init.d file service name to order srpd 
 set(SRP_DEFAULT_START "2 3 4 5" CACHE STRING "Default-Start service data for srpd")
 set(SRP_DEFAULT_STOP "0 1 6" CACHE STRING "Default-Stop service data for srpd")
 configure_file(srpd.in "${CMAKE_CURRENT_BINARY_DIR}/srpd")
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/srpd"
+rdma_install(FILES "${CMAKE_CURRENT_BINARY_DIR}/srpd"
   DESTINATION "${CMAKE_INSTALL_INITDDIR}"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -1,3 +1,5 @@
+rdma_component()
+
 publish_internal_headers(util
   cl_qmap.h
   compiler.h


### PR DESCRIPTION
This is achieved by semi-automatically assigning a component name based
on the current source dir.
For static libs, a seperate build is not sensibly possible due to how
they are generated. But it's at least made sure all the dependencies are
cleanly built, and ultimately only the requested lib is built.

With this, one can for example do "make install-libibverbs" to install
just libibverbs and its related files. Man pages and tests are
intentionally assigned a separate target, like install-libibverbs-man.

The motivation behind this comes from packaging this in a modular fashion.
Luckily, static libs are not overly common, so users who want them will just have to accept it how it is.