### PR TITLE
mlx5: Expose VAR DV APIs

### DIFF
--- a/Documentation/pyverbs.md
+++ b/Documentation/pyverbs.md
@@ -553,3 +553,20 @@ pd_ctx = ParentDomainContext(pd, alloc_p_func, free_p_func)
 pd_attr = ParentDomainInitAttr(pd=pd, pd_context=pd_ctx)
 parent_domain = ParentDomain(ctx, attr=pd_attr)
 ```
+
+##### MLX5 VAR
+The following code snippet demonstrates how to allocate an mlx5dv_var then using
+it for memory address mapping, then freeing the VAR.
+```python
+from pyverbs.providers.mlx5.mlx5dv import Mlx5VAR
+from pyverbs.device import Context
+import mmap
+
+ctx = Context(name='rocep0s8f0')
+var = Mlx5VAR(ctx)
+var_map = mmap.mmap(fileno=ctx.cmd_fd, length=var.length, offset=var.mmap_off)
+# There is no munmap method in mmap Python module, but by closing the mmap
+# instance the memory is unmapped.
+var_map.close()
+var.close()
+```

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -87,8 +87,10 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_get_event@MLX5_1.11 25
  mlx5dv_devx_subscribe_devx_event@MLX5_1.11 25
  mlx5dv_devx_subscribe_devx_event_fd@MLX5_1.11 25
+ mlx5dv_alloc_var@MLX5_1.12 28
  mlx5dv_dr_action_create_flow_meter@MLX5_1.12 28
  mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
+ mlx5dv_free_var@MLX5_1.12 28
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -115,6 +115,22 @@ enum mlx5_ib_devx_obj_methods {
 	MLX5_IB_METHOD_DEVX_OBJ_ASYNC_QUERY,
 };
 
+enum mlx5_ib_var_alloc_attrs {
+	MLX5_IB_ATTR_VAR_OBJ_ALLOC_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_ATTR_VAR_OBJ_ALLOC_MMAP_OFFSET,
+	MLX5_IB_ATTR_VAR_OBJ_ALLOC_MMAP_LENGTH,
+	MLX5_IB_ATTR_VAR_OBJ_ALLOC_PAGE_ID,
+};
+
+enum mlx5_ib_var_obj_destroy_attrs {
+	MLX5_IB_ATTR_VAR_OBJ_DESTROY_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum mlx5_ib_var_obj_methods {
+	MLX5_IB_METHOD_VAR_OBJ_ALLOC = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_METHOD_VAR_OBJ_DESTROY,
+};
+
 enum mlx5_ib_devx_umem_reg_attrs {
 	MLX5_IB_ATTR_DEVX_UMEM_REG_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
 	MLX5_IB_ATTR_DEVX_UMEM_REG_ADDR,
@@ -156,6 +172,7 @@ enum mlx5_ib_objects {
 	MLX5_IB_OBJECT_FLOW_MATCHER,
 	MLX5_IB_OBJECT_DEVX_ASYNC_CMD_FD,
 	MLX5_IB_OBJECT_DEVX_ASYNC_EVENT_FD,
+	MLX5_IB_OBJECT_VAR,
 };
 
 enum mlx5_ib_flow_matcher_create_attrs {

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -118,6 +118,8 @@ MLX5_1.11 {
 
 MLX5_1.12 {
 	global:
+		mlx5dv_alloc_var;
 		mlx5dv_dr_action_create_flow_meter;
 		mlx5dv_dr_action_modify_flow_meter;
+		mlx5dv_free_var;
 } MLX5_1.11;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -1,5 +1,6 @@
 rdma_man_pages(
   mlx5dv_alloc_dm.3.md
+  mlx5dv_alloc_var.3.md
   mlx5dv_create_cq.3.md
   mlx5dv_create_flow.3.md
   mlx5dv_create_flow_action_modify_header.3.md
@@ -28,6 +29,7 @@ rdma_man_pages(
   mlx5dv.7
 )
 rdma_alias_man_pages(
+ mlx5dv_alloc_var.3 mlx5dv_free_var.3
  mlx5dv_create_mkey.3 mlx5dv_destroy_mkey.3
  mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_destroy_cmd_comp.3

--- a/providers/mlx5/man/mlx5dv_alloc_var.3.md
+++ b/providers/mlx5/man/mlx5dv_alloc_var.3.md
@@ -1,0 +1,70 @@
+---
+layout: page
+title: mlx5dv_alloc_var / mlx5dv_free_var
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_alloc_var -  Allocates a VAR
+
+mlx5dv_free_var -   Frees a VAR
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_var *
+mlx5dv_alloc_var(struct ibv_context *context, uint32_t flags);
+
+void mlx5dv_free_var(struct mlx5dv_var *dv_var);
+```
+
+# DESCRIPTION
+
+Create / free a VAR which can be used for some device commands over the DEVX interface.
+
+The DEVX API enables direct access from the user space area to the mlx5 device
+driver, the VAR information is needed for few commands related to Virtio.
+
+
+# ARGUMENTS
+*context*
+:	RDMA device context to work on.
+
+*flags*
+:	Allocation flags for the UAR.
+
+## dv_var
+
+```c
+struct mlx5dv_var {
+	uint32_t page_id;
+	uint32_t length;
+	off_t mmap_off;
+	uint64_t comp_mask;
+};
+```
+*page_id*
+:	The device page id to be used.
+
+*length*
+:	The mmap length parameter to be used for mapping a VA to the allocated VAR entry.
+
+*mmap_off*
+:	The mmap offset parameter to be used for mapping a VA to the allocated VAR entry.
+
+# RETURN VALUE
+
+Upon success *mlx5dv_alloc_var* returns a pointer to the created VAR
+,on error NULL will be returned and errno will be set.
+
+# SEE ALSO
+
+**mlx5dv_open_device**, **mlx5dv_devx_obj_create**
+
+# AUTHOR
+
+Yishai Hadas  <yishaih@mellanox.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -631,6 +631,12 @@ struct mlx5dv_devx_obj {
 	uint32_t object_id;
 };
 
