### PR TITLE
vmw_pvrdma: Avoid double unlock on qp->sq.lock

### DIFF
--- a/providers/vmw_pvrdma/qp.c
+++ b/providers/vmw_pvrdma/qp.c
@@ -459,11 +459,12 @@ int pvrdma_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 	}
 
 	pthread_spin_lock(&qp->sq.lock);
+
 	ind = pvrdma_idx(&(qp->sq.ring_state->prod_tail), qp->sq.wqe_cnt);
 	if (ind < 0) {
 		pthread_spin_unlock(&qp->sq.lock);
-		ret = EINVAL;
-		goto out;
+		*bad_wr = wr;
+		return EINVAL;
 	}
 
 	for (nreq = 0; wr; ++nreq, wr = wr->next) {


### PR DESCRIPTION
qp->sq.lock is currently unlocked twice when the ring state is invalid.
Fix this by removing the goto, and also set bad_wr correctly.

Fixes: 36756a63b3b5 ("libpvrdma: Add queue pair functions")
Cc: stable@linux-rdma.org
Reviewed-by: Vishnu Dasa <vdasa@vmware.com>
Reviewed-by: Adit Ranadive <aditr@vmware.com>
Reviewed-by: Rajesh Jalisatgi <rjalisatgi@vmware.com>
Signed-off-by: Bryan Tan <bryantan@vmware.com>