### PR TITLE
rsockets: Add check for established connection

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -1454,7 +1454,7 @@ connected:
 		rs->state = rs_connect_rdwr;
 		break;
 	default:
-		ret = ERR(EINVAL);
+		ret = (rs->state & rs_connected) ? 0 : ERR(EINVAL);
 		break;
 	}
 


### PR DESCRIPTION
Rsockets will use a thread to drive connection state. However,
checks against the rsocket state are made outside of locks in
send/recv/poll.  If the state is still listed as opening, 
rs_do_connect will be called, where the state will be checked
under lock.  Because a separate thread is driving the connection
state, the rsocket state may be connected at this point.

Update rs_do_connect to return 0 (success) if the rsocket
is already in the connected state.  This fixes failures using
rsockets in the JDK test set.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>