### PR TITLE
rsockets: Do not overwrite connection failure error code

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -1453,9 +1453,14 @@ connected:
 
 		rs->state = rs_connect_rdwr;
 		break;
+	case rs_connect_error:
+	case rs_disconnected:
+	case rs_error:
+		ret = ERR(ENOTCONN);
+		goto unlock;
 	default:
 		ret = (rs->state & rs_connected) ? 0 : ERR(EINVAL);
-		break;
+		goto unlock;
 	}
 
 	if (ret) {
@@ -1466,6 +1471,7 @@ connected:
 			rs->err = errno;
 		}
 	}
+unlock:
 	fastlock_release(&rs->slock);
 	return ret;
 }


### PR DESCRIPTION
In rs_do_connect, if the rsocket state is not connected, we set
errno = EINVAL and ret = -1.  Later in the code, we modify the
rsocket state to an error state and save errno with the rsocket.
Apps can obtain the error data through getsockopt.

This can result in overwriting real connection error data that
may have been saved with the rsocket.  The JDK catches this error
in a negative test case.  It reads the EINVAL error code from the
socket, when it expects ECONNREFUSED.

Update the code so that we only save the error with the socket if
it came from a connection error.  In other cases, simply set errno
and return a failure.  We add explicit state checks for the other
non-connected rsocket cases.

Signed-off-by: Sean Hefty <sean.hefty@intel.com>