### PR TITLE
redhat: move rxe_cfg into sub-package libibverbs-utils

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -418,12 +418,10 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %{_libexecdir}/rdma-set-sriov-vf
 %{_libexecdir}/mlx4-setup.sh
 %{_libexecdir}/truescale-serdes.cmds
-%{_bindir}/rxe_cfg
 %{_sbindir}/rdma-ndd
 %{_unitdir}/rdma-ndd.service
 %{_mandir}/man7/rxe*
 %{_mandir}/man8/rdma-ndd.*
-%{_mandir}/man8/rxe*
 %license COPYING.*
 
 %files devel
@@ -573,6 +571,8 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 %files -n libibverbs-utils
 %{_bindir}/ibv_*
 %{_mandir}/man1/ibv_*
+%{_bindir}/rxe_cfg
+%{_mandir}/man8/rxe*
 
 %files -n ibacm
 %config(noreplace) %{_sysconfdir}/rdma/ibacm_opts.cfg


### PR DESCRIPTION
The rxe_cfg script attempts to run the ibv_devinfo command which is
provided by libibverbs-utils. The rdma-core package does not pull in
libibverbs-utils on installation, resulting on the error below.

$ sudo rxe_cfg
Can't exec "ibv_devinfo": No such file or directory at /usr/bin/rxe_cfg line 215.
  Name  Link  Driver  Speed  NMTU  IPv4_addr       RDEV  RMTU
  ens3  yes   8139cp         1500  192.168.122.13  rxe0  (?)

Signed-off-by: Honggang Li <honli@redhat.com>