### PR TITLE
verbs: Enable CQ creation with a parent domain

### DIFF
--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -29,6 +29,7 @@ int                     comp_vector;       /* Completion vector used to signal c
 uint64_t                wc_flags;          /* The wc_flags that should be returned in ibv_poll_cq_ex. Or'ed bit of enum ibv_wc_flags_ex. */
 uint32_t                comp_mask;         /* compatibility mask (extended verb). */
 uint32_t                flags              /* One or more flags from enum ibv_create_cq_attr_flags */
+struct ibv_pd           *parent_domain;    /* Parent domain to be used by this CQ */
 .in -8
 };
 
@@ -48,6 +49,7 @@ enum ibv_wc_flags_ex {
 
 enum ibv_cq_init_attr_mask {
         IBV_CQ_INIT_ATTR_MASK_FLAGS             = 1 << 0,
+        IBV_CQ_INIT_ATTR_MASK_PD                = 1 << 1,
 };
 
 enum ibv_create_cq_attr_flags {
@@ -175,7 +177,8 @@ CQ should be destroyed with ibv_destroy_cq.
 .BR ibv_resize_cq (3),
 .BR ibv_req_notify_cq (3),
 .BR ibv_ack_cq_events (3),
-.BR ibv_create_qp (3)
+.BR ibv_create_qp (3),
+.BR ibv_alloc_parent_domain (3)
 .SH "AUTHORS"
 .TP
 Matan Barak <matanb@mellanox.com>

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1946,6 +1946,7 @@ struct ibv_context {
 
 enum ibv_cq_init_attr_mask {
 	IBV_CQ_INIT_ATTR_MASK_FLAGS	= 1 << 0,
+	IBV_CQ_INIT_ATTR_MASK_PD	= 1 << 1,
 };
 
 enum ibv_create_cq_attr_flags {
@@ -1976,6 +1977,7 @@ struct ibv_cq_init_attr_ex {
 	 * enum ibv_create_cq_attr_flags
 	 */
 	uint32_t		flags;
+	struct ibv_pd		*parent_domain;
 };
 
 enum ibv_parent_domain_init_attr_mask {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -392,6 +392,7 @@ struct mlx5_cq {
 	uint32_t			cqn;
 	uint32_t			cons_index;
 	__be32			       *dbrec;
+	bool				custom_db;
 	int				arm_sn;
 	int				cqe_sz;
 	int				resize_cqe_sz;
@@ -406,6 +407,7 @@ struct mlx5_cq {
 	uint32_t			flags;
 	int			umr_opcode;
 	struct mlx5dv_clock_info	last_clock_info;
+	struct ibv_pd			*parent_domain;
 };
 
 struct mlx5_tag_entry {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -64,6 +64,7 @@ extern "C" {
 #define MLX5DV_RES_TYPE_RWQ ((uint64_t)RDMA_DRIVER_MLX5 << 32 | 2)
 #define MLX5DV_RES_TYPE_DBR ((uint64_t)RDMA_DRIVER_MLX5 << 32 | 3)
 #define MLX5DV_RES_TYPE_SRQ ((uint64_t)RDMA_DRIVER_MLX5 << 32 | 4)
+#define MLX5DV_RES_TYPE_CQ ((uint64_t)RDMA_DRIVER_MLX5 << 32 | 5)
 
 enum {
 	MLX5_RCV_DBR	= 0,

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -26,6 +26,7 @@ cdef class CQ(PyverbsCM):
 cdef class CqInitAttrEx(PyverbsObject):
     cdef v.ibv_cq_init_attr_ex attr
     cdef object channel
+    cdef object parent_domain
 
 cdef class CQEX(PyverbsCM):
     cdef v.ibv_cq_ex *cq

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -216,6 +216,7 @@ cdef extern from 'infiniband/verbs.h':
         unsigned long       wc_flags
         unsigned int        comp_mask
         unsigned int        flags
+        ibv_pd              *parent_domain
 
     cdef struct ibv_cq_ex:
         ibv_context         *context

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -347,6 +347,7 @@ cdef extern from '<infiniband/verbs.h>':
 
     cpdef enum ibv_cq_init_attr_mask:
         IBV_CQ_INIT_ATTR_MASK_FLAGS
+        IBV_CQ_INIT_ATTR_MASK_PD
 
     cpdef enum ibv_create_cq_attr_flags:
         IBV_CREATE_CQ_ATTR_SINGLE_THREADED

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -27,8 +27,9 @@ cdef class ParentDomainInitAttr(PyverbsObject):
     cdef object dealloc
 
 cdef class ParentDomain(PD):
+    cdef add_ref(self, obj)
     cdef object protection_domain
-    pass
+    cdef object cqs
 
 cdef class ParentDomainContext(PyverbsObject):
     cdef object p_alloc

--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -6,12 +6,12 @@ Test module for Pyverbs' ParentDomain.
 from pyverbs.pd import ParentDomainInitAttr, ParentDomain, ParentDomainContext
 from pyverbs.pyverbs_error import PyverbsRDMAError
 from pyverbs.srq import SrqAttr, SrqInitAttr, SRQ
+from pyverbs.cq import CqInitAttrEx, CQEX, CQ
 from pyverbs.qp import QPInitAttr, QP
 from tests.base import BaseResources
 from tests.base import RDMATestCase
 import pyverbs.mem_alloc as mem
 import pyverbs.enums as e
-from pyverbs.cq import CQ
 import tests.utils as u
 import unittest
 import errno
@@ -54,6 +54,9 @@ class ParentDomainTestCase(RDMATestCase):
         QP(self.pd_res.parent_domain, qia)
         srq_init_attr = SrqInitAttr(SrqAttr())
         SRQ(self.pd_res.parent_domain, srq_init_attr)
+        cq_init_attrs_ex = CqInitAttrEx(comp_mask=e.IBV_CQ_INIT_ATTR_MASK_PD,
+                                        parent_domain=self.pd_res.parent_domain)
+        CQEX(self.pd_res.ctx, cq_init_attrs_ex)
 
     def test_without_allocators(self):
         self._create_parent_domain_with_allocators(None, None)


### PR DESCRIPTION
The parent domain object enables some functionality for a given verb object once it's attached to.
This series extends CQ creation to get a parent domain object to enable using its functionality.

This new option is used by mlx5 driver to allow custom memory allocation for a CQ.