### PR TITLE
libhns: Not process return value of flushing cqe

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -916,9 +916,7 @@ out:
 		attr_mask = IBV_QP_STATE;
 		attr.qp_state = IBV_QPS_ERR;
 
-		ret = hns_roce_u_v2_modify_qp(ibvqp, &attr, attr_mask);
-		if (ret)
-			*bad_wr = wr;
+		hns_roce_u_v2_modify_qp(ibvqp, &attr, attr_mask);
 	}
 
 	return ret;
@@ -1019,9 +1017,7 @@ out:
 		attr_mask = IBV_QP_STATE;
 		attr.qp_state = IBV_QPS_ERR;
 
-		ret = hns_roce_u_v2_modify_qp(ibvqp, &attr, attr_mask);
-		if (ret)
-			*bad_wr = wr;
+		hns_roce_u_v2_modify_qp(ibvqp, &attr, attr_mask);
 	}
 
 	return ret;


### PR DESCRIPTION
When a firmware reset occurred because of some errors, modify qp to error
in post_send() will be failed. The bad_wr will be returned to the user,
then the user won't wait for the corresponding wc. But as sq db has been
updated, the driver will return a software wc to the user, which may cause
unexpected behaviours.

Because the result of modifying qp is meaningless in this scenario, codes
to handle the return value are removed.