### PR TITLE
rsockets: fix variable initialization

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -2133,8 +2133,8 @@ static int rs_process_cq(struct rsocket *rs, int nonblock, int (*test)(struct rs
 
 static int rs_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsocket *rs))
 {
-	uint64_t start_time;
-	uint32_t poll_time = 0;
+	uint64_t start_time = 0;
+	uint32_t poll_time;
 	int ret;
 
 	do {
@@ -2142,7 +2142,7 @@ static int rs_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsoc
 		if (!ret || nonblock || errno != EWOULDBLOCK)
 			return ret;
 
-		if (!poll_time)
+		if (!start_time)
 			start_time = rs_time_us();
 
 		poll_time = (uint32_t) (rs_time_us() - start_time);
@@ -2292,8 +2292,8 @@ static int ds_process_cqs(struct rsocket *rs, int nonblock, int (*test)(struct r
 
 static int ds_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsocket *rs))
 {
-	uint64_t start_time;
-	uint32_t poll_time = 0;
+	uint64_t start_time = 0;
+	uint32_t poll_time;
 	int ret;
 
 	do {
@@ -2301,7 +2301,7 @@ static int ds_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsoc
 		if (!ret || nonblock || errno != EWOULDBLOCK)
 			return ret;
 
-		if (!poll_time)
+		if (!start_time)
 			start_time = rs_time_us();
 
 		poll_time = (uint32_t) (rs_time_us() - start_time);
@@ -3306,8 +3306,8 @@ static int rs_poll_events(struct pollfd *rfds, struct pollfd *fds, nfds_t nfds)
 int rpoll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
 	struct pollfd *rfds;
-	uint64_t start_time;
-	uint32_t poll_time = 0;
+	uint64_t start_time = 0;
+	uint32_t poll_time;
 	int pollsleep, ret;
 
 	do {
@@ -3315,7 +3315,7 @@ int rpoll(struct pollfd *fds, nfds_t nfds, int timeout)
 		if (ret || !timeout)
 			return ret;
 
-		if (!poll_time)
+		if (!start_time)
 			start_time = rs_time_us();
 
 		poll_time = (uint32_t) (rs_time_us() - start_time);


### PR DESCRIPTION
This is to fix the error:
  ```
  [117/380] Building C object librdmacm/CMakeFiles/rdmacm.dir/rsocket.c.o
  FAILED: librdmacm/CMakeFiles/rdmacm.dir/rsocket.c.o
  /usr/bin/cc  -D_FILE_OFFSET_BITS=64 -Drdmacm_EXPORTS -Werror -m32
  -std=gnu11 -Wall -Wextra -Wno-sign-compare -Wno-unused-parameter
  -Wmissing-prototypes -Wmissing-declarations -Wwrite-strings -Wformat=2
  -Wformat-nonliteral -Wredundant-decls -Wnested-externs -Wshadow
  -Wno-missing-field-initializers -Wstrict-prototypes
  -Wold-style-definition -Wredundant-decls -O2 -g  -fPIC -Iinclude -MMD
  -MT librdmacm/CMakeFiles/rdmacm.dir/rsocket.c.o -MF
  "librdmacm/CMakeFiles/rdmacm.dir/rsocket.c.o.d" -o
  librdmacm/CMakeFiles/rdmacm.dir/rsocket.c.o   -c ../librdmacm/rsocket.c
  ../librdmacm/rsocket.c: In function ‘rs_get_comp’:
  ../librdmacm/rsocket.c:2148:15: error: ‘start_time’ may be used
  uninitialized in this function [-Werror=maybe-uninitialized]
     poll_time = (uint32_t) (rs_time_us() - start_time);
                 ^
  ../librdmacm/rsocket.c: In function ‘ds_get_comp’:
  ../librdmacm/rsocket.c:2307:15: error: ‘start_time’ may be used
  uninitialized in this function [-Werror=maybe-uninitialized]
     poll_time = (uint32_t) (rs_time_us() - start_time);
                 ^
  ../librdmacm/rsocket.c: In function ‘rpoll’:
  ../librdmacm/rsocket.c:3321:15: error: ‘start_time’ may be used
  uninitialized in this function [-Werror=maybe-uninitialized]
     poll_time = (uint32_t) (rs_time_us() - start_time);
                 ^
  cc1: all warnings being treated as errors
  [122/380] Building C object providers/efa/CMakeFiles/efa.dir/verbs.c.o
  ninja: build stopped: subcommand failed.
  ```
Which reproduces on RHEL7.5 with 4.8.5 20150623 (Red Hat 4.8.5-28)
and 32-bit libraries.

Build steps to reproduce:
  ```
  mkdir build32 && cd build32 && CFLAGS="-Werror -m32" cmake -GNinja \
  -DENABLE_RESOLVE_NEIGH=0 -DIOCTL_MODE=both -DNO_PYVERBS=1 && \
  ninja-build
  ```

meson version: 0.47.2
ninja-build version: 1.7.2

Fixes: 38c49232b67a ("rsockets: Replace gettimeofday with clock_gettime")
Cc: sean.hefty@intel.com

Signed-off-by: Ali Alnubani <alialnu@mellanox.com>