### PR TITLE
tests: Fix exception when running the tests from the tests directory

### DIFF
--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -7,6 +7,6 @@ import os
 from importlib.machinery import SourceFileLoader
 
 
-module_path = os.path.dirname(__file__) + '/__init__.py'
+module_path = os.path.join(os.path.dirname(__file__), '__init__.py')
 tests = SourceFileLoader('tests', module_path).load_module()
 unittest.main(module=tests)


### PR DESCRIPTION
Avoid the following failure when running the tests from the tests
directory.

[root@rdma-dev-25 tests]$ python3 run_tests.py -v
Traceback (most recent call last):
  File "run_tests.py", line 11, in <module>
    tests = SourceFileLoader('tests', module_path).load_module()
  File "<frozen importlib._bootstrap_external>", line 407, in _check_name_wrapper
  File "<frozen importlib._bootstrap_external>", line 907, in load_module
  File "<frozen importlib._bootstrap_external>", line 732, in load_module
  File "<frozen importlib._bootstrap>", line 265, in _load_module_shim
  File "<frozen importlib._bootstrap>", line 696, in _load
  File "<frozen importlib._bootstrap>", line 677, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 724, in exec_module
  File "<frozen importlib._bootstrap_external>", line 859, in get_code
  File "<frozen importlib._bootstrap_external>", line 916, in get_data
FileNotFoundError: [Errno 2] No such file or directory: '/__init__.py

Fixes: d6c1c23355e6 ("tests: Fix test locating process")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>