### PR TITLE
Add XRCD and SRQ support to pyverbs

### DIFF
--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -339,3 +339,54 @@ wr = pwr.SendWR()
 wr.set_wr_ud(ah, 0x1101, 0) # in real life, use real values
 udqp.post_send(wr)
 ```
+
+##### XRCD
+The following code demonstrates creation of an XRCD object.
+```python
+from pyverbs.xrcd import XRCD, XRCDInitAttr
+import pyverbs.device as d
+import pyverbs.enums as e
+import stat
+import os
+
+
+ctx = d.Context(name='ibp0s8f0')
+xrcd_fd = os.open('/tmp/xrcd', os.O_RDONLY | os.O_CREAT,
+                  stat.S_IRUSR | stat.S_IRGRP)
+init = XRCDInitAttr(e.IBV_XRCD_INIT_ATTR_FD | e.IBV_XRCD_INIT_ATTR_OFLAGS,
+                    os.O_CREAT, xrcd_fd)
+xrcd = XRCD(ctx, init)
+```
+
+##### SRQ
+The following code snippet will demonstrate creation of an XRC SRQ object.
+For more complex examples, please see pyverbs/tests/test_odp.
+```python
+from pyverbs.xrcd import XRCD, XRCDInitAttr
+from pyverbs.srq import SRQ, SrqInitAttrEx
+import pyverbs.device as d
+import pyverbs.enums as e
+from pyverbs.cq import CQ
+from pyverbs.pd import PD
+import stat
+import os
+
+
+ctx = d.Context(name='ibp0s8f0')
+pd = PD(ctx)
+cq = CQ(ctx, 100, None, None, 0)
+xrcd_fd = os.open('/tmp/xrcd', os.O_RDONLY | os.O_CREAT,
+                  stat.S_IRUSR | stat.S_IRGRP)
+init = XRCDInitAttr(e.IBV_XRCD_INIT_ATTR_FD | e.IBV_XRCD_INIT_ATTR_OFLAGS,
+                    os.O_CREAT, xrcd_fd)
+xrcd = XRCD(ctx, init)
+
+srq_attr = SrqInitAttrEx(max_wr=10)
+srq_attr.srq_type = e.IBV_SRQT_XRC
+srq_attr.pd = pd
+srq_attr.xrcd = xrcd
+srq_attr.cq = cq
+srq_attr.comp_mask = e.IBV_SRQ_INIT_ATTR_TYPE | e.IBV_SRQ_INIT_ATTR_PD | \
+                     e.IBV_SRQ_INIT_ATTR_CQ | e.IBV_SRQ_INIT_ATTR_XRCD
+srq = SRQ(ctx, srq_attr)
+```

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -11,6 +11,7 @@ rdma_cython_module(pyverbs
   pd.pyx
   qp.pyx
   wr.pyx
+  xrcd.pyx
   )
 
 rdma_python_module(pyverbs

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -12,6 +12,7 @@ rdma_cython_module(pyverbs
   qp.pyx
   wr.pyx
   xrcd.pyx
+  srq.pyx
   )
 
 rdma_python_module(pyverbs

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -19,6 +19,7 @@ cdef class CQ(PyverbsCM):
     cdef object context
     cdef add_ref(self, obj)
     cdef object qps
+    cdef object srqs
 
 cdef class CqInitAttrEx(PyverbsObject):
     cdef v.ibv_cq_init_attr_ex attr
@@ -31,6 +32,7 @@ cdef class CQEX(PyverbsCM):
     cdef object context
     cdef add_ref(self, obj)
     cdef object qps
+    cdef object srqs
 
 cdef class WC(PyverbsObject):
     cdef v.ibv_wc wc

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -366,18 +366,19 @@ cdef class WC(PyverbsObject):
     def __cinit__(self, wr_id=0, status=0, opcode=0, vendor_err=0, byte_len=0,
                   qp_num=0, src_qp=0, imm_data=0, wc_flags=0, pkey_index=0,
                   slid=0, sl=0, dlid_path_bits=0):
-        self.wr_id = wr_id
-        self.status = status
-        self.opcode = opcode
-        self.vendor_err = vendor_err
-        self.byte_len = byte_len
-        self.qp_num = qp_num
-        self.src_qp = src_qp
-        self.wc_flags = wc_flags
-        self.pkey_index = pkey_index
-        self.slid = slid
-        self.sl = sl
-        self.dlid_path_bits = dlid_path_bits
+        self.wc.wr_id = wr_id
+        self.wc.status = status
+        self.wc.opcode = opcode
+        self.wc.vendor_err = vendor_err
+        self.wc.byte_len = byte_len
+        self.wc.qp_num = qp_num
+        self.wc.src_qp = src_qp
+        self.wc.wc_flags = wc_flags
+        self.wc.pkey_index = pkey_index
+        self.wc.slid = slid
+        self.wc.imm_data = imm_data
+        self.wc.sl = sl
+        self.wc.dlid_path_bits = dlid_path_bits
 
     @property
     def wr_id(self):
@@ -457,6 +458,13 @@ cdef class WC(PyverbsObject):
         self.wc.sl = val
 
     @property
+    def imm_data(self):
+        return self.wc.imm_data
+    @imm_data.setter
+    def imm_data(self, val):
+        self.wc.imm_data = val
+
+    @property
     def dlid_path_bits(self):
         return self.wc.dlid_path_bits
     @dlid_path_bits.setter
@@ -476,6 +484,7 @@ cdef class WC(PyverbsObject):
             print_format.format('pkey index', self.pkey_index) +\
             print_format.format('slid', self.slid) +\
             print_format.format('sl', self.sl) +\
+            print_format.format('imm_data', self.imm_data) +\
             print_format.format('dlid path bits', self.dlid_path_bits)
 
 

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -579,6 +579,5 @@ def create_wc_flags_to_str(flags):
                  e.IBV_WC_EX_WITH_COMPLETION_TIMESTAMP: 'IBV_WC_EX_WITH_COMPLETION_TIMESTAMP',
                  e.IBV_WC_EX_WITH_CVLAN: 'IBV_WC_EX_WITH_CVLAN',
                  e.IBV_WC_EX_WITH_FLOW_TAG: 'IBV_WC_EX_WITH_FLOW_TAG',
-                 e.IBV_WC_EX_WITH_TM_INFO: 'IBV_WC_EX_WITH_TM_INFO',
                  e.IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK: 'IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK'}
     return flags_to_str(flags, cqe_flags)

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -16,6 +16,7 @@ cdef class Context(PyverbsCM):
     cdef object ccs
     cdef object cqs
     cdef object qps
+    cdef object xrcds
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -26,12 +26,16 @@ cdef class QueryDeviceExInput(PyverbsObject):
 
 cdef class ODPCaps(PyverbsObject):
     cdef v.ibv_odp_caps odp_caps
+    cdef object xrc_odp_caps
 
 cdef class RSSCaps(PyverbsObject):
     cdef v.ibv_rss_caps rss_caps
 
 cdef class PacketPacingCaps(PyverbsObject):
     cdef v.ibv_packet_pacing_caps packet_pacing_caps
+
+cdef class PCIAtomicCaps(PyverbsObject):
+    cdef v.ibv_pci_atomic_caps caps
 
 cdef class TMCaps(PyverbsObject):
     cdef v.ibv_tm_caps tm_caps

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -14,6 +14,7 @@ from .pyverbs_error import PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
 cimport pyverbs.libibverbs_enums as e
 cimport pyverbs.libibverbs as v
+from pyverbs.xrcd cimport XRCD
 from pyverbs.addr cimport GID
 from pyverbs.mr import DMMR
 from pyverbs.pd cimport PD
@@ -90,6 +91,7 @@ cdef class Context(PyverbsCM):
         self.ccs = weakref.WeakSet()
         self.cqs = weakref.WeakSet()
         self.qps = weakref.WeakSet()
+        self.xrcds = weakref.WeakSet()
 
         dev_name = kwargs.get('name')
 
@@ -126,7 +128,8 @@ cdef class Context(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing Context')
-        self.close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds])
+        self.close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
+                             self.xrcds])
         if self.context != NULL:
             rc = v.ibv_close_device(self.context)
             if rc != 0:
@@ -198,6 +201,8 @@ cdef class Context(PyverbsCM):
             self.cqs.add(obj)
         elif isinstance(obj, QP):
             self.qps.add(obj)
+        elif isinstance(obj, XRCD):
+            self.xrcds.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -393,6 +393,42 @@ cdef class ODPCaps(PyverbsObject):
     @property
     def ud_odp_caps(self):
         return self.odp_caps.per_transport_caps.ud_odp_caps
+    @property
+    def xrc_odp_caps(self):
+        return self.xrc_odp_caps
+    @xrc_odp_caps.setter
+    def xrc_odp_caps(self, val):
+       self.xrc_odp_caps = val
+
+    def __str__(self):
+        general_caps = {e.IBV_ODP_SUPPORT: 'IBV_ODP_SUPPORT',
+              e.IBV_ODP_SUPPORT_IMPLICIT: 'IBV_ODP_SUPPORT_IMPLICIT'}
+
+        l = {e.IBV_ODP_SUPPORT_SEND: 'IBV_ODP_SUPPORT_SEND',
+             e.IBV_ODP_SUPPORT_RECV: 'IBV_ODP_SUPPORT_RECV',
+             e.IBV_ODP_SUPPORT_WRITE: 'IBV_ODP_SUPPORT_WRITE',
+             e.IBV_ODP_SUPPORT_READ: 'IBV_ODP_SUPPORT_READ',
+             e.IBV_ODP_SUPPORT_ATOMIC: 'IBV_ODP_SUPPORT_ATOMIC',
+             e.IBV_ODP_SUPPORT_SRQ_RECV: 'IBV_ODP_SUPPORT_SRQ_RECV'}
+
+        print_format = '{}: {}\n'
+        return print_format.format('ODP General caps', str_from_flags(self.general_caps, general_caps)) +\
+            print_format.format('RC ODP caps', str_from_flags(self.rc_odp_caps, l)) +\
+            print_format.format('UD ODP caps', str_from_flags(self.ud_odp_caps, l)) +\
+            print_format.format('UC ODP caps', str_from_flags(self.uc_odp_caps, l)) +\
+            print_format.format('XRC ODP caps', str_from_flags(self.xrc_odp_caps, l))
+
+
+cdef class PCIAtomicCaps(PyverbsObject):
+    @property
+    def fetch_add(self):
+        return self.caps.fetch_add
+    @property
+    def swap(self):
+        return self.caps.swap
+    @property
+    def compare_swap(self):
+        return self.caps.compare_swap
 
 
 cdef class TSOCaps(PyverbsObject):
@@ -477,6 +513,7 @@ cdef class DeviceAttrEx(PyverbsObject):
     def odp_caps(self):
         caps = ODPCaps()
         caps.odp_caps = self.dev_attr.odp_caps
+        caps.xrc_odp_caps = self.dev_attr.xrc_odp_caps
         return caps
     @property
     def completion_timestamp_mask(self):
@@ -491,6 +528,11 @@ cdef class DeviceAttrEx(PyverbsObject):
     def tso_caps(self):
         caps = TSOCaps()
         caps.tso_caps = self.dev_attr.tso_caps
+        return caps
+    @property
+    def pci_atomic_caps(self):
+        caps = PCIAtomicCaps()
+        caps.caps = self.dev_attr.pci_atomic_caps
         return caps
     @property
     def rss_caps(self):

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -341,6 +341,11 @@ cdef extern from 'infiniband/verbs.h':
         ibv_qp_type     qp_type
         int             sq_sig_all
 
+    cdef struct ibv_xrcd_init_attr:
+        uint32_t comp_mask
+        int      fd
+        int      oflags
+
     cdef struct ibv_xrcd:
         pass
 
@@ -490,3 +495,6 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_destroy_qp(ibv_qp *qp)
     int ibv_post_recv(ibv_qp *qp, ibv_recv_wr *wr, ibv_recv_wr **bad_wr)
     int ibv_post_send(ibv_qp *qp, ibv_send_wr *wr, ibv_send_wr **bad_wr)
+    ibv_xrcd *ibv_open_xrcd(ibv_context *context,
+                            ibv_xrcd_init_attr *xrcd_init_attr)
+    int ibv_close_xrcd(ibv_xrcd *xrcd)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -2,7 +2,7 @@
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved. See COPYING file
 
 include 'libibverbs_enums.pxd'
-from libc.stdint cimport uint8_t, uint32_t, uint64_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 
 cdef extern from 'infiniband/verbs.h':
 
@@ -117,6 +117,11 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    max_cq_count
         unsigned int    max_cq_period
 
+    cdef struct ibv_pci_atomic_caps:
+        uint16_t fetch_add
+        uint16_t swap
+        uint16_t compare_swap
+
     cdef struct ibv_device_attr_ex:
         ibv_device_attr         orig_attr
         unsigned int            comp_mask
@@ -132,6 +137,8 @@ cdef extern from 'infiniband/verbs.h':
         ibv_tm_caps             tm_caps
         ibv_cq_moderation_caps  cq_mod_caps
         unsigned long           max_dm_size
+        ibv_pci_atomic_caps     pci_atomic_caps
+        uint32_t                xrc_odp_caps
 
     cdef struct ibv_mw:
         ibv_context     *context

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -349,6 +349,32 @@ cdef extern from 'infiniband/verbs.h':
     cdef struct ibv_xrcd:
         pass
 
+    cdef struct ibv_srq_attr:
+        unsigned int    max_wr
+        unsigned int    max_sge
+        unsigned int    srq_limit
+
+    cdef struct ibv_srq_init_attr:
+        void            *srq_context
+        ibv_srq_attr    attr
+
+    cdef struct ibv_srq_init_attr_ex:
+        void            *srq_context
+        ibv_srq_attr    attr
+        unsigned int    comp_mask
+        ibv_srq_type    srq_type
+        ibv_pd          *pd
+        ibv_xrcd        *xrcd
+        ibv_cq          *cq
+        ibv_tm_caps      tm_cap
+
+    cdef struct ibv_srq:
+        ibv_context     *context
+        void            *srq_context
+        ibv_pd          *pd
+        unsigned int    handle
+        unsigned int    events_completed
+
     cdef struct ibv_rwq_ind_table:
         pass
 
@@ -498,3 +524,12 @@ cdef extern from 'infiniband/verbs.h':
     ibv_xrcd *ibv_open_xrcd(ibv_context *context,
                             ibv_xrcd_init_attr *xrcd_init_attr)
     int ibv_close_xrcd(ibv_xrcd *xrcd)
+    ibv_srq *ibv_create_srq(ibv_pd *pd, ibv_srq_init_attr *srq_init_attr)
+    ibv_srq *ibv_create_srq_ex(ibv_context *context,
+                               ibv_srq_init_attr_ex *srq_init_attr)
+    int ibv_modify_srq(ibv_srq *srq, ibv_srq_attr *srq_attr, int srq_attr_mask)
+    int ibv_query_srq(ibv_srq *srq, ibv_srq_attr *srq_attr)
+    int ibv_get_srq_num(ibv_srq *srq, unsigned int *srq_num)
+    int ibv_destroy_srq(ibv_srq *srq)
+    int ibv_post_srq_recv(ibv_srq *srq, ibv_recv_wr *recv_wr,
+                          ibv_recv_wr **bad_recv_wr)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -393,6 +393,11 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_RAW_PACKET_CAP_IP_CSUM          = 1 << 2
         IBV_RAW_PACKET_CAP_DELAY_DROP       = 1 << 3
 
+    cpdef enum ibv_xrcd_init_attr_mask:
+        IBV_XRCD_INIT_ATTR_FD       = 1 << 0
+        IBV_XRCD_INIT_ATTR_OFLAGS   = 1 << 1
+        IBV_XRCD_INIT_ATTR_RESERVED = 1 << 2
+
     cdef unsigned long long IBV_DEVICE_RAW_SCATTER_FCS
     cdef unsigned long long IBV_DEVICE_PCI_WRITE_END_PADDING
 

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -202,7 +202,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_EX_WITH_COMPLETION_TIMESTAMP             = 1 << 7
         IBV_WC_EX_WITH_CVLAN                            = 1 << 8
         IBV_WC_EX_WITH_FLOW_TAG                         = 1 << 9
-        IBV_WC_EX_WITH_TM_INFO                          = 1 << 10
         IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK   = 1 << 11
 
     cpdef enum ibv_wc_flags:
@@ -210,12 +209,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_WITH_IMM         = 1 << 1
         IBV_WC_IP_CSUM_OK       = 1 << 2
         IBV_WC_WITH_INV         = 1 << 3
-        IBV_WC_TM_SYNC_REQ      = 1 << 4
-        IBV_WC_TM_MATCH         = 1 << 5
-        IBV_WC_TM_DATA_VALID    = 1 << 6
-
-    cpdef enum ibv_tm_cap_flags:
-        IBV_TM_CAP_RC       = 1 << 0,
 
     cpdef enum ibv_srq_attr_mask:
         IBV_SRQ_MAX_WR      = 1 << 0,
@@ -224,14 +217,12 @@ cdef extern from '<infiniband/verbs.h>':
     cpdef enum ibv_srq_type:
         IBV_SRQT_BASIC
         IBV_SRQT_XRC
-        IBV_SRQT_TM
 
     cpdef enum ibv_srq_init_attr_mask:
         IBV_SRQ_INIT_ATTR_TYPE      = 1 << 0
         IBV_SRQ_INIT_ATTR_PD        = 1 << 1
         IBV_SRQ_INIT_ATTR_XRCD      = 1 << 2
         IBV_SRQ_INIT_ATTR_CQ        = 1 << 3
-        IBV_SRQ_INIT_ATTR_TM        = 1 << 4
 
     cpdef enum ibv_mig_state:
         IBV_MIG_MIGRATED
@@ -312,15 +303,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_RX_HASH_DST_PORT_TCP    = 1 << 5
         IBV_RX_HASH_SRC_PORT_UDP    = 1 << 6
         IBV_RX_HASH_DST_PORT_UDP    = 1 << 7
-
-    cpdef enum ibv_ops_wr_opcode:
-        IBV_WR_TAG_ADD
-        IBV_WR_TAG_DEL
-        IBV_WR_TAG_SYNC
-
-    cpdef enum ibv_ops_flags:
-        IBV_OPS_SIGNALED            = 1 << 0
-        IBV_OPS_TM_SYNC             = 1 << 1
 
     cpdef enum ibv_flow_flags:
         IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK = 1 << 0
@@ -414,13 +396,6 @@ cdef extern from '<infiniband/verbs.h>':
     cdef unsigned long long IBV_DEVICE_RAW_SCATTER_FCS
     cdef unsigned long long IBV_DEVICE_PCI_WRITE_END_PADDING
 
-
-cdef extern from "<infiniband/tm_types.h>":
-    cpdef enum ibv_tmh_op:
-        IBV_TMH_NO_TAG        = 0
-        IBV_TMH_RNDV          = 1
-        IBV_TMH_FIN           = 2
-        IBV_TMH_EAGER         = 3
 
 _IBV_DEVICE_RAW_SCATTER_FCS = IBV_DEVICE_RAW_SCATTER_FCS
 _IBV_DEVICE_PCI_WRITE_END_PADDING = IBV_DEVICE_PCI_WRITE_END_PADDING

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -12,6 +12,7 @@ cdef class PD(PyverbsCM):
     cdef v.ibv_pd *pd
     cdef Context ctx
     cdef add_ref(self, obj)
+    cdef object srqs
     cdef object mrs
     cdef object mws
     cdef object ahs

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -13,6 +13,7 @@ cdef class QPInitAttr(PyverbsObject):
     cdef v.ibv_qp_init_attr attr
     cdef object scq
     cdef object rcq
+    cdef object srq
 
 cdef class QPInitAttrEx(PyverbsObject):
     cdef v.ibv_qp_init_attr_ex attr
@@ -20,6 +21,7 @@ cdef class QPInitAttrEx(PyverbsObject):
     cdef object rcq
     cdef object _pd
     cdef object xrcd
+    cdef object srq
 
 cdef class QPAttr(PyverbsObject):
     cdef v.ibv_qp_attr attr

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -19,6 +19,7 @@ cdef class QPInitAttrEx(PyverbsObject):
     cdef object scq
     cdef object rcq
     cdef object _pd
+    cdef object xrcd
 
 cdef class QPAttr(PyverbsObject):
     cdef v.ibv_qp_attr attr
@@ -29,6 +30,7 @@ cdef class QP(PyverbsCM):
     cdef int state
     cdef object pd
     cdef object context
+    cdef object xrcd
     cpdef close(self)
     cdef update_cqs(self, init_attr)
     cdef object scq

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -836,6 +836,8 @@ cdef class QP(PyverbsCM):
         if qp_attr is not None:
             funcs = {e.IBV_QPT_RC: self.to_init, e.IBV_QPT_UC: self.to_init,
                      e.IBV_QPT_UD: self.to_rts,
+                     e.IBV_QPT_XRC_RECV: self.to_init,
+                     e.IBV_QPT_XRC_SEND: self.to_init,
                      e.IBV_QPT_RAW_PACKET: self.to_rts}
             funcs[self.qp.qp_type](qp_attr)
 
@@ -899,7 +901,22 @@ cdef class QP(PyverbsCM):
                                e.IBV_QP_QKEY, 'RTR': 0,
                                'RTS': e.IBV_QP_SQ_PSN},
                 e.IBV_QPT_RAW_PACKET: {'INIT': e.IBV_QP_PORT, 'RTR': 0,
-                                       'RTS': 0}}
+                                       'RTS': 0},
+                e.IBV_QPT_XRC_RECV: {'INIT': e.IBV_QP_PKEY_INDEX |\
+                                e.IBV_QP_PORT | e.IBV_QP_ACCESS_FLAGS,
+                                'RTR': e.IBV_QP_AV | e.IBV_QP_PATH_MTU |\
+                                e.IBV_QP_DEST_QPN | e.IBV_QP_RQ_PSN |   \
+                                e.IBV_QP_MAX_DEST_RD_ATOMIC |\
+                                e.IBV_QP_MIN_RNR_TIMER,
+                                'RTS': e.IBV_QP_TIMEOUT | e.IBV_QP_SQ_PSN },
+                e.IBV_QPT_XRC_SEND: {'INIT': e.IBV_QP_PKEY_INDEX |\
+                                e.IBV_QP_PORT | e.IBV_QP_ACCESS_FLAGS,
+                                'RTR': e.IBV_QP_AV | e.IBV_QP_PATH_MTU |\
+                                e.IBV_QP_DEST_QPN | e.IBV_QP_RQ_PSN,
+                                'RTS': e.IBV_QP_TIMEOUT |\
+                                e.IBV_QP_RETRY_CNT | e.IBV_QP_RNR_RETRY |\
+                                e.IBV_QP_SQ_PSN | e.IBV_QP_MAX_QP_RD_ATOMIC}}
+
         return masks[self.qp.qp_type][dst] | e.IBV_QP_STATE
 
     def to_init(self, QPAttr qp_attr):

--- a/pyverbs/srq.pxd
+++ b/pyverbs/srq.pxd
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved.
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+from . cimport libibverbs as v
+
+cdef class SrqAttr(PyverbsObject):
+    cdef v.ibv_srq_attr attr
+
+cdef class SrqInitAttr(PyverbsObject):
+    cdef v.ibv_srq_init_attr    attr
+
+cdef class SrqInitAttrEx(PyverbsObject):
+    cdef v.ibv_srq_init_attr_ex attr
+    cdef object _cq
+    cdef object _pd
+    cdef object _xrcd
+
+cdef class SRQ(PyverbsCM):
+    cdef v.ibv_srq *srq
+    cdef object cq
+    cpdef close(self)

--- a/pyverbs/srq.pyx
+++ b/pyverbs/srq.pyx
@@ -1,0 +1,201 @@
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.device cimport Context
+from pyverbs.cq cimport CQEX, CQ
+from pyverbs.xrcd cimport XRCD
+from pyverbs.wr cimport RecvWR
+from pyverbs.pd cimport PD
+
+
+cdef extern from 'errno.h':
+    int errno
+cdef extern from 'string.h':
+    void *memcpy(void *dest, const void *src, size_t n)
+
+
+cdef class SrqAttr(PyverbsObject):
+    def __cinit__(self, max_wr=100, max_sge=1, srq_limit=0):
+        self.attr.max_wr = max_wr
+        self.attr.max_sge = max_sge
+        self.attr.srq_limit = srq_limit
+
+    @property
+    def max_wr(self):
+        return self.attr.max_wr
+    @max_wr.setter
+    def max_wr(self, val):
+        self.attr.max_wr = val
+
+    @property
+    def max_sge(self):
+        return self.attr.max_sge
+    @max_sge.setter
+    def max_sge(self, val):
+        self.attr.max_sge = val
+
+    @property
+    def srq_limit(self):
+        return self.attr.srq_limit
+    @srq_limit.setter
+    def srq_limit(self, val):
+        self.attr.srq_limit = val
+
+
+cdef class SrqInitAttr(PyverbsObject):
+    def __cinit__(self, SrqAttr attr = None):
+         if attr is not None:
+             self.attr.attr.max_wr = attr.max_wr
+             self.attr.attr.max_sge = attr.max_sge
+             self.attr.attr.srq_limit = attr.srq_limit
+
+    @property
+    def max_wr(self):
+        return self.attr.attr.max_wr
+
+    @property
+    def max_sge(self):
+        return self.attr.attr.max_sge
+
+    @property
+    def srq_limit(self):
+        return self.attr.attr.srq_limit
+
+
+cdef class SrqInitAttrEx(PyverbsObject):
+    def __cinit__(self, max_wr=100, max_sge=1, srq_limit=0):
+        self.attr.attr.max_wr = max_wr
+        self.attr.attr.max_sge = max_sge
+        self.attr.attr.srq_limit = srq_limit
+        self._cq = None
+        self._pd = None
+        self._xrcd = None
+
+    @property
+    def max_wr(self):
+        return self.attr.attr.max_wr
+
+    @property
+    def max_sge(self):
+        return self.attr.attr.max_sge
+
+    @property
+    def srq_limit(self):
+        return self.attr.attr.srq_limit
+
+    @property
+    def comp_mask(self):
+        return self.attr.comp_mask
+    @comp_mask.setter
+    def comp_mask(self, val):
+        self.attr.comp_mask = val
+
+    @property
+    def srq_type(self):
+        return self.attr.srq_type
+    @srq_type.setter
+    def srq_type(self, val):
+        self.attr.srq_type = val
+
+    @property
+    def pd(self):
+        return self._pd
+    @pd.setter
+    def pd(self, PD val):
+        self._pd = val
+        self.attr.pd = val.pd
+
+    @property
+    def xrcd(self):
+        return self._xrcd
+    @xrcd.setter
+    def xrcd(self, XRCD val):
+        self._xrcd = val
+        self.attr.xrcd = val.xrcd
+
+    @property
+    def cq(self):
+        return self._cq
+    @cq.setter
+    def cq(self, val):
+        if type(val) == CQ:
+            self.attr.cq = (<CQ>val).cq
+            self._cq = val
+        else:
+            self.attr.cq = (<CQEX>val).ibv_cq
+            self._cq = val
+
+
+cdef class SRQ(PyverbsCM):
+    def __cinit__(self, object creator not None, object attr not None):
+        self.srq = NULL
+        self.cq = None
+        if type(creator) == PD:
+            self._create_srq(creator, attr)
+        elif type(creator) == Context:
+            self._create_srq_ex(creator, attr)
+        else:
+            raise PyverbsRDMAError('Srq needs either Context or PD for creation')
+        if self.srq == NULL:
+            raise PyverbsRDMAErrno('Failed to create SRQ (errno is {err})'.
+                                   format(err=errno))
+        self.logger.debug('SRQ Created')
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        self.logger.debug('Closing SRQ')
+        if self.srq != NULL:
+            rc = v.ibv_destroy_srq(self.srq)
+            if rc != 0:
+                raise PyverbsRDMAErrno('Failed to destroy SRQ (errno is {err})'.
+                                        format(err=errno))
+            self.srq = NULL
+            self.cq =None
+
+    def _create_srq(self, PD pd, SrqInitAttr init_attr):
+        self.srq = v.ibv_create_srq(pd.pd, &init_attr.attr)
+
+    def _create_srq_ex(self, Context context, SrqInitAttrEx init_attr_ex):
+        self.srq = v.ibv_create_srq_ex(context.context, &init_attr_ex.attr)
+        if init_attr_ex.cq:
+            cq = <CQ>init_attr_ex.cq
+            cq.add_ref(self)
+            self.cq = cq
+        if init_attr_ex.xrcd:
+            xrcd = <XRCD>init_attr_ex.xrcd
+            xrcd.add_ref(self)
+        if init_attr_ex.pd:
+            pd = <PD>init_attr_ex.pd
+            pd.add_ref(self)
+
+    def get_srq_num(self):
+        cdef unsigned int srqn
+        rc = v.ibv_get_srq_num(self.srq, &srqn)
+        if rc != 0:
+           raise PyverbsRDMAErrno('Failed to retrieve SRQ number (returned {rc})'.
+                                   format(rc=rc))
+        return srqn
+
+    def modify(self, SrqAttr attr, comp_mask):
+        rc = v.ibv_modify_srq(self.srq, &attr.attr, comp_mask)
+        if rc != 0:
+            raise PyverbsRDMAErrno('Failed to modify SRQ ({err})'.
+                                   format(err=errno))
+
+    def query(self):
+        attr = SrqAttr()
+        rc = v.ibv_query_srq(self.srq, &attr.attr)
+        if rc != 0:
+            raise PyverbsRDMAErrno('Failed to query SRQ ({err})'.
+                                   format(err=errno))
+        return attr
+
+    def post_recv(self, RecvWR wr not None, RecvWR bad_wr=None):
+        cdef v.ibv_recv_wr *my_bad_wr
+        rc = v.ibv_post_srq_recv(self.srq, &wr.recv_wr, &my_bad_wr)
+        if rc != 0:
+            if bad_wr:
+                memcpy(&bad_wr.recv_wr, my_bad_wr, sizeof(bad_wr.recv_wr))
+            raise PyverbsRDMAErrno('Failed to post receive to SRQ ({err})'.
+                              format(err=rc))

--- a/pyverbs/xrcd.pxd
+++ b/pyverbs/xrcd.pxd
@@ -16,4 +16,5 @@ cdef class XRCD(PyverbsCM):
     cdef v.ibv_xrcd *xrcd
     cdef Context ctx
     cdef add_ref(self, obj)
+    cdef object srqs
     cdef object qps

--- a/pyverbs/xrcd.pxd
+++ b/pyverbs/xrcd.pxd
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsCM, PyverbsObject
+from pyverbs.device cimport Context
+cimport pyverbs.libibverbs as v
+
+
+cdef class XRCDInitAttr(PyverbsObject):
+    cdef v.ibv_xrcd_init_attr attr
+
+
+cdef class XRCD(PyverbsCM):
+    cdef v.ibv_xrcd *xrcd
+    cdef Context ctx
+    cdef add_ref(self, obj)
+    cdef object qps

--- a/pyverbs/xrcd.pyx
+++ b/pyverbs/xrcd.pyx
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+import weakref
+
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.device cimport Context
+from pyverbs.qp cimport QP
+
+cdef extern from 'errno.h':
+    int errno
+
+
+cdef class XRCDInitAttr(PyverbsObject):
+    def __cinit__(self, comp_mask, oflags, fd):
+        self.attr.fd = fd
+        self.attr.comp_mask = comp_mask
+        self.attr.oflags = oflags
+
+    @property
+    def fd(self):
+        return self.attr.fd
+    @fd.setter
+    def fd(self, val):
+        self.attr.fd = val
+
+    @property
+    def comp_mask(self):
+        return self.attr.comp_mask
+    @comp_mask.setter
+    def comp_mask(self, val):
+        self.attr.comp_mask = val
+
+    @property
+    def oflags(self):
+        return self.attr.oflags
+    @oflags.setter
+    def oflags(self, val):
+        self.attr.oflags = val
+
+
+cdef class XRCD(PyverbsCM):
+    def __cinit__(self, Context context not None, XRCDInitAttr init_attr not None):
+        """
+        Initializes a XRCD object.
+        :param context: The Context object creating the XRCD
+        :return: The newly created XRCD on success
+        """
+        self.xrcd = v.ibv_open_xrcd(<v.ibv_context*> context.context,
+                                    &init_attr.attr)
+        if self.xrcd == NULL:
+            raise PyverbsRDMAErrno('Failed to allocate XRCD', errno)
+        self.ctx = context
+        context.add_ref(self)
+        self.logger.debug('XRCD: Allocated ibv_xrcd')
+        self.qps = weakref.WeakSet()
+
+    def __dealloc__(self):
+        """
+        Closes the inner XRCD.
+        :return: None
+        """
+        self.close()
+
+    cpdef close(self):
+        """
+        Closes the underlying C object of the XRCD.
+        :return: None
+        """
+        self.logger.debug('Closing XRCD')
+        self.close_weakrefs([self.qps])
+        # XRCD may be deleted directly or indirectly by closing its context,
+        # which leaves the Python XRCD object without the underlying C object,
+        # so during destruction, need to check whether or not the C object
+        # exists.
+        if self.xrcd != NULL:
+            rc = v.ibv_close_xrcd(self.xrcd)
+            if rc != 0:
+                raise PyverbsRDMAErrno('Failed to dealloc XRCD')
+            self.xrcd = NULL
+            self.ctx = None
+
+    cdef add_ref(self, obj):
+        if isinstance(obj, QP):
+            self.qps.add(obj)
+        else:
+            raise PyverbsError('Unrecognized object type')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,18 +1,27 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc . All rights reserved. See COPYING file
 
-import unittest
+import importlib
 import os
 
+# Load every test as a module in the system so that unittest's loader can find it
+def _load_tests():
+    res = []
+    for fn in sorted(os.listdir(os.path.dirname(__file__))):
+        if fn.endswith(".py") and fn.startswith("test_"):
+            m  = importlib.import_module("." + os.path.basename(fn)[:-3], __name__)
+            res.append(m)
+    return res
+__test_modules__ = _load_tests()
+
+# unittest -v prints names like 'tests.test_foo', but it always starts
+# searching from the tests module, adding the name 'tests.test' lets the user
+# specify the same test name from logging on the command line to trivially run
+# a single test.
+tests = importlib.import_module(".", __name__)
 
 def load_tests(loader, standard_tests, pattern):
-    loader = unittest.TestLoader()
-    suite = loader.discover(start_dir=os.path.dirname(__file__))
-    return suite
-#   To run only some test cases / parametrized tests:
-#   1. Add RDMATestCase to the imports:
-#    from tests.base import RDMATestCase
-#   2. Replace the current TestSuite with a customized one and add tests to it
-#      (parameters are optional)
-#    suite = unittest.TestSuite()
-#    suite.addTest(RDMATestCase.parametrize(YourTestCase, dev_name='rocep0s8f0', ...))
+    """Implement the loadTestsFromModule protocol"""
+    for mod in __test_modules__:
+        standard_tests.addTests(loader.loadTestsFromModule(mod, pattern))
+    return standard_tests

--- a/tests/base.py
+++ b/tests/base.py
@@ -274,6 +274,7 @@ class RCResources(TrafficResources):
 class UDResources(TrafficResources):
     UD_QKEY = 0x11111111
     UD_PKEY_INDEX = 0
+    GRH_SIZE = 40
 
     def create_mr(self):
         self.mr = MR(self.pd, self.msg_size + self.GRH_SIZE,

--- a/tests/base.py
+++ b/tests/base.py
@@ -2,10 +2,15 @@
 # Copyright (c) 2019 Mellanox Technologies, Inc . All rights reserved. See COPYING file
 
 import unittest
+import tempfile
 import random
+import stat
+import os
 
-from pyverbs.qp import QPCap, QPInitAttr, QPAttr, QP
+from pyverbs.qp import QPCap, QPInitAttrEx, QPInitAttr, QPAttr, QP
 from pyverbs.addr import AHAttr, GlobalRoute
+from pyverbs.xrcd import XRCD, XRCDInitAttr
+from pyverbs.srq import SRQ, SrqInitAttrEx
 from pyverbs.device import Context
 import pyverbs.device as d
 import pyverbs.enums as e
@@ -297,3 +302,105 @@ class UDResources(TrafficResources):
     def pre_run(self, rpsn, rqpn):
         self.rqpn = rqpn
         self.rpsn = rpsn
+
+
+class XRCResources(TrafficResources):
+    def __init__(self, dev_name, ib_port, gid_index, qp_count=2):
+        self.temp_file = None
+        self.xrcd_fd = -1
+        self.xrcd = None
+        self.srq = None
+        self.qp_count = qp_count
+        self.sqp_lst = []
+        self.rqp_lst = []
+        self.qps_num = []
+        self.psns = []
+        self.rqps_num = None
+        self.rpsns = None
+        super(XRCResources, self).__init__(dev_name, ib_port, gid_index)
+
+    def close(self):
+        os.close(self.xrcd_fd)
+        self.temp_file.close()
+
+    def create_qp(self):
+        """
+        Initializes self.qp with an XRC SEND/RECV QP.
+        :return: None
+        """
+        qp_attr = QPAttr(port_num=self.ib_port)
+        qp_attr.pkey_index = 0
+
+        for _ in range(self.qp_count):
+            attr_ex = QPInitAttrEx(qp_type=e.IBV_QPT_XRC_RECV,
+                                   comp_mask=e.IBV_QP_INIT_ATTR_XRCD,
+                                   xrcd=self.xrcd)
+            qp_attr.qp_access_flags = e.IBV_ACCESS_REMOTE_WRITE | \
+                                      e.IBV_ACCESS_REMOTE_READ
+            recv_qp = QP(self.ctx, attr_ex, qp_attr)
+            self.rqp_lst.append(recv_qp)
+
+            qp_caps = QPCap(max_send_wr=self.num_msgs, max_recv_sge=0,
+                            max_recv_wr=0)
+            attr_ex = QPInitAttrEx(qp_type=e.IBV_QPT_XRC_SEND, sq_sig_all=1,
+                                   comp_mask=e.IBV_QP_INIT_ATTR_PD,
+                                   pd=self.pd, scq=self.cq, cap=qp_caps)
+            qp_attr.qp_access_flags = 0
+            send_qp =QP(self.ctx, attr_ex, qp_attr)
+            self.sqp_lst.append(send_qp)
+            self.qps_num.append((recv_qp.qp_num, send_qp.qp_num))
+            self.psns.append(random.getrandbits(24))
+
+    def create_xrcd(self):
+        """
+        Initializes self.xrcd with an XRC Domain object.
+        :return: None
+        """
+        self.temp_file = tempfile.NamedTemporaryFile()
+        self.xrcd_fd = os.open(self.temp_file.name, os.O_RDONLY | os.O_CREAT,
+                               stat.S_IRUSR | stat.S_IRGRP)
+        init = XRCDInitAttr(
+            e.IBV_XRCD_INIT_ATTR_FD | e.IBV_XRCD_INIT_ATTR_OFLAGS,
+            os.O_CREAT, self.xrcd_fd)
+        self.xrcd = XRCD(self.ctx, init)
+
+    def create_srq(self):
+        """
+        Initializes self.srq with a Shared Receive QP object.
+        :return: None
+        """
+        srq_attr = SrqInitAttrEx(max_wr=self.qp_count*self.num_msgs)
+        srq_attr.srq_type = e.IBV_SRQT_XRC
+        srq_attr.pd = self.pd
+        srq_attr.xrcd = self.xrcd
+        srq_attr.cq = self.cq
+        srq_attr.comp_mask = e.IBV_SRQ_INIT_ATTR_TYPE | e.IBV_SRQ_INIT_ATTR_PD | \
+                             e.IBV_SRQ_INIT_ATTR_CQ | e.IBV_SRQ_INIT_ATTR_XRCD
+        self.srq = SRQ(self.ctx, srq_attr)
+
+    def to_rts(self):
+        ah_attr = AHAttr(dlid=self.port_attr.lid)
+        qp_attr = QPAttr()
+        qp_attr.path_mtu = PATH_MTU
+        qp_attr.timeout = TIMEOUT
+        qp_attr.retry_cnt = RETRY_CNT
+        qp_attr.rnr_retry = RNR_RETRY
+        qp_attr.min_rnr_timer = MIN_RNR_TIMER
+        qp_attr.ah_attr = ah_attr
+        for i in range(self.qp_count):
+            qp_attr.dest_qp_num = self.rqps_num[i][1]
+            qp_attr.rq_psn = self.psns[i]
+            qp_attr.sq_psn = self.rpsns[i]
+            self.rqp_lst[i].to_rts(qp_attr)
+            qp_attr.dest_qp_num = self.rqps_num[i][0]
+            self.sqp_lst[i].to_rts(qp_attr)
+
+    def init_resources(self):
+        self.create_xrcd()
+        super(XRCResources, self).init_resources()
+        self.create_srq()
+
+    def pre_run(self, rpsns, rqps_num):
+        self.rqps_num = rqps_num
+        self.rpsns = rpsns
+        self.to_rts()

--- a/tests/base.py
+++ b/tests/base.py
@@ -379,7 +379,10 @@ class XRCResources(TrafficResources):
         self.srq = SRQ(self.ctx, srq_attr)
 
     def to_rts(self):
-        ah_attr = AHAttr(dlid=self.port_attr.lid)
+        gid = self.ctx.query_gid(self.ib_port, self.gid_index)
+        gr = GlobalRoute(dgid=gid, sgid_index=self.gid_index)
+        ah_attr = AHAttr(port_num=self.ib_port, is_global=True,
+                         gr=gr, dlid=self.port_attr.lid)
         qp_attr = QPAttr()
         qp_attr.path_mtu = PATH_MTU
         qp_attr.timeout = TIMEOUT

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -7,13 +7,6 @@ import os
 from importlib.machinery import SourceFileLoader
 
 
-def test_all():
-    module_path = os.path.dirname(__file__) + '/__init__.py'
-    module = SourceFileLoader('tests', module_path).load_module()
-    loader = unittest.TestLoader()
-    suite = loader.loadTestsFromModule(module)
-    return suite
-
-
-if __name__ == '__main__':
-    unittest.main(defaultTest="test_all")
+module_path = os.path.dirname(__file__) + '/__init__.py'
+tests = SourceFileLoader('tests', module_path).load_module()
+unittest.main(module=tests)

--- a/tests/test_cq.py
+++ b/tests/test_cq.py
@@ -117,8 +117,6 @@ class CQEXTest(PyverbsAPITestCase):
             cqe = get_num_cqes(attr)
             cq_init_attrs_ex = CqInitAttrEx(cqe=cqe, wc_flags=0, comp_mask=0, flags=0)
             wc_flags = get_cq_flags_with_caps()
-            if attr_ex.tm_caps.max_ops == 0:
-                wc_flags.remove(e.IBV_WC_EX_WITH_TM_INFO)
             if attr_ex.raw_packet_caps & e.IBV_RAW_PACKET_CAP_CVLAN_STRIPPING == 0:
                 wc_flags.remove(e.IBV_WC_EX_WITH_CVLAN)
             for f in wc_flags:
@@ -187,8 +185,6 @@ class CQEXTest(PyverbsAPITestCase):
             cqe = get_num_cqes(attr)
             cq_init_attrs_ex = CqInitAttrEx(cqe=cqe, wc_flags=0, comp_mask=0, flags=0)
             wc_flags = get_cq_flags_with_caps()
-            if attr_ex.tm_caps.max_ops == 0:
-                wc_flags.remove(e.IBV_WC_EX_WITH_TM_INFO)
             if attr_ex.raw_packet_caps & e.IBV_RAW_PACKET_CAP_CVLAN_STRIPPING == 0:
                 wc_flags.remove(e.IBV_WC_EX_WITH_CVLAN)
             for f in wc_flags:
@@ -225,10 +221,9 @@ def get_num_cqes(attr):
 
 def get_cq_flags_with_no_caps():
     wc_flags = list(e.ibv_create_cq_wc_flags)
-    wc_flags.remove(e.IBV_WC_EX_WITH_TM_INFO)
     wc_flags.remove(e.IBV_WC_EX_WITH_CVLAN)
     return wc_flags
 
 
 def get_cq_flags_with_caps():
-    return [e.IBV_WC_EX_WITH_TM_INFO, e.IBV_WC_EX_WITH_CVLAN]
+    return [e.IBV_WC_EX_WITH_CVLAN]

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -1,6 +1,6 @@
+from tests.base import RCResources, UDResources, XRCResources
+from tests.utils import requires_odp, traffic, xrc_traffic
 from tests.base import RDMATestCase
-from tests.utils import requires_odp, traffic
-from tests.base import RCResources, UDResources
 from pyverbs.mr import MR
 import pyverbs.enums as e
 
@@ -8,7 +8,7 @@ import pyverbs.enums as e
 class OdpUD(UDResources):
     @requires_odp('ud')
     def create_mr(self):
-        self.mr = MR(self.pd, self.msg_size + self.GRH_SIZE ,
+        self.mr = MR(self.pd, self.msg_size + self.GRH_SIZE,
                      e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
 
 
@@ -18,18 +18,30 @@ class OdpRC(RCResources):
         self.mr = MR(self.pd, self.msg_size,
                      e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
 
+class OdpXRC(XRCResources):
+    @requires_odp('xrc')
+    def create_mr(self):
+        self.mr = MR(self.pd, self.msg_size,
+                     e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
+
 
 class OdpTestCase(RDMATestCase):
     def setUp(self):
         super(OdpTestCase, self).setUp()
         self.iters = 100
-        self.qp_dict = {'rc': OdpRC, 'ud': OdpUD}
+        self.qp_dict = {'rc': OdpRC, 'ud': OdpUD, 'xrc': OdpXRC}
 
     def create_players(self, qp_type):
-        client = self.qp_dict[qp_type](self.dev_name, self.ib_port, self.gid_index)
-        server = self.qp_dict[qp_type](self.dev_name, self.ib_port, self.gid_index)
-        client.pre_run(server.psn, server.qpn)
-        server.pre_run(client.psn, client.qpn)
+        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        if qp_type == 'xrc':
+            client.pre_run(server.psns, server.qps_num)
+            server.pre_run(client.psns, client.qps_num)
+        else:
+            client.pre_run(server.psn, server.qpn)
+            server.pre_run(client.psn, client.qpn)
         return client, server
 
     def test_odp_rc_traffic(self):
@@ -39,3 +51,7 @@ class OdpTestCase(RDMATestCase):
     def test_odp_ud_traffic(self):
         client, server = self.create_players('ud')
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
+
+    def test_odp_xrc_traffic(self):
+        client, server = self.create_players('xrc')
+        xrc_traffic(client, server)


### PR DESCRIPTION
The following patches provide support for XRCD and SRQ objects in
pyverbs, including a documentation update, to demonstrate a basic
usage, and a test using these objects.
Preceding this support are a few fixes found on the way: wrong
assignments fixes and cleanup of redundant enum entries.