### PR TITLE
mlx5: Add support for ibv_open_qp

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -146,6 +146,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.modify_flow_action_esp = mlx5_modify_flow_action_esp,
 	.modify_qp_rate_limit = mlx5_modify_qp_rate_limit,
 	.modify_wq = mlx5_modify_wq,
+	.open_qp = mlx5_open_qp,
 	.open_xrcd = mlx5_open_xrcd,
 	.post_srq_ops = mlx5_post_srq_ops,
 	.query_device_ex = mlx5_query_device_ex,

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -899,6 +899,8 @@ int mlx5_copy_to_recv_srq(struct mlx5_srq *srq, int idx, void *buf, int size);
 struct ibv_xrcd *mlx5_open_xrcd(struct ibv_context *context,
 				struct ibv_xrcd_init_attr *xrcd_init_attr);
 int mlx5_get_srq_num(struct ibv_srq *srq, uint32_t *srq_num);
+struct ibv_qp *mlx5_open_qp(struct ibv_context *context,
+			    struct ibv_qp_open_attr *attr);
 int mlx5_close_xrcd(struct ibv_xrcd *ib_xrcd);
 struct ibv_wq *mlx5_create_wq(struct ibv_context *context,
 			      struct ibv_wq_init_attr *attr);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2647,6 +2647,30 @@ int mlx5_get_srq_num(struct ibv_srq *srq, uint32_t *srq_num)
 	return 0;
 }
 
+struct ibv_qp *mlx5_open_qp(struct ibv_context *context,
+			    struct ibv_qp_open_attr *attr)
+{
+	struct ibv_open_qp cmd;
+	struct ib_uverbs_create_qp_resp resp;
+	struct mlx5_qp *qp;
+	int ret;
+
+	qp = calloc(1, sizeof(*qp));
+	if (!qp)
+		return NULL;
+
+	ret = ibv_cmd_open_qp(context, &qp->verbs_qp, sizeof(qp->verbs_qp),
+			      attr, &cmd, sizeof(cmd), &resp, sizeof(resp));
+	if (ret)
+		goto err;
+
+	return &qp->verbs_qp.qp;
+
+err:
+	free(qp);
+	return NULL;
+}
+
 struct ibv_xrcd *
 mlx5_open_xrcd(struct ibv_context *context,
 	       struct ibv_xrcd_init_attr *xrcd_init_attr)


### PR DESCRIPTION
Add support to allow the opening of an existing XRC QP. This
support existed in downstream mlx5 and is needed to share
an XRC Receive QP between processes using rdma-core.

Signed-off-by: Steve Welch <swelch@systemfabricworks.com>