### PR TITLE
pyverbs: Code refactoring

### DIFF
--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -18,7 +18,8 @@ cdef class GID(PyverbsObject):
     """
     GID class represents ibv_gid. It enables user to query for GIDs values.
     """
-    def __cinit__(self, val=None):
+    def __init__(self, val=None):
+        super().__init__()
         if val is not None:
             vals = gid_str_to_array(val)
 
@@ -59,8 +60,8 @@ cdef class GRH(PyverbsObject):
     Represents ibv_grh struct. Used when creating or initializing an
     Address Handle from a Work Completion.
     """
-    def __cinit__(self, GID sgid=None, GID dgid=None, version_tclass_flow=0,
-                  paylen=0, next_hdr=0, hop_limit=1):
+    def __init__(self, GID sgid=None, GID dgid=None, version_tclass_flow=0,
+                 paylen=0, next_hdr=0, hop_limit=1):
         """
         Initializes a GRH object
         :param sgid: Source GID
@@ -78,6 +79,7 @@ cdef class GRH(PyverbsObject):
                           prior to being discarded
         :return: A GRH object
         """
+        super().__init__()
         self.grh.dgid = dgid.gid
         self.grh.sgid = sgid.gid
         self.grh.version_tclass_flow = version_tclass_flow
@@ -150,8 +152,8 @@ cdef class GlobalRoute(PyverbsObject):
     the values to be used in the GRH of the packets that will be sent using
     this Address Handle.
     """
-    def __cinit__(self, GID dgid=None, flow_label=0, sgid_index=0, hop_limit=1,
-                  traffic_class=0):
+    def __init__(self, GID dgid=None, flow_label=0, sgid_index=0, hop_limit=1,
+                 traffic_class=0):
         """
         Initializes a GlobalRoute object with given parameters.
         :param dgid: Destination GID
@@ -167,6 +169,7 @@ cdef class GlobalRoute(PyverbsObject):
                               delivery priority for routers
         :return: A GlobalRoute object
         """
+        super().__init__()
         self.gr.dgid=dgid.gid
         self.gr.flow_label = flow_label
         self.gr.sgid_index = sgid_index
@@ -222,8 +225,8 @@ cdef class GlobalRoute(PyverbsObject):
 
 cdef class AHAttr(PyverbsObject):
     """ Represents ibv_ah_attr struct """
-    def __cinit__(self, dlid=0, sl=0, src_path_bits=0, static_rate=0,
-                  is_global=0, port_num=1, GlobalRoute gr=None):
+    def __init__(self, dlid=0, sl=0, src_path_bits=0, static_rate=0,
+                 is_global=0, port_num=1, GlobalRoute gr=None):
         """
         Initializes an AHAttr object.
         :param dlid: Destination LID, a 16b unsigned integer
@@ -242,6 +245,7 @@ cdef class AHAttr(PyverbsObject):
                     is_global is non zero.
         :return: An AHAttr object
         """
+        super().__init__()
         self.ah_attr.port_num = port_num
         self.ah_attr.sl = sl
         self.ah_attr.src_path_bits = src_path_bits
@@ -363,7 +367,7 @@ cdef class AHAttr(PyverbsObject):
 
 
 cdef class AH(PyverbsCM):
-    def __cinit__(self, PD pd, **kwargs):
+    def __init__(self, PD pd, **kwargs):
         """
         Initializes an AH object with the given values.
         Two creation methods are supported:
@@ -371,7 +375,7 @@ cdef class AH(PyverbsCM):
         - Creation via a WC object (calls ibv_create_ah_from_wc)
         :param pd: PD object this AH belongs to
         :param kwargs: Arguments:
-           * *attr* (AHAttr)
+            * *attr* (AHAttr)
                An AHAttr object (represents ibv_ah_attr struct)
             * *wc*
                A WC object to use for AH initialization
@@ -381,6 +385,7 @@ cdef class AH(PyverbsCM):
                Port number to be used for this AH (when using wc)
         :return: An AH object on success
         """
+        super().__init__()
         if len(kwargs) == 1:
             # Create AH via ib_create_ah
             ah_attr = <AHAttr>kwargs['attr']

--- a/pyverbs/base.pxd
+++ b/pyverbs/base.pxd
@@ -9,3 +9,5 @@ cdef class PyverbsObject(object):
 
 cdef class PyverbsCM(PyverbsObject):
     cpdef close(self)
+
+cdef close_weakrefs(iterables)

--- a/pyverbs/base.pyx
+++ b/pyverbs/base.pyx
@@ -5,8 +5,10 @@ import logging
 from pyverbs.pyverbs_error import PyverbsRDMAError
 from libc.errno cimport errno
 
+
 cpdef PyverbsRDMAErrno(str msg):
     return PyverbsRDMAError(msg, errno)
