### PR TITLE
libibverbs: Fix query_device_ex dummy function not to return EOPNOTSUPP

### DIFF
--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -369,11 +369,22 @@ static int query_device(struct ibv_context *context,
 	return EOPNOTSUPP;
 }
 
+/* Provide a generic implementation for all providers that don't implement
+ * query_device_ex.
+ */
 static int query_device_ex(struct ibv_context *context,
 			   const struct ibv_query_device_ex_input *input,
 			   struct ibv_device_attr_ex *attr, size_t attr_size)
 {
-	return EOPNOTSUPP;
+	if (input && input->comp_mask)
+		return EINVAL;
+
+	if (attr_size < sizeof(attr->orig_attr))
+		return EOPNOTSUPP;
+
+	memset(&attr->orig_attr, 0, sizeof(attr->orig_attr));
+
+	return ibv_query_device(context, &attr->orig_attr);
 }
 
 static int query_port(struct ibv_context *context, uint8_t port_num,

--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -3,18 +3,23 @@
 .\"
 .TH IBV_QUERY_DEVICE_EX 3 2014-12-17 libibverbs "Libibverbs Programmer's Manual"
 .SH "NAME"
-ibv_query_device_ex \- query an RDMA device's attributes
+ibv_query_device_ex \- query an RDMA device's attributes including extended
+device properties.
 .SH "SYNOPSIS"
 .nf
 .B #include <infiniband/verbs.h>
 .sp
 .BI "int ibv_query_device_ex(struct ibv_context " "*context",
+.BI "                        struct ibv_query_device_ex_input " "*input",
 .BI "                        struct ibv_device_attr_ex " "*attr" );
 .fi
 .SH "DESCRIPTION"
 .B ibv_query_device_ex()
 returns the attributes of the device with context
 .I context\fR.
+The argument
+.I input
+is a pointer to an ibv_query_device_ex_input structure, used for future extensions
 The argument
 .I attr
 is a pointer to an ibv_device_attr_ex struct, as defined in <infiniband/verbs.h>.

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2962,12 +2962,15 @@ ibv_query_device_ex(struct ibv_context *context,
 	struct verbs_context *vctx;
 	int ret;
 
+	if (input && input->comp_mask)
+		return EINVAL;
+
 	vctx = verbs_get_ctx_op(context, query_device_ex);
 	if (!vctx)
 		goto legacy;
 
 	ret = vctx->query_device_ex(context, input, attr, sizeof(*attr));
-	if (ret == EOPNOTSUPP)
+	if (ret == EOPNOTSUPP || ret == ENOSYS)
 		goto legacy;
 
 	return ret;


### PR DESCRIPTION
Following thread on broken compatibility between v28 and older version:
https://www.spinics.net/lists/linux-rdma/msg89386.html

Implement query_device_ex dummy function for all providers.
Returning EOPNOTSUPP broke compatibility with apps compiled against
older rdma-core

Suggested-by: Jason Gunthorpe <jgg@mellanox.com>
Cc: stable@linux-rdma.org # v28
Fixes: commit c28410765bdf ("libibverbs: Fix incorrect return code")
Signed-off-by: Michal Kalderon <michal.kalderon@marvell.com>