### PR TITLE
ibacm: Allocate end-point addresses dynamically

### DIFF
--- a/ibacm/man/ibacm.1
+++ b/ibacm/man/ibacm.1
@@ -146,13 +146,7 @@ The current implementation of the provider ibacmp has several additional restric
 - The ibacmp is limited in its handling of dynamic changes.
 ibacm must be stopped and restarted if a cluster is reconfigured.
 .P
-- Cached data does not timed out and is only updated if a new resolution
-request is received from a different QPN than a cached request.
-.P
 - Support for IPv6 has not been verified.
-.P
-- The number of addresses that can be assigned to a single endpoint is
-limited to 4.
 .P
 - The number of multicast groups that an endpoint can support is limited to 2.
 .P

--- a/ibacm/man/ibacm.1
+++ b/ibacm/man/ibacm.1
@@ -16,7 +16,7 @@ needed to establish a connection, but does not implement the CM protocol.
 .P
 A primary user of the ibacm service is the librdmacm library.  This
 enables applications to make use of the ibacm service without code
-changes or needing to be aware that the service is in use. 
+changes or needing to be aware that the service is in use.
 librdmacm versions 1.0.12 - 1.0.15 can invoke IB ACM services when built using
 the --with-ib_acm option.  Version 1.0.16 and newer of librdmacm will automatically
 use the IB ACM if it is installed.  The IB ACM services tie in under the
@@ -26,7 +26,7 @@ however existing applications should still see significant connection
 scaling benefits using the calls
 available in librdmacm 1.0.11 and previous releases.
 .P
-The IB ACM is focused on being scalable, efficient, and extensible.  It implements 
+The IB ACM is focused on being scalable, efficient, and extensible.  It implements
 a plugin architecture that allows a vendor to supply its proprietary provider in
 addition to the default provider.  The current default provider implementation
 ibacmp limits network traffic, SA interactions, and centralized
@@ -34,8 +34,8 @@ services.  Ibacmp supports multiple resolution protocols in order to handle
 different fabric topologies.
 .P
 The IB ACM package is comprised of three components: the ibacm core service,
-the default provider ibacmp shared library, and a test/configuration utility 
-- ib_acme.  All three are userspace components and are available for Linux.  
+the default provider ibacmp shared library, and a test/configuration utility
+- ib_acme.  All three are userspace components and are available for Linux.
 Additional details are given below.
 .SH "OPTIONS"
 .TP
@@ -90,15 +90,15 @@ The ibacm service relies on two configuration files.
 .P
 The ibacm_addr.cfg file contains name and address mappings for each IB
 <device, port, pkey> endpoint.  Although the names in the ibacm_addr.cfg
-file can be anything, ib_acme maps the host name to the IB endpoints.  IP 
-addresses, on the other hand, are assigned dynamically.  If the address file 
-cannot be found, the ibacm service will attempt to create one using default 
+file can be anything, ib_acme maps the host name to the IB endpoints.  IP
+addresses, on the other hand, are assigned dynamically.  If the address file
+cannot be found, the ibacm service will attempt to create one using default
 values.
 .P
 The ibacm_opts.cfg file provides a set of configurable options for the
 ibacm core service and default provider, such as timeout, number of retries,
-logging level, etc.  ib_acme generates the ibacm_opts.cfg file using static 
-information.  If an option file cannot be found, ibacm will use default values. 
+logging level, etc.  ib_acme generates the ibacm_opts.cfg file using static
+information.  If an option file cannot be found, ibacm will use default values.
 .P
 ibacm:
 .P
@@ -131,8 +131,8 @@ and destination names or addresses as input to the service, and receive
 as output path record data.
 .P
 The service maps a client's source name/address to a local IB endpoint.