+
 
 LOG_LEVEL=logging.INFO
 LOG_FORMAT='[%(levelname)s] %(asctime)s %(filename)s:%(lineno)s: %(message)s'
@@ -38,7 +40,7 @@ cdef close_weakrefs(iterables):
 
 cdef class PyverbsObject(object):
 
-    def __cinit__(self):
+    def __init__(self):
         self.logger = logging.getLogger(self.__class__.__name__)
 
     def set_log_level(self, val):

--- a/pyverbs/base.pyx
+++ b/pyverbs/base.pyx
@@ -12,6 +12,30 @@ LOG_LEVEL=logging.INFO
 LOG_FORMAT='[%(levelname)s] %(asctime)s %(filename)s:%(lineno)s: %(message)s'
 logging.basicConfig(format=LOG_FORMAT, level=LOG_LEVEL, datefmt='%d %b %Y %H:%M:%S')
 
+
+cdef close_weakrefs(iterables):
+    """
+    For each iterable element of iterables, pop each element and
+    call its close() method. This method is used when an object is being
+    closed while other objects still hold C references to it; the object
+    holds weakrefs to such other object, and closes them before trying to
+    teardown the C resources.
+    :param iterables: an array of WeakSets
+    :return: None
+    """
+    # None elements can be present if an object's close() was called more
+    # than once (e.g. GC and by another object)
+    for it in iterables:
+        if it is None:
+            continue
+        while True:
+            try:
+                tmp = it.pop()
+                tmp.close()
+            except KeyError: # popping an empty set
+                break
+
+
 cdef class PyverbsObject(object):
 
     def __cinit__(self):
@@ -19,28 +43,6 @@ cdef class PyverbsObject(object):
 
     def set_log_level(self, val):
         self.logger.setLevel(val)
-
-    def close_weakrefs(self, iterables):
-        """
-        For each iterable element of iterables, pop each element and
-        call its close() method. This method is used when an object is being
-        closed while other objects still hold C references to it; the object
-        holds weakrefs to such other object, and closes them before trying to
-        teardown the C resources.
-        :param iterables: an array of WeakSets
-        :return: None
-        """
-        # None elements can be present if an object's close() was called more
-        # than once (e.g. GC and by another object)
-        for it in iterables:
-            if it is None:
-                continue
-            while True:
-                try:
-                    tmp = it.pop()
-                    tmp.close()
-                except KeyError: # popping an empty set
-                    break
 
 
 cdef class PyverbsCM(PyverbsObject):

--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -13,8 +13,8 @@ from pyverbs.cq cimport WC
 
 cdef class ConnParam(PyverbsObject):
 
-    def __cinit__(self, resources=1, depth=1, flow_control=0, retry=5,
-                  rnr_retry=5, srq=0, qp_num=0):
+    def __init__(self, resources=1, depth=1, flow_control=0, retry=5,
+                 rnr_retry=5, srq=0, qp_num=0):
         """
         Initialize a ConnParam object over an underlying rdma_conn_param
         C object which contains connection parameters. There are a few types of
@@ -38,6 +38,7 @@ cdef class ConnParam(PyverbsObject):
                        CMID.
         :return: ConnParam object
         """
+        super().__init__()
         memset(&self.conn_param, 0, sizeof(cm.rdma_conn_param))
         self.conn_param.responder_resources = resources
         self.conn_param.initiator_depth = depth
@@ -60,7 +61,7 @@ cdef class ConnParam(PyverbsObject):
 
 
 cdef class AddrInfo(PyverbsObject):
-    def __cinit__(self, node=None, service=None, port_space=0, flags=0):
+    def __init__(self, node=None, service=None, port_space=0, flags=0):
         """
         Initialize an AddrInfo object over an underlying rdma_addrinfo C object.
         :param node: Name, dotted-decimal IPv4 or IPv6 hex address to resolve.
@@ -75,6 +76,7 @@ cdef class AddrInfo(PyverbsObject):
         cdef cm.rdma_addrinfo hints
         cdef cm.rdma_addrinfo *hints_ptr = NULL
 
+        super().__init__()
         if node is not None:
             node = node.encode('utf-8')
             address = <char*>node
@@ -102,8 +104,8 @@ cdef class AddrInfo(PyverbsObject):
 
 cdef class CMID(PyverbsCM):
 
-    def __cinit__(self, object creator=None, QPInitAttr qp_init_attr=None,
-                  PD pd=None):
+    def __init__(self, object creator=None, QPInitAttr qp_init_attr=None,
+                 PD pd=None):
         """
         Initialize a CMID object over an underlying rdma_cm_id C object.
         This is the main RDMA CM object which provides most of the rdmacm API.
