### PR TITLE
mlx5: Add support to query HCA clock via mlx5dv_query_device

### DIFF
--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -52,6 +52,7 @@ uint32_t        max_dynamic_bfregs /* max blue-flame registers that can be dynam
 uint64_t        max_clock_info_update_nsec;
 uint32_t        flow_action_flags; /* use enum mlx5dv_flow_action_cap_flags */
 uint32_t        dc_odp_caps; /* use enum ibv_odp_transport_cap_bits */
+void		*hca_core_clock; /* points to a memory location that is mapped to the HCA's core clock */
 .in -8
 };
 
@@ -82,6 +83,7 @@ MLX5DV_CONTEXT_MASK_DYN_BFREGS          = 1 << 4,
 MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE   = 1 << 5,
 MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS   = 1 << 6,
 MLX5DV_CONTEXT_MASK_DC_ODP_CAPS         = 1 << 7,
+MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK      = 1 << 8,
 .in -8
 };
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -785,6 +785,13 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_DC_ODP_CAPS;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK) {
+		if (mctx->hca_core_clock) {
+			attrs_out->hca_core_clock = mctx->hca_core_clock;
+			comp_mask_out |= MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK;
+		}
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -79,6 +79,7 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE	= 1 << 5,
 	MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS	= 1 << 6,
 	MLX5DV_CONTEXT_MASK_DC_ODP_CAPS		= 1 << 7,
+	MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK	= 1 << 8,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -130,6 +131,7 @@ struct mlx5dv_context {
 	uint64_t	max_clock_info_update_nsec;
 	uint32_t        flow_action_flags; /* use enum mlx5dv_flow_action_cap_flags */
 	uint32_t	dc_odp_caps; /* use enum ibv_odp_transport_cap_bits */
+	void		*hca_core_clock;
 };
 
 enum mlx5dv_context_flags {


### PR DESCRIPTION
Added a new mlx5dv context mask value so that HCA clock address can be
queried via mlx5dv_query_device.