### PR TITLE
pyverbs: Expose additional DV objects

### DIFF
--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -254,7 +254,8 @@ cdef class CqInitAttrEx(PyverbsObject):
 
 
 cdef class CQEX(PyverbsCM):
-    def __cinit__(self, Context context not None, CqInitAttrEx init_attr):
+    def __cinit__(self, Context context not None, CqInitAttrEx init_attr,
+                  **kwargs):
         """
         Initializes a CQEX object on the given device's context with the given
         attributes.
@@ -262,6 +263,11 @@ cdef class CQEX(PyverbsCM):
         :param init_attr: Initial attributes that describe the CQ
         :return: The newly created CQEX on success
         """
+        self.qps = weakref.WeakSet()
+        self.srqs = weakref.WeakSet()
+        if len(kwargs) > 0:
+            # Leave CQ initialization to the provider
+            return
         if init_attr is None:
             init_attr = CqInitAttrEx()
         self.cq = v.ibv_create_cq_ex(context.context, &init_attr.attr)
@@ -272,8 +278,6 @@ cdef class CQEX(PyverbsCM):
         self.ibv_cq = v.ibv_cq_ex_to_cq(self.cq)
         self.context = context
         context.add_ref(self)
-        self.qps = weakref.WeakSet()
-        self.srqs = weakref.WeakSet()
 
     cdef add_ref(self, obj):
         if isinstance(obj, QP):

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -67,8 +67,8 @@ cdef class CQ(PyverbsCM):
     A Completion Queue is the notification mechanism for work request
     completions. A CQ can have 0 or more associated QPs.
     """
-    def __cinit__(self, Context context not None, cqe, cq_context,
-                  CompChannel channel, comp_vector):
+    def __cinit__(self, Context context not None, cqe, cq_context=None,
+                  CompChannel channel=None, comp_vector=0):
         """
         Initializes a CQ object with the given parameters.
         :param context: The device's context on which to open the CQ

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -398,6 +398,9 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_XRCD_INIT_ATTR_OFLAGS
         IBV_XRCD_INIT_ATTR_RESERVED
 
+    cpdef enum:
+        IBV_WC_STANDARD_FLAGS
+
     cdef unsigned long long IBV_DEVICE_RAW_SCATTER_FCS
     cdef unsigned long long IBV_DEVICE_PCI_WRITE_END_PADDING
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -52,6 +52,12 @@ cdef extern from 'infiniband/mlx5dv.h':
         mlx5dv_dc_init_attr dc_init_attr
         unsigned long       send_ops_flags
 
+    cdef struct mlx5dv_cq_init_attr:
+        unsigned long   comp_mask
+        unsigned char   cqe_comp_res_format
+        unsigned int    flags
+        unsigned short  cqe_size
+
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)
@@ -59,3 +65,6 @@ cdef extern from 'infiniband/mlx5dv.h':
     v.ibv_qp *mlx5dv_create_qp(v.ibv_context *context,
                                v.ibv_qp_init_attr_ex *qp_attr,
                                mlx5dv_qp_init_attr *mlx5_qp_attr)
+    v.ibv_cq_ex *mlx5dv_create_cq(v.ibv_context *context,
+                                  v.ibv_cq_init_attr_ex *cq_attr,
+                                  mlx5dv_cq_init_attr *mlx5_cq_attr)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
 
+include 'mlx5dv_enums.pxd'
+
 from libcpp cimport bool
 
 cimport pyverbs.libibverbs as v
@@ -40,7 +42,20 @@ cdef extern from 'infiniband/mlx5dv.h':
         unsigned int            flow_action_flags
         unsigned int            dc_odp_caps
 
+    cdef struct mlx5dv_dc_init_attr:
+        mlx5dv_dc_type      dc_type
+        unsigned long       dct_access_key
+
+    cdef struct mlx5dv_qp_init_attr:
+        unsigned long       comp_mask
+        unsigned int        create_flags
+        mlx5dv_dc_init_attr dc_init_attr
+        unsigned long       send_ops_flags
+
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)
     int mlx5dv_query_device(v.ibv_context *ctx, mlx5dv_context *attrs_out)
