### PR TITLE
pyverbs: Support CQ events properly

### DIFF
--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -20,6 +20,8 @@ cdef class CQ(PyverbsCM):
     cdef add_ref(self, obj)
     cdef object qps
     cdef object srqs
+    cdef object channel
+    cdef object num_events
 
 cdef class CqInitAttrEx(PyverbsObject):
     cdef v.ibv_cq_init_attr_ex attr

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ rdma_python_test(tests
   test_addr.py
   base.py
   test_cq.py
+  test_cq_events.py
   test_cqex.py
   test_device.py
   test_mr.py

--- a/tests/test_cq_events.py
+++ b/tests/test_cq_events.py
@@ -1,0 +1,45 @@
+from tests.base import RCResources, UDResources
+from tests.base import RDMATestCase
+from tests.utils import traffic
+
+from pyverbs.cq import CQ, CompChannel
+
+
+def create_cq_with_comp_channel(agr_obj):
+    agr_obj.comp_channel = CompChannel(agr_obj.ctx)
+    agr_obj.cq = CQ(agr_obj.ctx, agr_obj.num_msgs, None, agr_obj.comp_channel)
+    agr_obj.cq.req_notify()
+
+
+class CqEventsUD(UDResources):
+    def create_cq(self):
+        create_cq_with_comp_channel(self)
+
+
+class CqEventsRC(RCResources):
+    def create_cq(self):
+        create_cq_with_comp_channel(self)
+
+
+class CqEventsTestCase(RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.iters = 100
+        self.qp_dict = {'ud': CqEventsUD, 'rc': CqEventsRC}
+
+    def create_players(self, qp_type):
+        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        client.pre_run(server.psn, server.qpn)
+        server.pre_run(client.psn, client.qpn)
+        return client, server
+
+    def test_cq_events_ud(self):
+        client, server = self.create_players('ud')
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+
+    def test_cq_events_rc(self):
+        client, server = self.create_players('rc')
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -332,14 +332,19 @@ def poll_cq(cq, count=1):
     :return: An array of work completions of length <count>, None
              when events are used
     """
-    wcs = None
+    wcs = []
+    channel = cq.comp_channel
     while count > 0:
-        nc, wcs = cq.poll(count)
-        for wc in wcs:
+        if channel:
+            channel.get_cq_event(cq)
+            cq.req_notify()
+        nc, tmp_wcs = cq.poll(count)
+        for wc in tmp_wcs:
             if wc.status != e.IBV_WC_SUCCESS:
                 raise PyverbsRDMAError('Completion status is {s}'.
                                        format(s=wc_status_to_str(wc.status)))
         count -= nc
+        wcs.extend(tmp_wcs)
     return wcs
 
 


### PR DESCRIPTION
CQ events have to be acked prior to CQ destruction. Otherwise, CQ
destruction will wait indefinitely for those events to be acked.
In Python it's possible for a simple syntax error to cause a runtime
error which leads to teardown of all objects. For CQ, this can mean
a destruction without acking CQ events.

To avoid that, keep track of the number of events and during teardown,
if there are events that weren't acked, do so implicitly.

The first patch adds this support. The second one adds a simple
traffic test that uses CQ events mechanism rather than poll.
