### PR TITLE
pyverbs: Support asynchronous RDMA CM 

### DIFF
--- a/pyverbs/cmid.pxd
+++ b/pyverbs/cmid.pxd
@@ -16,6 +16,16 @@ cdef class CMID(PyverbsCM):
     cpdef close(self)
 
 
+cdef class CMEventChannel(PyverbsObject):
+    cdef cm.rdma_event_channel *event_channel
+    cpdef close(self)
+
+
+cdef class CMEvent(PyverbsObject):
+    cdef cm.rdma_cm_event *event
+    cpdef close(self)
+
+
 cdef class AddrInfo(PyverbsObject):
     cdef cm.rdma_addrinfo *addr_info
     cpdef close(self)

--- a/pyverbs/cmid.pxd
+++ b/pyverbs/cmid.pxd
@@ -11,6 +11,7 @@ cimport pyverbs.librdmacm as cm
 
 cdef class CMID(PyverbsCM):
     cdef cm.rdma_cm_id *id
+    cdef object event_channel
     cdef object ctx
     cdef object pd
     cpdef close(self)

--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -61,10 +61,13 @@ cdef class ConnParam(PyverbsObject):
 
 
 cdef class AddrInfo(PyverbsObject):
-    def __init__(self, node=None, service=None, port_space=0, flags=0):
+
+    def __init__(self, src=None, dst=None, service=None, port_space=0,
+                  flags=0):
         """
         Initialize an AddrInfo object over an underlying rdma_addrinfo C object.
-        :param node: Name, dotted-decimal IPv4 or IPv6 hex address to resolve.
+        :param src: Name, dotted-decimal IPv4 or IPv6 hex address to bind to.
+        :param dst: Name, dotted-decimal IPv4 or IPv6 hex address to connect to.
         :param service: The service name or port number of the address.
         :param port_space: RDMA port space used (RDMA_PS_UDP or RDMA_PS_TCP).
         :param flags: Hint flags which control the operation.
@@ -72,23 +75,46 @@ cdef class AddrInfo(PyverbsObject):
         establish communication.
         """
         cdef char* srvc = NULL
-        cdef char* address = NULL
+        cdef char* src_addr = NULL
+        cdef char* dst_addr = NULL
         cdef cm.rdma_addrinfo hints
         cdef cm.rdma_addrinfo *hints_ptr = NULL
+        cdef cm.rdma_addrinfo *res = NULL
 
         super().__init__()
-        if node is not None:
-            node = node.encode('utf-8')
-            address = <char*>node
+        if src is not None:
+            if isinstance(src, str):
+                src = src.encode('utf-8')
+            src_addr = <char*>src
+        if dst is not None:
+            if isinstance(dst, str):
+                dst = dst.encode('utf-8')
+            dst_addr = <char*>dst
         if service is not None:
-            service = service.encode('utf-8')
+            if isinstance(service, str):
+                service = service.encode('utf-8')
             srvc = <char*>service
-        if port_space != 0:
-            hints_ptr = &hints
-            memset(hints_ptr, 0, sizeof(cm.rdma_addrinfo))
-            hints.ai_port_space = port_space
-            hints.ai_flags = flags
-        ret = cm.rdma_getaddrinfo(address, srvc, hints_ptr, &self.addr_info)
+
+        hints_ptr = &hints
+        memset(hints_ptr, 0, sizeof(cm.rdma_addrinfo))
+        hints.ai_port_space = port_space
+        hints.ai_flags = flags
+        if flags & ce.RAI_PASSIVE:
+            ret = cm.rdma_getaddrinfo(src_addr, srvc, hints_ptr,
+                                      &self.addr_info)
+        else:
+            if src:
+                hints.ai_flags |= ce.RAI_PASSIVE
+                ret = cm.rdma_getaddrinfo(src_addr, NULL, hints_ptr, &res)
+                if ret != 0:
+                    raise PyverbsRDMAErrno('Failed to get Address Info')
+                hints.ai_src_addr = <cm.sockaddr*>res.ai_src_addr
+                hints.ai_src_len = res.ai_src_len
+                hints.ai_flags &= ~ce.RAI_PASSIVE
+            ret = cm.rdma_getaddrinfo(dst_addr, srvc, hints_ptr,
+                                      &self.addr_info)
+            if src:
+                cm.rdma_freeaddrinfo(res)
         if ret != 0:
             raise PyverbsRDMAErrno('Failed to get Address Info')
 

