### PR TITLE
mlx5: SW steering improvements

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -19,6 +19,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.9@MLX5_1.9 23
  MLX5_1.10@MLX5_1.10 24
  MLX5_1.11@MLX5_1.11 25
+ MLX5_1.12@MLX5_1.12 28
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -86,6 +87,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_get_event@MLX5_1.11 25
  mlx5dv_devx_subscribe_devx_event@MLX5_1.11 25
  mlx5dv_devx_subscribe_devx_event_fd@MLX5_1.11 25
+ mlx5dv_dr_action_create_flow_meter@MLX5_1.12 28
+ mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.11.${PACKAGE_VERSION}
+  1 1.12.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -64,6 +64,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -73,6 +74,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
@@ -80,6 +82,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -87,6 +90,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -100,6 +104,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -107,10 +112,12 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 		},
@@ -118,6 +125,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -131,6 +139,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -139,18 +148,21 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -166,6 +178,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -173,11 +186,13 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -187,6 +202,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -616,6 +632,20 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			}
 			attr.reformat_size = action->reformat.reformat_size;
 			attr.reformat_id = action->reformat.dvo->object_id;
+			break;
+		case DR_ACTION_TYP_METER:
+			if (action->meter.next_ft->dmn != dmn) {
+				dr_dbg(dmn, "Next table belongs to a different domain\n");
+				goto out_invalid_arg;
+			}
+			if (action->meter.next_ft->level <=
+			    matcher->tbl->level) {
+				dr_dbg(dmn, "Next table level should he higher than source table\n");
+				goto out_invalid_arg;
+			}
+			attr.final_icm_addr = rx_rule ?
+				action->meter.rx_icm_addr :
+				action->meter.tx_icm_addr;
 			break;
 		case DR_ACTION_TYP_VPORT:
 			if (action->vport.dmn != dmn) {
@@ -1491,6 +1521,69 @@ dec_ref:
 	return NULL;
 }
 
