### PR TITLE
redhat: rhel distros should BuildRequires pandoc

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -61,7 +61,7 @@ BuildRequires: make
 %define cmake_install DESTDIR=%{buildroot} make install
 %endif
 
-%if 0%{?fedora} >= 25
+%if 0%{?fedora} >= 25 || 0%{?rhel} >= 7
 # pandoc was introduced in FC25
 BuildRequires: pandoc
 %endif


### PR DESCRIPTION
rpmbuild for latest rdma-core package failed for rhel7 and rhel8
with this error message:

CMake Error at libibumad/man/cmake_install.cmake:241 (file):
  file INSTALL cannot find
  "/root/rpmbuild/BUILD/rdma-core-26.0/buildlib/pandoc-prebuilt/41bbb0bed7a781be59e8c0dcd8b7278af2ce6882".
Call Stack (most recent call first):
  cmake_install.cmake:60 (include)

pandoc is available for rhel7 and rhel8 now.

Signed-off-by: Honggang Li <honli@redhat.com>