### PR TITLE
libhns: Add support for extended atomic

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -291,4 +291,10 @@ struct hns_roce_wqe_atomic_seg {
 int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 			    struct ibv_send_wr **bad_wr);
 
+#define DATA_TYPE_NUM 2
+#define STANDARD_ATOMIC_U_BYTE_8 0x8
+#define EXTEND_ATOMIC_U_BYTE_16 0x10
+#define EXTEND_ATOMIC_U_BYTE_32 0x20
+#define EXTEND_ATOMIC_U_BYTE_64 0x40
+
 #endif /* _HNS_ROCE_U_HW_V2_H */


### PR DESCRIPTION
Support extended atomic operations including cmp & swap and fetch & add
of 8 bytes, 16 bytes, 32 bytes, 64 bytes on hip08.