-If the destination name/address is not cached locally in the default provider, 
-it sends a multicast request out on the lowest priority multicast group on the 
+If the destination name/address is not cached locally in the default provider,
+it sends a multicast request out on the lowest priority multicast group on the
 local endpoint.  The request carries a list of multicast groups that the sender can use.
 The recipient of the request selects the highest priority multicast group
 that it can use as well and returns that information directly to the sender.

--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -68,7 +68,6 @@
 #include "acm_mad.h"
 #include "acm_util.h"
 
-#define MAX_EP_ADDR 4
 #define NL_MSG_BUF_SIZE 4096
 #define ACM_PROV_NAME_SIZE 64
 #define NL_CLIENT_INDEX 0
@@ -135,7 +134,11 @@ struct acmc_ep {
 	struct acmc_port      *port;
 	struct acm_endpoint   endpoint;
 	void                  *prov_ep_context;
-	struct acmc_addr      addr_info[MAX_EP_ADDR];
+	/* Although the below two entries are used for dynamic allocations,
+	 * they are accessed by a single thread, so no locking is required.
+	 */
+	int                   nmbr_ep_addrs;
+	struct acmc_addr      *addr_info;
 	struct list_node      entry;
 };
 
@@ -417,7 +420,7 @@ static void acm_mark_addr_invalid(struct acmc_ep *ep,
 {
 	int i;
 
-	for (i = 0; i < MAX_EP_ADDR; i++) {
+	for (i = 0; i < ep->nmbr_ep_addrs; i++) {
 		if (!acm_addr_cmp(&ep->addr_info[i].addr, data->info.addr, data->type)) {
 			ep->addr_info[i].addr.type = ACM_ADDRESS_INVALID;
 			ep->port->prov->remove_address(ep->addr_info[i].prov_addr_context);
@@ -433,7 +436,7 @@ acm_addr_lookup(const struct acm_endpoint *endpoint, uint8_t *addr, uint8_t addr
 	int i;
 
 	ep = container_of(endpoint, struct acmc_ep, endpoint);
-	for (i = 0; i < MAX_EP_ADDR; i++)
+	for (i = 0; i < ep->nmbr_ep_addrs; i++)
 		if (!acm_addr_cmp(&ep->addr_info[i].addr, addr, addr_type))
 			return &ep->addr_info[i].addr;
 
@@ -842,7 +845,7 @@ acm_get_port_ep_address(struct acmc_port *port, struct acm_ep_addr_data *data)
 		if ((data->type == ACM_EP_INFO_PATH) &&
 		    (!data->info.path.pkey ||
 		     acm_same_partition(be16toh(data->info.path.pkey), ep->endpoint.pkey))) {
-			for (i = 0; i < MAX_EP_ADDR; i++) {
+			for (i = 0; i < ep->nmbr_ep_addrs; i++) {
 				if (ep->addr_info[i].addr.type)
 					return &ep->addr_info[i];
 			}
@@ -1192,12 +1195,46 @@ static int acm_svr_perf_query(struct acmc_client *client, struct acm_msg *msg)
 	return ret;
 }
 
-static int acm_svr_ep_query(struct acmc_client *client, struct acm_msg *msg)
+static int may_be_realloc(struct acm_msg **msg_ptr,
+			  int len,
+			  int cnt,
+			  int *cur_msg_siz_ptr,
+			  int max_msg_siz)
 {
+
+	/* Check if a new address exceeds the protocol constrained max size */
+	if (len + (cnt + 1) * ACM_MAX_ADDRESS > max_msg_siz) {
+		acm_log(0, "ERROR - unable to amend more addresses to acm_msg due to protocol constraints\n");
+			return ENOMEM;
+	}
+
+	/* Check if a new address exceeds current size of msg */
+	if (len + (cnt + 1) * ACM_MAX_ADDRESS > *cur_msg_siz_ptr) {
+		const size_t chunk_size = 16 * ACM_MAX_ADDRESS;
+		struct acm_msg *new_msg = realloc(*msg_ptr, *cur_msg_siz_ptr + chunk_size);
+
+		if (!new_msg) {
+			acm_log(0, "ERROR - failed to allocate longer acm_msg\n");
+			return ENOMEM;
+		}
+
+		*msg_ptr = new_msg;
+		*cur_msg_siz_ptr += chunk_size;
+	}
+
+	return 0;
+}
+
+static int acm_svr_ep_query(struct acmc_client *client, struct acm_msg **_msg)
+{
+	int sts;
 	int ret, i;
 	uint16_t len;
 	struct acmc_ep *ep;
 	int index, cnt = 0;
+	struct acm_msg *msg = *_msg;
+	int cur_msg_siz = sizeof(*msg);
+	int max_msg_siz = USHRT_MAX;
 
 	acm_log(2, "client %d\n", client->index);
 	index = msg->hdr.src_out;
@@ -1212,8 +1249,12 @@ static int acm_svr_ep_query(struct acmc_client *client, struct acm_msg *msg)
 			ACM_MAX_PROV_NAME - 1);
 		msg->ep_data[0].prov_name[ACM_MAX_PROV_NAME - 1] = '\0';
 		len = ACM_MSG_HDR_LENGTH + sizeof(struct acm_ep_config_data);
-		for (i = 0; i < MAX_EP_ADDR; i++) {
+		for (i = 0; i < ep->nmbr_ep_addrs; i++) {
 			if (ep->addr_info[i].addr.type != ACM_ADDRESS_INVALID) {
+				sts = may_be_realloc(_msg, len, cnt, &cur_msg_siz, max_msg_siz);
+				msg = *_msg;
+				if (sts)
+					break;
 				memcpy(msg->ep_data[0].addrs[cnt++].name,
 				       ep->addr_info[i].string_buf,
 				       ACM_MAX_ADDRESS);
@@ -1247,39 +1288,46 @@ static int acm_msg_length(struct acm_msg *msg)
 
 static void acm_svr_receive(struct acmc_client *client)
 {
-	struct acm_msg msg;
+	struct acm_msg *msg = malloc(sizeof(*msg));
 	int ret;
 
+	if (!msg) {
+		acm_log(0, "ERROR - Unable to alloc acm_msg\n");
+		ret = ENOMEM;
+		goto out;
+	}
+
 	acm_log(2, "client %d\n", client->index);
-	ret = recv(client->sock, (char *) &msg, sizeof msg, 0);
-	if (ret <= 0 || ret != acm_msg_length(&msg)) {
+	ret = recv(client->sock, (char *)msg, sizeof(*msg), 0);
+	if (ret <= 0 || ret != acm_msg_length(msg)) {
 		acm_log(2, "client disconnected\n");
 		ret = ACM_STATUS_ENOTCONN;
 		goto out;
 	}
 
-	if (msg.hdr.version != ACM_VERSION) {
-		acm_log(0, "ERROR - unsupported version %d\n", msg.hdr.version);
+	if (msg->hdr.version != ACM_VERSION) {
+		acm_log(0, "ERROR - unsupported version %d\n", msg->hdr.version);
 		goto out;
 	}
 
-	switch (msg.hdr.opcode & ACM_OP_MASK) {
+	switch (msg->hdr.opcode & ACM_OP_MASK) {
 	case ACM_OP_RESOLVE:
 		atomic_inc(&counter[ACM_CNTR_RESOLVE]);
-		ret = acm_svr_resolve(client, &msg);
+		ret = acm_svr_resolve(client, msg);
 		break;
 	case ACM_OP_PERF_QUERY:
-		ret = acm_svr_perf_query(client, &msg);
+		ret = acm_svr_perf_query(client, msg);
 		break;
 	case ACM_OP_EP_QUERY:
 		ret = acm_svr_ep_query(client, &msg);
 		break;
 	default:
-		acm_log(0, "ERROR - unknown opcode 0x%x\n", msg.hdr.opcode);
+		acm_log(0, "ERROR - unknown opcode 0x%x\n", msg->hdr.opcode);
 		break;
 	}
 
 out:
+	free(msg);
 	if (ret)
 		acm_disconnect_client(client);
 }
@@ -1421,7 +1469,7 @@ static int resync_system_ips(void)
 			port = &dev->port[cnt];
 
 			list_for_each(&port->ep_list, ep, entry) {
-				for (i = 0; i < MAX_EP_ADDR; i++) {
+				for (i = 0; i < ep->nmbr_ep_addrs; i++) {
 					if (ep->addr_info[i].addr.type == ACM_ADDRESS_IP ||
 					    ep->addr_info[i].addr.type == ACM_ADDRESS_IP6)
 						ep->addr_info[i].addr.type = ACM_ADDRESS_INVALID;
@@ -2019,49 +2067,70 @@ static FILE *acm_open_addr_file(void)
 }
 
 static int
-acm_ep_insert_addr(struct acmc_ep *ep, const char *name, uint8_t *addr,
+__acm_ep_insert_addr(struct acmc_ep *ep, const char *name, uint8_t *addr,
 		   uint8_t addr_type)
 {
-	int i, ret = -1;
-	uint8_t tmp[ACM_MAX_ADDRESS];
+	int i;
+	int ret;
+	uint8_t tmp[ACM_MAX_ADDRESS] = {};
 
-	memset(tmp, 0, sizeof tmp);
 	memcpy(tmp, addr, acm_addr_len(addr_type));
 
-	if (!acm_addr_lookup(&ep->endpoint, addr, addr_type)) {
-		for (i = 0; (i < MAX_EP_ADDR) &&
-			    (ep->addr_info[i].addr.type != ACM_ADDRESS_INVALID); i++)
-			;
-		if (i == MAX_EP_ADDR) {
+	for (i = 0; (i < ep->nmbr_ep_addrs) &&
+		     (ep->addr_info[i].addr.type != ACM_ADDRESS_INVALID); i++)
+		;
+	if (i == ep->nmbr_ep_addrs) {
+		struct acmc_addr *new_info;
+		new_info = realloc(ep->addr_info, (i + 1) * sizeof(*ep->addr_info));
+		if (!new_info) {
 			ret = ENOMEM;
 			goto out;
 		}
+		ep->addr_info = new_info;
 
-		/* Open the provider endpoint only if at least a name or
-		   address is found */
-		if (!ep->prov_ep_context) {
-			ret = ep->port->prov->open_endpoint(&ep->endpoint,
-				ep->port->prov_port_context,
-				&ep->prov_ep_context);
-			if (ret) {
-				acm_log(0, "Error: failed to open prov ep\n");
-				goto out;
-			}
-		}
-		ep->addr_info[i].addr.type = addr_type;
-		strncpy(ep->addr_info[i].string_buf, name, ACM_MAX_ADDRESS);
-		memcpy(ep->addr_info[i].addr.info.addr, tmp, ACM_MAX_ADDRESS);
-		ret = ep->port->prov->add_address(&ep->addr_info[i].addr,
-						  ep->prov_ep_context,
-						  &ep->addr_info[i].prov_addr_context);
+		/* Added memory is not initialized */
+		memset(ep->addr_info + i, 0, sizeof(*ep->addr_info));
+		ep->addr_info[i].addr.endpoint = &ep->endpoint;
+		ep->addr_info[i].addr.id_string = ep->addr_info[i].string_buf;
+		++ep->nmbr_ep_addrs;
+	}
+
+	/* Open the provider endpoint only if at least a name or
+	   address is found */
+	if (!ep->prov_ep_context) {
+		ret = ep->port->prov->open_endpoint(&ep->endpoint,
+						    ep->port->prov_port_context,
+						    &ep->prov_ep_context);
 		if (ret) {
-			acm_log(0, "Error: failed to add addr to provider\n");
-			ep->addr_info[i].addr.type = ACM_ADDRESS_INVALID;
+			acm_log(0, "Error: failed to open prov ep\n");
 			goto out;
 		}
 	}
-	ret = 0;
+	ep->addr_info[i].addr.type = addr_type;
+	strncpy(ep->addr_info[i].string_buf, name, ACM_MAX_ADDRESS);
+	memcpy(ep->addr_info[i].addr.info.addr, tmp, ACM_MAX_ADDRESS);
+	ret = ep->port->prov->add_address(&ep->addr_info[i].addr,
+					  ep->prov_ep_context,
+					  &ep->addr_info[i].prov_addr_context);
+	if (ret) {
+		acm_log(0, "Error: failed to add addr to provider\n");
+		ep->addr_info[i].addr.type = ACM_ADDRESS_INVALID;
+	}
+
 out:
+	return ret;
+}
+
+static int
+acm_ep_insert_addr(struct acmc_ep *ep, const char *name, uint8_t *addr,
+		   uint8_t addr_type)
+{
+	int ret = -1;
+
+	if (!acm_addr_lookup(&ep->endpoint, addr, addr_type)) {
+		ret = __acm_ep_insert_addr(ep, name, addr, addr_type);
+	}
+
 	return ret;
 }
 
@@ -2180,7 +2249,7 @@ static int acm_assign_ep_names(struct acmc_ep *ep)
 	fclose(faddr);
 
 out:
-	return (ep->addr_info[0].addr.type == ACM_ADDRESS_INVALID);
+	return (!ep->nmbr_ep_addrs || ep->addr_info[0].addr.type == ACM_ADDRESS_INVALID);
 }
 
 static struct acmc_ep *acm_find_ep(struct acmc_port *port, uint16_t pkey)
@@ -2205,7 +2274,8 @@ static void acm_ep_down(struct acmc_ep *ep)
 	acm_log(1, "%s %d pkey 0x%04x\n",
 		ep->port->dev->device.verbs->device->name,
 		ep->port->port.port_num, ep->endpoint.pkey);
-	for (i = 0; i < MAX_EP_ADDR; i++) {
+
+	for (i = 0; i < ep->nmbr_ep_addrs; i++) {
 		if (ep->addr_info[i].addr.type &&
 		    ep->addr_info[i].prov_addr_context)
 			ep->port->prov->remove_address(ep->addr_info[i].
@@ -2222,7 +2292,6 @@ static struct acmc_ep *
 acm_alloc_ep(struct acmc_port *port, uint16_t pkey)
 {
 	struct acmc_ep *ep;
-	int i;
 
 	acm_log(1, "\n");
 	ep = calloc(1, sizeof *ep);
@@ -2232,11 +2301,8 @@ acm_alloc_ep(struct acmc_port *port, uint16_t pkey)
 	ep->port = port;
 	ep->endpoint.port = &port->port;
 	ep->endpoint.pkey = pkey;
-
-	for (i = 0; i < MAX_EP_ADDR; i++) {
-		ep->addr_info[i].addr.endpoint = &ep->endpoint;
-		ep->addr_info[i].addr.id_string = ep->addr_info[i].string_buf;
-	}
+	ep->addr_info = NULL;
+	ep->nmbr_ep_addrs = 0;
 
 	return ep;
 }


### PR DESCRIPTION
This is a re-wrap of my series made in November 2018.

On a system with a CX-3, which has 8 VFs enabled, this series has been tested by adding thousands of addresses and deleting them in parallel, concurrently with issuing path queries by means of ib_acme.

On top of this cmtime has been run in a loop creating/deleting 1000 QPs per invocation.

On top of the above, Oracle's Active/Active RDMA failover mechanism, https://blogs.oracle.com/linux/resilient-rdma-ip-addresses, has been triggered to move the above IP addresses back and forth between the ports by means of IB port down/up transitions.
