### PR TITLE
mlx5: Introduce DV APIs to dump DR information

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -90,6 +90,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_alloc_var@MLX5_1.12 28
  mlx5dv_dr_action_create_flow_meter@MLX5_1.12 28
  mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
+ mlx5dv_dump_dr_matcher@MLX5_1.12 28
  mlx5dv_dump_dr_rule@MLX5_1.12 28
  mlx5dv_free_var@MLX5_1.12 28
 libefa.so.1 ibverbs-providers #MINVER#

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -90,6 +90,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_alloc_var@MLX5_1.12 28
  mlx5dv_dr_action_create_flow_meter@MLX5_1.12 28
  mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
+ mlx5dv_dump_dr_domain@MLX5_1.12 28
  mlx5dv_dump_dr_matcher@MLX5_1.12 28
  mlx5dv_dump_dr_rule@MLX5_1.12 28
  mlx5dv_dump_dr_table@MLX5_1.12 28

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -90,6 +90,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_alloc_var@MLX5_1.12 28
  mlx5dv_dr_action_create_flow_meter@MLX5_1.12 28
  mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
+ mlx5dv_dump_dr_rule@MLX5_1.12 28
  mlx5dv_free_var@MLX5_1.12 28
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -92,6 +92,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_modify_flow_meter@MLX5_1.12 28
  mlx5dv_dump_dr_matcher@MLX5_1.12 28
  mlx5dv_dump_dr_rule@MLX5_1.12 28
