### PR TITLE
suse: packaging fixes

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -290,6 +290,7 @@ library knows how to talk directly to the ibacm daemon to retrieve data.
 %package -n infiniband-diags
 Summary:        InfiniBand Diagnostic Tools
 Group:          Productivity/Networking/Diagnostic
+Requires:       perl = %{perl_version}
 
 %description -n infiniband-diags
 diags provides IB diagnostic programs and scripts needed to diagnose an

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -62,11 +62,11 @@ BuildRequires:  gcc
 BuildRequires:  pandoc
 BuildRequires:  pkgconfig
 BuildRequires:  python3-base
+BuildRequires:  python3-docutils
 BuildRequires:  pkgconfig(libsystemd)
 BuildRequires:  pkgconfig(libudev)
 BuildRequires:  pkgconfig(systemd)
 BuildRequires:  pkgconfig(udev)
-BuildRequires:  /usr/bin/rst2man
 %if %{with_pyverbs}
 BuildRequires:  python3-Cython
 BuildRequires:  python3-devel

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -698,7 +698,6 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 
 %files -n infiniband-diags
 %defattr(-, root, root)
-%config %{_sysconfdir}/infiniband-diags/error_thresholds
 %dir %{_sysconfdir}/infiniband-diags
 %config(noreplace) %{_sysconfdir}/infiniband-diags/*
 %{_sbindir}/ibaddr

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -165,9 +165,11 @@ BuildRequires:  pkgconfig(libnl-3.0)
 BuildRequires:  pkgconfig(libnl-route-3.0)
 %endif
 
-Requires: infiniband-diags = %{version}-%{release}
-Provides: infiniband-diags-devel = %{version}-%{release}
-Obsoletes: infiniband-diags-devel < %{version}-%{release}
+Requires:       infiniband-diags = %{version}-%{release}
+Provides:       infiniband-diags-devel = %{version}-%{release}
+Obsoletes:      infiniband-diags-devel < %{version}-%{release}
+Provides:       libibmad-devel = %{version}-%{release}
+Obsoletes:      libibmad-devel < %{version}
 
 %description devel
 RDMA core development libraries and headers.

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -38,7 +38,7 @@ Group:          Productivity/Networking/Other
 %define ibnetdisc_major 5
 %define mad_major       5
 
-%define  efa_lname    libefa-%{efa_so_major}
+%define  efa_lname    libefa%{efa_so_major}
 %define  verbs_lname  libibverbs%{verbs_so_major}
 %define  rdmacm_lname librdmacm%{rdmacm_so_major}
 %define  umad_lname   libibumad%{umad_so_major}


### PR DESCRIPTION
Lib major version should only be prefixed by a '-' if the libname itself
ends with a number (ie libibverbs1, libmlx5-1)

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>