### PR TITLE
Topic/ldpm

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -90,12 +90,18 @@ struct efa_ibv_create_ah_resp {
 	__u8 reserved_30[2];
 };
 
+enum {
+	EFA_QUERY_DEVICE_CAPS_RDMA_READ = 1 << 0,
+};
+
 struct efa_ibv_ex_query_device_resp {
 	__u32 comp_mask;
 	__u32 max_sq_wr;
 	__u32 max_rq_wr;
 	__u16 max_sq_sge;
 	__u16 max_rq_sge;
+	__u32 max_rdma_size;
+	__u32 device_caps;
 };
 
 #endif /* EFA_ABI_USER_H */

--- a/kernel-headers/rdma/qedr-abi.h
+++ b/kernel-headers/rdma/qedr-abi.h
@@ -48,6 +48,18 @@ struct qedr_alloc_ucontext_req {
 	__u32 reserved;
 };
 
+#define QEDR_LDPM_MAX_SIZE	(8192)
+#define QEDR_EDPM_TRANS_SIZE	(64)
+
+enum qedr_rdma_dpm_type {
+	QEDR_DPM_TYPE_NONE		= 0,
+	QEDR_DPM_TYPE_ROCE_ENHANCED	= 1 << 0,
+	QEDR_DPM_TYPE_ROCE_LEGACY	= 1 << 1,
+	QEDR_DPM_TYPE_IWARP_LEGACY	= 1 << 2,
+	QEDR_DPM_TYPE_RESERVED		= 1 << 3,
+	QEDR_DPM_SIZES_SET		= 1 << 4,
+};
+
 struct qedr_alloc_ucontext_resp {
 	__aligned_u64 db_pa;
 	__u32 db_size;
@@ -59,10 +71,12 @@ struct qedr_alloc_ucontext_resp {
 	__u32 sges_per_recv_wr;
 	__u32 sges_per_srq_wr;
 	__u32 max_cqes;
-	__u8 dpm_enabled;
+	__u8 dpm_flags;
 	__u8 wids_enabled;
 	__u16 wid_count;
-	__u32 reserved;
+	__u16 ldpm_limit_size;
+	__u8 edpm_trans_size;
+	__u8 reserved;
 };
 
 struct qedr_alloc_pd_ureq {

--- a/providers/cxgb4/libcxgb4.h
+++ b/providers/cxgb4/libcxgb4.h
@@ -257,11 +257,6 @@ void c4iw_flush_srqidx(struct c4iw_qp *qhp, u32 srqidx);
 #define FW_MAJ 0
 #define FW_MIN 0
 
-static inline unsigned long align(unsigned long val, unsigned long align)
-{
-	return (val + align - 1) & ~(align - 1);
-}
-
 #ifdef STATS
 
 #define INC_STAT(a) { c4iw_stats.a++; }

--- a/providers/cxgb4/t4.h
+++ b/providers/cxgb4/t4.h
@@ -39,6 +39,7 @@
 #include <linux/types.h>
 #include <util/compiler.h>
 #include <util/udma_barrier.h>
+#include <util/util.h>
 #include <endian.h>
 
 /*
@@ -53,7 +54,6 @@
 #define __iomem
 #define BUG_ON(c) assert(!(c))
 #define ROUND_UP(x, n) (((x) + (n) - 1u) & ~((n) - 1u))
-#define DIV_ROUND_UP(n,d) (((n) + (d) - 1) / (d))
 
 /* FIXME: Move me to a generic PCI mmio accessor */
 #define cpu_to_pci32(val) htole32(val)

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -671,11 +671,6 @@ extern int mlx5_stall_cq_inc_step;
 extern int mlx5_stall_cq_dec_step;
 extern int mlx5_single_threaded;
 
-static inline unsigned DIV_ROUND_UP(unsigned n, unsigned d)
-{
-	return (n + d - 1u) / d;
-}
-
 #define to_mxxx(xxx, type) container_of(ib##xxx, struct mlx5_##type, ibv_##xxx)
 
 static inline struct mlx5_device *to_mdev(struct ibv_device *ibdev)

--- a/providers/qedr/qelr.h
+++ b/providers/qedr/qelr.h
@@ -115,8 +115,16 @@ struct qelr_buf {
 					 */
 };
 
+#define IS_IWARP(_dev)		(_dev->node_type == IBV_NODE_RNIC)
+#define IS_ROCE(_dev)		(_dev->node_type == IBV_NODE_CA)
+
 struct qelr_device {
 	struct verbs_device ibv_dev;
+};
+
+enum qelr_dpm_flags {
+	QELR_DPM_FLAGS_ENHANCED = (1 << 0),
+	QELR_DPM_FLAGS_LEGACY	= (1 << 1),
 };
 
 struct qelr_devctx {
@@ -126,8 +134,10 @@ struct qelr_devctx {
 	uint64_t		db_pa;
 	struct qedr_user_db_rec	db_rec_addr_dummy;
 	uint32_t		db_size;
-	uint8_t			disable_edpm;
+	enum qelr_dpm_flags	dpm_flags;
 	uint32_t		kernel_page_size;
+	uint16_t		ldpm_limit_size;
+	uint8_t			edpm_trans_size;
 
 	uint32_t		max_send_wr;
 	uint32_t		max_recv_wr;
@@ -220,6 +230,7 @@ struct qelr_rdma_ext {
 			       ROCE_REQ_MAX_INLINE_DATA_SIZE)
 struct qelr_dpm {
 	uint8_t			is_edpm;
+	uint8_t			is_ldpm;
 	union {
 		struct db_roce_dpm_data	data;
 		uint64_t raw;

--- a/util/util.h
+++ b/util/util.h
@@ -33,6 +33,11 @@ static inline uint64_t roundup_pow_of_two(uint64_t n)
 	return n == 1 ? 1 : 1ULL << ilog64(n - 1);
 }
 
+static inline unsigned long DIV_ROUND_UP(unsigned long n, unsigned long d)
+{
+	return (n + d - 1) / d;
+}
+
 int set_fd_nonblock(int fd, bool nonblock);
 
 int open_cdev(const char *devname_hint, dev_t cdev);


### PR DESCRIPTION
Add support for iWARP + RoCE Legacy DPM (Direct Packet Mode).
LDPM (legacy dpm) is a mode where the WQE is passed to the
doorbell and copied directly to device RAM and improves latency.
Several bits and fields were added for forward-backward compatibility, 
Also moved DIV_ROUND_UP functionality to common file to avoid defining
it again for qedr.

Signed-off-by: Yuval Bason <Yuval.Bason@cavium.com>
Signed-off-by: Michal Kalderon <michal.kalderon@marvell.com>