### PR TITLE
libhns: Use syslog for debugging while no print by default

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -115,7 +115,7 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	context->uar = mmap(NULL, to_hr_dev(ibdev)->page_size,
 			    PROT_READ | PROT_WRITE, MAP_SHARED, cmd_fd, 0);
 	if (context->uar == MAP_FAILED) {
-		fprintf(stderr, PFX "Warning: failed to mmap() uar page.\n");
+		HR_LOG("Failed to mmap() uar page!\n");
 		goto err_free;
 	}
 
@@ -128,8 +128,7 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 					     PROT_READ | PROT_WRITE, MAP_SHARED,
 					     cmd_fd, HNS_ROCE_TPTR_OFFSET);
 		if (context->cq_tptr_base == MAP_FAILED) {
-			fprintf(stderr,
-				PFX "Warning: Failed to mmap cq_tptr page.\n");
+			HR_LOG("Failed to mmap() cq_tptr page!\n");
 			goto db_free;
 		}
 	}
@@ -150,8 +149,9 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 
 tptr_free:
 	if (hr_dev->hw_version == HNS_ROCE_HW_VER1) {
-		if (munmap(context->cq_tptr_base, HNS_ROCE_CQ_DB_BUF_SIZE))
-			fprintf(stderr, PFX "Warning: Munmap tptr failed.\n");
+		if (munmap(context->cq_tptr_base, HNS_ROCE_CQ_DB_BUF_SIZE)) {
+			HR_LOG("Failed to munmap() cq_tptr page!\n");
+		}
 		context->cq_tptr_base = NULL;
 	}
 
@@ -191,6 +191,8 @@ static struct verbs_device *hns_device_alloc(struct verbs_sysfs_dev *sysfs_dev)
 	dev = calloc(1, sizeof(*dev));
 	if (!dev)
 		return NULL;
+
+	OPEN_LOG("hns");
 
 	dev->u_hw = sysfs_dev->match->driver_data;
 	dev->hw_version = dev->u_hw->hw_version;

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -47,14 +47,23 @@
 
 #define HNS_ROCE_HW_VER2		('h' << 24 | 'i' << 16 | '0' << 8 | '8')
 
-#define PFX				"hns: "
-
 #define HNS_ROCE_MAX_INLINE_DATA_LEN	32
 #define HNS_ROCE_MAX_CQ_NUM		0x10000
 #define HNS_ROCE_MAX_SRQWQE_NUM		0x8000
 #define HNS_ROCE_MAX_SRQSGE_NUM		0x100
 #define HNS_ROCE_MIN_CQE_NUM		0x40
 #define HNS_ROCE_MIN_WQE_NUM		0x20
+
+#ifdef HNS_ROCE_DEBUG
+#include <syslog.h>
+#define OPEN_LOG(s)			openlog(s, LOG_NDELAY|LOG_PID, LOG_USER)
+#define HR_LOG_DBG(level, fmt, args...)	syslog(level, fmt, ##args)
+#define HR_LOG(fmt, args...)		syslog(LOG_ERR, fmt, ##args)
+#else
+#define OPEN_LOG(s)
+#define HR_LOG_DBG(level, fmt, args...)
+#define HR_LOG(fmt, args...)
+#endif
 
 #define HNS_ROCE_CQE_ENTRY_SIZE		0x20
 #define HNS_ROCE_SQWQE_SHIFT		6

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -131,7 +131,8 @@ static struct hns_roce_v2_cqe *next_cqe_sw_v2(struct hns_roce_cq *cq)
 static void *get_recv_wqe_v2(struct hns_roce_qp *qp, int n)
 {
 	if ((n < 0) || (n > qp->rq.wqe_cnt)) {
-		printf("rq wqe index:%d,rq wqe cnt:%d\r\n", n, qp->rq.wqe_cnt);
+		HR_LOG("rq wqe index = %d, rq wqe cnt = %d\n", n,
+		       qp->rq.wqe_cnt);
 		return NULL;
 	}
 
@@ -288,7 +289,7 @@ static int hns_roce_flush_cqe(struct hns_roce_qp **cur_qp, struct ibv_wc *wc)
 		ret = hns_roce_u_v2_modify_qp(&(*cur_qp)->ibv_qp,
 						      &attr, attr_mask);
 		if (ret) {
-			fprintf(stderr, PFX "failed to modify qp!\n");
+			HR_LOG("Failed to modify qp!\n");
 			return ret;
 		}
 		(*cur_qp)->ibv_qp.state = IBV_QPS_ERR;
@@ -470,7 +471,7 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 		*cur_qp = hns_roce_v2_find_qp(to_hr_ctx(cq->ibv_cq.context),
 					      qpn & 0xffffff);
 		if (!*cur_qp) {
-			fprintf(stderr, PFX "can't find qp!\n");
+			HR_LOG("Failed to find qp!\n");
 			return V2_CQ_POLL_ERR;
 		}
 	}
@@ -536,8 +537,7 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 
 		ret = hns_roce_handle_recv_inl_wqe(cqe, cur_qp, wc, opcode);
 		if (ret) {
-			fprintf(stderr,
-				PFX "failed to handle recv inline wqe!\n");
+			HR_LOG("Failed to handle recv inline wqe!\n");
 			return ret;
 		}
 	}
@@ -824,7 +824,7 @@ int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 					       RC_SQ_WQE_BYTE_4_OPCODE_M,
 					       RC_SQ_WQE_BYTE_4_OPCODE_S,
 					       HNS_ROCE_WQE_OP_MASK);
-				printf("Not supported transport opcode %d\n",
+				HR_LOG("Not supported transport opcode %d\n",
 				       wr->opcode);
 				break;
 			}
@@ -846,15 +846,15 @@ int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 			if (le32toh(rc_sq_wqe->msg_len) > qp->max_inline_data) {
 				ret = EINVAL;
 				*bad_wr = wr;
-				printf("data len=%d, send_flags = 0x%x!\r\n",
-					rc_sq_wqe->msg_len, wr->send_flags);
+				HR_LOG("data len = %d, send_flags = 0x%x!\n",
+				       rc_sq_wqe->msg_len, wr->send_flags);
 				goto out;
 			}
 
 			if (wr->opcode == IBV_WR_RDMA_READ) {
 				ret = EINVAL;
 				*bad_wr = wr;
-				printf("Not supported inline data!\n");
+				HR_LOG("Not supported inline data!\n");
 				goto out;
 			}
 


### PR DESCRIPTION
There should be no fprintf/printf in libraries by default unless
debugging. So replace all fprintf/printf in libhns with a macro that is
controlled by HNS_ROCE_DEBUG.
This patch also standardizes all printtings to maintain a uniform style.

Signed-off-by: Lang Cheng <chenglang@huawei.com>
Signed-off-by: Weihang Li <liweihang@hisilicon.com>