### PR TITLE
General fixes

### DIFF
--- a/libibverbs/examples/ud_pingpong.c
+++ b/libibverbs/examples/ud_pingpong.c
@@ -563,7 +563,7 @@ int main(int argc, char *argv[])
 	char                    *servername = NULL;
 	unsigned int             port = 18515;
 	int                      ib_port = 1;
-	unsigned int             size = 2048;
+	unsigned int             size = 1024;
 	unsigned int             rx_depth = 500;
 	unsigned int             iters = 1000;
 	int                      use_event = 0;

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -18,7 +18,7 @@ cdef class QPInitAttrEx(PyverbsObject):
     cdef v.ibv_qp_init_attr_ex attr
     cdef object scq
     cdef object rcq
-    cdef object pd
+    cdef object _pd
 
 cdef class QPAttr(PyverbsObject):
     cdef v.ibv_qp_attr attr

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -250,7 +250,8 @@ cdef class QPInitAttrEx(PyverbsObject):
             raise PyverbsUserError('XRCD and RSS are not yet supported in pyverbs')
         self.attr.comp_mask = comp_mask
         if pd is not None:
-            self.pd = pd
+            self._pd = pd
+            self.attr.pd = <v.ibv_pd*>pd.pd
         self.attr.create_flags = create_flags
         self.attr.max_tso_header = max_tso_header
         self.attr.source_qpn = source_qpn
@@ -311,11 +312,11 @@ cdef class QPInitAttrEx(PyverbsObject):
 
     @property
     def pd(self):
-        return self.pd
+        return self._pd
     @pd.setter
     def pd(self, PD val):
         self.attr.pd = <v.ibv_pd*>val.pd
-        self.pd = val
+        self._pd = val
 
     @property
     def create_flags(self):


### PR DESCRIPTION
This pull request fixes a few issues found in rdma-core:
1. In UD pingpong, change the default MTU value to be smaller than the default MTU for Ethernet devices, to avoid an error.
2. Fix a wrong assignment done in pyverbs.
3. Add missing errno reports in mlx4 (CQ creation, QP creation and AH creation).