@@ -118,6 +120,8 @@ cdef class CMID(PyverbsCM):
         """
         cdef v.ibv_qp_init_attr *init
         cdef v.ibv_pd *in_pd = NULL
+
+        super().__init__()
         self.pd = None
         self.ctx = None
         if creator is None:

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -17,12 +17,13 @@ cdef class CompChannel(PyverbsCM):
     for a CQ, the event is delivered via the completion channel attached to the
     CQ.
     """
-    def __cinit__(self, Context context not None):
+    def __init__(self, Context context not None):
         """
         Initializes a completion channel object on the given device.
         :param context: The device's context to use
         :return: A CompChannel object on success
         """
+        super().__init__()
         self.cc = v.ibv_create_comp_channel(context.context)
         if self.cc == NULL:
             raise PyverbsRDMAErrno('Failed to create a completion channel')
@@ -68,8 +69,8 @@ cdef class CQ(PyverbsCM):
     A Completion Queue is the notification mechanism for work request
     completions. A CQ can have 0 or more associated QPs.
     """
-    def __cinit__(self, Context context not None, cqe, cq_context=None,
-                  CompChannel channel=None, comp_vector=0):
+    def __init__(self, Context context not None, cqe, cq_context=None,
+                 CompChannel channel=None, comp_vector=0):
         """
         Initializes a CQ object with the given parameters.
         :param context: The device's context on which to open the CQ
@@ -81,6 +82,7 @@ cdef class CQ(PyverbsCM):
                             context's num_comp_vectors
         :return: The newly created CQ
         """
+        super().__init__()
         if channel is not None:
             self.cq = v.ibv_create_cq(context.context, cqe, <void*>cq_context,
                                       channel.cc, comp_vector)
@@ -173,8 +175,8 @@ cdef class CQ(PyverbsCM):
 
 
 cdef class CqInitAttrEx(PyverbsObject):
-    def __cinit__(self, cqe = 100, CompChannel channel = None, comp_vector = 0,
-                  wc_flags = 0, comp_mask = 0, flags = 0):
+    def __init__(self, cqe = 100, CompChannel channel = None, comp_vector = 0,
+                 wc_flags = 0, comp_mask = 0, flags = 0):
         """
         Initializes a CqInitAttrEx object with the given parameters.
         :param cqe: CQ's capacity
@@ -189,6 +191,7 @@ cdef class CqInitAttrEx(PyverbsObject):
                       ibv_create_cq_attr_flags enum
         :return:
         """
+        super().__init__()
         self.attr.cqe = cqe
         self.attr.cq_context = NULL
         self.attr.channel = NULL if channel is None else channel.cc
@@ -255,8 +258,7 @@ cdef class CqInitAttrEx(PyverbsObject):
 
 
 cdef class CQEX(PyverbsCM):
-    def __cinit__(self, Context context not None, CqInitAttrEx init_attr,
-                  **kwargs):
+    def __init__(self, Context context not None, CqInitAttrEx init_attr):
         """
         Initializes a CQEX object on the given device's context with the given
         attributes.
@@ -264,9 +266,10 @@ cdef class CQEX(PyverbsCM):
         :param init_attr: Initial attributes that describe the CQ
         :return: The newly created CQEX on success
         """
+        super().__init__()
         self.qps = weakref.WeakSet()
         self.srqs = weakref.WeakSet()
-        if len(kwargs) > 0:
+        if self.cq != NULL:
             # Leave CQ initialization to the provider
             return
         if init_attr is None:
@@ -380,9 +383,10 @@ cdef class CQEX(PyverbsCM):
 
 
 cdef class WC(PyverbsObject):
-    def __cinit__(self, wr_id=0, status=0, opcode=0, vendor_err=0, byte_len=0,
-                  qp_num=0, src_qp=0, imm_data=0, wc_flags=0, pkey_index=0,
-                  slid=0, sl=0, dlid_path_bits=0):
+    def __init__(self, wr_id=0, status=0, opcode=0, vendor_err=0, byte_len=0,
+                 qp_num=0, src_qp=0, imm_data=0, wc_flags=0, pkey_index=0,
+                 slid=0, sl=0, dlid_path_bits=0):
+        super().__init__()
         self.wc.wr_id = wr_id
         self.wc.status = status
         self.wc.opcode = opcode

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -4,6 +4,7 @@ import weakref
 
 from pyverbs.pyverbs_error import PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
 cimport pyverbs.libibverbs_enums as e
 from pyverbs.device cimport Context
 from pyverbs.srq cimport SRQ
@@ -35,7 +36,7 @@ cdef class CompChannel(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing completion channel')
-        self.close_weakrefs([self.cqs])
+        close_weakrefs([self.cqs])
         if self.cc != NULL:
             rc = v.ibv_destroy_comp_channel(self.cc)
             if rc != 0:
@@ -108,7 +109,7 @@ cdef class CQ(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing CQ')
-        self.close_weakrefs([self.qps, self.srqs])
+        close_weakrefs([self.qps, self.srqs])
         if self.cq != NULL:
             rc = v.ibv_destroy_cq(self.cq)
             if rc != 0:
@@ -292,7 +293,7 @@ cdef class CQEX(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing CQEx')
-        self.close_weakrefs([self.srqs, self.qps])
+        close_weakrefs([self.srqs, self.qps])
         if self.cq != NULL:
             rc = v.ibv_destroy_cq(<v.ibv_cq*>self.cq)
             if rc != 0:

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -70,7 +70,7 @@ cdef class Context(PyverbsCM):
     """
     Context class represents the C ibv_context.
     """
-    def __cinit__(self, **kwargs):
+    def __init__(self, **kwargs):
         """
         Initializes a Context object. The function searches the IB devices list
         for a device with the name provided by the user. If such a device is