--- a/pyverbs/librdmacm.pxd
+++ b/pyverbs/librdmacm.pxd
@@ -94,14 +94,27 @@ cdef extern from '<rdma/rdma_cma.h>':
     int rdma_create_ep(rdma_cm_id **id, rdma_addrinfo *res,
                        ibv_pd *pd, ibv_qp_init_attr *qp_init_attr)
     void rdma_destroy_ep(rdma_cm_id *id)
+    int rdma_create_id(rdma_event_channel *channel, rdma_cm_id **id,
+                       void *context, rdma_port_space ps)
+    int rdma_destroy_id(rdma_cm_id *id)
     int rdma_get_request(rdma_cm_id *listen, rdma_cm_id **id)
+    int rdma_bind_addr(rdma_cm_id *id, sockaddr *addr)
+    int rdma_resolve_addr(rdma_cm_id *id, sockaddr *src_addr,
+                          sockaddr *dst_addr, int timeout_ms)
+    int rdma_resolve_route(rdma_cm_id *id, int timeout_ms)
     int rdma_connect(rdma_cm_id *id, rdma_conn_param *conn_param)
     int rdma_disconnect(rdma_cm_id *id)
     int rdma_listen(rdma_cm_id *id, int backlog)
     int rdma_accept(rdma_cm_id *id, rdma_conn_param *conn_param)
+    int rdma_establish(rdma_cm_id *id)
     int rdma_getaddrinfo(char *node, char *service, rdma_addrinfo *hints,
                          rdma_addrinfo **res)
     void rdma_freeaddrinfo(rdma_addrinfo *res)
