### PR TITLE
libqedr: Fix doorbell recording compatibility

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -720,7 +720,7 @@ struct ibv_qp *qelr_create_qp(struct ibv_pd *pd,
 			      struct ibv_qp_init_attr *attrs)
 {
 	struct qelr_devctx *cxt = get_qelr_ctx(pd->context);
-	struct qelr_create_qp_resp resp;
+	struct qelr_create_qp_resp resp = {};
 	struct qelr_create_qp req;
 	struct qelr_qp *qp;
 	int rc;


### PR DESCRIPTION
The create_qp response structure needs to be zeroed before receiving
data from kernel, otherwise, when running over an old kernel we can get
garbage for db_rec_addr and fail when attempting to map it.

Signed-off-by: Ariel Elior <ariel.elior@marvell.com>
Signed-off-by: Michal Kalderon <michal.kalderon@marvell.com>