### PR TITLE
librdmacm: Use sched_yield instead of pthread_yield

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -3038,7 +3038,7 @@ static int rs_poll_enter(void)
 	pthread_mutex_lock(&mut);
 	if (suspendpoll) {
 		pthread_mutex_unlock(&mut);
-		pthread_yield();
+		sched_yield();
 		return -EBUSY;
 	}
 


### PR DESCRIPTION
glibc redirects pthread_yield to sched_yield additionally we get it
working with musl on linux

Signed-off-by: Khem Raj <raj.khem@gmail.com>