### PR TITLE
efa: Extended QP and new send API support

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -91,5 +91,6 @@ libefa.so.1 ibverbs-providers #MINVER#
  EFA_1.0@EFA_1.0 24
  EFA_1.1@EFA_1.1 26
  efadv_create_driver_qp@EFA_1.0 24
+ efadv_create_qp_ex@EFA_1.1 26
  efadv_query_device@EFA_1.1 26
  efadv_query_ah@EFA_1.1 26

--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -25,6 +25,7 @@ static const struct verbs_context_ops efa_ctx_ops = {
 	.create_ah = efa_create_ah,
 	.create_cq = efa_create_cq,
 	.create_qp = efa_create_qp,
+	.create_qp_ex = efa_create_qp_ex,
 	.dealloc_pd = efa_dealloc_pd,
 	.dereg_mr = efa_dereg_mr,
 	.destroy_ah = efa_destroy_ah,

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -93,7 +93,7 @@ struct efa_sq {
 };
 
 struct efa_qp {
-	struct ibv_qp ibvqp;
+	struct verbs_qp verbs_qp;
 	struct efa_sq sq;
 	struct efa_rq rq;
 	int page_size;
@@ -142,7 +142,12 @@ static inline struct efa_cq *to_efa_cq(struct ibv_cq *ibvcq)
 
 static inline struct efa_qp *to_efa_qp(struct ibv_qp *ibvqp)
 {
-	return container_of(ibvqp, struct efa_qp, ibvqp);
+	return container_of(ibvqp, struct efa_qp, verbs_qp.qp);
+}
+
+static inline struct efa_qp *to_efa_qp_ex(struct ibv_qp_ex *ibvqpx)
+{
+	return container_of(ibvqpx, struct efa_qp, verbs_qp.qp_ex);
 }
 
 static inline struct efa_ah *to_efa_ah(struct ibv_ah *ibvah)

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -90,6 +90,15 @@ struct efa_sq {
 	size_t desc_ring_mmap_size;
 	size_t max_inline_data;
 	uint16_t sub_cq_idx;
+
+	/* Buffer for pending WR entries in the current session */
+	uint8_t *local_queue;
+	/* Number of WR entries posted in the current session */
+	uint32_t num_wqe_pending;
+	/* Phase before current session */
+	int phase_rb;
+	/* Current wqe being built */
+	struct efa_io_tx_wqe *curr_tx_wqe;
 };
 
 struct efa_qp {
@@ -100,6 +109,7 @@ struct efa_qp {
 	struct efa_cq *rcq;
 	struct efa_cq *scq;
 	int sq_sig_all;
+	int wr_session_err;
 };
 
 struct efa_mr {

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -24,6 +24,17 @@ struct ibv_qp *efadv_create_driver_qp(struct ibv_pd *ibvpd,
 				      struct ibv_qp_init_attr *attr,
 				      uint32_t driver_qp_type);
 
+struct efadv_qp_init_attr {
+	uint64_t comp_mask;
+	uint32_t driver_qp_type;
+	uint8_t reserved[4];
+};
+
+struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
+				  struct ibv_qp_init_attr_ex *attr_ex,
+				  struct efadv_qp_init_attr *efa_attr,
+				  uint32_t inlen);
+
 struct efadv_device_attr {
 	uint64_t comp_mask;
 	uint32_t max_sq_wr;

--- a/providers/efa/libefa.map
+++ b/providers/efa/libefa.map
@@ -8,6 +8,7 @@ EFA_1.0 {
 
 EFA_1.1 {
 	global:
+		efadv_create_qp_ex;
 		efadv_query_ah;
 		efadv_query_device;
 } EFA_1.0;

--- a/providers/efa/man/efadv_create_qp_ex.3.md
+++ b/providers/efa/man/efadv_create_qp_ex.3.md
@@ -1,0 +1,74 @@
+---
+layout: page
+title: EFADV_CREATE_QP_EX
+section: 3
+tagline: Verbs
+date: 2019-08-06
+header: "EFA Direct Verbs Manual"
+footer: efa
+---
+
+# NAME
+
+efadv_create_qp_ex - Create EFA specific extended Queue Pair
+
+# SYNOPSIS
+
+```c
+#include <infiniband/efadv.h>
+
+struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
+				  struct ibv_qp_init_attr_ex *attr_ex,
+				  struct efadv_qp_init_attr *efa_attr,
+				  uint32_t inlen);
+```
+
+# DESCRIPTION
+
+**efadv_create_qp_ex()** creates device-specific extended Queue Pair.
+
+The argument attr_ex is an ibv_qp_init_attr_ex struct,
+as defined in <infiniband/verbs.h>.
+
+Use ibv_qp_to_qp_ex() to get the ibv_qp_ex for accessing the send ops
+iterator interface, when QP create attr IBV_QP_INIT_ATTR_SEND_OPS_FLAGS is used.
+
+Scalable Reliable Datagram (SRD) transport provides reliable out-of-order
+delivery, transparently utilizing multiple network paths to reduce network tail
+latency. Its interface is similar to UD, in particular it supports message size
+up to MTU, with error handling extended to support reliable communication.
+
+Compatibility is handled using the comp_mask and inlen fields.
+
+```c
+struct efadv_qp_init_attr {
+	uint64_t comp_mask;
+	uint32_t driver_qp_type;
+	uint8_t reserved[4];
+};
+```
+
+*inlen*
+:	In: Size of struct efadv_qp_init_attr.
+
+*comp_mask*
+:	Compatibility mask.
+
+*driver_qp_type*
+:	The type of QP to be created:
+
+	EFADV_QP_DRIVER_TYPE_SRD:
+		Create an SRD QP.
+
+# RETURN VALUE
+
+efadv_create_qp_ex() returns a pointer to the created QP, or NULL if the request fails.
+
+# SEE ALSO
+
+**efadv**(7), **ibv_create_qp_ex**(3)
+
+# AUTHORS
+
+Gal Pressman <galpress@amazon.com>
+Daniel Kranzdorf <dkkranzd@amazon.com>

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -823,6 +823,17 @@ struct ibv_qp *efa_create_qp(struct ibv_pd *ibvpd,
 	return ibvqp;
 }
 
+struct ibv_qp *efa_create_qp_ex(struct ibv_context *ibvctx,
+				struct ibv_qp_init_attr_ex *attr_ex)
+{
+	if (attr_ex->qp_type != IBV_QPT_UD) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	return create_qp(ibvctx, attr_ex, 0);
+}
+
 struct ibv_qp *efadv_create_driver_qp(struct ibv_pd *ibvpd,
 				      struct ibv_qp_init_attr *attr,
 				      uint32_t driver_qp_type)

--- a/providers/efa/verbs.h
+++ b/providers/efa/verbs.h
@@ -28,6 +28,8 @@ int efa_poll_cq(struct ibv_cq *ibvcq, int nwc, struct ibv_wc *wc);
 
 struct ibv_qp *efa_create_qp(struct ibv_pd *ibvpd,
 			     struct ibv_qp_init_attr *attr);
+struct ibv_qp *efa_create_qp_ex(struct ibv_context *ibvctx,
+				struct ibv_qp_init_attr_ex *attr_ex);
 int efa_modify_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr,
 		  int ibv_qp_attr_mask);
 int efa_query_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr, int attr_mask,


### PR DESCRIPTION
The following series from Daniel adds support for extended QP creation and the new verbs send API to the EFA provider.

Short summary of the series:
* Set errno in case of different verbs failures.
* Refactor the code to helper functions that will later be shared between post_send and the new API flows (no functional changes).
* Allow creation of extended QPs.
* Add a direct verb that creates EFA specific extended QPs, for now it allows creation of SRD extended QPs.
* Add support for the new verbs send API.