+struct mlx5_var_obj {
+	struct mlx5dv_var dv_var;
+	struct ibv_context *context;
+	uint32_t handle;
+};
+
 struct mlx5_devx_umem {
 	struct mlx5dv_devx_umem dv_devx_umem;
 	struct ibv_context *context;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1281,6 +1281,19 @@ struct mlx5dv_devx_uar {
 struct mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(struct ibv_context *context,
 					      uint32_t flags);
 void mlx5dv_devx_free_uar(struct mlx5dv_devx_uar *devx_uar);
+
+
+struct mlx5dv_var {
+	uint32_t page_id;
+	uint32_t length;
+	off_t mmap_off;
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_var *
+mlx5dv_alloc_var(struct ibv_context *context, uint32_t flags);
+void mlx5dv_free_var(struct mlx5dv_var *dv_var);
+
 int mlx5dv_devx_query_eqn(struct ibv_context *context, uint32_t vector,
 			  uint32_t *eqn);
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4902,3 +4902,70 @@ int mlx5dv_destroy_mkey(struct mlx5dv_mkey *dv_mkey)
 	return 0;
 }
 
+struct mlx5dv_var *
+mlx5dv_alloc_var(struct ibv_context *context, uint32_t flags)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       MLX5_IB_OBJECT_VAR,
+			       MLX5_IB_METHOD_VAR_OBJ_ALLOC,
+			       4);
+
+	struct ib_uverbs_attr *handle;
+	struct mlx5_var_obj *obj;
+	int ret;
+
+	if (!is_mlx5_dev(context->device)) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	if (flags) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	obj = calloc(1, sizeof(*obj));
+	if (!obj) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	handle = fill_attr_out_obj(cmd, MLX5_IB_ATTR_VAR_OBJ_ALLOC_HANDLE);
+	fill_attr_out_ptr(cmd, MLX5_IB_ATTR_VAR_OBJ_ALLOC_MMAP_OFFSET,
+		      &obj->dv_var.mmap_off);
+	fill_attr_out_ptr(cmd, MLX5_IB_ATTR_VAR_OBJ_ALLOC_MMAP_LENGTH,
+		      &obj->dv_var.length);
+	fill_attr_out_ptr(cmd, MLX5_IB_ATTR_VAR_OBJ_ALLOC_PAGE_ID,
+		      &obj->dv_var.page_id);
+
+	ret = execute_ioctl(context, cmd);
+	if (ret)
+		goto err;
+
+	obj->handle = read_attr_obj(MLX5_IB_ATTR_VAR_OBJ_ALLOC_HANDLE, handle);
+	obj->context = context;
+
+	return &obj->dv_var;
+
+err:
+	free(obj);
+	return NULL;
+}
+
+
+void mlx5dv_free_var(struct mlx5dv_var *dv_var)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       MLX5_IB_OBJECT_VAR,
+			       MLX5_IB_METHOD_VAR_OBJ_DESTROY,
+			       1);
+
+	struct mlx5_var_obj *obj = container_of(dv_var, struct mlx5_var_obj,
+						dv_var);
+
+	fill_attr_in_obj(cmd, MLX5_IB_ATTR_VAR_OBJ_DESTROY_HANDLE, obj->handle);
+	if (execute_ioctl(obj->context, cmd))
+		assert(false);
+
+	free(obj);
+}

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -18,6 +18,7 @@ cdef class Context(PyverbsCM):
     cdef object cqs
     cdef object qps
     cdef object xrcds
