### PR TITLE
mlx5: Add ConnectX-7 to the list of supported devices

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -78,6 +78,7 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x101c),	/* ConnectX-6 VF */
 	HCA(MELLANOX, 0x101d),	/* ConnectX-6 DX */
 	HCA(MELLANOX, 0x101e),	/* ConnectX family mlx5Gen Virtual Function */
+	HCA(MELLANOX, 0x1021),  /* ConnectX-7 */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
 	HCA(MELLANOX, 0xa2d6),  /* BlueField-2 integrated ConnectX-6 Dx network controller */


### PR DESCRIPTION
Update list of supported PCI devices with Mellanox ConnectX-7 network controller.