### PR TITLE
libibumad: Support 128 devices

### DIFF
--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -62,7 +62,7 @@ union umad_gid {
 	} global;
 } __attribute__((aligned(4))) __attribute__((packed));
 
-#define UMAD_MAX_DEVICES 32
+#define UMAD_MAX_DEVICES 128
 #define UMAD_ANY_PORT	0
 typedef struct ib_mad_addr {
 	__be32 qpn;


### PR DESCRIPTION
Extend the maximum of available InfiniBand devices
by changing the macro from 32 to 128.

Signed-off-by: Haim Boozaglo <haimbo@mellanox.com>