### PR TITLE
mlx5: Extend direct rule support

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -373,10 +373,10 @@ dr_action_reformat_to_action_type(enum mlx5dv_flow_action_packet_reformat_type t
 	}
 }
 
-static inline void dr_actions_init_next_ste(uint8_t **last_ste,
-					    uint32_t *added_stes,
-					    enum dr_ste_entry_type entry_type,
-					    uint16_t gvmi)
+static void dr_actions_init_next_ste(uint8_t **last_ste,
+				     uint32_t *added_stes,
+				     enum dr_ste_entry_type entry_type,
+				     uint16_t gvmi)
 {
 	(*added_stes)++;
 	*last_ste += DR_STE_SIZE;
@@ -504,10 +504,10 @@ dr_action_get_action_domain(enum mlx5dv_dr_domain_type domain,
 	}
 }
 
-static inline
-int dr_action_validate_and_get_next_state(enum dr_action_domain action_domain,
-					  uint32_t action_type,
-					  uint32_t *state)
+static int
+dr_action_validate_and_get_next_state(enum dr_action_domain action_domain,
+				      uint32_t action_type,
+				      uint32_t *state)
 {
 	uint32_t cur_state = *state;
 

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -582,7 +582,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			break;
 		case DR_ACTION_TYP_CTR:
 			attr.ctr_id = action->ctr.devx_obj->object_id +
-				action->ctr.offeset;
+				action->ctr.offset;
 			break;
 		case DR_ACTION_TYP_TAG:
 			attr.flow_tag = action->flow_tag;
@@ -886,7 +886,7 @@ dec_ref:
 
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_counter(struct mlx5dv_devx_obj *devx_obj,
-				     uint32_t offeset)
+				     uint32_t offset)
 {
 	struct mlx5dv_dr_action *action;
 
@@ -900,7 +900,7 @@ mlx5dv_dr_action_create_flow_counter(struct mlx5dv_devx_obj *devx_obj,
 		return NULL;
 
 	action->ctr.devx_obj = devx_obj;
-	action->ctr.offeset = offeset;
+	action->ctr.offset = offset;
 
 	return action;
 }

--- a/providers/mlx5/dr_crc32.c
+++ b/providers/mlx5/dr_crc32.c
@@ -60,8 +60,8 @@
 
 static uint32_t dr_ste_crc_tab32[8][256];
 
-static inline void dr_crc32_calc_lookup_entry(uint32_t (*tbl)[256], uint8_t i,
-					      uint8_t j)
+static void dr_crc32_calc_lookup_entry(uint32_t (*tbl)[256], uint8_t i,
+				       uint8_t j)
 {
 	tbl[i][j] = (tbl[i-1][j] >> 8) ^ tbl[0][tbl[i-1][j] & 0xff];
 }

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -160,6 +160,29 @@ dr_mask_is_flex_parser_tnl_vxlan_gpe_set(struct dr_match_param *mask,
 	       dr_matcher_supp_flex_parser_vxlan_gpe(&dmn->info.caps);
 }
 
+static bool dr_mask_is_misc_geneve_set(struct dr_match_misc *misc)
+{
+	return misc->geneve_vni ||
+	       misc->geneve_oam ||
+	       misc->geneve_protocol_type ||
+	       misc->geneve_opt_len;
+}
+
+static bool
+dr_matcher_supp_flex_parser_geneve(struct dr_devx_caps *caps)
+{
+	return caps->flex_protocols &
+	       MLX5_FLEX_PARSER_GENEVE_ENABLED;
+}
+
+static bool
+dr_mask_is_flex_parser_tnl_geneve_set(struct dr_match_param *mask,
+				      struct mlx5dv_dr_domain *dmn)
+{
+	return dr_mask_is_misc_geneve_set(&mask->misc) &&
+	       dr_matcher_supp_flex_parser_geneve(&dmn->info.caps);
+}
+
 static bool dr_mask_is_flex_parser_icmpv6_set(struct dr_match_misc3 *misc3)
 {
 	return (misc3->icmpv6_type || misc3->icmpv6_code ||
@@ -290,6 +313,9 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 		if (dr_mask_is_flex_parser_tnl_vxlan_gpe_set(&mask, dmn))
 			dr_ste_build_flex_parser_tnl_vxlan_gpe(&sb[idx++], &mask,
 							       inner, rx);
+		else if (dr_mask_is_flex_parser_tnl_geneve_set(&mask, dmn))
+			dr_ste_build_flex_parser_tnl_geneve(&sb[idx++], &mask,
+							    inner, rx);
 
 		if (DR_MASK_IS_ETH_L4_MISC_SET(mask.misc3, outer))
 			dr_ste_build_eth_l4_misc(&sb[idx++], &mask, inner, rx);

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -38,58 +38,58 @@
 #define DR_MASK_IP_VERSION_IPV4       0x4
 #define DR_MASK_IP_VERSION_IPV6       0x6
 
-static inline bool dr_mask_is_smac_set(struct dr_match_spec *spec)
+static bool dr_mask_is_smac_set(struct dr_match_spec *spec)
 {
 	return (spec->smac_47_16 || spec->smac_15_0);
 }
 
-static inline bool dr_mask_is_dmac_set(struct dr_match_spec *spec)
+static bool dr_mask_is_dmac_set(struct dr_match_spec *spec)
 {
 	return (spec->dmac_47_16 || spec->dmac_15_0);
 }
 
-static inline bool dr_mask_is_src_addr_set(struct dr_match_spec *spec)
+static bool dr_mask_is_src_addr_set(struct dr_match_spec *spec)
 {
 	return (spec->src_ip_127_96 || spec->src_ip_95_64 ||
 		spec->src_ip_63_32 || spec->src_ip_31_0);
 }
 
-static inline bool dr_mask_is_dst_addr_set(struct dr_match_spec *spec)
+static bool dr_mask_is_dst_addr_set(struct dr_match_spec *spec)
 {
 	return (spec->dst_ip_127_96 || spec->dst_ip_95_64 ||
 		spec->dst_ip_63_32 || spec->dst_ip_31_0);
 }
 
-static inline bool dr_mask_is_l3_base_set(struct dr_match_spec *spec)
+static bool dr_mask_is_l3_base_set(struct dr_match_spec *spec)
 {
 	return (spec->ip_protocol || spec->frag || spec->tcp_flags ||
 		spec->ip_ecn || spec->ip_dscp);
 }
 
-static inline bool dr_mask_is_tcp_udp_base_set(struct dr_match_spec *spec)
+static bool dr_mask_is_tcp_udp_base_set(struct dr_match_spec *spec)
 {
 	return (spec->tcp_sport || spec->tcp_dport ||
 		spec->udp_sport || spec->udp_dport);
 }
 
-static inline bool dr_mask_is_ipv4_set(struct dr_match_spec *spec)
+static bool dr_mask_is_ipv4_set(struct dr_match_spec *spec)
 {
 	return (spec->dst_ip_31_0 || spec->src_ip_31_0);
 }
 
-static inline bool dr_mask_is_ipv4_5_tuple_set(struct dr_match_spec *spec)
+static bool dr_mask_is_ipv4_5_tuple_set(struct dr_match_spec *spec)
 {
 	return (dr_mask_is_l3_base_set(spec) ||
 		dr_mask_is_tcp_udp_base_set(spec) ||
 		dr_mask_is_ipv4_set(spec));
 }
 
-static inline bool dr_mask_is_eth_l2_tnl_set(struct dr_match_misc *misc)
+static bool dr_mask_is_eth_l2_tnl_set(struct dr_match_misc *misc)
 {
 	return misc->vxlan_vni;
 }
 
-static inline bool dr_mask_is_ttl_set(struct dr_match_spec *spec)
+static bool dr_mask_is_ttl_set(struct dr_match_spec *spec)
 {
 	return spec->ip_ttl_hoplimit;
 }
@@ -120,7 +120,7 @@ static inline bool dr_mask_is_ttl_set(struct dr_match_spec *spec)
 	(_misc2)._inner_outer##_first_mpls_s_bos || \
 	(_misc2)._inner_outer##_first_mpls_ttl)
 
-static inline bool dr_mask_is_gre_set(struct dr_match_misc *misc)
+static bool dr_mask_is_gre_set(struct dr_match_misc *misc)
 {
 	return (misc->gre_key_h || misc->gre_key_l ||
 		misc->gre_protocol || misc->gre_c_present ||
@@ -137,42 +137,42 @@ static inline bool dr_mask_is_gre_set(struct dr_match_misc *misc)
 	DR_MASK_IS_OUTER_MPLS_OVER_GRE_UDP_SET(_misc2, gre) || \
 	DR_MASK_IS_OUTER_MPLS_OVER_GRE_UDP_SET(_misc2, udp))
 
-static inline bool dr_mask_is_flex_parser_tnl_set(struct dr_match_misc3 *misc3)
+static bool dr_mask_is_flex_parser_tnl_set(struct dr_match_misc3 *misc3)
 {
 	return 	(misc3->outer_vxlan_gpe_vni ||
 		 misc3->outer_vxlan_gpe_next_protocol ||
 		 misc3->outer_vxlan_gpe_flags);
 }
 
-static inline bool dr_mask_is_flex_parser_icmpv6_set(struct dr_match_misc3 *misc3)
+static bool dr_mask_is_flex_parser_icmpv6_set(struct dr_match_misc3 *misc3)
 {
 	return (misc3->icmpv6_type || misc3->icmpv6_code ||
 		misc3->icmpv6_header_data);
 }
 
-static inline bool dr_mask_is_wqe_metadata_set(struct dr_match_misc2 *misc2)
+static bool dr_mask_is_wqe_metadata_set(struct dr_match_misc2 *misc2)
 {
 	return misc2->metadata_reg_a;
 }
 
-static inline bool dr_mask_is_reg_c_0_3_set(struct dr_match_misc2 *misc2)
+static bool dr_mask_is_reg_c_0_3_set(struct dr_match_misc2 *misc2)
 {
 	return (misc2->metadata_reg_c_0 || misc2->metadata_reg_c_1 ||
 		misc2->metadata_reg_c_2 || misc2->metadata_reg_c_3);
 }
 
-static inline bool dr_mask_is_reg_c_4_7_set(struct dr_match_misc2 *misc2)
+static bool dr_mask_is_reg_c_4_7_set(struct dr_match_misc2 *misc2)
 {
 	return (misc2->metadata_reg_c_4 || misc2->metadata_reg_c_5 ||
 		misc2->metadata_reg_c_6 || misc2->metadata_reg_c_7);
 }
 
-static inline bool dr_mask_is_gvmi_or_qpn_set(struct dr_match_misc *misc)
+static bool dr_mask_is_gvmi_or_qpn_set(struct dr_match_misc *misc)
 {
 	return (misc->source_sqn || misc->source_port);
 }
 
-static inline bool
+static bool
 dr_matcher_supp_flex_parser_vxlan_gpe(struct mlx5dv_dr_domain *dmn)
 {
 	return dmn->info.caps.flex_protocols &

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -137,11 +137,27 @@ static bool dr_mask_is_gre_set(struct dr_match_misc *misc)
 	DR_MASK_IS_OUTER_MPLS_OVER_GRE_UDP_SET(_misc2, gre) || \
 	DR_MASK_IS_OUTER_MPLS_OVER_GRE_UDP_SET(_misc2, udp))
 
-static bool dr_mask_is_flex_parser_tnl_set(struct dr_match_misc3 *misc3)
+static bool
+dr_mask_is_misc3_vxlan_gpe_set(struct dr_match_misc3 *misc3)
 {
-	return 	(misc3->outer_vxlan_gpe_vni ||
-		 misc3->outer_vxlan_gpe_next_protocol ||
-		 misc3->outer_vxlan_gpe_flags);
+	return misc3->outer_vxlan_gpe_vni ||
+	       misc3->outer_vxlan_gpe_next_protocol ||
+	       misc3->outer_vxlan_gpe_flags;
+}
+
+static bool
+dr_matcher_supp_flex_parser_vxlan_gpe(struct dr_devx_caps *caps)
+{
+	return caps->flex_protocols &
+	       MLX5_FLEX_PARSER_VXLAN_GPE_ENABLED;
+}
+
+static bool
+dr_mask_is_flex_parser_tnl_vxlan_gpe_set(struct dr_match_param *mask,
+					 struct mlx5dv_dr_domain *dmn)
+{
+	return dr_mask_is_misc3_vxlan_gpe_set(&mask->misc3) &&
+	       dr_matcher_supp_flex_parser_vxlan_gpe(&dmn->info.caps);
 }
 
 static bool dr_mask_is_flex_parser_icmpv6_set(struct dr_match_misc3 *misc3)
@@ -170,13 +186,6 @@ static bool dr_mask_is_reg_c_4_7_set(struct dr_match_misc2 *misc2)
 static bool dr_mask_is_gvmi_or_qpn_set(struct dr_match_misc *misc)
 {
 	return (misc->source_sqn || misc->source_port);
-}
-
-static bool
-dr_matcher_supp_flex_parser_vxlan_gpe(struct mlx5dv_dr_domain *dmn)
-{
-	return dmn->info.caps.flex_protocols &
-	       MLX5_FLEX_PARSER_VXLAN_GPE_ENABLED;
 }
 
 static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
@@ -278,9 +287,9 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 							inner, rx);
 		}
 
-		if (dr_mask_is_flex_parser_tnl_set(&mask.misc3) &&
-		    dr_matcher_supp_flex_parser_vxlan_gpe(dmn))
-			dr_ste_build_flex_parser_tnl(&sb[idx++], &mask, inner, rx);
+		if (dr_mask_is_flex_parser_tnl_vxlan_gpe_set(&mask, dmn))
+			dr_ste_build_flex_parser_tnl_vxlan_gpe(&sb[idx++], &mask,
+							       inner, rx);
 
 		if (DR_MASK_IS_ETH_L4_MISC_SET(mask.misc3, outer))
 			dr_ste_build_eth_l4_misc(&sb[idx++], &mask, inner, rx);

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -54,12 +54,12 @@ struct dr_qp_init_attr {
 	struct ibv_qp_cap	cap;
 };
 
-static inline void *dr_cq_get_cqe(struct dr_cq *dr_cq, int n)
+static void *dr_cq_get_cqe(struct dr_cq *dr_cq, int n)
 {
 	return dr_cq->buf + n * dr_cq->cqe_sz;
 }
 
-static inline void *dr_cq_get_sw_cqe(struct dr_cq *dr_cq, int n)
+static void *dr_cq_get_sw_cqe(struct dr_cq *dr_cq, int n)
 {
 	void *cqe = dr_cq_get_cqe(dr_cq, n & (dr_cq->ncqe - 1));
 	struct mlx5_cqe64 *cqe64;
@@ -74,8 +74,8 @@ static inline void *dr_cq_get_sw_cqe(struct dr_cq *dr_cq, int n)
 		return NULL;
 }
 
-static inline int dr_get_next_cqe(struct dr_cq *dr_cq,
-				  struct mlx5_cqe64 **pcqe64)
+static int dr_get_next_cqe(struct dr_cq *dr_cq,
+			   struct mlx5_cqe64 **pcqe64)
 {
 	struct mlx5_cqe64 *cqe64;
 
@@ -95,7 +95,7 @@ static inline int dr_get_next_cqe(struct dr_cq *dr_cq,
 	return CQ_OK;
 }
 
-static inline int dr_parse_cqe(struct dr_cq *dr_cq, struct mlx5_cqe64 *cqe64)
+static int dr_parse_cqe(struct dr_cq *dr_cq, struct mlx5_cqe64 *cqe64)
 {
 	uint16_t wqe_ctr;
 	uint8_t opcode;
@@ -118,7 +118,7 @@ static inline int dr_parse_cqe(struct dr_cq *dr_cq, struct mlx5_cqe64 *cqe64)
 	return CQ_POLL_ERR;
 }
 
-static inline int dr_cq_poll_one(struct dr_cq *dr_cq)
+static int dr_cq_poll_one(struct dr_cq *dr_cq)
 {
 	struct mlx5_cqe64 *cqe64;
 	int err;
@@ -371,15 +371,15 @@ static int dr_destroy_qp(struct dr_qp *dr_qp)
 	return 0;
 }
 
-static inline void dr_set_raddr_seg(struct mlx5_wqe_raddr_seg *rseg,
-				    uint64_t remote_addr, uint32_t rkey)
+static void dr_set_raddr_seg(struct mlx5_wqe_raddr_seg *rseg,
+			     uint64_t remote_addr, uint32_t rkey)
 {
 	rseg->raddr    = htobe64(remote_addr);
 	rseg->rkey     = htobe32(rkey);
 	rseg->reserved = 0;
 }
 
-static inline void dr_post_send_db(struct dr_qp *dr_qp, int size, void *ctrl)
+static void dr_post_send_db(struct dr_qp *dr_qp, int size, void *ctrl)
 {
 	dr_qp->sq.head += 2; /* RDMA_WRITE + RDMA_READ */
 
@@ -406,9 +406,9 @@ static void dr_set_data_ptr_seg(struct mlx5_wqe_data_seg *dseg,
 	dseg->addr       = htobe64(data_seg->addr);
 }
 
-static inline int dr_set_data_inl_seg(struct dr_qp *dr_qp,
-				      struct dr_data_seg *data_seg,
-				      void *wqe, uint32_t opcode, int *sz)
+static int dr_set_data_inl_seg(struct dr_qp *dr_qp,
+			       struct dr_data_seg *data_seg,
+			       void *wqe, uint32_t opcode, int *sz)
 {
 	struct mlx5_wqe_inline_seg *seg;
 	void *qend = dr_qp->sq.qend;

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -2177,6 +2177,59 @@ void dr_ste_build_flex_parser_tnl_vxlan_gpe(struct dr_ste_build *sb,
 	sb->ste_build_tag_func = &dr_ste_build_flex_parser_tnl_vxlan_gpe_tag;
 }
 
+static void
+dr_ste_build_flex_parser_tnl_geneve_bit_mask(struct dr_match_param *value,
+					     uint8_t *bit_mask)
+{
+	struct dr_match_misc *misc_mask = &value->misc;
+
+	DR_STE_SET_MASK_V(flex_parser_tnl_geneve, bit_mask,
+			  geneve_protocol_type,
+			  misc_mask, geneve_protocol_type);
+	DR_STE_SET_MASK_V(flex_parser_tnl_geneve, bit_mask,
+			  geneve_oam,
+			  misc_mask, geneve_oam);
+	DR_STE_SET_MASK_V(flex_parser_tnl_geneve, bit_mask,
+			  geneve_opt_len,
+			  misc_mask, geneve_opt_len);
+	DR_STE_SET_MASK_V(flex_parser_tnl_geneve, bit_mask,
+			  geneve_vni,
+			  misc_mask, geneve_vni);
+}
+
+static int
+dr_ste_build_flex_parser_tnl_geneve_tag(struct dr_match_param *value,
+					struct dr_ste_build *sb,
+					uint8_t *hw_ste_p)
+{
+	struct dr_hw_ste_format *hw_ste = (struct dr_hw_ste_format *)hw_ste_p;
+	struct dr_match_misc *misc = &value->misc;
+	uint8_t *tag = hw_ste->tag;
+
+	DR_STE_SET_TAG(flex_parser_tnl_geneve, tag,
+		       geneve_protocol_type, misc, geneve_protocol_type);
+	DR_STE_SET_TAG(flex_parser_tnl_geneve, tag,
+		       geneve_oam, misc, geneve_oam);
+	DR_STE_SET_TAG(flex_parser_tnl_geneve, tag,
+		       geneve_opt_len, misc, geneve_opt_len);
+	DR_STE_SET_TAG(flex_parser_tnl_geneve, tag,
+		       geneve_vni, misc, geneve_vni);
+
+	return 0;
+}
+
+void dr_ste_build_flex_parser_tnl_geneve(struct dr_ste_build *sb,
+					 struct dr_match_param *mask,
+					 bool inner, bool rx)
+{
+	dr_ste_build_flex_parser_tnl_geneve_bit_mask(mask, sb->bit_mask);
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->lu_type = DR_STE_LU_TYPE_FLEX_PARSER_TNL_HEADER;
+	sb->byte_mask = dr_ste_conv_bit_to_byte_mask(sb->bit_mask);
+	sb->ste_build_tag_func = &dr_ste_build_flex_parser_tnl_geneve_tag;
+}
+
 static void dr_ste_build_register_0_bit_mask(struct dr_match_param *value,
 					     uint8_t *bit_mask)
 {

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -2125,68 +2125,56 @@ void dr_ste_build_eth_l4_misc(struct dr_ste_build *sb,
 	sb->ste_build_tag_func = &dr_ste_build_eth_l4_misc_tag;
 }
 
-static void dr_ste_build_flex_parser_tnl_bit_mask(struct dr_match_param *value,
-						  bool inner, uint8_t *bit_mask)
+static void
+dr_ste_build_flex_parser_tnl_vxlan_gpe_bit_mask(struct dr_match_param *value,
+						bool inner, uint8_t *bit_mask)
 {
 	struct dr_match_misc3 *misc_3_mask = &value->misc3;
 
-	if (misc_3_mask->outer_vxlan_gpe_flags ||
-	    misc_3_mask->outer_vxlan_gpe_next_protocol) {
-		DR_STE_SET(flex_parser_tnl, bit_mask,
-			   flex_parser_tunneling_header_63_32,
-			   (misc_3_mask->outer_vxlan_gpe_flags << 24) |
-			   (misc_3_mask->outer_vxlan_gpe_next_protocol));
-		misc_3_mask->outer_vxlan_gpe_flags = 0;
-		misc_3_mask->outer_vxlan_gpe_next_protocol = 0;
-	}
-
-	if (misc_3_mask->outer_vxlan_gpe_vni) {
-		DR_STE_SET(flex_parser_tnl, bit_mask,
-			   flex_parser_tunneling_header_31_0,
-			   misc_3_mask->outer_vxlan_gpe_vni << 8);
-		misc_3_mask->outer_vxlan_gpe_vni = 0;
-	}
+	DR_STE_SET_MASK_V(flex_parser_tnl_vxlan_gpe, bit_mask,
+			  outer_vxlan_gpe_flags,
+			  misc_3_mask, outer_vxlan_gpe_flags);
+	DR_STE_SET_MASK_V(flex_parser_tnl_vxlan_gpe, bit_mask,
+			  outer_vxlan_gpe_next_protocol,
+			  misc_3_mask, outer_vxlan_gpe_next_protocol);
+	DR_STE_SET_MASK_V(flex_parser_tnl_vxlan_gpe, bit_mask,
+			  outer_vxlan_gpe_vni,
+			  misc_3_mask, outer_vxlan_gpe_vni);
 }
 
-static int dr_ste_build_flex_parser_tnl_tag(struct dr_match_param *value,
-					    struct dr_ste_build *sb,
-					    uint8_t *hw_ste_p)
+static int
+dr_ste_build_flex_parser_tnl_vxlan_gpe_tag(struct dr_match_param *value,
+					   struct dr_ste_build *sb,
+					   uint8_t *hw_ste_p)
 {
 	struct dr_hw_ste_format *hw_ste = (struct dr_hw_ste_format *)hw_ste_p;
 	struct dr_match_misc3 *misc3 = &value->misc3;
 	uint8_t *tag = hw_ste->tag;
 
-	if (misc3->outer_vxlan_gpe_flags ||
-	    misc3->outer_vxlan_gpe_next_protocol) {
-		DR_STE_SET(flex_parser_tnl, tag,
-			   flex_parser_tunneling_header_63_32,
-			   (misc3->outer_vxlan_gpe_flags << 24) |
-			   (misc3->outer_vxlan_gpe_next_protocol));
-		misc3->outer_vxlan_gpe_flags = 0;
-		misc3->outer_vxlan_gpe_next_protocol = 0;
-	}
-
-	if (misc3->outer_vxlan_gpe_vni) {
-		DR_STE_SET(flex_parser_tnl, tag,
-			   flex_parser_tunneling_header_31_0,
-			   misc3->outer_vxlan_gpe_vni << 8);
-		misc3->outer_vxlan_gpe_vni = 0;
-	}
+	DR_STE_SET_TAG(flex_parser_tnl_vxlan_gpe, tag,
+		       outer_vxlan_gpe_flags, misc3,
+		       outer_vxlan_gpe_flags);
+	DR_STE_SET_TAG(flex_parser_tnl_vxlan_gpe, tag,
+		       outer_vxlan_gpe_next_protocol, misc3,
+		       outer_vxlan_gpe_next_protocol);
+	DR_STE_SET_TAG(flex_parser_tnl_vxlan_gpe, tag,
+		       outer_vxlan_gpe_vni, misc3,
+		       outer_vxlan_gpe_vni);
 
 	return 0;
 }
 
-void dr_ste_build_flex_parser_tnl(struct dr_ste_build *sb,
-				  struct dr_match_param *mask,
-				  bool inner, bool rx)
+void dr_ste_build_flex_parser_tnl_vxlan_gpe(struct dr_ste_build *sb,
+					    struct dr_match_param *mask,
+					    bool inner, bool rx)
 {
-	dr_ste_build_flex_parser_tnl_bit_mask(mask, inner, sb->bit_mask);
-
+	dr_ste_build_flex_parser_tnl_vxlan_gpe_bit_mask(mask, inner,
+							sb->bit_mask);
 	sb->rx = rx;
 	sb->inner = inner;
 	sb->lu_type = DR_STE_LU_TYPE_FLEX_PARSER_TNL_HEADER;
 	sb->byte_mask = dr_ste_conv_bit_to_byte_mask(sb->bit_mask);
-	sb->ste_build_tag_func = &dr_ste_build_flex_parser_tnl_tag;
+	sb->ste_build_tag_func = &dr_ste_build_flex_parser_tnl_vxlan_gpe_tag;
 }
 
 static void dr_ste_build_register_0_bit_mask(struct dr_match_param *value,

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -566,7 +566,7 @@ bool dr_ste_not_used_ste(struct dr_ste *ste)
 	return !atomic_load(&ste->refcount);
 }
 
-static inline uint16_t get_bits_per_mask(uint16_t byte_mask)
+static uint16_t get_bits_per_mask(uint16_t byte_mask)
 {
 	uint16_t bits = 0;
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1597,10 +1597,13 @@ struct mlx5_ifc_ste_flex_parser_1_bits {
 	u8         flex_parser_4[0x20];
 };
 
-struct mlx5_ifc_ste_flex_parser_tnl_bits {
-	u8         flex_parser_tunneling_header_63_32[0x20];
+struct mlx5_ifc_ste_flex_parser_tnl_vxlan_gpe_bits {
+	u8         outer_vxlan_gpe_flags[0x8];
+	u8         reserved_at_8[0x10];
+	u8         outer_vxlan_gpe_next_protocol[0x8];
 
-	u8         flex_parser_tunneling_header_31_0[0x20];
+	u8         outer_vxlan_gpe_vni[0x18];
+	u8         reserved_at_38[0x8];
 
 	u8         reserved_at_40[0x40];
 };

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1180,36 +1180,43 @@ struct mlx5_ifc_ste_sx_transmit_bits {
 	u8         reserved_at_4[0x4];
 	u8         entry_sub_type[0x8];
 	u8         byte_mask[0x10];
+
 	u8         next_table_base_63_48[0x10];
 	u8         next_lu_type[0x8];
 	u8         next_table_base_39_32_size[0x8];
+
 	u8         next_table_base_31_5_size[0x1b];
 	u8         linear_hash_enable[0x1];
 	u8         reserved_at_5c[0x2];
 	u8         next_table_rank[0x2];
-	u8         sx_wire;
-	u8         sx_func_lb;
-	u8         sx_sniffer;
-	u8         sx_wire_enable;
-	u8         sx_func_lb_enable;
-	u8         sx_sniffer_enable;
-	u8         action_type[3];
-	u8         reserved_at_69;
-	u8         action_description[6];
-	u8         gvmi[16];
-	u8         encap_pointer_vlan_data[32];
-	u8         loopback_syndome_en[8];
-	u8         loopback_syndome[8];
-	u8         counter_trigger[16];
-	u8         miss_address_63_48[16];
-	u8         counter_trigger_23_16[8];
-	u8         miss_address_39_32[8];
-	u8         miss_address_31_6[26];
-	u8         learning_point;
-	u8         go_back;
-	u8         match_polarity;
-	u8         mask_mode;
-	u8         miss_rank[2];
+
+	u8         sx_wire[0x1];
+	u8         sx_func_lb[0x1];
+	u8         sx_sniffer[0x1];
+	u8         sx_wire_enable[0x1];
+	u8         sx_func_lb_enable[0x1];
+	u8         sx_sniffer_enable[0x1];
+	u8         action_type[0x3];
+	u8         reserved_at_69[0x1];
+	u8         action_description[0x6];
+	u8         gvmi[0x10];
+
+	u8         encap_pointer_vlan_data[0x20];
+
+	u8         loopback_syndome_en[0x8];
+	u8         loopback_syndome[0x8];
+	u8         counter_trigger[0x10];
+
+	u8         miss_address_63_48[0x10];
+	u8         counter_trigger_23_16[0x8];
+	u8         miss_address_39_32[0x8];
+
+	u8         miss_address_31_6[0x1a];
+	u8         learning_point[0x1];
+	u8         go_back[0x1];
+	u8         match_polarity[0x1];
+	u8         mask_mode[0x1];
+	u8         miss_rank[0x2];
 };
 
 struct mlx5_ifc_ste_rx_steering_mult_bits {
@@ -1217,24 +1224,31 @@ struct mlx5_ifc_ste_rx_steering_mult_bits {
 	u8         reserved_at_4[0x4];
 	u8         entry_sub_type[0x8];
 	u8         byte_mask[0x10];
+
 	u8         next_table_base_63_48[0x10];
 	u8         next_lu_type[0x8];
 	u8         next_table_base_39_32_size[0x8];
+
 	u8         next_table_base_31_5_size[0x1b];
 	u8         linear_hash_enable[0x1];
-	u8         reserved_at_[0x2];
+	u8         reserved_at_5c[0x2];
 	u8         next_table_rank[0x2];
+
 	u8         member_count[0x10];
 	u8         gvmi[0x10];
+
 	u8         qp_list_pointer[0x20];
+
 	u8         reserved_at_a0[0x1];
 	u8         tunneling_action[0x3];
 	u8         action_description[0x4];
 	u8         reserved_at_a8[0x8];
 	u8         counter_trigger_15_0[0x10];
+
 	u8         miss_address_63_48[0x10];
 	u8         counter_trigger_23_16[0x08];
 	u8         miss_address_39_32[0x8];
+
 	u8         miss_address_31_6[0x1a];
 	u8         learning_point[0x1];
 	u8         fail_on_error[0x1];
@@ -1248,24 +1262,31 @@ struct mlx5_ifc_ste_modify_packet_bits {
 	u8         reserved_at_4[0x4];
 	u8         entry_sub_type[0x8];
 	u8         byte_mask[0x10];
+
 	u8         next_table_base_63_48[0x10];
 	u8         next_lu_type[0x8];
 	u8         next_table_base_39_32_size[0x8];
+
 	u8         next_table_base_31_5_size[0x1b];
 	u8         linear_hash_enable[0x1];
-	u8         reserved_at_[0x2];
+	u8         reserved_at_5c[0x2];
 	u8         next_table_rank[0x2];
+
 	u8         number_of_re_write_actions[0x10];
 	u8         gvmi[0x10];
+
 	u8         header_re_write_actions_pointer[0x20];
+
 	u8         reserved_at_a0[0x1];
 	u8         tunneling_action[0x3];
 	u8         action_description[0x4];
 	u8         reserved_at_a8[0x8];
 	u8         counter_trigger_15_0[0x10];
+
 	u8         miss_address_63_48[0x10];
 	u8         counter_trigger_23_16[0x08];
 	u8         miss_address_39_32[0x8];
+
 	u8         miss_address_31_6[0x1a];
 	u8         learning_point[0x1];
 	u8         fail_on_error[0x1];
@@ -1276,8 +1297,10 @@ struct mlx5_ifc_ste_modify_packet_bits {
 
 struct mlx5_ifc_ste_eth_l2_src_bits {
 	u8         smac_47_16[0x20];
+
 	u8         smac_15_0[0x10];
 	u8         l3_ethertype[0x10];
+
 	u8         qp_type[0x2];
 	u8         ethertype_filter[0x1];
 	u8         reserved_at_43[0x1];
@@ -1291,6 +1314,7 @@ struct mlx5_ifc_ste_eth_l2_src_bits {
 	u8         first_vlan_qualifier[0x2];
 	u8         reserved_at_52[0x2];
 	u8         first_vlan_id[0xc];
+
 	u8         ip_fragmented[0x1];
 	u8         tcp_syn[0x1];
 	u8         encp_type[0x2];
@@ -1306,8 +1330,10 @@ struct mlx5_ifc_ste_eth_l2_src_bits {
 
 struct mlx5_ifc_ste_eth_l2_dst_bits {
 	u8         dmac_47_16[0x20];
+
 	u8         dmac_15_0[0x10];
 	u8         l3_ethertype[0x10];
+
 	u8         qp_type[0x2];
 	u8         ethertype_filter[0x1];
 	u8         reserved_at_43[0x1];
@@ -1321,6 +1347,7 @@ struct mlx5_ifc_ste_eth_l2_dst_bits {
 	u8         first_vlan_qualifier[0x2];
 	u8         reserved_at_52[0x2];
 	u8         first_vlan_id[0xc];
+
 	u8         ip_fragmented[0x1];
 	u8         tcp_syn[0x1];
 	u8         encp_type[0x2];
@@ -1336,9 +1363,12 @@ struct mlx5_ifc_ste_eth_l2_dst_bits {
 
 struct mlx5_ifc_ste_eth_l2_src_dst_bits {
 	u8         dmac_47_16[0x20];
+
 	u8         dmac_15_0[0x10];
 	u8         smac_47_32[0x10];
+
 	u8         smac_31_0[0x20];
+
 	u8         sx_sniffer[0x1];
 	u8         force_lb[0x1];
 	u8         functional_lb[0x1];
@@ -1354,9 +1384,12 @@ struct mlx5_ifc_ste_eth_l2_src_dst_bits {
 
 struct mlx5_ifc_ste_eth_l3_ipv4_5_tuple_bits {
 	u8         destination_address[0x20];
+
 	u8         source_address[0x20];
+
 	u8         source_port[0x10];
 	u8         destination_port[0x10];
+
 	u8         fragmented[0x1];
 	u8         first_fragment[0x1];
 	u8         reserved_at_62[0x2];
@@ -1378,16 +1411,22 @@ struct mlx5_ifc_ste_eth_l3_ipv4_5_tuple_bits {
 
 struct mlx5_ifc_ste_eth_l3_ipv6_dst_bits {
 	u8         dst_ip_127_96[0x20];
+
 	u8         dst_ip_95_64[0x20];
+
 	u8         dst_ip_63_32[0x20];
+
 	u8         dst_ip_31_0[0x20];
 };
 
 struct mlx5_ifc_ste_eth_l2_tnl_bits {
 	u8         dmac_47_16[0x20];
+
 	u8         dmac_15_0[0x10];
 	u8         l3_ethertype[0x10];
+
 	u8         l2_tunneling_network_id[0x20];
+
 	u8         ip_fragmented[0x1];
 	u8         tcp_syn[0x1];
 	u8         encp_type[0x2];
@@ -1404,8 +1443,11 @@ struct mlx5_ifc_ste_eth_l2_tnl_bits {
 
 struct mlx5_ifc_ste_eth_l3_ipv6_src_bits {
 	u8         src_ip_127_96[0x20];
+
 	u8         src_ip_95_64[0x20];
+
 	u8         src_ip_63_32[0x20];
+
 	u8         src_ip_31_0[0x20];
 };
 
@@ -1414,12 +1456,15 @@ struct mlx5_ifc_ste_eth_l3_ipv4_misc_bits {
 	u8         ihl[0x4];
 	u8         reserved_at_8[0x8];
 	u8         total_length[0x10];
+
 	u8         identification[0x10];
 	u8         flags[0x3];
 	u8         fragment_offset[0xd];
+
 	u8         time_to_live[0x8];
 	u8         reserved_at_48[0x8];
 	u8         checksum[0x10];
+
 	u8         reserved_at_60[0x20];
 };
 
@@ -1429,6 +1474,7 @@ struct mlx5_ifc_ste_eth_l4_bits {
 	u8         reserved_at_2[0x6];
 	u8         protocol[0x8];
 	u8         dst_port[0x10];
+
 	u8         ipv6_version[0x4];
 	u8         reserved_at_24[0x1];
 	u8         ecn[0x2];
@@ -1442,10 +1488,12 @@ struct mlx5_ifc_ste_eth_l4_bits {
 	u8         tcp_syn[0x1];
 	u8         tcp_fin[0x1];
 	u8         src_port[0x10];
+
 	u8         ipv6_payload_length[0x10];
 	u8         ipv6_hop_limit[0x8];
 	u8         dscp[0x6];
 	u8         reserved_at_5e[0x2];
+
 	u8         tcp_data_offset[0x4];
 	u8         reserved_at_64[0x8];
 	u8         flow_label[0x14];
@@ -1454,8 +1502,11 @@ struct mlx5_ifc_ste_eth_l4_bits {
 struct mlx5_ifc_ste_eth_l4_misc_bits {
 	u8         checksum[0x10];
 	u8         length[0x10];
+
 	u8         seq_num[0x20];
+
 	u8         ack_num[0x20];
+
 	u8         urgent_pointer[0x10];
 	u8         window_size[0x10];
 };
@@ -1465,8 +1516,11 @@ struct mlx5_ifc_ste_mpls_bits {
 	u8         mpls0_exp[0x3];
 	u8         mpls0_s_bos[0x1];
 	u8         mpls0_ttl[0x8];
+
 	u8         mpls1_label[0x20];
+
 	u8         mpls2_label[0x20];
+
 	u8         reserved_at_60[0x16];
 	u8         mpls4_s_bit[0x1];
 	u8         mpls4_qualifier[0x1];
@@ -1482,21 +1536,27 @@ struct mlx5_ifc_ste_mpls_bits {
 
 struct mlx5_ifc_ste_register_0_bits {
 	u8         register_0_h[0x20];
+
 	u8         register_0_l[0x20];
+
 	u8         register_1_h[0x20];
+
 	u8         register_1_l[0x20];
 };
 
 struct mlx5_ifc_ste_register_1_bits {
 	u8         register_2_h[0x20];
+
 	u8         register_2_l[0x20];
+
 	u8         register_3_h[0x20];
+
 	u8         register_3_l[0x20];
 };
 
 struct mlx5_ifc_ste_gre_bits {
 	u8         gre_c_present[0x1];
-	u8         reserved_at_30[0x1];
+	u8         reserved_at_1[0x1];
 	u8         gre_k_present[0x1];
 	u8         gre_s_present[0x1];
 	u8         strict_src_route[0x1];
@@ -1504,10 +1564,13 @@ struct mlx5_ifc_ste_gre_bits {
 	u8         flags[0x5];
 	u8         version[0x3];
 	u8         gre_protocol[0x10];
+
 	u8         checksum[0x10];
 	u8         offset[0x10];
+
 	u8         gre_key_h[0x18];
 	u8         gre_key_l[0x8];
+
 	u8         seq_num[0x20];
 };
 
@@ -1516,28 +1579,39 @@ struct mlx5_ifc_ste_flex_parser_0_bits {
 	u8         parser_3_exp[0x3];
 	u8         parser_3_s_bos[0x1];
 	u8         parser_3_ttl[0x8];
+
 	u8         flex_parser_2[0x20];
+
 	u8         flex_parser_1[0x20];
+
 	u8         flex_parser_0[0x20];
 };
 
 struct mlx5_ifc_ste_flex_parser_1_bits {
 	u8         flex_parser_7[0x20];
+
 	u8         flex_parser_6[0x20];
+
 	u8         flex_parser_5[0x20];
+
 	u8         flex_parser_4[0x20];
 };
 
 struct mlx5_ifc_ste_flex_parser_tnl_bits {
 	u8         flex_parser_tunneling_header_63_32[0x20];
+
 	u8         flex_parser_tunneling_header_31_0[0x20];
+
 	u8         reserved_at_40[0x40];
 };
 
 struct mlx5_ifc_ste_general_purpose_bits {
 	u8         general_purpose_lookup_field[0x20];
+
 	u8         reserved_at_20[0x20];
+
 	u8         reserved_at_40[0x20];
+
 	u8         reserved_at_60[0x20];
 };
 
@@ -1545,12 +1619,15 @@ struct mlx5_ifc_ste_src_gvmi_qp_bits {
 	u8         loopback_syndrome[0x8];
 	u8         reserved_at_8[0x8];
 	u8         source_gvmi[0x10];
+
 	u8         reserved_at_20[0x5];
 	u8         force_lb[0x1];
 	u8         functional_lb[0x1];
 	u8         source_is_requestor[0x1];
 	u8         source_qp[0x18];
+
 	u8         reserved_at_40[0x20];
+
 	u8         reserved_at_60[0x20];
 };
 
@@ -2141,6 +2218,7 @@ struct mlx5_ifc_dr_action_hw_set_bits {
 	u8         destination_left_shifter[0x6];
 	u8         reserved_at_18[0x3];
 	u8         destination_length[0x5];
+
 	u8         inline_data[0x20];
 };
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -502,6 +502,7 @@ struct mlx5_ifc_flow_table_prop_layout_bits {
 };
 
 enum {
+	MLX5_FLEX_PARSER_GENEVE_ENABLED		= 1 << 3,
 	MLX5_FLEX_PARSER_VXLAN_GPE_ENABLED	= 1 << 7,
 	MLX5_FLEX_PARSER_ICMP_V4_ENABLED	= 1 << 8,
 	MLX5_FLEX_PARSER_ICMP_V6_ENABLED	= 1 << 9,
@@ -1603,6 +1604,19 @@ struct mlx5_ifc_ste_flex_parser_tnl_vxlan_gpe_bits {
 	u8         outer_vxlan_gpe_next_protocol[0x8];
 
 	u8         outer_vxlan_gpe_vni[0x18];
+	u8         reserved_at_38[0x8];
+
+	u8         reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_ste_flex_parser_tnl_geneve_bits {
+	u8         reserved_at_0[0x2];
+	u8         geneve_opt_len[0x6];
+	u8         geneve_oam[0x1];
+	u8         reserved_at_9[0x7];
+	u8         geneve_protocol_type[0x10];
+
+	u8         geneve_vni[0x18];
 	u8         reserved_at_38[0x8];
 
 	u8         reserved_at_40[0x40];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1467,7 +1467,7 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value);
 
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_counter(struct mlx5dv_devx_obj *devx_obj,
-				     uint32_t offeset);
+				     uint32_t offset);
 
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_packet_reformat(struct mlx5dv_dr_domain *domain,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -711,7 +711,7 @@ struct mlx5dv_dr_action {
 		struct mlx5dv_dr_table	*dest_tbl;
 		struct {
 			struct mlx5dv_devx_obj	*devx_obj;
-			uint32_t		offeset;
+			uint32_t		offset;
 		} ctr;
 		struct {
 			struct mlx5dv_dr_domain		*dmn;

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -399,9 +399,9 @@ int dr_ste_build_flex_parser_1(struct dr_ste_build *sb,
 			       struct dr_match_param *mask,
 			       struct dr_devx_caps *caps,
 			       bool inner, bool rx);
-void dr_ste_build_flex_parser_tnl(struct dr_ste_build *sb,
-				  struct dr_match_param *mask,
-				  bool inner, bool rx);
+void dr_ste_build_flex_parser_tnl_vxlan_gpe(struct dr_ste_build *sb,
+					    struct dr_match_param *mask,
+					    bool inner, bool rx);
 void dr_ste_build_general_purpose(struct dr_ste_build *sb,
 				  struct dr_match_param *mask,
 				  bool inner, bool rx);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -402,6 +402,9 @@ int dr_ste_build_flex_parser_1(struct dr_ste_build *sb,
 void dr_ste_build_flex_parser_tnl_vxlan_gpe(struct dr_ste_build *sb,
 					    struct dr_match_param *mask,
 					    bool inner, bool rx);
+void dr_ste_build_flex_parser_tnl_geneve(struct dr_ste_build *sb,
+					 struct dr_match_param *mask,
+					 bool inner, bool rx);
 void dr_ste_build_general_purpose(struct dr_ste_build *sb,
 				  struct dr_match_param *mask,
 				  bool inner, bool rx);


### PR DESCRIPTION
This series extends the direct rule functionality to support Geneve packets as part of the flex parser.

It includes some refactoring of the VXLAN GPE mode in the flex parser area to enable smooth adding of the Geneve support.

In addition, some typos were fixed.