+ mlx5dv_dump_dr_table@MLX5_1.12 28
  mlx5dv_free_var@MLX5_1.12 28
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -17,6 +17,7 @@ rdma_shared_provider(mlx5 libmlx5.map
   dbrec.c
   dr_action.c
   dr_crc32.c
+  dr_dbg.c
   dr_devx.c
   dr_icm_pool.c
   dr_matcher.c

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2019 Mellanox Technologies, Inc.  All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *     Redistribution and use in source and binary forms, with or
+ *     without modification, are permitted provided that the following
+ *     conditions are met:
+ *
+ *      - Redistributions of source code must retain the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer.
+ *
+ *      - Redistributions in binary form must reproduce the above
+ *        copyright notice, this list of conditions and the following
+ *        disclaimer in the documentation and/or other materials
+ *        provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <unistd.h>
+#include <inttypes.h>
+#include "mlx5dv_dr.h"
+
+#define BUFF_SIZE	1024
+
+enum dr_dump_rec_type {
+	DR_DUMP_REC_TYPE_RULE = 3300,
+	DR_DUMP_REC_TYPE_RULE_RX_ENTRY = 3301,
+	DR_DUMP_REC_TYPE_RULE_TX_ENTRY = 3302,
+
+	DR_DUMP_REC_TYPE_ACTION_ENCAP_L2 = 3400,
+	DR_DUMP_REC_TYPE_ACTION_ENCAP_L3 = 3401,
+	DR_DUMP_REC_TYPE_ACTION_MODIFY_HDR = 3402,
+	DR_DUMP_REC_TYPE_ACTION_DROP = 3403,
+	DR_DUMP_REC_TYPE_ACTION_QP = 3404,
+	DR_DUMP_REC_TYPE_ACTION_FT = 3405,
+	DR_DUMP_REC_TYPE_ACTION_CTR = 3406,
+	DR_DUMP_REC_TYPE_ACTION_TAG = 3407,
+	DR_DUMP_REC_TYPE_ACTION_VPORT = 3408,
+	DR_DUMP_REC_TYPE_ACTION_DECAP_L2 = 3409,
+	DR_DUMP_REC_TYPE_ACTION_DECAP_L3 = 3410,
+};
+
+static uint64_t dr_dump_icm_to_idx(uint64_t icm_addr)
+{
+	return (icm_addr >> 6) & 0xffffffff;
+}
+
+static void dump_hex_print(char *dest, char *src, uint32_t size)
+{
+	int i;
+
+	for (i = 0; i < size; i++)
+		sprintf(&dest[2 * i], "%02x", (uint8_t)src[i]);
+}
+
+static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
+				   struct dr_rule_action_member *action_mem)
+{
+	struct mlx5dv_dr_action *action = action_mem->action;
+	const uint64_t action_id = (uint64_t)action;
+	int ret;
+
+	switch (action->action_type) {
+	case DR_ACTION_TYP_DROP:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
+			      DR_DUMP_REC_TYPE_ACTION_DROP, action_id, rule_id);
+		break;
+	case DR_ACTION_TYP_FT:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_FT, action_id, rule_id,
+			      action->dest_tbl->devx_obj->object_id);
+		break;
+	case DR_ACTION_TYP_QP:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_QP, action_id, rule_id,
+			      action->qp->qp_num);
+		break;
+	case DR_ACTION_TYP_CTR:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_CTR, action_id, rule_id,
+			      action->ctr.devx_obj->object_id +
+			      action->ctr.offset);
+		break;
+	case DR_ACTION_TYP_TAG:
+		ret = fprintf(f, "%d,,0x%" PRIx64 ",0x%" PRIx64 "0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_TAG, action_id, rule_id,
+			      action->flow_tag);
+		break;
+	case DR_ACTION_TYP_MODIFY_HDR:
+		ret = fprintf(f, "%d,,0x%" PRIx64 ",0x%" PRIx64 "0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_MODIFY_HDR, action_id,
+			      rule_id, action->rewrite.index);
+		break;
+	case DR_ACTION_TYP_VPORT:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_VPORT, action_id, rule_id,
+			      action->vport.num);
+		break;
+	case DR_ACTION_TYP_TNL_L2_TO_L2:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
+			      DR_DUMP_REC_TYPE_ACTION_DECAP_L2, action_id,
+			      rule_id);
+		break;
+	case DR_ACTION_TYP_TNL_L3_TO_L2:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_DECAP_L3, action_id,
+			      rule_id, action->rewrite.index);
+		break;
+	case DR_ACTION_TYP_L2_TO_TNL_L2:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_ENCAP_L2, action_id,
+			      rule_id, action->reformat.dvo->object_id);
+		break;
+	case DR_ACTION_TYP_L2_TO_TNL_L3:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_ENCAP_L3, action_id,
+			      rule_id, action->reformat.dvo->object_id);
+		break;
+	default:
+		return 0;
+	}
+
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int dr_dump_rule_mem(FILE *f, struct dr_rule_member *rule_mem,
+			    bool is_rx, const uint64_t rule_id)
+{
+	char hw_ste_dump[BUFF_SIZE] = {};
+	enum dr_dump_rec_type mem_rec_type;
+	int ret;
+
+	mem_rec_type = is_rx ? DR_DUMP_REC_TYPE_RULE_RX_ENTRY :
+			       DR_DUMP_REC_TYPE_RULE_TX_ENTRY;
+
+	dump_hex_print(hw_ste_dump, (char *)rule_mem->ste->hw_ste, DR_STE_SIZE_REDUCED);
+	ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",%s\n",
+		      mem_rec_type,
+		      dr_dump_icm_to_idx(dr_ste_get_icm_addr(rule_mem->ste)),
+		      rule_id,
+		      hw_ste_dump);
+	if (ret < 0)
+		return ret;
+
+	return 0;
+}
+
+static int dr_dump_rule_rx_tx(FILE *f, struct dr_rule_rx_tx *rule_rx_tx,
+			      bool is_rx, const uint64_t rule_id)
+{
+	struct dr_rule_member *rule_mem;
+	int ret;
+
+	list_for_each(&rule_rx_tx->rule_members_list, rule_mem, list) {
+		ret = dr_dump_rule_mem(f, rule_mem, is_rx, rule_id);
+		if (ret < 0)
+			return ret;
+	}
+	return 0;
+}
+
+static int dr_dump_rule(FILE *f, struct mlx5dv_dr_rule *rule)
+{
+	struct dr_rule_action_member *action_mem;
+	const uint64_t rule_id = (uint64_t)rule;
+	struct dr_rule_rx_tx *rx = &rule->rx;
+	struct dr_rule_rx_tx *tx = &rule->tx;
+	int ret;
+
+	ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
+		      DR_DUMP_REC_TYPE_RULE,
+		      rule_id,
+		      (uint64_t)rule->matcher);
+	if (ret < 0)
+		return ret;
+
+	if (!dr_is_root_table(rule->matcher->tbl)) {
+		if (rx->nic_matcher) {
+			ret = dr_dump_rule_rx_tx(f, rx, true, rule_id);
+			if (ret < 0)
+				return ret;
+		}
+
+		if (tx->nic_matcher) {
+			ret = dr_dump_rule_rx_tx(f, tx, false, rule_id);
+			if (ret < 0)
+				return ret;
+		}
+	}
+
+	list_for_each(&rule->rule_actions_list, action_mem, list) {
+		ret = dr_dump_rule_action_mem(f, rule_id, action_mem);
+		if (ret < 0)
+			return ret;
+	}
+
+	return 0;
+}
+
+int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule)
+{
+	int ret;
+
+	if (!fout || !rule)
+		return -EINVAL;
+
+	pthread_mutex_lock(&rule->matcher->tbl->dmn->mutex);
+
+	ret = dr_dump_rule(fout, rule);
+
+	pthread_mutex_unlock(&rule->matcher->tbl->dmn->mutex);
+
+	return ret;
+}

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -279,6 +279,7 @@ mlx5dv_dr_domain_create(struct ibv_context *ctx,
 	dmn->ctx = ctx;
 	dmn->type = type;
 	atomic_init(&dmn->refcount, 1);
+	list_head_init(&dmn->tbl_list);
 
 	if (dr_domain_caps_init(ctx, dmn)) {
 		dr_dbg(dmn, "Failed init domain, no caps\n");

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -732,6 +732,7 @@ mlx5dv_dr_matcher_create(struct mlx5dv_dr_table *tbl,
 	matcher->match_criteria = match_criteria_enable;
 	atomic_init(&matcher->refcount, 1);
 	list_node_init(&matcher->matcher_list);
+	list_head_init(&matcher->rule_list);
 
 	pthread_mutex_lock(&tbl->dmn->mutex);
 

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -36,11 +36,6 @@
 
 #define DR_RULE_MAX_STE_CHAIN (DR_RULE_MAX_STES + DR_ACTION_MAX_STES)
 
-struct dr_rule_action_member {
-	struct mlx5dv_dr_action *action;
-	struct list_node	list;
-};
-
 static int dr_rule_append_to_miss_list(struct dr_ste *new_last_ste,
 				       struct list_head *miss_list,
 				       struct list_head *send_list)

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -976,6 +976,7 @@ static int dr_rule_destroy_rule(struct mlx5dv_dr_rule *rule)
 	}
 
 	dr_rule_remove_action_members(rule);
+	list_del(&rule->rule_list);
 	free(rule);
 	return 0;
 }
@@ -1171,6 +1172,7 @@ dr_rule_create_rule(struct mlx5dv_dr_matcher *matcher,
 
 	rule->matcher = matcher;
 	list_head_init(&rule->rule_actions_list);
+	list_node_init(&rule->rule_list);
 
 	ret = dr_rule_add_action_members(rule, num_actions, actions);
 	if (ret)
@@ -1202,6 +1204,7 @@ dr_rule_create_rule(struct mlx5dv_dr_matcher *matcher,
 	if (ret)
 		goto remove_action_members;
 
+	list_add_tail(&matcher->rule_list, &rule->rule_list);
 	return rule;
 
 remove_action_members:

--- a/providers/mlx5/dr_table.c
+++ b/providers/mlx5/dr_table.c
@@ -204,6 +204,9 @@ struct mlx5dv_dr_table *mlx5dv_dr_table_create(struct mlx5dv_dr_domain *dmn,
 			goto uninit_tbl;
 	}
 
+	list_node_init(&tbl->tbl_list);
+	list_add_tail(&dmn->tbl_list, &tbl->tbl_list);
+
 	return tbl;
 
 uninit_tbl:
@@ -230,6 +233,7 @@ int mlx5dv_dr_table_destroy(struct mlx5dv_dr_table *tbl)
 		dr_table_uninit(tbl);
 	}
 
+	list_del(&tbl->tbl_list);
 	atomic_fetch_sub(&tbl->dmn->refcount, 1);
 	free(tbl);
 

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -121,6 +121,7 @@ MLX5_1.12 {
 		mlx5dv_alloc_var;
 		mlx5dv_dr_action_create_flow_meter;
 		mlx5dv_dr_action_modify_flow_meter;
+		mlx5dv_dump_dr_domain;
 		mlx5dv_dump_dr_matcher;
 		mlx5dv_dump_dr_rule;
 		mlx5dv_dump_dr_table;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -121,6 +121,7 @@ MLX5_1.12 {
 		mlx5dv_alloc_var;
 		mlx5dv_dr_action_create_flow_meter;
 		mlx5dv_dr_action_modify_flow_meter;
+		mlx5dv_dump_dr_matcher;
 		mlx5dv_dump_dr_rule;
 		mlx5dv_free_var;
 } MLX5_1.11;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -121,5 +121,6 @@ MLX5_1.12 {
 		mlx5dv_alloc_var;
 		mlx5dv_dr_action_create_flow_meter;
 		mlx5dv_dr_action_modify_flow_meter;
+		mlx5dv_dump_dr_rule;
 		mlx5dv_free_var;
 } MLX5_1.11;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -123,5 +123,6 @@ MLX5_1.12 {
 		mlx5dv_dr_action_modify_flow_meter;
 		mlx5dv_dump_dr_matcher;
 		mlx5dv_dump_dr_rule;
+		mlx5dv_dump_dr_table;
 		mlx5dv_free_var;
 } MLX5_1.11;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -72,6 +72,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_destroy.3
+ mlx5dv_dump.3 mlx5dv_dump_dr_matcher.3
  mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -74,6 +74,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_table_destroy.3
  mlx5dv_dump.3 mlx5dv_dump_dr_matcher.3
  mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
+ mlx5dv_dump.3 mlx5dv_dump_dr_table.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
 )

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -72,6 +72,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_destroy.3
+ mlx5dv_dump.3 mlx5dv_dump_dr_domain.3
  mlx5dv_dump.3 mlx5dv_dump_dr_matcher.3
  mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
  mlx5dv_dump.3 mlx5dv_dump_dr_table.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -18,6 +18,7 @@ rdma_man_pages(
   mlx5dv_devx_subscribe_devx_event.3.md
   mlx5dv_devx_umem_reg.3.md
   mlx5dv_dr_flow.3.md
+  mlx5dv_dump.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3
@@ -71,6 +72,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_destroy.3
+ mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
 )

--- a/providers/mlx5/man/mlx5dv_dump.3.md
+++ b/providers/mlx5/man/mlx5dv_dump.3.md
@@ -10,6 +10,8 @@ footer: mlx5
 
 # NAME
 
+mlx5dv_dump_dr_domain - Dump DR Domain
+
 mlx5dv_dump_dr_table - Dump DR Table
 
 mlx5dv_dump_dr_matcher - Dump DR Matcher
@@ -21,6 +23,7 @@ mlx5dv_dump_dr_rule - Dump DR Rule
 ```c
 #include <infiniband/mlx5dv.h>
 
+int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *domain);
 int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *table);
 int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
@@ -30,6 +33,8 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 
 The Dump API (mlx5dv_dump_\*) allows the dumping of the existing rdma-core resources to the provided file.
 The output file format is vendor specific.
+
+*mlx5dv_dump_dr_domain()* dumps a DR Domain object properties to a specified file.
 
 *mlx5dv_dump_dr_table()* dumps a DR Table object properties to a specified file.
 

--- a/providers/mlx5/man/mlx5dv_dump.3.md
+++ b/providers/mlx5/man/mlx5dv_dump.3.md
@@ -10,6 +10,8 @@ footer: mlx5
 
 # NAME
 
+mlx5dv_dump_dr_matcher - Dump DR Matcher
+
 mlx5dv_dump_dr_rule - Dump DR Rule
 
 # SYNOPSIS
@@ -17,6 +19,7 @@ mlx5dv_dump_dr_rule - Dump DR Rule
 ```c
 #include <infiniband/mlx5dv.h>
 
+int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 ```
 
@@ -24,6 +27,8 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 
 The Dump API (mlx5dv_dump_\*) allows the dumping of the existing rdma-core resources to the provided file.
 The output file format is vendor specific.
+
+*mlx5dv_dump_dr_matcher()* dumps a DR Matcher object properties to a specified file.
 
 *mlx5dv_dump_dr_rule()* dumps a DR Rule object properties to a specified file.
 

--- a/providers/mlx5/man/mlx5dv_dump.3.md
+++ b/providers/mlx5/man/mlx5dv_dump.3.md
@@ -1,0 +1,37 @@
+---
+date: 2019-11-18
+layout: page
+title: MLX5DV_DUMP API
+section: 3
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_dump_dr_rule - Dump DR Rule
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
+```
+
+# DESCRIPTION
+
+The Dump API (mlx5dv_dump_\*) allows the dumping of the existing rdma-core resources to the provided file.
+The output file format is vendor specific.
+
+*mlx5dv_dump_dr_rule()* dumps a DR Rule object properties to a specified file.
+
+# RETURN VALUE
+The API calls returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+The calls are blocking - function returns only when all related resources info is written to the file.
+
+# AUTHOR
+
+Yevgeny Kliteynik <kliteyn@mellanox.com>
+Muhammad Sammar <muhammads@mellanox.com>

--- a/providers/mlx5/man/mlx5dv_dump.3.md
+++ b/providers/mlx5/man/mlx5dv_dump.3.md
@@ -10,6 +10,8 @@ footer: mlx5
 
 # NAME
 
+mlx5dv_dump_dr_table - Dump DR Table
+
 mlx5dv_dump_dr_matcher - Dump DR Matcher
 
 mlx5dv_dump_dr_rule - Dump DR Rule
@@ -19,6 +21,7 @@ mlx5dv_dump_dr_rule - Dump DR Rule
 ```c
 #include <infiniband/mlx5dv.h>
 
+int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *table);
 int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 ```
@@ -27,6 +30,8 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 
 The Dump API (mlx5dv_dump_\*) allows the dumping of the existing rdma-core resources to the provided file.
 The output file format is vendor specific.
+
+*mlx5dv_dump_dr_table()* dumps a DR Table object properties to a specified file.
 
 *mlx5dv_dump_dr_matcher()* dumps a DR Matcher object properties to a specified file.
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1519,6 +1519,7 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
+int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 
 #ifdef __cplusplus

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1519,6 +1519,7 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
+int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *table);
 int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1518,6 +1518,9 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 				       __be64 modify_field_select);
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
+
+int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1519,6 +1519,7 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
+int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *domain);
 int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *table);
 int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher);
 int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -734,6 +734,11 @@ struct mlx5dv_dr_action {
 	};
 };
 