+int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
+				       struct mlx5dv_dr_flow_meter_attr *attr,
+				       __be64 modify_field_select)
+{
+	int ret;
+
+	if (action->action_type != DR_ACTION_TYP_METER) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	ret = dr_devx_modify_meter(action->meter.devx_obj, attr,
+				   modify_field_select);
+	return ret;
+}
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_flow_meter(struct mlx5dv_dr_flow_meter_attr *attr)
+{
+	struct mlx5dv_dr_domain *dmn = attr->next_table->dmn;
+	uint64_t rx_icm_addr, tx_icm_addr;
+	struct mlx5dv_devx_obj *devx_obj;
+	struct mlx5dv_dr_action *action;
+	int ret;
+
+	if (!dmn->info.supp_sw_steering) {
+		dr_dbg(dmn, "Meter action is not supported on current domain\n");
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	if (dr_is_root_table(attr->next_table)) {
+		dr_dbg(dmn, "Next table cannot be root\n");
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	devx_obj = dr_devx_create_meter(dmn->ctx, attr);
+	if (!devx_obj)
+		return NULL;
+
+	ret = dr_devx_query_meter(devx_obj, &rx_icm_addr, &tx_icm_addr);
+	if (ret)
+		goto destroy_obj;
+
+	action = dr_action_create_generic(DR_ACTION_TYP_METER);
+	if (!action)
+		goto destroy_obj;
+
+	action->meter.devx_obj = devx_obj;
+	action->meter.next_ft = attr->next_table;
+	action->meter.rx_icm_addr = rx_icm_addr;
+	action->meter.tx_icm_addr = tx_icm_addr;
+
+	atomic_fetch_add(&attr->next_table->refcount, 1);
+
+	return action;
+
+destroy_obj:
+	mlx5dv_devx_obj_destroy(devx_obj);
+	return NULL;
+}
+
 struct mlx5dv_dr_action
 *mlx5dv_dr_action_create_dest_vport(struct mlx5dv_dr_domain *dmn, uint32_t vport)
 {
@@ -1558,6 +1651,10 @@ int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action)
 			free(action->rewrite.data);
 		}
 		atomic_fetch_sub(&action->rewrite.dmn->refcount, 1);
+		break;
+	case DR_ACTION_TYP_METER:
+		mlx5dv_devx_obj_destroy(action->meter.devx_obj);
+		atomic_fetch_sub(&action->meter.next_ft->refcount, 1);
 		break;
 	default:
 		break;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -233,19 +233,13 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 		dmn->info.tx.ste_type = DR_STE_TYPE_TX;
 		vport_cap = dr_get_vport_cap(&dmn->info.caps, 0);
 		if (!vport_cap) {
-			dr_dbg(dmn, "Failed to get vport 0 caps\n");
-			return errno;
-		}
-
-		dmn->info.rx.default_icm_addr = vport_cap->icm_address_rx;
-		vport_cap = dr_get_vport_cap(&dmn->info.caps, WIRE_PORT);
-		if (!vport_cap) {
-			dr_dbg(dmn, "Failed to get vport WIRE caps\n");
+			dr_dbg(dmn, "Failed to get eswitch manager vport\n");
 			return errno;
 		}
 
 		dmn->info.supp_sw_steering = true;
 		dmn->info.tx.default_icm_addr = vport_cap->icm_address_tx;
+		dmn->info.rx.default_icm_addr = vport_cap->icm_address_rx;
 		dmn->info.rx.drop_icm_addr = dmn->info.caps.esw_rx_drop_address;
 		dmn->info.tx.drop_icm_addr = dmn->info.caps.esw_tx_drop_address;
 		break;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -115,3 +115,9 @@ MLX5_1.11 {
 		mlx5dv_devx_subscribe_devx_event;
 		mlx5dv_devx_subscribe_devx_event_fd;
 } MLX5_1.10;
+
+MLX5_1.12 {
+	global:
+		mlx5dv_dr_action_create_flow_meter;
+		mlx5dv_dr_action_modify_flow_meter;
+} MLX5_1.11;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -54,10 +54,12 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_vport.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_flow_counter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_drop.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_flow_meter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_modify_header.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_packet_reformat.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_tag.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_sync.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -30,6 +30,8 @@ mlx5dv_dr_action_create_modify_header - Create modify header actions
 
 mlx5dv_dr_action_create_flow_counter - Create devx flow counter actions
 
+mlx5dv_dr_action_create_flow_meter, mlx5dv_dr_action_modify_flow_meter - Create and modify meter action
+
 mlx5dv_dr_action_destroy - Destroy actions
 
 # SYNOPSIS
@@ -99,6 +101,13 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_modify_header(
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_flow_counter(
 		struct mlx5dv_devx_obj *devx_obj,
 		uint32_t offset);
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_flow_meter(struct mlx5dv_dr_flow_meter_attr *attr);
+
+int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
+				       struct mlx5dv_dr_flow_meter_attr *attr,
+				       __be64 modify_field_select);
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 ```
@@ -173,6 +182,10 @@ Action: Modify Header
 
 Action: Flow Count
 *mlx5dv_dr_action_create_flow_counter* creates a flow counter action from a DEVX flow counter object, based on **devx_obj** and specific counter index from **offset** in the counter bulk.
+
+Action: Meter
+*mlx5dv_dr_action_create_flow_meter* creates a meter action based on the flow meter parameters. The paramertes are according to the device specification.
+*mlx5dv_dr_action_modify_flow_meter* modifies existing flow meter **action** based on **modify_field_select**. **modify_field_select** is according to the device specification.
 
 Action Flags: action **flags** can be set to one of the types of *enum mlx5dv_dr_action_flags*:
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1820,6 +1820,38 @@ struct mlx5_ifc_general_obj_out_cmd_hdr_bits {
 	u8         reserved_at_60[0x20];
 };
 
+struct mlx5_ifc_flow_meter_bits {
+	u8         modify_field_select[0x40];
+
+	u8         active[0x1];
+	u8         reserved_at_41[0x3];
+	u8         return_reg_id[0x4];
+	u8         table_type[0x8];
+	u8         reserved_at_50[0x10];
+
+	u8         reserved_at_60[0x8];
+	u8         destination_table_id[0x18];
+
+	u8         reserved_at_80[0x80];
+
+	u8         flow_meter_params[0x100];
+
+	u8         reserved_at_180[0x180];
+
+	u8         sw_steering_icm_address_rx[0x40];
+	u8         sw_steering_icm_address_tx[0x40];
+};
+
+struct mlx5_ifc_create_flow_meter_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits   hdr;
+	struct mlx5_ifc_flow_meter_bits               meter;
+};
+
+struct mlx5_ifc_query_flow_meter_out_bits {
+	struct mlx5_ifc_general_obj_out_cmd_hdr_bits   hdr;
+	struct mlx5_ifc_flow_meter_bits                obj;
+};
+
 struct mlx5_ifc_esw_vport_context_bits {
 	u8         reserved_at_0[0x3];
 	u8         vport_svlan_strip[0x1];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1497,6 +1497,13 @@ mlx5dv_dr_action_create_modify_header(struct mlx5dv_dr_domain *domain,
 				      size_t actions_sz,
 				      __be64 actions[]);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_flow_meter(struct mlx5dv_dr_flow_meter_attr *attr);
+
+int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
+				       struct mlx5dv_dr_flow_meter_attr *attr,
+				       __be64 modify_field_select);
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 #ifdef __cplusplus
 }

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1426,6 +1426,14 @@ enum mlx5dv_dr_domain_sync_flags {
 	MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW		= 1 << 1,
 };
 
+struct mlx5dv_dr_flow_meter_attr {
+	struct mlx5dv_dr_table  *next_table;
+	uint8_t                 active;
+	uint8_t                 reg_c_index;
+	size_t			flow_meter_parameter_sz;
+	__be64			flow_meter_parameter[];
+};
+
 struct mlx5dv_dr_domain *
 mlx5dv_dr_domain_create(struct ibv_context *ctx,
 			enum mlx5dv_dr_domain_type type);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -838,6 +838,14 @@ struct mlx5dv_devx_obj *dr_devx_create_reformat_ctx(struct ibv_context *ctx,
 						    enum reformat_type rt,
 						    size_t reformat_size,
 						    void *reformat_data);
+struct mlx5dv_devx_obj
+*dr_devx_create_meter(struct ibv_context *ctx,
+		      struct mlx5dv_dr_flow_meter_attr *attr);
+int dr_devx_query_meter(struct mlx5dv_devx_obj *obj, uint64_t *rx_icm_addr,
+			uint64_t *tx_icm_addr);
+int dr_devx_modify_meter(struct mlx5dv_devx_obj *obj,
+			 struct mlx5dv_dr_flow_meter_attr *attr,
+			 __be64 modify_bits);
 struct mlx5dv_devx_obj *dr_devx_create_cq(struct ibv_context *ctx,
 					  uint32_t page_id,
 					  uint32_t buff_umem_id,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -180,6 +180,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_TAG,
 	DR_ACTION_TYP_MODIFY_HDR,
 	DR_ACTION_TYP_VPORT,
+	DR_ACTION_TYP_METER,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -709,6 +710,12 @@ struct mlx5dv_dr_action {
 				};
 			};
 		} reformat;
+		struct {
+			struct mlx5dv_dr_table	*next_ft;
+			struct mlx5dv_devx_obj	*devx_obj;
+			uint64_t		rx_icm_addr;
+			uint64_t		tx_icm_addr;
+		} meter;
 		struct mlx5dv_dr_table	*dest_tbl;
 		struct {
 			struct mlx5dv_devx_obj	*devx_obj;


### PR DESCRIPTION
In switchdev mode, all unmatched traffic in FDB flow table should go to the eswitch manager, the first patch from the series makes this to work as expected.

The next two patches introduce some extra DV APIs to expose the device metering functionality to applications.