+    v.ibv_qp *mlx5dv_create_qp(v.ibv_context *context,
+                               v.ibv_qp_init_attr_ex *qp_attr,
+                               mlx5dv_qp_init_attr *mlx5_qp_attr)

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -6,6 +6,8 @@
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsObject
 from pyverbs.device cimport Context
+from pyverbs.qp cimport QP
+
 
 cdef class Mlx5Context(Context):
     pass
@@ -15,3 +17,12 @@ cdef class Mlx5DVContextAttr(PyverbsObject):
 
 cdef class Mlx5DVContext(PyverbsObject):
     cdef dv.mlx5dv_context dv
+
+cdef class Mlx5DVDCInitAttr(PyverbsObject):
+    cdef dv.mlx5dv_dc_init_attr attr
+
+cdef class Mlx5DVQPInitAttr(PyverbsObject):
+    cdef dv.mlx5dv_qp_init_attr attr
+
+cdef class Mlx5QP(QP):
+    cdef object dc_type

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -6,6 +6,7 @@
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsObject
 from pyverbs.device cimport Context
+from pyverbs.cq cimport CQEX
 from pyverbs.qp cimport QP
 
 
@@ -26,3 +27,9 @@ cdef class Mlx5DVQPInitAttr(PyverbsObject):
 
 cdef class Mlx5QP(QP):
     cdef object dc_type
+
+cdef class Mlx5DVCQInitAttr(PyverbsObject):
+    cdef dv.mlx5dv_cq_init_attr attr
+
+cdef class Mlx5CQ(CQEX):
+    pass

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -67,6 +67,15 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_QP_EX_WITH_MR_INTERLEAVED    = 1 << 0
         MLX5DV_QP_EX_WITH_MR_LIST           = 1 << 1
 
+    cpdef enum mlx5dv_cq_init_attr_mask:
+        MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE = 1 << 0
+        MLX5DV_CQ_INIT_ATTR_MASK_FLAGS          = 1 << 1
+        MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE       = 1 << 2
+
+    cpdef enum mlx5dv_cq_init_attr_flags:
+        MLX5DV_CQ_INIT_ATTR_FLAGS_CQE_PAD   = 1 << 0
+        MLX5DV_CQ_INIT_ATTR_FLAGS_RESERVED  = 1 << 1
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -46,6 +46,27 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_FLOW_ACTION_FLAGS_ESP_AES_GCM_FULL_OFFLOAD   = 1 << 3
         MLX5DV_FLOW_ACTION_FLAGS_ESP_AES_GCM_TX_IV_IS_ESN   = 1 << 4
 
+    cpdef enum mlx5dv_qp_init_attr_mask:
+        MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS    = 1 << 0
+        MLX5DV_QP_INIT_ATTR_MASK_DC                 = 1 << 1
+        MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS     = 1 << 2
+
+    cpdef enum mlx5dv_qp_create_flags:
+        MLX5DV_QP_CREATE_TUNNEL_OFFLOADS            = 1 << 0
+        MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_UC = 1 << 1
+        MLX5DV_QP_CREATE_TIR_ALLOW_SELF_LOOPBACK_MC = 1 << 2
+        MLX5DV_QP_CREATE_DISABLE_SCATTER_TO_CQE     = 1 << 3
+        MLX5DV_QP_CREATE_ALLOW_SCATTER_TO_CQE       = 1 << 4
+        MLX5DV_QP_CREATE_PACKET_BASED_CREDIT_MODE   = 1 << 5
+
+    cpdef enum mlx5dv_dc_type:
+        MLX5DV_DCTYPE_DCT   = 1
+        MLX5DV_DCTYPE_DCI   = 2
+
+    cpdef enum mlx5dv_qp_create_send_ops_flags:
+        MLX5DV_QP_EX_WITH_MR_INTERLEAVED    = 1 << 0
+        MLX5DV_QP_EX_WITH_MR_LIST           = 1 << 1
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -853,7 +853,7 @@ cdef class QPAttr(PyverbsObject):
 
 cdef class QP(PyverbsCM):
     def __cinit__(self, object creator not None, object init_attr not None,
-                  QPAttr qp_attr=None):
+                  QPAttr qp_attr=None, **kwargs):
         """
         Initializes a QP object and performs state transitions according to
         user request.
@@ -873,11 +873,16 @@ cdef class QP(PyverbsCM):
                           using Context).
         :param qp_attr: Optional QPAttr object. Will be used for QP state
                         transitions after creation.
+        :param kwargs: Provider-specific QP creation attributes, meaning that
+                       the QP will be created by the provider.
         :return: An initialized QP object
         """
         cdef PD pd
         cdef Context ctx
         self.update_cqs(init_attr)
