### PR TITLE
kernel-boot: Use node GUID instead of system image GUID

### DIFF
--- a/Documentation/udev.md
+++ b/Documentation/udev.md
@@ -168,7 +168,7 @@ directory.
  * NAME_PCI - read PCI location and topology as a source for stable names,
  which won't change in any software event (reset, PCI probe e.t.c.).
  Example: "ibp0s12f4".
- * NAME_GUID - read system image GUID information in similar manner to
+ * NAME_GUID - read node GUID information in similar manner to
  net MAC naming policy. Example "rocex525400c0fe123455".
  * NAME_ONBOARD - read Firmware/BIOS provided index numbers for on-board devices.
  Example: "ibo3".
@@ -188,7 +188,7 @@ Type of names:
 
  * o<index> - on-board device index number
  * s<slot>[f<function>] - hotplug slot index number
- * x<GUID> - System image GUID
+ * x<GUID> - Node GUID
  * [P<domain>]p<bus>s<slot>[f<function>] - PCI geographical location
 
 Notes:

--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -25,7 +25,7 @@
  *                 by->onboard -> by-pci -> by-guid -> kernel
  * NAME_KERNEL - leave name as kernel provided
  * NAME_PCI - based on PCI/slot/function location
- * NAME_GUID - based on system image GUID
+ * NAME_GUID - based on node GUID
  * NAME_ONBOARD - based on-board device index
  *
  * The stable names are combination of device type technology and rename mode.
@@ -53,7 +53,7 @@
 struct data {
 	const char *curr;
 	char *prefix;
-	uint64_t sys_image_guid;
+	uint64_t node_guid;
 	char *name;
 	int idx;
 };
@@ -466,11 +466,11 @@ static int by_guid(struct data *d)
 	uint16_t vp[4];
 	int ret = -1;
 
-	if (!d->sys_image_guid)
+	if (!d->node_guid)
 		/* virtual devices start without GUID */
 		goto out;
 
-	memcpy(vp, &d->sys_image_guid, sizeof(uint64_t));
+	memcpy(vp, &d->node_guid, sizeof(uint64_t));
 	ret = asprintf(&d->name, "%sx%04x%04x%04x%04x", d->prefix, vp[3], vp[2],
 		       vp[1], vp[0]);
 out:
@@ -522,7 +522,7 @@ static int get_nldata_cb(struct nl_msg *msg, void *data)
 		return NL_STOP;
 
 	if (!tb[RDMA_NLDEV_ATTR_DEV_NAME] || !tb[RDMA_NLDEV_ATTR_DEV_INDEX] ||
-	    !tb[RDMA_NLDEV_ATTR_SYS_IMAGE_GUID])
+	    !tb[RDMA_NLDEV_ATTR_NODE_GUID])
 		return NL_STOP;
 
 	ret = strcmp(d->curr, nla_get_string(tb[RDMA_NLDEV_ATTR_DEV_NAME]));
@@ -538,7 +538,7 @@ static int get_nldata_cb(struct nl_msg *msg, void *data)
 		return NL_STOP;
 
 	d->idx = nla_get_u32(tb[RDMA_NLDEV_ATTR_DEV_INDEX]);
-	d->sys_image_guid = nla_get_u64(tb[RDMA_NLDEV_ATTR_SYS_IMAGE_GUID]);
+	d->node_guid = nla_get_u64(tb[RDMA_NLDEV_ATTR_NODE_GUID]);
 	return NL_STOP;
 }
 


### PR DESCRIPTION
The multi-function devices have same system image GUID while presented
with multiple IB devices. This leads to the failures for NAME_GUID
option to rename second device. Instead of system image GUID use
node GUID as a unique identifier.

Cc: <stable@linux-rdma.org>
Fixes: 6b4099d47be3 ("kernel-boot: Perform device rename to make stable names")
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>