### PR TITLE
efa: Replace zero-length array with flexible-array member

### DIFF
--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -52,7 +52,7 @@ struct efa_cq {
 	/* Index of next sub cq idx to poll. This is used to guarantee fairness for sub cqs */
 	uint16_t next_poll_idx;
 	pthread_spinlock_t lock;
-	struct efa_sub_cq sub_cq_arr[0];
+	struct efa_sub_cq sub_cq_arr[];
 };
 
 struct efa_wq {


### PR DESCRIPTION
The preferred mechanism to declare variable-length types is using a
flexible array member.

By using a flexible array we'll get a compiler warning in case the
flexible array does not occur last in the struct.

Signed-off-by: Gal Pressman <galpress@amazon.com>