### PR TITLE
man: Fix return value for ibv_reg_dm_mr

### DIFF
--- a/libibverbs/man/ibv_alloc_dm.3
+++ b/libibverbs/man/ibv_alloc_dm.3
@@ -70,7 +70,7 @@ is done with a byte offset from the beginning of the region.
 .sp
 This type of registration is done using ibv_reg_dm_mr.
 .sp
-.BI "int ibv_reg_dm_mr(struct ibv_pd " "*pd" ", struct ibv_dm " "*dm" ", uint64_t " "dm_offset",
+.BI "struct ibv_mr* ibv_reg_dm_mr(struct ibv_pd " "*pd" ", struct ibv_dm " "*dm" ", uint64_t " "dm_offset",
 .BI "                  size_t " "length" ", uint32_t " "access");
 .sp
 .I pd


### PR DESCRIPTION
ibv_reg_dm_mr returns a struct ibv_mr pointer while man page defined
it as returning an int. Fix the description.

Fixes: e1cebbf50c262 ('verbs: Add device memory (DM) support in libibverbs')
Signed-off-by: Noa Osherovich <noaos@mellanox.com>