### PR TITLE
mlx5: Add Mellanox ConnectX-6 LX PCI ID

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -80,6 +80,7 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0x101c),	/* ConnectX-6 VF */
 	HCA(MELLANOX, 0x101d),	/* ConnectX-6 DX */
 	HCA(MELLANOX, 0x101e),	/* ConnectX family mlx5Gen Virtual Function */
+	HCA(MELLANOX, 0x101f),	/* ConnectX-6 LX */
 	HCA(MELLANOX, 0x1021),  /* ConnectX-7 */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */


### PR DESCRIPTION
Update PCI ID table to support Mellanox ConnectX-6 LX cards.

Signed-off-by: Moshe Tal <moshet@mellanox.com>
Reviewed-by: Feras Daoud <ferasda@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>