### PR TITLE
Fix static library regex check

### DIFF
--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -472,7 +472,7 @@ def test_static_libs(args):
     with inDirectory(libd):
         fns = set(fn for fn in os.listdir(".") if not os.path.islink(fn))
         for static_lib in fns:
-            g = re.match(r"lib(.+)\.a", static_lib)
+            g = re.match(r"lib(.+)\.a$", static_lib)
             if g:
                 for shared_lib in fns:
                     if re.match(r"lib%s.*\.so" % (g.group(1)), shared_lib):


### PR DESCRIPTION
The current regular expression doesn't take into account that the
package version might contain a ".a" as part of the vendor version, for
example, vXX.amznX.
Explicitly check for strings that end with ".a" by adding a $.

Signed-off-by: Gal Pressman <galpress@amazon.com>