+struct dr_rule_action_member {
+	struct mlx5dv_dr_action *action;
+	struct list_node	list;
+};
+
 enum dr_connect_type {
 	CONNECT_HIT	= 1,
 	CONNECT_MISS	= 2,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -634,6 +634,7 @@ struct mlx5dv_dr_domain {
 	struct dr_icm_pool		*action_icm_pool;
 	struct dr_send_ring		*send_ring;
 	struct dr_domain_info		info;
+	struct list_head		tbl_list;
 };
 
 struct dr_table_rx_tx {
@@ -650,6 +651,7 @@ struct mlx5dv_dr_table {
 	struct list_head		matcher_list;
 	struct mlx5dv_devx_obj		*devx_obj;
 	atomic_int			refcount;
+	struct list_node		tbl_list;
 };
 
 struct dr_matcher_rx_tx {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -671,6 +671,7 @@ struct mlx5dv_dr_matcher {
 	uint8_t				match_criteria;
 	atomic_int			refcount;
 	struct mlx5dv_flow_matcher	*dv_matcher;
+	struct list_head		rule_list;
 };
 
 struct dr_rule_member {
@@ -768,6 +769,7 @@ struct mlx5dv_dr_rule {
 		struct ibv_flow *flow;
 	};
 	struct list_head	rule_actions_list;
+	struct list_node	rule_list;
 };
 
 void dr_rule_update_rule_member(struct dr_ste *new_ste, struct dr_ste *ste);


### PR DESCRIPTION
This series introduces few DV APIs that allows the dumping of existing DR resources to a provided file.  

The output file can be parsed as part of debugging/analyzing the DR state,  the data format is mlx5 vendor specific.