### PR TITLE
libqedr: Fix user context allocation forward compatibility

### DIFF
--- a/providers/qedr/qelr_main.c
+++ b/providers/qedr/qelr_main.c
@@ -181,7 +181,7 @@ static struct verbs_context *qelr_alloc_context(struct ibv_device *ibdev,
 	qelr_open_debug_file(ctx);
 	qelr_set_debug_mask();
 
-	cmd.context_flags |= QEDR_ALLOC_UCTX_DB_REC;
+	cmd.context_flags = QEDR_ALLOC_UCTX_DB_REC;
 	if (ibv_cmd_get_context(&ctx->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto cmd_err;


### PR DESCRIPTION
The user context alloc request structure introduced a new field
to indicate doorbell recovery is supported. This field was added so
that additional features could be added in the future by setting a
capability flag. However, the field wasn't zeroed, and was initialized
using "|=" instead of "=" leading to garbage in the other bits.
For forward compatability, we need to make sure all other bits are
zero.

Cc: stable@linux-rdma.org # v27 v28
Fixes: d9b2ba480af5 ("libqedr: Add support for Doorbell Overflow Recovery")
Signed-off-by: Ariel Elior <ariel.elior@marvell.com>
Signed-off-by: Michal Kalderon <michal.kalderon@marvell.com>