### PR TITLE
mlx5: Support atomic operations when device reports IBV_ATOMIC_GLOB

### DIFF
--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1968,7 +1968,7 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 		return ibqp;
 	}
 
-	if (ctx->atomic_cap == IBV_ATOMIC_HCA)
+	if (ctx->atomic_cap)
 		qp->atomics_enabled = 1;
 
 	if (attr->comp_mask & IBV_QP_INIT_ATTR_SEND_OPS_FLAGS ||


### PR DESCRIPTION
Atomic operations are supported when either the device supports IBV_ATOMIC_HCA or IBV_ATOMIC_GLOB.
Allow QP to execute atomic operations when atomic device capabilities are not zero (i.e. not IBV_ATOMIC_NONE).