### PR TITLE
Revert "mlx5: Use ilog32 instead of mlx5_ilog2"

### DIFF
--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -324,9 +324,9 @@ struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, uar_page, attr->page_id);
 	DEVX_SET(qpc, qpc, cqn_snd, attr->cqn);
 	DEVX_SET(qpc, qpc, cqn_rcv, attr->cqn);
-	DEVX_SET(qpc, qpc, log_sq_size, ilog32(attr->sq_wqe_cnt));
+	DEVX_SET(qpc, qpc, log_sq_size, mlx5_ilog2(attr->sq_wqe_cnt));
 	DEVX_SET(qpc, qpc, log_rq_stride, attr->rq_wqe_shift - 4);
-	DEVX_SET(qpc, qpc, log_rq_size, ilog32(attr->rq_wqe_cnt));
+	DEVX_SET(qpc, qpc, log_rq_size, mlx5_ilog2(attr->rq_wqe_cnt));
 	DEVX_SET(qpc, qpc, dbr_umem_id, attr->db_umem_id);
 
 	DEVX_SET(create_qp_in, in, wq_umem_id, attr->buff_umem_id);

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -179,7 +179,7 @@ static int dr_calc_sq_size(struct dr_qp *dr_qp,
 
 	wq_size = roundup_pow_of_two(attr->cap.max_send_wr * wqe_size);
 	dr_qp->sq.wqe_cnt = wq_size / MLX5_SEND_WQE_BB;
-	dr_qp->sq.wqe_shift = ilog32(MLX5_SEND_WQE_BB);
+	dr_qp->sq.wqe_shift = mlx5_ilog2(MLX5_SEND_WQE_BB);
 	dr_qp->sq.max_gs = attr->cap.max_send_sge;
 	dr_qp->sq.max_post = wq_size / wqe_size;
 
@@ -210,8 +210,8 @@ static int dr_calc_rq_size(struct dr_qp *dr_qp,
 	wq_size = roundup_pow_of_two(attr->cap.max_recv_wr) * wqe_size;
 	wq_size = max(wq_size, MLX5_SEND_WQE_BB);
 	dr_qp->rq.wqe_cnt = wq_size / wqe_size;
-	dr_qp->rq.wqe_shift = ilog32(wqe_size);
-	dr_qp->rq.max_post = 1 << ilog32(wq_size / wqe_size);
+	dr_qp->rq.wqe_shift = mlx5_ilog2(wqe_size);
+	dr_qp->rq.max_post = 1 << mlx5_ilog2(wq_size / wqe_size);
 	dr_qp->rq.max_gs = wqe_size / sizeof(struct mlx5_wqe_data_seg);
 
 	return wq_size;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -635,6 +635,20 @@ struct mlx5_devx_event_channel {
 	struct mlx5dv_devx_event_channel dv_event_channel;
 };
 
+static inline int mlx5_ilog2(int n)
+{
+	int t;
+
+	if (n <= 0)
+		return -1;
+
+	t = 0;
+	while ((1 << t) < n)
+		++t;
+
+	return t;
+}
+
 extern int mlx5_stall_num_loop;
 extern int mlx5_stall_cq_poll_min;
 extern int mlx5_stall_cq_poll_max;

--- a/providers/mlx5/srq.c
+++ b/providers/mlx5/srq.c
@@ -291,7 +291,7 @@ int mlx5_alloc_srq_buf(struct ibv_context *context, struct mlx5_srq *srq,
 	srq->max_gs = (size - sizeof(struct mlx5_wqe_srq_next_seg)) /
 		sizeof(struct mlx5_wqe_data_seg);
 
-	srq->wqe_shift = ilog32(size);
+	srq->wqe_shift = mlx5_ilog2(size);
 
 	srq->max = align_queue_size(max_wr);
 	buf_size = srq->max * size;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1352,7 +1352,7 @@ static int mlx5_calc_sq_size(struct mlx5_context *ctx,
 		return -EINVAL;
 	}
 
-	qp->sq.wqe_shift = ilog32(MLX5_SEND_WQE_BB);
+	qp->sq.wqe_shift = mlx5_ilog2(MLX5_SEND_WQE_BB);
 	qp->sq.max_gs = attr->cap.max_send_sge;
 	qp->sq.max_post = wq_size / wqe_size;
 
@@ -1400,8 +1400,8 @@ static int mlx5_calc_rwq_size(struct mlx5_context *ctx,
 	wq_size = roundup_pow_of_two(attr->max_wr) * wqe_size;
 	wq_size = max(wq_size, MLX5_SEND_WQE_BB);
 	rwq->rq.wqe_cnt = wq_size / wqe_size;
-	rwq->rq.wqe_shift = ilog32(wqe_size);
-	rwq->rq.max_post = 1 << ilog32(wq_size / wqe_size);
+	rwq->rq.wqe_shift = mlx5_ilog2(wqe_size);
+	rwq->rq.max_post = 1 << mlx5_ilog2(wq_size / wqe_size);
 	scat_spc = wqe_size -
 		((rwq->wq_sig) ? sizeof(struct mlx5_rwqe_sig) : 0) -
 		is_mprq * sizeof(struct mlx5_wqe_srq_next_seg);
@@ -1436,8 +1436,8 @@ static int mlx5_calc_rq_size(struct mlx5_context *ctx,
 	if (wqe_size) {
 		wq_size = max(wq_size, MLX5_SEND_WQE_BB);
 		qp->rq.wqe_cnt = wq_size / wqe_size;
-		qp->rq.wqe_shift = ilog32(wqe_size);
-		qp->rq.max_post = 1 << ilog32(wq_size / wqe_size);
+		qp->rq.wqe_shift = mlx5_ilog2(wqe_size);
+		qp->rq.max_post = 1 << mlx5_ilog2(wq_size / wqe_size);
 		scat_spc = wqe_size -
 			(qp->wq_sig ? sizeof(struct mlx5_rwqe_sig) : 0);
 		qp->rq.max_gs = scat_spc / sizeof(struct mlx5_wqe_data_seg);


### PR DESCRIPTION
This reverts commit 9f35ce228f9a6c6fc4575d56a15d1b26ff7b9467.

Basic usage of ilog32 doesn't work properly, for example ilog32(64)
returns -25 and driver is broken.

Signed-off-by: Yishai Hadas <yishaih@mellanox.com>