### PR TITLE
Update centos6 spec file to library version 27.0

### DIFF
--- a/buildlib/centos6.spec
+++ b/buildlib/centos6.spec
@@ -1,5 +1,5 @@
 Name: rdma-core
-Version: 26.0
+Version: 27.0
 Release: 1%{?dist}
 Summary: RDMA core userspace libraries and daemons
 


### PR DESCRIPTION
fix centos6 Azure pipeline failure:

....
-rw-r--r-- vsts_azpcontainer/vsts_azpcontainer  2789 2019-11-05 09:51
rdma-core-27.0/buildlib/pandoc-prebuilt/9fcf3f165ed59609a3e94199a5b963ba461c423a
+ STATUS=0
+ '[' 0 -ne 0 ']'
+ cd rdma-core-26.0
/__w/1/s/tmp/rpm-tmp.oWTBf9: line 38: cd: rdma-core-26.0: No such file or directory
error: Bad exit status from /__w/1/s/tmp/rpm-tmp.oWTBf9 (%prep)

Fixes: 35f5864d6fd2 ("Update library version to be 27.0")
Reported-by: Michal Kalderon <mkalderon@marvell.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>