### PR TITLE
cbuild: Upgrade PyYAML load call to v5.1

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -258,7 +258,7 @@ class travis(APTEnvironment):
 
         # Load the commands from the travis file
         with open(".travis.yml") as F:
-            self._yaml = yaml.load(F);
+            self._yaml = yaml.safe_load(F);
         return self._yaml;
     yaml = property(get_yaml);
 
@@ -790,7 +790,7 @@ def run_travis_build(args,env):
 
         # Load the commands from the travis file
         with open(os.path.join(opwd,".travis.yml")) as F:
-            cmds = yaml.load(F)["script"];
+            cmds = yaml.safe_load(F)["script"];
 
         with open(os.path.join(tmpdir,"go.sh"),"w") as F:
             print >> F,"#!/bin/bash";
@@ -818,7 +818,7 @@ def run_azp_build(args,env):
     import yaml
     # Load the commands from the pipelines file
     with open("buildlib/azure-pipelines.yml") as F:
-        azp = yaml.load(F);
+        azp = yaml.safe_load(F);
     for bst in azp["stages"]:
         if bst["stage"] == "Build":
             break;

--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -56,7 +56,7 @@ static struct nla_policy policy[RDMA_NLDEV_ATTR_MAX] = {
 
 struct data {
 	const char *curr;
-	const char *prefix;
+	char *prefix;
 	uint64_t sys_image_guid;
 	char *name;
 	int idx;
@@ -413,7 +413,7 @@ static int get_nldata_cb(struct nl_msg *msg, void *data)
 	if (ret)
 		return NL_OK;
 
-	d->prefix = nla_get_string(tb[RDMA_NLDEV_ATTR_DEV_PROTOCOL]);
+	d->prefix = strdup(nla_get_string(tb[RDMA_NLDEV_ATTR_DEV_PROTOCOL]));
 	d->idx = nla_get_u32(tb[RDMA_NLDEV_ATTR_DEV_INDEX]);
 	d->sys_image_guid = nla_get_u64(tb[RDMA_NLDEV_ATTR_SYS_IMAGE_GUID]);
 	return NL_STOP;
@@ -491,7 +491,7 @@ int main(int argc, const char *argv[])
 
 	d.curr = argv[1];
 	ret = get_nldata(nl, &d);
-	if (ret || d.idx == -1)
+	if (ret || d.idx == -1 || !d.prefix)
 		goto out;
 
 	ret = -1;
@@ -512,6 +512,7 @@ int main(int argc, const char *argv[])
 	free(d.name);
 
 out:
+	free(d.prefix);
 	nl_socket_free(nl);
 err:
 	ret = (ret) ? 1 : 0;


### PR DESCRIPTION
Use of PyYAML's yaml.load function without specifying the Loader=...
parameter, has been deprecated. In PyYAML version 5.1.

Before PyYAML 5.1, the PyYAML.load function could be easily exploited
to call any Python function. That means it could call any system command
using os.system().

Signed-off-by: Leon Romanovsky <leonro@mellanox.com>