### PR TITLE
libhns: Use log file for debugging while no print by default

### DIFF
--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -47,14 +47,23 @@
 
 #define HNS_ROCE_HW_VER2		('h' << 24 | 'i' << 16 | '0' << 8 | '8')
 
-#define PFX				"hns: "
-
 #define HNS_ROCE_MAX_INLINE_DATA_LEN	32
 #define HNS_ROCE_MAX_CQ_NUM		0x10000
 #define HNS_ROCE_MAX_SRQWQE_NUM		0x8000
 #define HNS_ROCE_MAX_SRQSGE_NUM		0x100
 #define HNS_ROCE_MIN_CQE_NUM		0x40
 #define HNS_ROCE_MIN_WQE_NUM		0x20
+
+#ifdef HNS_ROCE_DEBUG
+#define HR_LOG(fp, fmt, args...) \
+	fprintf(fp, "%s:%d: " fmt, __func__, __LINE__, ##args)
+#else
+static inline void HR_LOG(FILE *fp, const char *fmt, ...)
+	__attribute__((format(printf, 2, 3)));
+static inline void HR_LOG(FILE *fp, const char *fmt, ...)
+{
+}
+#endif
 
 #define HNS_ROCE_CQE_ENTRY_SIZE		0x20
 #define HNS_ROCE_SQWQE_SHIFT		6
@@ -148,6 +157,7 @@ struct hns_roce_context {
 	unsigned int			max_qp_wr;
 	unsigned int			max_sge;
 	int				max_cqe;
+	FILE				*dbg_fp;
 };
 
 struct hns_roce_pd {


### PR DESCRIPTION
There should be no fprintf/printf in libraries by default unless
debugging. So replace all fprintf/printf in libhns with a macro that is
controlled by HNS_ROCE_DEBUG.
Users can specify a log file for debugging by setting an environment
variable "HR_DEBUG_FILE", otherwice printings will be redirected to
stderr.

This patch also standardizes all printtings to maintain a uniform style.

Signed-off-by: Weihang Li <liweihang@hisilicon.com>
Signed-off-by: Lang Cheng <chenglang@huawei.com>