### PR TITLE
vmw_pvrdma: Use QP handle when attempting to flush CQEs

### DIFF
--- a/providers/vmw_pvrdma/cq.c
+++ b/providers/vmw_pvrdma/cq.c
@@ -157,7 +157,7 @@ int pvrdma_poll_cq(struct ibv_cq *ibcq, int num_entries, struct ibv_wc *wc)
 	return npolled;
 }
 
-void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qpn)
+void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qp_handle)
 {
 	/* Flush CQEs from specified QP */
 	int has_data;
@@ -185,7 +185,7 @@ void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qpn)
 				tail = cq->cqe_cnt - 1;
 			curr_cqe = get_cqe(cq, curr);
 			udma_from_device_barrier();
-			if ((curr_cqe->qp & 0xFFFF) != qpn) {
+			if ((curr_cqe->qp & 0xFFFF) != qp_handle) {
 				if (curr != tail) {
 					cqe = get_cqe(cq, tail);
 					udma_from_device_barrier();
@@ -202,10 +202,10 @@ void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qpn)
 	}
 }
 
-void pvrdma_cq_clean(struct pvrdma_cq *cq, uint32_t qpn)
+void pvrdma_cq_clean(struct pvrdma_cq *cq, uint32_t qp_handle)
 {
 	pthread_spin_lock(&cq->lock);
-	pvrdma_cq_clean_int(cq, qpn);
+	pvrdma_cq_clean_int(cq, qp_handle);
 	pthread_spin_unlock(&cq->lock);
 }
 

--- a/providers/vmw_pvrdma/pvrdma.h
+++ b/providers/vmw_pvrdma/pvrdma.h
@@ -295,8 +295,8 @@ int pvrdma_destroy_cq(struct ibv_cq *cq);
 int pvrdma_req_notify_cq(struct ibv_cq *cq, int solicited);
 int pvrdma_poll_cq(struct ibv_cq *cq, int ne, struct ibv_wc *wc);
 void pvrdma_cq_event(struct ibv_cq *cq);
-void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qpn);
-void pvrdma_cq_clean(struct pvrdma_cq *cq, uint32_t qpn);
+void pvrdma_cq_clean_int(struct pvrdma_cq *cq, uint32_t qp_handle);
+void pvrdma_cq_clean(struct pvrdma_cq *cq, uint32_t qp_handle);
 int pvrdma_get_outstanding_cqes(struct pvrdma_cq *cq);
 void pvrdma_cq_resize_copy_cqes(struct pvrdma_cq *cq, void *buf,
 				int new_cqe);


### PR DESCRIPTION
After the change to distinguish QP numbers and QP handles, the
cqe->qp field contains the QP handle so as to make lookup for
QPs simple. Flushing CQEs upon destroy of QP needs to be done
by comparing the cqe->qp field with the QP handle, not the QP
number. This change fixes this issue.

Fixes: 3dbaeba640d7  ("vmw_pvrdma: Use resource ids from physical device
if available")
Reviewed-by: Jorgen Hansen <jhansen@vmware.com>
Reviewed-by: Rajesh Jalisatgi <rjalisatgi@vmware.com>
Signed-off-by: Bryan Tan <bryantan@vmware.com>