### PR TITLE
efa: Use the correct barrier between BAR writes on post send flow

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -1191,7 +1191,7 @@ int efa_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 	struct efa_ah *ah;
 	int err = 0;
 
-	pthread_spin_lock(&qp->sq.wq.wqlock);
+	mmio_wc_spinlock(&qp->sq.wq.wqlock);
 	while (wr) {
 		err = efa_post_send_validate_wr(qp, wr);
 		if (err) {
@@ -1236,9 +1236,13 @@ int efa_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 	}
 
 ring_db:
-	udma_to_device_barrier();
+	mmio_flush_writes();
 	mmio_write32(qp->sq.db, qp->sq.wq.desc_idx);
 
+	/*
+	 * Not using mmio_wc_spinunlock as the doorbell write should be done
+	 * inside the lock.
+	 */
 	pthread_spin_unlock(&qp->sq.wq.wqlock);
 	return err;
 }
@@ -1452,7 +1456,7 @@ static void efa_send_wr_start(struct ibv_qp_ex *ibvqpx)
 {
 	struct efa_qp *qp = to_efa_qp_ex(ibvqpx);
 
-	pthread_spin_lock(&qp->sq.wq.wqlock);
+	mmio_wc_spinlock(&qp->sq.wq.wqlock);
 	qp->wr_session_err = 0;
 	qp->sq.num_wqe_pending = 0;
 	qp->sq.phase_rb = qp->sq.wq.phase;
@@ -1498,9 +1502,13 @@ static int efa_send_wr_complete(struct ibv_qp_ex *ibvqpx)
 			      qp->sq.wq.desc_mask;
 	}
 
-	udma_to_device_barrier();
+	mmio_flush_writes();
 	mmio_write32(qp->sq.db, qp->sq.wq.desc_idx);
 out:
+	/*
+	 * Not using mmio_wc_spinunlock as the doorbell write should be done
+	 * inside the lock.
+	 */
 	pthread_spin_unlock(&qp->sq.wq.wqlock);
 
 	return qp->wr_session_err;


### PR DESCRIPTION
The TX Low Latency Queue (LLQ) is stored on the device's BAR, hence
mmio_flush_writes should be used instead of udma_to_device_barrier
before ringing the doorbell.

Fixes: f7f275ff2b1a ("efa: Elastic Fabric Adapter (EFA) userspace RDMA provider")
Fixes: f189a2ac12d6 ("efa: Support send using extended QP API")
Signed-off-by: Gal Pressman <galpress@amazon.com>