### PR TITLE
mlx5: Add ConnectX-6 DX Bluefield 2 to the list of supported devices

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -80,6 +80,7 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x101e),	/* ConnectX family mlx5Gen Virtual Function */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
+	HCA(MELLANOX, 0xa2d6),  /* BlueField-2 integrated ConnectX-6 Dx network controller */
 	{}
 };
 


### PR DESCRIPTION
Update list of supported PCI devices with Mellanox BlueField-2
integrated ConnectX-6 Dx network controller.

Signed-off-by: Shani Shapp <shanish@mellanox.com>
Reviewed-by: Eran Ben Elisha <eranbe@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>