### PR TITLE
tests: Fix checking page_size_cap

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -73,7 +73,7 @@ class DeviceTest(unittest.TestCase):
         assert attr.node_guid != 0
         assert attr.sys_image_guid != 0
         assert attr.max_mr_size > PAGE_SIZE
-        assert attr.page_size_cap > PAGE_SIZE
+        assert attr.page_size_cap >= PAGE_SIZE
         assert attr.vendor_id != 0
         assert attr.vendor_part_id != 0
         assert attr.max_qp > 0


### PR DESCRIPTION
In some devices, the page_size_cap is equal to PAGE_SIZE.

Fixes: 9d66a1abc0bd ("pyverbs: Add support for extended query_device")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>