### PR TITLE
verbs: Initialize reserved attributes in create AH command

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -1428,16 +1428,19 @@ int ibv_cmd_create_ah(struct ibv_pd *pd, struct ibv_ah *ah,
 
 	cmd.user_handle            = (uintptr_t) ah;
 	cmd.pd_handle              = pd->handle;
+	cmd.reserved               = 0;
 	cmd.attr.dlid              = attr->dlid;
 	cmd.attr.sl                = attr->sl;
 	cmd.attr.src_path_bits     = attr->src_path_bits;
 	cmd.attr.static_rate       = attr->static_rate;
 	cmd.attr.is_global         = attr->is_global;
 	cmd.attr.port_num          = attr->port_num;
+	cmd.attr.reserved          = 0;
 	cmd.attr.grh.flow_label    = attr->grh.flow_label;
 	cmd.attr.grh.sgid_index    = attr->grh.sgid_index;
 	cmd.attr.grh.hop_limit     = attr->grh.hop_limit;
 	cmd.attr.grh.traffic_class = attr->grh.traffic_class;
+	cmd.attr.grh.reserved      = 0;
 	memcpy(cmd.attr.grh.dgid, attr->grh.dgid.raw, 16);
 
 	ret = execute_cmd_write(pd->context, IB_USER_VERBS_CMD_CREATE_AH, &cmd,


### PR DESCRIPTION
Initialize the reserved fields in create AH command to eliminate
valgrind warnings such as:

==18022== Syscall param write(buf) points to uninitialised byte(s)
==18022==    at 0x513A894: write (in /usr/lib64/libc-2.26.so)
==18022==    by 0x4E440C0: _execute_cmd_write (cmd_fallback.c:250)
==18022==    by 0x4E418BC: ibv_cmd_create_ah (cmd.c:1443)
==18022==    by 0x7E9E0F7: efa_create_ah (verbs.c:1180)
==18022==    by 0x4E4C120: ibv_create_ah@@IBVERBS_1.1 (verbs.c:641)
==18022==    by 0x403191: pp_connect_ctx (ud_pingpong.c:117)
==18022==    by 0x402694: main (ud_pingpong.c:741)
==18022==  Address 0x1ffefffe0c is on thread 1's stack
==18022==  in frame #2, created by ibv_cmd_create_ah (cmd.c:1425)

Signed-off-by: Gal Pressman <galpress@amazon.com>