+    int rdma_init_qp_attr(rdma_cm_id *id, ibv_qp_attr *qp_attr,
+                          int *qp_attr_mask)
+    int rdma_create_qp(rdma_cm_id *id, ibv_pd *pd,
+                       ibv_qp_init_attr *qp_init_attr)
+    void rdma_destroy_qp(rdma_cm_id *id)
 
 cdef extern from '<rdma/rdma_verbs.h>':
     int rdma_post_recv(rdma_cm_id *id, void *context, void *addr,

--- a/pyverbs/librdmacm.pxd
+++ b/pyverbs/librdmacm.pxd
@@ -86,6 +86,11 @@ cdef extern from '<rdma/rdma_cma.h>':
         in_addr         sin_addr
         char            sin_zero[8]
 
+    rdma_event_channel *rdma_create_event_channel()
+    void rdma_destroy_event_channel(rdma_event_channel *channel)
+    int rdma_get_cm_event(rdma_event_channel *channel, rdma_cm_event **event)
+    int rdma_ack_cm_event(rdma_cm_event *event)
+    char *rdma_event_str(rdma_cm_event_type event)
     int rdma_create_ep(rdma_cm_id **id, rdma_addrinfo *res,
                        ibv_pd *pd, ibv_qp_init_attr *qp_init_attr)
     void rdma_destroy_ep(rdma_cm_id *id)

--- a/tests/base.py
+++ b/tests/base.py
@@ -173,9 +173,10 @@ class CMResources:
         self.port = kwargs.get('port') if kwargs.get('port') else '7471'
         self.mr = None
         if self.is_server:
-            self.ai = AddrInfo(src, self.port, ce.RDMA_PS_TCP, ce.RAI_PASSIVE)
+            self.ai = AddrInfo(src, None, self.port, ce.RDMA_PS_TCP,
+                               ce.RAI_PASSIVE)
         else:
-            self.ai = AddrInfo(dst, self.port, ce.RDMA_PS_TCP)
+            self.ai = AddrInfo(src, dst, self.port, ce.RDMA_PS_TCP)
         self.create_qp_init_attr()
         self.cmid = CMID(creator=self.ai, qp_init_attr=self.qp_init_attr)
 

--- a/tests/rdmacm_utils.py
+++ b/tests/rdmacm_utils.py
@@ -20,9 +20,9 @@ def active_side(dst_addr, syncer, notifier):
     try:
         client = CMResources(dst=dst_addr)
         syncer.wait()
-        client.pre_run()
+        client.cmid.connect()
         connected_id = client.cmid
-        client.create_mr(connected_id)
+        client.create_mr()
         send_msg = 'c' * client.msg_size
         for _ in range(client.num_msgs):
             client.mr.write(send_msg, client.msg_size)
@@ -55,11 +55,11 @@ def passive_side(src_addr, syncer, notifier):
     """
     try:
         server = CMResources(src=src_addr)
-        server.pre_run()
+        server.cmid.listen()
         syncer.wait()
         connected_id = server.cmid.get_request()
         connected_id.accept()
-        server.create_mr(connected_id)
+        server.create_mr()
         send_msg = 's' * server.msg_size
         for _ in range(server.num_msgs):
             connected_id.post_recv(server.mr)

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -1,5 +1,5 @@
-from tests.rdmacm_utils import active_side, passive_side
 from pyverbs.pyverbs_error import PyverbsError
+from tests.rdmacm_utils import sync_traffic
 from tests.base import RDMATestCase
 import multiprocessing as mp
 import pyverbs.device as d
@@ -51,10 +51,10 @@ class CMTestCase(RDMATestCase):
         ctx = mp.get_context('fork')
         syncer = ctx.Barrier(2, timeout=5)
         notifier = ctx.Queue()
-        passive = ctx.Process(target=passive_side, args=[self.ip_addr, syncer,
-                                                         notifier])
-        active = ctx.Process(target=active_side, args=[self.ip_addr, syncer,
-                                                       notifier])
+        passive = ctx.Process(target=sync_traffic, args=[self.ip_addr, syncer,
+                                                         notifier, True])
+        active = ctx.Process(target=sync_traffic, args=[self.ip_addr, syncer,
+                                                       notifier, False])
         passive.start()
         active.start()
         while notifier.empty():

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -10,7 +10,6 @@ import json
 
 class CMTestCase(RDMATestCase):
     def setUp(self):
-        mp.set_start_method('fork')
         if self.dev_name is not None:
             net_name = self.get_net_name(self.dev_name)
             try:
@@ -49,12 +48,13 @@ class CMTestCase(RDMATestCase):
         return interface
 
     def test_rdmacm_sync_traffic(self):
-        syncer = mp.Barrier(2, timeout=5)
-        notifier = mp.Queue()
-        passive = mp.Process(target=passive_side, args=[self.ip_addr, syncer,
-                                                        notifier])
-        active = mp.Process(target=active_side, args=[self.ip_addr, syncer,
-                                                      notifier])
+        ctx = mp.get_context('fork')
+        syncer = ctx.Barrier(2, timeout=5)
+        notifier = ctx.Queue()
+        passive = ctx.Process(target=passive_side, args=[self.ip_addr, syncer,
+                                                         notifier])
+        active = ctx.Process(target=active_side, args=[self.ip_addr, syncer,
+                                                       notifier])
         passive.start()
         active.start()
         while notifier.empty():


### PR DESCRIPTION
This series exposes asynchronous RDMACM control path and adds a new related test.

Pyverbs:
With CMEvent and CMEventChannel (wrapper objects of rdma_cm_event and
rdma_event_channel) we allow CMID object to establish a connection
using the events API.
Expansion of CMID object:
Added necessary API for asynchronous control path e.g. bind_addr(),
resolve_addr(), resolve_route(), establish() and more.

tests:
Added necessary API to CMResources object which is the base aggregation
object for RDMACM and expended rdmacm_utils.py for asynchronous control
path.
