### PR TITLE
suse: Fix post scripts to work with systemd 244

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -506,8 +506,8 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 
 %post
 # we ship udev rules, so trigger an update.
-/sbin/udevadm trigger --subsystem-match=infiniband --action=change || true
-/sbin/udevadm trigger --subsystem-match=infiniband_mad --action=change || true
+%{_bindir}/udevadm trigger --subsystem-match=infiniband --action=change || true
+%{_bindir}/udevadm trigger --subsystem-match=infiniband_mad --action=change || true
 
 #
 # ibacm
@@ -533,7 +533,7 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %post -n srp_daemon
 %service_add_post srp_daemon.service
 # we ship udev rules, so trigger an update.
-/sbin/udevadm trigger --subsystem-match=infiniband_mad --action=change
+%{_bindir}/udevadm trigger --subsystem-match=infiniband_mad --action=change
 
 %preun -n srp_daemon
 %service_del_preun srp_daemon.service


### PR DESCRIPTION
udevadm has been moved from /sbin to /usr/bin and systemd is
 dropping the compat links now.

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>