### PR TITLE
build: Do not open code compiler flag detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,16 +182,6 @@ endif()
 
 #-------------------------
 # Setup the basic C compiler
-# Check if the current compiler supports -fvar-tracking-assignments.
-# For that, we need to try and compile some code with it. Save the current
-# CMAKE_REQUIRED_FLAGS so we can restore it later.
-set(TMP_FLAGS ${CMAKE_REQUIRED_FLAGS})
-set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fvar-tracking-assignments")
-CHECK_C_SOURCE_COMPILES("
- int main(int argc,const char *argv[]) {return 0;}"
- HAVE_FVAR_TRACKING_ASSIGNMENTS)
-set(CMAKE_REQUIRED_FLAGS ${TMP_FLAGS})
-
 RDMA_BuildType()
 include_directories(${BUILD_INCLUDE})
 
@@ -261,6 +251,11 @@ endif()
 set(NO_STRICT_ALIASING_FLAGS "")
 RDMA_AddOptCFlag(NO_STRICT_ALIASING_FLAGS HAVE_NO_STRICT_ALIASING
   "-fno-strict-aliasing")
+
+# pyverbs has a problem with var-tracking warnings, turn it off if we can.
+set(NO_VAR_TRACKING_FLAGS "")
+RDMA_AddOptCFlag(NO_VAR_TRACKING_FLAGS HAVE_NO_VAR_TRACKING_ASSIGNMENTS
+  "-fno-var-tracking-assignments")
 
 CHECK_C_SOURCE_COMPILES("
  #include <unistd.h>

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -16,13 +16,8 @@ function(rdma_cython_module PY_MODULE)
 
     string(REGEX REPLACE "\\.so$" "" SONAME "${FILENAME}${CMAKE_PYTHON_SO_SUFFIX}")
     add_library(${SONAME} SHARED ${CFILE})
-    # We need to disable -fvar-tracking-assignments if it's supported as it
-	# complains about some pyverbs.
-    if (HAVE_FVAR_TRACKING_ASSIGNMENTS)
-      set(PYVERBS_DEBUG_FLAGS "-fno-var-tracking-assignments")
-    endif()
     set_target_properties(${SONAME} PROPERTIES
-        COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option ${PYVERBS_DEBUG_FLAGS}"
+      COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option ${NO_VAR_TRACKING_FLAGS}"
       LIBRARY_OUTPUT_DIRECTORY "${BUILD_PYTHON}/${PY_MODULE}"
       PREFIX "")
     target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs)


### PR DESCRIPTION
There is already a scheme to do this, don't duplicate it.

Fixes: fe53213d5b6e ("build: Remove warning-causing compilation flag from pyverbs")
Signed-off-by: Jason Gunthorpe <jgg@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>