+        if len(kwargs) > 0:
+            # Leave QP initialization to the provider
+            return
         # In order to use cdef'd methods, a proper casting must be done, let's
         # infer the type.
         if issubclass(type(creator), Context):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rdma_python_test(tests
   test_addr.py
   base.py
   test_cq.py
+  test_cqex.py
   test_device.py
   test_mr.py
   test_pd.py

--- a/tests/test_cqex.py
+++ b/tests/test_cqex.py
@@ -1,0 +1,75 @@
+from pyverbs.cq import CqInitAttrEx, CQEX
+import pyverbs.enums as e
+from pyverbs.mr import MR
+
+from tests.base import RCResources, UDResources, XRCResources, RDMATestCase
+import tests.utils as u
+
+
+def create_ex_cq(res):
+    """
+    Create an Extended CQ using res's context and assign it to res's cq member.
+    IBV_WC_STANDARD_FLAGS is used for WC flags to avoid support differences
+    between devices.
+    :param res: An instance of TrafficResources
+    """
+    wc_flags = e.IBV_WC_STANDARD_FLAGS
+    cia = CqInitAttrEx(cqe=2000, wc_flags=wc_flags)
+    res.cq = CQEX(res.ctx, cia)
+
+
+class CqExUD(UDResources):
+    def create_cq(self):
+        create_ex_cq(self)
+
+    def create_mr(self):
+        self.mr = MR(self.pd, self.msg_size + self.GRH_SIZE,
+                     e.IBV_ACCESS_LOCAL_WRITE)
+
+
+class CqExRC(RCResources):
+    def create_cq(self):
+        create_ex_cq(self)
+
+
+class CqExXRC(XRCResources):
+    def create_cq(self):
+        create_ex_cq(self)
+
+
+class CqExTestCase(RDMATestCase):
+    """
+    Run traffic over the existing UD, RC and XRC infrastructure, but use
+    ibv_cq_ex instead of legacy ibv_cq
+    """
+    def setUp(self):
+        super().setUp()
+        self.iters = 100
+        self.qp_dict = {'ud': CqExUD, 'rc': CqExRC, 'xrc': CqExXRC}
+
+    def create_players(self, qp_type):
+        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        if qp_type == 'xrc':
+            client.pre_run(server.psns, server.qps_num)
+            server.pre_run(client.psns, client.qps_num)
+        else:
+            client.pre_run(server.psn, server.qpn)
+            server.pre_run(client.psn, client.qpn)
+        return client, server
+
+    def test_ud_traffic_cq_ex(self):
+        client, server = self.create_players('ud')
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
+                  is_cq_ex=True)
+
+    def test_rc_traffic_cq_ex(self):
+        client, server = self.create_players('rc')
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
+                  is_cq_ex=True)
+
+    def test_xrc_traffic_cq_ex(self):
+        client, server = self.create_players('xrc')
+        u.xrc_traffic(client, server, is_cq_ex=True)


### PR DESCRIPTION
This series adds the needed infrastructure to pyverbs to allow users
to create mlx5 CQ and QP.

Tests using the extended CQ were added as well.