### PR TITLE
verbs: Add unspecified node/transport types

### DIFF
--- a/libibverbs/enum_strs.c
+++ b/libibverbs/enum_strs.c
@@ -41,9 +41,10 @@ const char *ibv_node_type_str(enum ibv_node_type node_type)
 		[IBV_NODE_RNIC]		= "iWARP NIC",
 		[IBV_NODE_USNIC]	= "usNIC",
 		[IBV_NODE_USNIC_UDP]	= "usNIC UDP",
+		[IBV_NODE_UNSPECIFIED]	= "unspecified",
 	};
 
-	if (node_type < IBV_NODE_CA || node_type > IBV_NODE_USNIC_UDP)
+	if (node_type < IBV_NODE_CA || node_type > IBV_NODE_UNSPECIFIED)
 		return "unknown";
 
 	return node_type_str[node_type];

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -70,6 +70,7 @@ static const char *transport_str(enum ibv_transport_type transport)
 	case IBV_TRANSPORT_IWARP:	return "iWARP";
 	case IBV_TRANSPORT_USNIC:	return "usNIC";
 	case IBV_TRANSPORT_USNIC_UDP:	return "usNIC UDP";
+	case IBV_TRANSPORT_UNSPECIFIED:	return "unspecified";
 	default:			return "invalid transport";
 	}
 }

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -95,7 +95,7 @@ enum ibv_node_type decode_knode_type(unsigned int knode_type)
 	case RDMA_NODE_USNIC_UDP:
 		return IBV_NODE_USNIC_UDP;
 	case RDMA_NODE_UNSPECIFIED:
-		return IBV_NODE_UNKNOWN;
+		return IBV_NODE_UNSPECIFIED;
 	}
 	return IBV_NODE_UNKNOWN;
 }
@@ -391,6 +391,9 @@ static struct verbs_device *try_driver(const struct verbs_device_ops *ops,
 		break;
 	case IBV_NODE_USNIC_UDP:
 		dev->transport_type = IBV_TRANSPORT_USNIC_UDP;
+		break;
+	case IBV_NODE_UNSPECIFIED:
+		dev->transport_type = IBV_TRANSPORT_UNSPECIFIED;
 		break;
 	default:
 		dev->transport_type = IBV_TRANSPORT_UNKNOWN;

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -84,6 +84,7 @@ enum ibv_node_type {
 	IBV_NODE_RNIC,
 	IBV_NODE_USNIC,
 	IBV_NODE_USNIC_UDP,
+	IBV_NODE_UNSPECIFIED,
 };
 
 enum ibv_transport_type {
@@ -92,6 +93,7 @@ enum ibv_transport_type {
 	IBV_TRANSPORT_IWARP,
 	IBV_TRANSPORT_USNIC,
 	IBV_TRANSPORT_USNIC_UDP,
+	IBV_TRANSPORT_UNSPECIFIED,
 };
 
 enum ibv_device_cap_flags {


### PR DESCRIPTION
Kernel commit f95be3d28d89 ("RDMA: Add EFA related definitions")
introduced the unspecified node/transport types, reflect them in
libibverbs.

Signed-off-by: Gal Pressman <galpress@amazon.com>