### PR TITLE
ibacm: Fix bug in acm_get_ep()

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -898,6 +898,7 @@ static struct acmc_ep *acm_get_ep(int index, uint8_t port_num)
 			list_for_each(&dev->port[i].ep_list, ep, entry) {
 				if (index == inx)
 					return ep;
+				++inx;
 			}
 		}
 	}


### PR DESCRIPTION
Commit 26e05f8304a5 ("ibacm: use ccan/list.h") introduced a bug in
acm_get_ep() by not incrementing inx.

Fixes: 26e05f8304a5 ("ibacm: use ccan/list.h")
Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>