### PR TITLE
libhns: Fix for the error code when polling cq

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -460,7 +460,7 @@ static int hns_roce_handle_recv_inl_wqe(struct hns_roce_v2_cqe *cqe,
 		sge_num = (*cur_qp)->rq_rinl_buf.wqe_list[wr_cnt].sge_cnt;
 		wqe_buf = (uint8_t *)get_recv_wqe_v2(*cur_qp, wr_cnt);
 		if (!wqe_buf)
-			return -EINVAL;
+			return V2_CQ_POLL_ERR;
 
 		data_len = wc->byte_len;
 
@@ -609,7 +609,7 @@ static int hns_roce_u_v2_poll_cq(struct ibv_cq *ibvcq, int ne,
 			break;
 	}
 
-	if (npolled) {
+	if (npolled || err == V2_CQ_POLL_ERR) {
 		mmio_ordered_writes_hack();
 
 		if (cq->flags & HNS_ROCE_SUPPORT_CQ_RECORD_DB)


### PR DESCRIPTION
CQ has its private error codes, there is no need to use other error codes
in hns_roce_handle_recv_inl_wqe(), which will affect the return value of the
poll cq function.

And if the err state is V2_CQ_POLL_ERR, the ci pointer needs to be
updated as the cqe has already been generated.