### PR TITLE
tests: test_parent_domain: Fix exception when no IB device found

### DIFF
--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -8,8 +8,8 @@ from pyverbs.pyverbs_error import PyverbsRDMAError
 from pyverbs.srq import SrqAttr, SrqInitAttr, SRQ
 from pyverbs.qp import QPInitAttr, QP
 from tests.base import BaseResources
+from tests.base import RDMATestCase
 import pyverbs.mem_alloc as mem
-import pyverbs.device as d
 import pyverbs.enums as e
 from pyverbs.cq import CQ
 import tests.utils as u
@@ -25,15 +25,9 @@ class ParentDomainRes(BaseResources):
         self.parent_domain = None
 
 
-class ParentDomainTestCase(unittest.TestCase):
-    def __init__(self, methodName='runTest', dev_name=None):
-        super().__init__(methodName)
-        self.dev_name = dev_name
-
+class ParentDomainTestCase(RDMATestCase):
     def setUp(self):
-        if self.dev_name is None:
-            dev = d.get_device_list()[-1]
-            self.dev_name = dev.name.decode()
+        super().setUp()
         self.pd_res = ParentDomainRes(self.dev_name)
 
     def _create_parent_domain_with_allocators(self, alloc_func, free_func):


### PR DESCRIPTION
Avoid the following exception when no IB device found, by skipping the test.

ERROR: test_default_allocators (tests.test_parent_domain.ParentDomainTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kheib/git/upstream/rdma-core/tests/test_parent_domain.py", line 35, in setUp
    dev = d.get_device_list()[-1]
IndexError: list index out of range

Fixes: 4fec6737c9bd ("tests: Add a test for parent domain")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>