### PR TITLE
2019 08 15 fixes

### DIFF
--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -29,7 +29,6 @@ struct efa_context {
 
 struct efa_pd {
 	struct ibv_pd ibvpd;
-	struct efa_context *context;
 	uint16_t pdn;
 };
 
@@ -95,7 +94,6 @@ struct efa_sq {
 
 struct efa_qp {
 	struct ibv_qp ibvqp;
-	struct efa_context *ctx;
 	struct efa_sq sq;
 	struct efa_rq rq;
 	int page_size;
@@ -115,7 +113,6 @@ struct efa_ah {
 
 struct efa_dev {
 	struct verbs_device vdev;
-	uint8_t abi_version;
 	uint32_t pg_sz;
 	uint32_t max_sq_wr;
 	uint32_t max_rq_wr;

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -21,14 +21,8 @@ enum efa_io_queue_type {
 };
 
 enum efa_io_send_op_type {
-	/* invalid op */
-	EFA_IO_INVALID_OP                           = 0,
 	/* send message */
-	EFA_IO_SEND                                 = 1,
-	/* RDMA read, future, not supported yet */
-	EFA_IO_RDMA_READ                            = 2,
-	/* RDMA write, future, not supported yet */
-	EFA_IO_RDMA_WRITE                           = 3,
+	EFA_IO_SEND                                 = 0,
 };
 
 enum efa_io_comp_status {

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -985,6 +985,7 @@ int efa_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 
 		/* Set rest of the descriptor fields */
 		set_efa_io_tx_meta_desc_meta_desc(meta_desc, 1);
+		set_efa_io_tx_meta_desc_op_type(meta_desc, EFA_IO_SEND);
 		set_efa_io_tx_meta_desc_phase(meta_desc, qp->sq.wq.phase);
 		set_efa_io_tx_meta_desc_first(meta_desc, 1);
 		set_efa_io_tx_meta_desc_last(meta_desc, 1);

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -127,7 +127,6 @@ struct ibv_pd *efa_alloc_pd(struct ibv_context *ibvctx)
 			     &resp.ibv_resp, sizeof(resp)))
 		goto out;
 
-	pd->context = to_efa_context(ibvctx);
 	pd->pdn = resp.pdn;
 
 	return &pd->ibvpd;
@@ -725,7 +724,6 @@ static struct ibv_qp *create_qp(struct ibv_pd *ibvpd,
 
 	qp->ibvqp.state = IBV_QPS_RESET;
 	qp->sq_sig_all = attr->sq_sig_all;
-	qp->ctx = ctx;
 
 	err = efa_rq_initialize(qp, &resp);
 	if (err)

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -384,10 +384,13 @@ static int efa_poll_sub_cq(struct efa_cq *cq, struct efa_sub_cq *sub_cq,
 
 	wc->wc_flags = 0;
 	wc->qp_num = qpn;
+
+	pthread_spin_lock(&wq->wqlock);
 	wq->wrid_idx_pool_next--;
 	wq->wrid_idx_pool[wq->wrid_idx_pool_next] = wrid_idx;
 	wc->wr_id = wq->wrid[wrid_idx];
 	wq->wqe_completed++;
+	pthread_spin_unlock(&wq->wqlock);
 
 	return 0;
 }


### PR DESCRIPTION
Hi,

Another round of fixes for the EFA provider.
First patch is a simple removal of unused fields from various structs.
Second patch is fixing an unprotected access to the wrid pool in poll_cq flow by acquiring the wqlock.

The third patch is a bit tricky as it turns out we forgot to fill the send operation type in the TX WQE (always passed 0 - invalid), which the device wrongly treated as send.
We fixed it in a backwards compatible way by changing the zero value to be send, and removed the invalid operation type.

Thanks,
Gal