### PR TITLE
tests: Use error code to determine the failure

### DIFF
--- a/tests/test_mlx5_var.py
+++ b/tests/test_mlx5_var.py
@@ -10,6 +10,7 @@ from pyverbs.providers.mlx5.mlx5dv import Mlx5VAR
 from tests.base import BaseResources
 from tests.base import RDMATestCase
 import unittest
+import errno
 import mmap
 
 
@@ -19,7 +20,7 @@ class Mlx5VarRes(BaseResources):
         try:
             self.var = Mlx5VAR(self.ctx)
         except PyverbsRDMAError as ex:
-            if 'not supported' in str(ex):
+            if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('VAR allocation is not supported')
 
 

--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -14,6 +14,7 @@ import pyverbs.enums as e
 from pyverbs.cq import CQ
 import tests.utils as u
 import unittest
+import errno
 
 
 class ParentDomainRes(BaseResources):
@@ -40,7 +41,7 @@ class ParentDomainTestCase(RDMATestCase):
             self.pd_res.parent_domain = ParentDomain(self.pd_res.ctx,
                                                      attr=pd_attr)
         except PyverbsRDMAError as ex:
-            if 'not supported' in str(ex) or 'not implemented' in str(ex):
+            if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Parent Domain is not supported on this device')
             raise ex
 


### PR DESCRIPTION
Instead of comare strings, use the stored error code in the
PyverbsRDMAError exception to determine the failure.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>