### PR TITLE
srp_daemon: Move man page from section 1 to section 8

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -234,7 +234,7 @@ Copyright: 2005, Topspin Communications.
            2006, Mellanox Technologies Ltd.
 License: BSD-MIT or GPL-2
 
-Files: srp_daemon/srp_daemon.1.in
+Files: srp_daemon/srp_daemon.8.in
 Copyright: 2006 Mellanox Technologies.
 License: CPL-1.0 or BSD-2-clause or GPL-2
 

--- a/debian/srptools.install
+++ b/debian/srptools.install
@@ -8,6 +8,6 @@ usr/sbin/ibsrpdm
 usr/sbin/srp_daemon
 usr/share/doc/rdma-core/ibsrpdm.md usr/share/doc/srptools/
 usr/share/man/man1/ibsrpdm.1
-usr/share/man/man1/srp_daemon.1
 usr/share/man/man5/srp_daemon.service.5
 usr/share/man/man5/srp_daemon_port@.service.5
+usr/share/man/man8/srp_daemon.8

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -640,9 +640,9 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %{_sbindir}/run_srp_daemon
 %{_udevrulesdir}/60-srp_daemon.rules
 %{_mandir}/man1/ibsrpdm.1*
-%{_mandir}/man1/srp_daemon.1*
 %{_mandir}/man5/srp_daemon.service.5*
 %{_mandir}/man5/srp_daemon_port@.service.5*
+%{_mandir}/man8/srp_daemon.8*
 %doc %{_docdir}/%{name}-%{version}/ibsrpdm.md
 
 %if %{with_pyverbs}

--- a/srp_daemon/CMakeLists.txt
+++ b/srp_daemon/CMakeLists.txt
@@ -2,7 +2,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${NO_STRICT_ALIASING_FLAGS}")
 
 rdma_man_pages(
   ibsrpdm.1
-  srp_daemon.1.in
+  srp_daemon.8.in
   srp_daemon.service.5
   srp_daemon_port@.service.5
   )

--- a/srp_daemon/ibsrpdm.1
+++ b/srp_daemon/ibsrpdm.1
@@ -1,5 +1,5 @@
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
-.TH IBSRPDM 1 "August 30, 2005" "OpenFabrics" "USER COMMANDS"
+.TH IBSRPDM 8 "August 30, 2005" "OpenFabrics" "USER COMMANDS"
 
 .SH NAME
 ibsrpdm \- Discover SRP targets on an InfiniBand Fabric

--- a/srp_daemon/srp_daemon.8.in
+++ b/srp_daemon/srp_daemon.8.in
@@ -1,5 +1,5 @@
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
-.TH SRP_DAEMON 1 "September 5, 2006" "OpenFabrics" "USER COMMANDS"
+.TH SRP_DAEMON 8 "September 5, 2006" "OpenFabrics" "USER COMMANDS"
 
 .SH NAME
 srp_daemon \- Discovers SRP targets in an InfiniBand Fabric

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -842,9 +842,9 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %{_sbindir}/run_srp_daemon
 %{_sbindir}/rcsrp_daemon
 %{_mandir}/man1/ibsrpdm.1*
-%{_mandir}/man1/srp_daemon.1*
 %{_mandir}/man5/srp_daemon.service.5*
 %{_mandir}/man5/srp_daemon_port@.service.5*
+%{_mandir}/man8/srp_daemon.8*
 %doc %{_docdir}/%{name}-%{version}/ibsrpdm.md
 
 %files -n rdma-ndd


### PR DESCRIPTION
A quote from Benjamin Drung: "The command in /sbin or /usr/sbin are
system administration commands; their manpages thus belong in section
8, not section 1."

Cc: Benjamin Drung <benjamin.drung@cloud.ionos.com>
Signed-off-by: Bart Van Assche <bvanassche@acm.org>