### PR TITLE
libhns: Record more info into wc after poll cqe

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -587,6 +587,15 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 				PFX "failed to handle recv inline wqe!\n");
 			return ret;
 		}
+
+		wc->sl = (uint8_t)roce_get_field(cqe->byte_32, CQE_BYTE_32_SL_M,
+						 CQE_BYTE_32_SL_S);
+		wc->src_qp = roce_get_field(cqe->byte_32, CQE_BYTE_32_RMT_QPN_M,
+					    CQE_BYTE_32_RMT_QPN_S);
+		wc->slid = 0;
+		wc->wc_flags |= roce_get_bit(cqe->byte_32, CQE_BYTE_32_GRH_S) ?
+				IBV_WC_GRH : 0;
+		wc->pkey_index = 0;
 	}
 
 	return V2_CQ_OK;

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -216,7 +216,7 @@ struct hns_roce_v2_cqe {
 #define CQE_BYTE_32_PORTN_S 27
 #define CQE_BYTE_32_PORTN_M   (((1UL << 3) - 1) << CQE_BYTE_32_PORTN_S)
 
-#define CQE_BYTE_32_GLH_S 30
+#define CQE_BYTE_32_GRH_S 30
 
 #define CQE_BYTE_32_LPK_S 31
 


### PR DESCRIPTION
When poll cqe successfully, more cqe information needs to be recorded into
wc.