+    cdef object vars
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr
@@ -61,3 +62,7 @@ cdef class DM(PyverbsCM):
 
 cdef class PortAttr(PyverbsObject):
     cdef v.ibv_port_attr attr
+
+cdef class VAR(PyverbsObject):
+    cdef object context
+    cpdef close(self)

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -223,6 +223,10 @@ cdef class Context(PyverbsCM):
         else:
             raise PyverbsError('Unrecognized object type')
 
+    @property
+    def cmd_fd(self):
+        return self.context.cmd_fd
+
 
 cdef class DeviceAttr(PyverbsObject):
     """

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -101,6 +101,7 @@ cdef class Context(PyverbsCM):
         self.cqs = weakref.WeakSet()
         self.qps = weakref.WeakSet()
         self.xrcds = weakref.WeakSet()
+        self.vars = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -146,7 +147,7 @@ cdef class Context(PyverbsCM):
     cpdef close(self):
         self.logger.debug('Closing Context')
         close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
-                        self.xrcds])
+                        self.xrcds, self.vars])
         if self.context != NULL:
             rc = v.ibv_close_device(self.context)
             if rc != 0:
@@ -220,6 +221,8 @@ cdef class Context(PyverbsCM):
             self.qps.add(obj)
         elif isinstance(obj, XRCD):
             self.xrcds.add(obj)
+        elif isinstance(obj, VAR):
+            self.vars.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 
@@ -964,3 +967,19 @@ def get_device_list():
     finally:
         v.ibv_free_device_list(dev_list)
     return devices
+
+
+cdef class VAR(PyverbsObject):
+    """
+    This is an abstract class of Virtio Access Region (VAR).
+    Each device specific VAR implementation should inherit this class
+    and initialize it according to the device attributes.
+    """
+    def __cinit__(self, Context context not None, **kwargs):
+        self.context = context
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        pass

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -22,6 +22,7 @@ cdef extern from 'infiniband/verbs.h':
     cdef struct ibv_context:
         ibv_device *device
         int num_comp_vectors
+        int cmd_fd
 
     cdef struct ibv_device_attr:
         char            *fw_ver

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -3,6 +3,7 @@
 
 include 'mlx5dv_enums.pxd'
 
+from libc.stdint cimport uint32_t, uint64_t
 from libcpp cimport bool
 
 cimport pyverbs.libibverbs as v
@@ -58,13 +59,23 @@ cdef extern from 'infiniband/mlx5dv.h':
         unsigned int    flags
         unsigned short  cqe_size
 
+    cdef struct mlx5dv_var:
+        uint32_t    page_id
+        uint32_t    length
+        long        mmap_off
+        uint64_t    comp_mask
+
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)
     int mlx5dv_query_device(v.ibv_context *ctx, mlx5dv_context *attrs_out)
+
     v.ibv_qp *mlx5dv_create_qp(v.ibv_context *context,
                                v.ibv_qp_init_attr_ex *qp_attr,
                                mlx5dv_qp_init_attr *mlx5_qp_attr)
     v.ibv_cq_ex *mlx5dv_create_cq(v.ibv_context *context,
                                   v.ibv_cq_init_attr_ex *cq_attr,
                                   mlx5dv_cq_init_attr *mlx5_cq_attr)
+
+    mlx5dv_var *mlx5dv_alloc_var(v.ibv_context *context, uint32_t flags)
+    void mlx5dv_free_var(mlx5dv_var *dv_var)

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -4,8 +4,8 @@
 #cython: language_level=3
 
 cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.device cimport Context, VAR
 from pyverbs.base cimport PyverbsObject
-from pyverbs.device cimport Context
 from pyverbs.cq cimport CQEX
 from pyverbs.qp cimport QP
 
@@ -33,3 +33,7 @@ cdef class Mlx5DVCQInitAttr(PyverbsObject):
 
 cdef class Mlx5CQ(CQEX):
     pass
+
+cdef class Mlx5VAR(VAR):
+    cdef dv.mlx5dv_var *var
+    cpdef close(self)

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -551,3 +551,42 @@ def send_ops_flags_to_str(flags):
     l = {dve.MLX5DV_QP_EX_WITH_MR_INTERLEAVED: 'With MR interleaved',
          dve.MLX5DV_QP_EX_WITH_MR_LIST: 'With MR list'}
     return bitmask_to_str(flags, l)
+
+
+cdef class Mlx5VAR(VAR):
+    def __cinit__(self, Context context not None, flags=0):
+        self.var = dv.mlx5dv_alloc_var(context.context, flags)
+        if self.var == NULL:
+            raise PyverbsRDMAErrno('Failed to allocate VAR')
+        context.add_ref(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.var != NULL:
+            dv.mlx5dv_free_var(self.var)
+            self.var = NULL
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return print_format.format('page id', self.var.page_id) +\
+               print_format.format('length', self.var.length) +\
+               print_format.format('mmap offset', self.var.mmap_off) +\
+               print_format.format('compatibility mask', self.var.comp_mask)
+
+    @property
+    def page_id(self):
+        return self.var.page_id
+
+    @property
+    def length(self):
+        return self.var.length
+
+    @property
+    def mmap_off(self):
+        return self.var.mmap_off
+
+    @property
+    def comp_mask(self):
+        return self.var.comp_mask

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ rdma_python_test(tests
   test_cq_events.py
   test_cqex.py
   test_device.py
+  test_mlx5_var.py
   test_mr.py
   test_pd.py
   test_qp.py

--- a/tests/test_mlx5_var.py
+++ b/tests/test_mlx5_var.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
+
+"""
+Test module for Mlx5 VAR allocation.
+"""
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.providers.mlx5.mlx5dv import Mlx5VAR
+from tests.base import BaseResources
+from tests.base import RDMATestCase
+import unittest
+import mmap
+
+
+class Mlx5VarRes(BaseResources):
+    def __init__(self, dev_name, ib_port=None, gid_index=None):
+        super().__init__(dev_name, ib_port, gid_index)
+        try:
+            self.var = Mlx5VAR(self.ctx)
+        except PyverbsRDMAError as ex:
+            if 'not supported' in str(ex):
+                raise unittest.SkipTest('VAR allocation is not supported')
+
+
+class Mlx5VarTestCase(RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.var_res = Mlx5VarRes(self.dev_name)
+
+    def test_var_map_unmap(self):
+        var_map = mmap.mmap(fileno=self.var_res.ctx.cmd_fd,
+                            length=self.var_res.var.length,
+                            offset=self.var_res.var.mmap_off)
+        # There is no munmap method in mmap Python module, but by closing the
+        # mmap instance the memory is unmapped.
+        var_map.close()
+        self.var_res.var.close()


### PR DESCRIPTION
This series exposes mlx5 direct verbs to allocate/free a VAR.

The allocated VAR can be used in Virtio environment to set a DB and also with some DEVX commands by vDPA applications.

The series includes also some pyverbs infrastructure and test on top which uses the new APIs.
The matching kernel part was already sent into rdma-next.