@@ -79,19 +79,22 @@ cdef class Context(PyverbsCM):
         initiated pointer, hence all we have to do is assign this pointer to
         Context's object pointer.
         :param kwargs: Arguments:
-            * *name* (str)
-               The RDMA device's name
-            * *attr* (object)
-               Device-specific attributes, meaning that the device is to be
-               opened by the provider
-            * *cmid* (CMID)
-                A CMID object (represents rdma_cm_id struct)
+            * *name*
+              The device's name
+            * *attr*
+              Provider-specific attributes. If not None, it means that the
+              device will be opened by the provider and __init__ will return
+              after locating the requested device.
+            * *cmid*
+              A CMID object. If not None, it means that the device was already
+              opened by a CMID class, and only a pointer assignment is missing.
         :return: None
         """
         cdef int count
         cdef v.ibv_device **dev_list
         cdef CMID cmid
 
+        super().__init__()
         self.pds = weakref.WeakSet()
         self.dms = weakref.WeakSet()
         self.ccs = weakref.WeakSet()
@@ -99,19 +102,16 @@ cdef class Context(PyverbsCM):
         self.qps = weakref.WeakSet()
         self.xrcds = weakref.WeakSet()
 
-        dev_name = kwargs.get('name')
+        self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
         cmid = kwargs.get('cmid')
-
         if cmid is not None:
             self.context = cmid.id.verbs
             cmid.ctx = self
             return
-        elif dev_name is not None:
-            self.name = dev_name
-        else:
-            raise PyverbsUserError('Device name must be provided')
 
+        if self.name is None:
+            raise PyverbsUserError('Device name must be provided')
         dev_list = v.ibv_get_device_list(&count)
         if dev_list == NULL:
             raise PyverbsRDMAError('Failed to get devices list')
@@ -393,7 +393,8 @@ cdef class DeviceAttr(PyverbsObject):
 
 
 cdef class QueryDeviceExInput(PyverbsObject):
-    def __cinit__(self, comp_mask):
+    def __init__(self, comp_mask):
+        super().__init__()
         self.ex_input.comp_mask = comp_mask
 
 
@@ -583,7 +584,7 @@ cdef class DeviceAttrEx(PyverbsObject):
 
 
 cdef class AllocDmAttr(PyverbsObject):
-    def __cinit__(self, length, log_align_req = 0, comp_mask = 0):
+    def __init__(self, length, log_align_req = 0, comp_mask = 0):
         """
         Creates an AllocDmAttr object with the given parameters. This object
         can than be used to create a DM object.
@@ -592,6 +593,7 @@ cdef class AllocDmAttr(PyverbsObject):
         :param comp_mask: compatibility mask
         :return: An AllocDmAttr object
         """
+        super().__init__()
         self.alloc_dm_attr.length = length
         self.alloc_dm_attr.log_align_req = log_align_req
         self.alloc_dm_attr.comp_mask = comp_mask
@@ -622,13 +624,14 @@ cdef class AllocDmAttr(PyverbsObject):
 
 
 cdef class DM(PyverbsCM):
-    def __cinit__(self, Context context, AllocDmAttr dm_attr not None):
+    def __init__(self, Context context, AllocDmAttr dm_attr not None):
         """
         Allocate a device (direct) memory.
         :param context: The context of the device on which to allocate memory
         :param dm_attr: Attributes that define the DM
         :return: A DM object on success
         """
+        super().__init__()
         self.dm_mrs = weakref.WeakSet()
         device_attr = context.query_device_ex()
         if device_attr.max_dm_size <= 0:

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -12,6 +12,7 @@ from .pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.cq cimport CQEX, CQ, CompChannel
 from .pyverbs_error import PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
 cimport pyverbs.libibverbs_enums as e
 cimport pyverbs.libibverbs as v
 from pyverbs.cmid cimport CMID
@@ -144,8 +145,8 @@ cdef class Context(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing Context')
-        self.close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
-                             self.xrcds])
+        close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
+                        self.xrcds])
         if self.context != NULL:
             rc = v.ibv_close_device(self.context)
             if rc != 0:
@@ -647,7 +648,7 @@ cdef class DM(PyverbsCM):
 
     cpdef close(self):
         self.logger.debug('Closing DM')
-        self.close_weakrefs([self.dm_mrs])
+        close_weakrefs([self.dm_mrs])
         if self.dm != NULL:
             rc = v.ibv_free_dm(self.dm)
             if rc != 0:

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -4,6 +4,7 @@ import weakref
 
 from pyverbs.pyverbs_error import PyverbsUserError, PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
 from pyverbs.device cimport Context
 from libc.stdint cimport uintptr_t
 from pyverbs.cmid cimport CMID
@@ -65,8 +66,8 @@ cdef class PD(PyverbsCM):
         :return: None
         """
         self.logger.debug('Closing PD')
