### PR TITLE
tests: Fix exception when query GIDs

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -133,15 +133,12 @@ class RDMATestCase(unittest.TestCase):
         # Don't add ports which are not active
         if ctx.query_port(port).state != e.IBV_PORT_ACTIVE:
             return
-        idx = 0
-        while True:
+
+        for idx in range(ctx.query_port(port).gid_tbl_len):
             gid = ctx.query_gid(port, idx)
-            if gid.gid[-19:] == self.ZERO_GID:
-                # No point iterating on
-                break
-            else:
+            # Avoid adding ZERO GIDs
+            if gid.gid[-19:] != self.ZERO_GID:
                 self.args.append([dev, port, idx])
-                idx += 1
 
     def _add_gids_per_device(self, ctx, dev):
         port_count = ctx.query_device().phys_port_cnt


### PR DESCRIPTION
Avoid the following error by iterating over the availbe gid range.

Traceback (most recent call last):
  File "/home/rdma-core/tests/test_cq_events.py", line 26, in setUp
    super().setUp()
  File "/home/rdma-core/tests/base.py", line 122, in setUp
    self._add_gids_per_device(ctx, dev_name)
  File "/home/rdma-core/tests/base.py", line 149, in _add_gids_per_device
    self._add_gids_per_port(ctx, dev, port+1)
  File "/home/rdma-core/tests/base.py", line 138, in _add_gids_per_port
    gid = ctx.query_gid(port, idx)
  File "device.pyx", line 195, in pyverbs.device.Context.query_gid
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to query gid 1 of port 1

Fixes: bb5958680256 ("tests: RDMATestCase")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>