### PR TITLE
libhns: Update ibvqp->state in hns_roce_u_v2_modify_qp()

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -1107,6 +1107,9 @@ static int hns_roce_u_v2_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 	if (ret)
 		return ret;
 
+	if (attr_mask & IBV_QP_STATE)
+		qp->state = attr->qp_state;
+
 	if ((attr_mask & IBV_QP_STATE) && attr->qp_state == IBV_QPS_RESET) {
 		hns_roce_v2_cq_clean(to_hr_cq(qp->recv_cq), qp->qp_num,
 				     qp->srq ? to_hr_srq(qp->srq) : NULL);


### PR DESCRIPTION
The state of ibvqp will be updated after calling modify_qp(), because the
assignment of ibvqp->state is out of hns driver, it can't be guaranteed
that the configuration of ibvqp->state will take effect immediately. This
may cause hns_roce_u_v2_modify_qp() in post_send/post_recv process is
skipped.

Therefore, update value of ibvqp->state in modify_qp().