-        self.close_weakrefs([self.parent_domains, self.qps, self.ahs, self.mws,
-                             self.mrs, self.srqs])
+        close_weakrefs([self.parent_domains, self.qps, self.ahs, self.mws,
+                        self.mrs, self.srqs])
         if self.pd != NULL:
             rc = v.ibv_dealloc_pd(self.pd)
             if rc != 0:

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
 
+import logging
+
 from pyverbs.pyverbs_error import PyverbsUserError
 cimport pyverbs.providers.mlx5.mlx5dv_enums as dve
 cimport pyverbs.providers.mlx5.libmlx5 as dv
@@ -16,7 +18,8 @@ cdef class Mlx5DVContextAttr(PyverbsObject):
     Represent mlx5dv_context_attr struct. This class is used to open an mlx5
     device.
     """
-    def __cinit__(self, flags=0, comp_mask=0):
+    def __init__(self, flags=0, comp_mask=0):
+        super().__init__()
         self.attr.flags = flags
         self.attr.comp_mask = comp_mask
 
@@ -44,22 +47,16 @@ cdef class Mlx5Context(Context):
     """
     Represent mlx5 context, which extends Context.
     """
-    def __cinit__(self, **kwargs):
+    def __init__(self, Mlx5DVContextAttr attr not None, name=''):
         """
         Open an mlx5 device using the given attributes
-        :param kwargs: Arguments:
-            * *name* (str)
-               The RDMA device's name (used by parent class)
-            * *attr* (Mlx5DVContextAttr)
-               mlx5-specific device attributes
+        :param name: The RDMA device's name (used by parent class)
+        :param attr: mlx5-specific device attributes
         :return: None
         """
-        cdef Mlx5DVContextAttr attr
-        attr = kwargs.get('attr')
-        if not attr or not isinstance(attr, Mlx5DVContextAttr):
-            raise PyverbsUserError('Missing provider attributes')
         if not dv.mlx5dv_is_supported(self.device):
             raise PyverbsUserError('This is not an MLX5 device')
+        super().__init__(name=name, attr=attr)
         self.context = dv.mlx5dv_open_device(self.device, &attr.attr)
 
     def query_mlx5_device(self, comp_mask=-1):
@@ -187,7 +184,7 @@ cdef class Mlx5DVDCInitAttr(PyverbsObject):
     Represents mlx5dv_dc_init_attr struct, which defines initial attributes
     for DC QP creation.
     """
-    def __cinit__(self, dc_type=dve.MLX5DV_DCTYPE_DCI, dct_access_key=0):
+    def __init__(self, dc_type=dve.MLX5DV_DCTYPE_DCI, dct_access_key=0):
         """
         Initializes an Mlx5DVDCInitAttr object with the given DC type and DCT
         access key.
@@ -195,6 +192,7 @@ cdef class Mlx5DVDCInitAttr(PyverbsObject):
         :param dct_access_key: Access key to be used by the DCT
         :return: An initializes object
         """
+        super().__init__()
         self.attr.dc_type = dc_type
         self.attr.dct_access_key = dct_access_key
 
@@ -223,8 +221,8 @@ cdef class Mlx5DVQPInitAttr(PyverbsObject):
     Represents mlx5dv_qp_init_attr struct, initial attributes used for mlx5 QP
     creation.
     """
-    def __cinit__(self, comp_mask=0, create_flags=0,
-                  Mlx5DVDCInitAttr dc_init_attr=None, send_ops_flags=0):
+    def __init__(self, comp_mask=0, create_flags=0,
+                 Mlx5DVDCInitAttr dc_init_attr=None, send_ops_flags=0):
         """
         Initializes an Mlx5DVQPInitAttr object with the given user data.
         :param comp_mask: A bitmask specifying which fields are valid
