### PR TITLE
verbs: Expose IBV_ACCESS_HUGETLB access flag

### DIFF
--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -43,6 +43,8 @@ describes the desired memory protection attributes; it is either 0 or the bitwis
 .B IBV_ACCESS_ZERO_BASED\fR    Use byte offset from beginning of MR to access this MR, instead of a pointer address
 .TP
 .B IBV_ACCESS_ON_DEMAND\fR    Create an on-demand paging MR
+.TP
+.B IBV_ACCESS_HUGETLB\fR      Huge pages are guaranteed to be used for this MR, applicable with IBV_ACCESS_ON_DEMAND in explicit mode only
 .PP
 If
 .B IBV_ACCESS_REMOTE_WRITE
@@ -55,6 +57,10 @@ must be set too.
 Local read access is always enabled for the MR.
 .PP
 To create an implicit ODP MR, IBV_ACCESS_ON_DEMAND should be set, addr should be 0 and length should be SIZE_MAX.
+.PP
+If
+.B IBV_ACCESS_HUGETLB
+is set, then application awares that for this MR all pages are huge and must promise it will never do anything to break huge pages.
 .PP
 .B ibv_reg_mr_iova()
 ibv_reg_mr_iova is the same as the normal reg_mr, except that the user is

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -580,6 +580,7 @@ enum ibv_access_flags {
 	IBV_ACCESS_MW_BIND		= (1<<4),
 	IBV_ACCESS_ZERO_BASED		= (1<<5),
 	IBV_ACCESS_ON_DEMAND		= (1<<6),
+	IBV_ACCESS_HUGETLB		= (1<<7),
 };
 
 struct ibv_mw_bind_info {

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -111,6 +111,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_ACCESS_MW_BIND
         IBV_ACCESS_ZERO_BASED
         IBV_ACCESS_ON_DEMAND
+        IBV_ACCESS_HUGETLB
 
     cpdef enum ibv_wr_opcode:
         IBV_WR_RDMA_WRITE

--- a/pyverbs/mem_alloc.pyx
+++ b/pyverbs/mem_alloc.pyx
@@ -5,7 +5,43 @@
 
 from posix.stdlib cimport posix_memalign as c_posix_memalign
 from libc.stdlib cimport malloc as c_malloc, free as c_free
+from posix.mman cimport mmap as c_mmap, munmap as c_munmap
 from libc.stdint cimport uintptr_t
+cimport posix.mman as mm
+
+cdef extern from 'sys/mman.h':
+    cdef void* MAP_FAILED
+
+
+def mmap(addr=0, length=100, prot=mm.PROT_READ | mm.PROT_WRITE,
+         flags=mm.MAP_PRIVATE | mm.MAP_ANONYMOUS, fd=0, offset=0):
+    """
+    Python wrapper for sys mmap function
+    :param addr: Address to mmap the memory
+    :param length: The length of the requested memory in bytes
+    :param prot: Indicate the protection of this memory
+    :param flags: Specify speicific flags to this memory
+    :param fd: File descriptor to mmap specific file
+    :param offset: Offset to use when mmap
+    :return: The address to the mapped memory
+    """
+    # uintptr_t is guaranteed to be large enough to hold any pointer.
+    # In order to safely cast addr to void*, it is firstly cast to uintptr_t.
+    ptr = c_mmap(<void*><uintptr_t>addr, length, prot, flags, fd, offset)
+    if <void *>ptr == MAP_FAILED:
+        raise MemoryError('Failed to mmap memory')
+    return <uintptr_t> ptr
+
+
+def munmap(addr, length):
+    """
+    Python wrapper for sys munmap function
+    :param addr: The address of the mapped memory to unmap
+    :param length: The length of this mapped memory
+    """
+    ret = c_munmap(<void*><uintptr_t>addr, length)
+    if ret:
+        raise MemoryError('Failed to munmap requested memory')
 
 
 def malloc(size):
@@ -41,3 +77,22 @@ def free(ptr):
     :param ptr: The address of a previously allocated memory block
     """
     c_free(<void*><uintptr_t>ptr)
+
+
+# protection bits for mmap/mprotect
+PROT_EXEC_ = mm.PROT_EXEC
+PROT_READ_ = mm.PROT_READ
+PROT_WRITE_ = mm.PROT_WRITE
+PROT_NONE_ = mm.PROT_NONE
+
+# flag bits for mmap
+MAP_PRIVATE_ = mm.MAP_PRIVATE
+MAP_SHARED_ = mm.MAP_SHARED
+MAP_FIXED_ = mm.MAP_FIXED
+MAP_ANONYMOUS_ = mm.MAP_ANONYMOUS
+MAP_STACK_ = mm.MAP_STACK
+MAP_LOCKED_ = mm.MAP_LOCKED
+MAP_HUGETLB_ = mm.MAP_HUGETLB
+MAP_POPULATE_ = mm.MAP_POPULATE
+MAP_NORESERVE_ = mm.MAP_NORESERVE
+MAP_GROWSDOWN_ = mm.MAP_GROWSDOWN

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -12,6 +12,7 @@ cdef class MR(PyverbsCM):
     cdef v.ibv_mr *mr
     cdef int mmap_length
     cdef object is_huge
+    cdef object is_user_addr
     cdef void *buf
     cpdef read(self, length, offset)
 

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -10,6 +10,8 @@ from . cimport libibverbs as v
 cdef class MR(PyverbsCM):
     cdef object pd
     cdef v.ibv_mr *mr
+    cdef int mmap_length
+    cdef object is_huge
     cdef void *buf
     cpdef read(self, length, offset)
 

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -1,8 +1,13 @@
+from pyverbs.mem_alloc import mmap, munmap, MAP_ANONYMOUS_, MAP_PRIVATE_, \
+    MAP_HUGETLB_, MAP_FIXED_
+from tests.utils import requires_odp, requires_huge_pages, traffic, xrc_traffic
 from tests.base import RCResources, UDResources, XRCResources
-from tests.utils import requires_odp, traffic, xrc_traffic
 from tests.base import RDMATestCase
 from pyverbs.mr import MR
 import pyverbs.enums as e
+
+
+HUGE_PAGE_SIZE = 0x200000
 
 
 class OdpUD(UDResources):
@@ -13,10 +18,28 @@ class OdpUD(UDResources):
 
 
 class OdpRC(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index, is_huge=False,
+                 user_addr=None):
+        """
+        Initialize an OdpRC object.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param is_huge: If True, use huge pages for MR registration
+        :param user_addr: The MR's buffer address. If None, the buffer will be
+                          allocated by pyverbs.
+        """
+        self.is_huge = is_huge
+        self.user_addr = user_addr
+        super(OdpRC, self).__init__(dev_name=dev_name, ib_port=ib_port,
+                                    gid_index=gid_index)
+
     @requires_odp('rc')
     def create_mr(self):
-        self.mr = MR(self.pd, self.msg_size,
-                     e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
+        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND
+        if self.is_huge:
+            access |= e.IBV_ACCESS_HUGETLB
+        self.mr = MR(self.pd, self.msg_size, access, address=self.user_addr)
 
 class OdpXRC(XRCResources):
     @requires_odp('xrc')
@@ -29,13 +52,22 @@ class OdpTestCase(RDMATestCase):
     def setUp(self):
         super(OdpTestCase, self).setUp()
         self.iters = 100
+        self.user_addr = None
         self.qp_dict = {'rc': OdpRC, 'ud': OdpUD, 'xrc': OdpXRC}
 
-    def create_players(self, qp_type):
-        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
-        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
+    def create_players(self, qp_type, is_huge=False):
+        if qp_type == 'rc':
+            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index, is_huge=is_huge,
+                                           user_addr=self.user_addr)
+            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index, is_huge=is_huge,
+                                           user_addr=self.user_addr)
+        else:
+            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index)
+            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index)
         if qp_type == 'xrc':
             client.pre_run(server.psns, server.qps_num)
             server.pre_run(client.psns, client.qps_num)
@@ -43,6 +75,11 @@ class OdpTestCase(RDMATestCase):
             client.pre_run(server.psn, server.qpn)
             server.pre_run(client.psn, client.qpn)
         return client, server
+
+    def tearDown(self):
+        if self.user_addr:
+            munmap(self.user_addr, HUGE_PAGE_SIZE)
+        super(OdpTestCase, self).tearDown()
 
     def test_odp_rc_traffic(self):
         client, server = self.create_players('rc')
@@ -55,3 +92,16 @@ class OdpTestCase(RDMATestCase):
     def test_odp_xrc_traffic(self):
         client, server = self.create_players('xrc')
         xrc_traffic(client, server)
+
+    @requires_huge_pages()
+    def test_odp_rc_huge_traffic(self):
+        client, server = self.create_players('rc', is_huge=True)
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+
+    @requires_huge_pages()
+    def test_odp_rc_huge_user_addr_traffic(self):
+        self.user_addr = mmap(length=HUGE_PAGE_SIZE,
+                              flags=MAP_ANONYMOUS_| MAP_PRIVATE_| MAP_HUGETLB_)
+        client, server = self.create_players('rc', is_huge=True)
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+


### PR DESCRIPTION
This series exposes the IBV_ACCESS_HUGETLB access flag to indicate that the MR range will be mmaped by huge pages, the flag is applicable only with conjunction of IBV_ACCESS_ON_DEMAND.

In addition, the series includes some pyverbs infrastructure to enable using this flag and some new ODP test on top.