### PR TITLE
tests: Add a timeout mechanism

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,7 +2,20 @@
 # Copyright (c) 2019 Mellanox Technologies, Inc . All rights reserved. See COPYING file
 
 import importlib
+import signal
 import os
+
+from pyverbs.pyverbs_error import PyverbsError
+
+
+# Handler for timeouts to be used by the test methods
+def sig_handler(signum, frame):
+    raise PyverbsError('Timeout expired')
+
+
+# Register the above handler to catch SIGALRM
+signal.signal(signal.SIGALRM, sig_handler)
+
 
 # Load every test as a module in the system so that unittest's loader can find it
 def _load_tests():

--- a/tests/test_cqex.py
+++ b/tests/test_cqex.py
@@ -60,16 +60,19 @@ class CqExTestCase(RDMATestCase):
             server.pre_run(client.psn, client.qpn)
         return client, server
 
+    @u.timeout_decorator
     def test_ud_traffic_cq_ex(self):
         client, server = self.create_players('ud')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
                   is_cq_ex=True)
 
+    @u.timeout_decorator
     def test_rc_traffic_cq_ex(self):
         client, server = self.create_players('rc')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
                   is_cq_ex=True)
 
+    @u.timeout_decorator
     def test_xrc_traffic_cq_ex(self):
         client, server = self.create_players('xrc')
         u.xrc_traffic(client, server, is_cq_ex=True)

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -1,5 +1,5 @@
+from tests.utils import requires_odp, traffic, xrc_traffic, timeout_decorator
 from tests.base import RCResources, UDResources, XRCResources
-from tests.utils import requires_odp, traffic, xrc_traffic
 from tests.base import RDMATestCase
 from pyverbs.mr import MR
 import pyverbs.enums as e
@@ -44,14 +44,17 @@ class OdpTestCase(RDMATestCase):
             server.pre_run(client.psn, client.qpn)
         return client, server
 
+    @timeout_decorator
     def test_odp_rc_traffic(self):
         client, server = self.create_players('rc')
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
+    @timeout_decorator
     def test_odp_ud_traffic(self):
         client, server = self.create_players('ud')
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
+    @timeout_decorator
     def test_odp_xrc_traffic(self):
         client, server = self.create_players('xrc')
         xrc_traffic(client, server)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,6 +7,7 @@ from itertools import combinations as com
 from string import ascii_lowercase as al
 import unittest
 import random
+import signal
 
 from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
 from pyverbs.addr import AHAttr, AH, GlobalRoute
@@ -479,6 +480,22 @@ def requires_odp(qp_type):
             return func(instance)
         return inner
     return outer
+
+
+# Decorator for test methods to apply a 3 seconds timeout
+def timeout_decorator(func):
+    """
+    Calls the test method func after setting an alarm signal to fire in 3
+    seconds. Pyverbs tests take significantly less time to run, so if the
+    timeout expires we assume the test hung and fail it.
+    If the test method finishes before the timeout expires, the alarm is
+    cancelled.
+    """
+    def func_wrapper(func_self):
+        signal.alarm(3)
+        func(func_self)
+        signal.alarm(0)
+    return func_wrapper
 
 
 def odp_supported(ctx, qp_type):


### PR DESCRIPTION
Some tests, especially those involving traffic, might hang sometimes
due to dropped packets, bugs etc. During execution of run_tests.py,
such issues stuck the run indefinitely.
Python's unittest framework does not provide a builtin timeout
mechanism, but the signal module can be used to achieve such behavior.

Register a handler for SIGALRM that simply raises a PyverbsError if
it expires (the rest of the tests will continue to run as usual).
Provide a decorator to wrap a test method call with a setting of a
timer (3 seconds, as this is more than enough time for our tests).
Decorate traffic methods with the above decorator.

An execution with an expired timeout will look as follows:

$ python3 /usr/share/doc/rdma-core-28.0/tests/run_tests.py --verbose -k
test_cqex
test_rc_traffic_cq_ex (tests.test_cqex.CqExTestCase) ... ok
test_ud_traffic_cq_ex (tests.test_cqex.CqExTestCase) ... ERROR
test_xrc_traffic_cq_ex (tests.test_cqex.CqExTestCase) ... ok

======================================================================
ERROR: test_ud_traffic_cq_ex (tests.test_cqex.CqExTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/share/doc/rdma-core-28.0/tests/utils.py", line 46, in func_wrapper
    func(func_self)
  File "/usr/share/doc/rdma-core-28.0/tests/test_cqex.py", line 69, in test_ud_traffic_cq_ex
    is_cq_ex=True)
  File "/usr/share/doc/rdma-core-28.0/tests/utils.py", line 439, in traffic
    poll(server.cq)
  File "/usr/share/doc/rdma-core-28.0/tests/utils.py", line 373, in poll_cq_ex
    ret = cqex.start_poll(poll_attr)
  File "/usr/share/doc/rdma-core-28.0/tests/utils.py", line 37, in sig_handler
    raise PyverbsError('Timeout expired')
pyverbs.pyverbs_error.PyverbsError: Timeout expired

----------------------------------------------------------------------
Ran 3 tests in 3.149s

FAILED (errors=1)

Signed-off-by: Noa Osherovich <noaos@mellanox.com>
Reviewed-by: Edward Srouji <edwards@mellanox.com>