@@ -233,6 +231,7 @@ cdef class Mlx5DVQPInitAttr(PyverbsObject):
         :param send_ops_flags: A bitwise OR of mlx5dv_qp_create_send_ops_flags
         :return: An initialized Mlx5DVQPInitAttr object
         """
+        super().__init__()
         self.attr.comp_mask = comp_mask
         self.attr.create_flags = create_flags
         self.attr.send_ops_flags = send_ops_flags
@@ -291,8 +290,8 @@ cdef class Mlx5DVQPInitAttr(PyverbsObject):
 
 
 cdef class Mlx5QP(QP):
-    def __cinit__(self, Mlx5Context context, QPInitAttrEx init_attr,
-                  Mlx5DVQPInitAttr dv_init_attr):
+    def __init__(self, Mlx5Context context, QPInitAttrEx init_attr,
+                 Mlx5DVQPInitAttr dv_init_attr):
         """
         Initializes an mlx5 QP according to the user-provided data.
         :param context: mlx5 Context object
@@ -301,6 +300,11 @@ cdef class Mlx5QP(QP):
         :return: An initialized Mlx5QP
         """
         cdef PD pd
+
+        # Initialize the logger here as the parent's __init__ is called after
+        # the QP is allocated. Allocation can fail, which will lead to exceptions
+        # thrown during object's teardown.
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.dc_type = dv_init_attr.dc_type if dv_init_attr else 0
         if init_attr.pd is not None:
             pd = <PD>init_attr.pd
@@ -314,6 +318,7 @@ cdef class Mlx5QP(QP):
             raise PyverbsRDMAErrno('Failed to create MLX5 QP.\nQPInitAttrEx '
                                    'attributes:\n{}\nMLX5DVQPInitAttr:\n{}'.
                                    format(init_attr, dv_init_attr))
+        super().__init__(context, init_attr)
 
     def _get_comp_mask(self, dst):
         masks = {dve.MLX5DV_DCTYPE_DCT: {'INIT': e.IBV_QP_PKEY_INDEX |
@@ -338,7 +343,7 @@ cdef class Mlx5DVCQInitAttr(PyverbsObject):
     Represents mlx5dv_cq_init_attr struct, initial attributes used for mlx5 CQ
     creation.
     """
-    def __cinit__(self, comp_mask=0, cqe_comp_res_format=0, flags=0, cqe_size=0):
+    def __init__(self, comp_mask=0, cqe_comp_res_format=0, flags=0, cqe_size=0):
         """
         Initializes an Mlx5CQInitAttr object with zeroes as default values.
         :param comp_mask: Marks which of the following fields should be
@@ -353,6 +358,7 @@ cdef class Mlx5DVCQInitAttr(PyverbsObject):
                          Valid when MLX5DV_CQ_INIT_ATTR_MASK_CQE_SIZE is set.
         :return: None
         """
+        super().__init__()
         self.attr.comp_mask = comp_mask
         self.attr.cqe_comp_res_format = cqe_comp_res_format
         self.attr.flags = flags
@@ -413,8 +419,12 @@ cdef class Mlx5DVCQInitAttr(PyverbsObject):
 
 
 cdef class Mlx5CQ(CQEX):
