### PR TITLE
ibdiag: Compare CA device names by using the maximum length between them

### DIFF
--- a/infiniband-diags/ibstat.c
+++ b/infiniband-diags/ibstat.c
@@ -311,8 +311,7 @@ int main(int argc, char *argv[])
 
 	if (argc) {
 		for (node = device_list; node; node = node->next)
-			if (!strncmp(node->ca_name, argv[0],
-				     strlen(node->ca_name)))
+			if (!strcmp(node->ca_name, argv[0]))
 				break;
 		if (!node)
 			IBPANIC("'%s' IB device can't be found", argv[0]);


### PR DESCRIPTION
Compare CA device names by using the maximum length between them in order to
avoid matches of sub strings between CA device names that can match the
wrong device.

Example before the fix:
Input CA name: abc_11
List CA names: abc_1, def_1
When running : ibstat abc_11, the output will be the details of abc_1 even
though abc_11 does not exist.

After the fix, the output of this case will be:
'abc_11' IB device can't be found

Signed-off-by: Haim Boozaglo <haimbo@mellanox.com>