### PR TITLE
Fix a wrong field name in ibv_wr_post's man page

### DIFF
--- a/libibverbs/man/ibv_wr_post.3.md
+++ b/libibverbs/man/ibv_wr_post.3.md
@@ -315,7 +315,7 @@ ibv_wr_set_sge(qpx, lkey, local_addr_1, length_1);
 
 /* create 2nd WRITE_WITH_IMM WR entry */
 qpx->wr_id = my_wr_id_2;
-qpx->send_flags = IBV_SEND_SIGNALED;
+qpx->wr_flags = IBV_SEND_SIGNALED;
 ibv_wr_rdma_write_imm(qpx, rkey, remote_addr_2, htonl(0x1234));
 ibv_set_wr_sge(qpx, lkey, local_addr_2, length_2);
 


### PR DESCRIPTION
The example in the man page refers to a non-existing field.
Update to the correct field name.

Fixes: 58ef962809865 ('verbs: Introduce a new post send API')
Signed-off-by: Noa Osherovich <noaos@mellanox.com>