-    def __cinit__(self, Mlx5Context context, CqInitAttrEx init_attr,
-                  Mlx5DVCQInitAttr dv_init_attr):
+    def __init__(self, Mlx5Context context, CqInitAttrEx init_attr,
+                 Mlx5DVCQInitAttr dv_init_attr):
+        # Initialize the logger here as the parent's __init__ is called after
+        # the CQ is allocated. Allocation can fail, which will lead to exceptions
+        # thrown during object's teardown.
+        self.logger = logging.getLogger(self.__class__.__name__)
         self.cq = \
             dv.mlx5dv_create_cq(context.context, &init_attr.attr,
                                 &dv_init_attr.attr if dv_init_attr is not None
@@ -426,6 +436,7 @@ cdef class Mlx5CQ(CQEX):
         self.ibv_cq = v.ibv_cq_ex_to_cq(self.cq)
         self.context = context
         context.add_ref(self)
+        super().__init__(context, init_attr)
 
     def __str__(self):
         print_format = '{:<22}: {:<20}\n'

--- a/pyverbs/srq.pyx
+++ b/pyverbs/srq.pyx
@@ -10,7 +10,8 @@ from libc.string cimport memcpy
 
 
 cdef class SrqAttr(PyverbsObject):
-    def __cinit__(self, max_wr=100, max_sge=1, srq_limit=0):
+    def __init__(self, max_wr=100, max_sge=1, srq_limit=0):
+        super().__init__()
         self.attr.max_wr = max_wr
         self.attr.max_sge = max_sge
         self.attr.srq_limit = srq_limit
@@ -38,11 +39,12 @@ cdef class SrqAttr(PyverbsObject):
 
 
 cdef class SrqInitAttr(PyverbsObject):
-    def __cinit__(self, SrqAttr attr = None):
-         if attr is not None:
-             self.attr.attr.max_wr = attr.max_wr
-             self.attr.attr.max_sge = attr.max_sge
-             self.attr.attr.srq_limit = attr.srq_limit
+    def __init__(self, SrqAttr attr = None):
+        super().__init__()
+        if attr is not None:
+            self.attr.attr.max_wr = attr.max_wr
+            self.attr.attr.max_sge = attr.max_sge
+            self.attr.attr.srq_limit = attr.srq_limit
 
     @property
     def max_wr(self):
@@ -58,7 +60,8 @@ cdef class SrqInitAttr(PyverbsObject):
 
 
 cdef class SrqInitAttrEx(PyverbsObject):
-    def __cinit__(self, max_wr=100, max_sge=1, srq_limit=0):
+    def __init__(self, max_wr=100, max_sge=1, srq_limit=0):
+        super().__init__()
         self.attr.attr.max_wr = max_wr
         self.attr.attr.max_sge = max_sge
         self.attr.attr.srq_limit = srq_limit
@@ -122,7 +125,8 @@ cdef class SrqInitAttrEx(PyverbsObject):
 
 
 cdef class SRQ(PyverbsCM):
-    def __cinit__(self, object creator not None, object attr not None):
+    def __init__(self, object creator not None, object attr not None):
+        super().__init__()
         self.srq = NULL
         self.cq = None
         if isinstance(creator, PD):

--- a/pyverbs/wr.pyx
+++ b/pyverbs/wr.pyx
@@ -17,7 +17,7 @@ cdef class SGE(PyverbsCM):
     write can't be done using memcpy that relies on CPU-specific optimizations.
     A SGE has no way to tell which memory it is using.
     """
-    def __cinit__(self, addr, length, lkey):
+    def __init__(self, addr, length, lkey):
         """
         Initializes a SGE object.
         :param addr: The address to be used for read/write
@@ -25,6 +25,7 @@ cdef class SGE(PyverbsCM):
         :param lkey: Local key of the used MR/DMMR
         :return: A SGE object
         """
+        super().__init__()
         self.sge = <v.ibv_sge*>malloc(sizeof(v.ibv_sge))
         if self.sge == NULL:
             raise PyverbsError('Failed to allocate an SGE')
@@ -80,8 +81,8 @@ cdef class SGE(PyverbsCM):
 
 
 cdef class RecvWR(PyverbsCM):
-    def __cinit__(self, wr_id=0, num_sge=0, sg=None,
-                  RecvWR next_wr=None):
+    def __init__(self, wr_id=0, num_sge=0, sg=None,
+                 RecvWR next_wr=None):
         """
         Initializes a RecvWR object.
         :param wr_id: A user-defined WR ID
@@ -90,6 +91,7 @@ cdef class RecvWR(PyverbsCM):
         :param: next_wr: The next WR in the list
         :return: A RecvWR object
         """
+        super().__init__()
         cdef v.ibv_sge *dst
         if num_sge < 1 or sg is None:
             raise PyverbsUserError('A WR needs at least one SGE')
@@ -141,8 +143,8 @@ cdef class RecvWR(PyverbsCM):
 
 
 cdef class SendWR(PyverbsCM):
-    def __cinit__(self, wr_id=0, opcode=e.IBV_WR_SEND, num_sge=0, sg = None,
-                  send_flags=e.IBV_SEND_SIGNALED, SendWR next_wr = None):
+    def __init__(self, wr_id=0, opcode=e.IBV_WR_SEND, num_sge=0, sg = None,
+                 send_flags=e.IBV_SEND_SIGNALED, SendWR next_wr = None):
         """
         Initialize a SendWR object with user-provided or default values.
         :param wr_id: A user-defined WR ID
@@ -153,6 +155,8 @@ cdef class SendWR(PyverbsCM):
         :return: An initialized SendWR object
         """
         cdef v.ibv_sge *dst
+
+        super().__init__()
         if num_sge < 1 or sg is None:
             raise PyverbsUserError('A WR needs at least one SGE')
         self.send_wr.sg_list = <v.ibv_sge*>malloc(num_sge * sizeof(v.ibv_sge))

--- a/pyverbs/xrcd.pyx
+++ b/pyverbs/xrcd.pyx
@@ -4,6 +4,7 @@ import weakref
 
 from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
 from pyverbs.device cimport Context
 from pyverbs.srq cimport SRQ
 from pyverbs.qp cimport QP
@@ -68,7 +69,7 @@ cdef class XRCD(PyverbsCM):
         :return: None
         """
         self.logger.debug('Closing XRCD')
-        self.close_weakrefs([self.qps, self.srqs])
+        close_weakrefs([self.qps, self.srqs])
         # XRCD may be deleted directly or indirectly by closing its context,
         # which leaves the Python XRCD object without the underlying C object,
         # so during destruction, need to check whether or not the C object

--- a/pyverbs/xrcd.pyx
+++ b/pyverbs/xrcd.pyx
@@ -12,7 +12,8 @@ from libc.errno cimport errno
 
 
 cdef class XRCDInitAttr(PyverbsObject):
-    def __cinit__(self, comp_mask, oflags, fd):
+    def __init__(self, comp_mask, oflags, fd):
+        super().__init__()
         self.attr.fd = fd
         self.attr.comp_mask = comp_mask
         self.attr.oflags = oflags
@@ -40,12 +41,13 @@ cdef class XRCDInitAttr(PyverbsObject):
 
 
 cdef class XRCD(PyverbsCM):
-    def __cinit__(self, Context context not None, XRCDInitAttr init_attr not None):
+    def __init__(self, Context context not None, XRCDInitAttr init_attr not None):
         """
         Initializes a XRCD object.
         :param context: The Context object creating the XRCD
         :return: The newly created XRCD on success
         """
+        super().__init__()
         self.xrcd = v.ibv_open_xrcd(<v.ibv_context*> context.context,
                                     &init_attr.attr)
         if self.xrcd == NULL:

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -45,20 +45,6 @@ class MRTest(PyverbsAPITestCase):
                     with MR(pd, u.get_mr_length(), f) as mr:
                         mr.close()
 
-    @staticmethod
-    def test_reg_mr_bad_flow():
-        """
-        Verify that trying to register a MR with None PD fails
-        """
-        try:
-            # Use the simplest access flags necessary
-            MR(None, random.randint(0, 10000), e.IBV_ACCESS_LOCAL_WRITE)
-        except TypeError as te:
-            assert 'expected pyverbs.pd.PD' in te.args[0]
-            assert 'got NoneType' in te.args[0]
-        else:
-            raise PyverbsRDMAErrno('Created a MR with None PD')
-
     def test_dereg_mr_twice(self):
         """
         Verify that explicit call to MR's close() doesn't fail

--- a/tests/test_pd.py
+++ b/tests/test_pd.py
@@ -40,18 +40,6 @@ class PDTest(PyverbsAPITestCase):
                 with PD(ctx) as pd:
                     pd.close()
 
-    @staticmethod
-    def test_create_pd_none_ctx():
-        """
-        Verify that PD can't be created with a None context
-        """
-        try:
-            PD(None)
-        except TypeError as te:
-            assert 'must not be None' in te.args[0]
-        else:
-            raise PyverbsRDMAErrno('Created a PD with None context')
-
     def test_destroy_pd_twice(self):
         """
         Test bad flow cases in destruction of a PD object

--- a/tests/test_qp.py
+++ b/tests/test_qp.py
@@ -154,8 +154,6 @@ class QPTest(PyverbsAPITestCase):
             with PD(ctx) as pd:
                 with CQ(ctx, 100, None, None, 0) as cq:
                     for i in range(1, attr.phys_port_cnt + 1):
-                        qpts = [e.IBV_QPT_UD, e.IBV_QPT_RAW_PACKET] \
-                            if is_eth(ctx, i) else [e.IBV_QPT_UD]
                         qia = get_qp_init_attr_ex(cq, pd, attr, attr_ex,
                                                   e.IBV_QPT_UD)
                         with QP(ctx, qia, QPAttr()) as qp:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -227,6 +227,9 @@ def random_qp_init_attr_ex(attr_ex, attr, qpt=None):
                 random.randint(16, int(attr_ex.tso_caps.max_tso / 400))
     qia = QPInitAttrEx(qp_type=qpt, cap=qp_cap, sq_sig_all=sig, comp_mask=mask,
                        create_flags=cflags, max_tso_header=max_tso)
+    if mask & e.IBV_QP_INIT_ATTR_MAX_TSO_HEADER:
+        # TSO increases send WQE size, let's be on the safe side
+        qia.cap.max_send_sge = 2
     return qia
 
 


### PR DESCRIPTION
The following series refactors pyverbs' objects creation process and
cleans up some redundant tests:
The first patch removes its close_weakrefs() out of the base objects,
as it doesn't use 'self' and is called during teardown, when the
object might not be fully valid.

The second patch switches pyverbs to use Python's init method rather
thab Cython's cinit method, during which the Python object is not yet
valid. Calling rdma-core's objects creation methods can be done in
init just as well.

The last patch removes some unneeded tests and adapts QP creation
tests to consider TSO existance when setting QP caps.
