### PR TITLE
mlx5: Allow insertion of duplicate rules using DR API

### DIFF
--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -815,12 +815,10 @@ again:
 			 * it means that all the previous stes are the same,
 			 * if so, this rule is duplicated.
 			 */
-			if (dr_ste_is_last_in_rule(nic_matcher, matched_ste->ste_chain_location)) {
-				dr_dbg(dmn, "Duplicate rule inserted, aborting\n");
-				errno = EINVAL;
-				return NULL;
-			}
-			return matched_ste;
+			if (!dr_ste_is_last_in_rule(nic_matcher, ste_location))
+				return matched_ste;
+
+			dr_dbg(dmn, "Duplicate rule inserted\n");
 		}
 
 		if (!skip_rehash && dr_rule_need_enlarge_hash(cur_htbl, dmn, nic_dmn)) {


### PR DESCRIPTION
Duplicate rules were not allowed to be configured with SW steering, unlike when working over root, fix to allow that. This functionality is useful for replacing rules without dropping
packets.