### PR TITLE
pyverbs: Support external QP usage with rdmacm 

### DIFF
--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -50,6 +50,13 @@ cdef class ConnParam(PyverbsObject):
         self.conn_param.srq = srq
         self.conn_param.qp_num = qp_num
 
+    @property
+    def qpn(self):
+        return self.conn_param.qp_num
+    @qpn.setter
+    def qpn(self, val):
+        self.conn_param.qp_num = val
+
     def __str__(self):
         print_format  = '{:<4}: {:<4}\n'
         return '{}: {}\n'.format('Connection parameters', "") +\
@@ -266,6 +273,10 @@ cdef class CMID(PyverbsCM):
     @property
     def context(self):
         return self.ctx
+
+    @property
+    def pd(self):
+        return self.pd
 
     def __dealloc__(self):
         self.close()

--- a/tests/rdmacm_utils.py
+++ b/tests/rdmacm_utils.py
@@ -3,9 +3,9 @@
 """
 Provide some useful helper function for pyverbs rdmacm' tests.
 """
+from tests.utils import validate, poll_cq, get_send_element, get_recv_wr
 from pyverbs.pyverbs_error import PyverbsError
 from tests.base import CMResources
-from tests.utils import validate
 from pyverbs.cmid import CMEvent
 import pyverbs.cm_enums as ce
 import os
@@ -22,15 +22,32 @@ events_dict = {ce.RDMA_CM_EVENT_ADDR_ERROR: 'Resolve Address Error',
                ce.RDMA_CM_EVENT_TIMEWAIT_EXIT: 'Time wait Exit'}
 
 
+def _server_traffic_with_ext_qp(agr_obj, syncer):
+    recv_wr = get_recv_wr(agr_obj)
+    agr_obj.qp.post_recv(recv_wr)
+    syncer.wait()
+    for _ in range(agr_obj.num_msgs):
+        poll_cq(agr_obj.cq)
+        agr_obj.qp.post_recv(recv_wr)
+        msg_received = agr_obj.mr.read(agr_obj.msg_size, 0)
+        validate(msg_received, agr_obj.is_server, agr_obj.msg_size)
+        send_wr = get_send_element(agr_obj, agr_obj.is_server)[0]
+        agr_obj.qp.post_send(send_wr)
+        poll_cq(agr_obj.cq)
+
+
 def server_traffic(agr_obj, syncer):
     """
-    RDMACM passive side traffic function which uses RDMACM's QP, this function
-    sends and receives a message, and then validate the received message, this
-    operation executed <agr_obj.num_msgs> times.
+    RDMACM passive side traffic function which sends and receives a message, and
+    then validates the received message. This operation is executed
+    <agr_obj.num_msgs> times. If agr_obj.with_ext_qp is set, the traffic will
+    use the external QP (agr_obj.qp).
     :param agr_obj: Aggregation object which contains all necessary resources
     :param syncer: multiprocessing.Barrier object for processes synchronization
     :return: None
     """
+    if agr_obj.with_ext_qp:
+        return _server_traffic_with_ext_qp(agr_obj, syncer)
     send_msg = agr_obj.msg_size * 's'
     cmid = agr_obj.child_id
     for _ in range(agr_obj.num_msgs):
@@ -46,15 +63,31 @@ def server_traffic(agr_obj, syncer):
         syncer.wait()
 
 
+def _client_traffic_with_ext_qp(agr_obj, syncer):
+    recv_wr = get_recv_wr(agr_obj)
+    syncer.wait()
+    for _ in range(agr_obj.num_msgs):
+        send_wr = get_send_element(agr_obj, agr_obj.is_server)[0]
+        agr_obj.qp.post_send(send_wr)
+        poll_cq(agr_obj.cq)
+        agr_obj.qp.post_recv(recv_wr)
+        poll_cq(agr_obj.cq)
+        msg_received = agr_obj.mr.read(agr_obj.msg_size, 0)
+        validate(msg_received, agr_obj.is_server, agr_obj.msg_size)
+
+
 def client_traffic(agr_obj, syncer):
     """
-    RDMACM active side traffic function which uses RDMACM's QP, this function
-    sends and receives a message, and then validate the received message, this
-    operation executed <agr_obj.num_msgs> times.
+    RDMACM active side traffic function which sends and receives a message, and
+    then validates the received message. This operation is executed
+    <agr_obj.num_msgs> times. If agr_obj.with_ext_qp is set, the traffic will
+    use the external QP (agr_obj.qp).
     :param agr_obj: Aggregation object which contains all necessary resources
     :param syncer: multiprocessing.Barrier object for processes synchronization
     :return: None
     """
+    if agr_obj.with_ext_qp:
+        return _client_traffic_with_ext_qp(agr_obj, syncer)
     send_msg = agr_obj.msg_size * 'c'
     cmid = agr_obj.cmid
     for _ in range(agr_obj.num_msgs):
@@ -82,15 +115,24 @@ def event_handler(agr_obj):
         agr_obj.cmid.resolve_route()
     elif cm_event.event_type == ce.RDMA_CM_EVENT_ROUTE_RESOLVED:
         agr_obj.create_qp()
-        agr_obj.cmid.connect(agr_obj.create_conn_param())
+        param = agr_obj.create_conn_param()
+        if agr_obj.with_ext_qp:
+            param.qpn = agr_obj.qp.qp_num
+        agr_obj.cmid.connect(param)
     elif cm_event.event_type == ce.RDMA_CM_EVENT_CONNECT_REQUEST:
         agr_obj.create_child_id(cm_event)
+        param = agr_obj.create_conn_param()
         agr_obj.create_qp()
-        agr_obj.child_id.accept(agr_obj.create_conn_param())
+        if agr_obj.with_ext_qp:
+            agr_obj.modify_ext_qp_to_rts()
+            param.qpn = agr_obj.qp.qp_num
+        agr_obj.child_id.accept(param)
     elif cm_event.event_type == ce.RDMA_CM_EVENT_ESTABLISHED:
         agr_obj.connected = True
     elif cm_event.event_type == ce.RDMA_CM_EVENT_CONNECT_RESPONSE:
         agr_obj.connected = True
+        if agr_obj.with_ext_qp:
+            agr_obj.modify_ext_qp_to_rts()
         agr_obj.cmid.establish()
     elif cm_event.event_type == ce.RDMA_CM_EVENT_DISCONNECTED:
         if agr_obj.is_server:
@@ -145,7 +187,11 @@ def sync_traffic(addr, syncer, notifier, is_server):
         notifier.put(None)
 
 
-def async_traffic(addr, syncer, notifier, is_server):
+def async_traffic_with_ext_qp(addr, syncer, notifier, is_server):
+    return async_traffic(addr, syncer, notifier, is_server, True)
+
+
+def async_traffic(addr, syncer, notifier, is_server, with_ext_qp=False):
     """
     RDMACM asynchronous data and control path function that first establishes a
     connection using RDMACM events API and then executes RDMACM asynchronous
@@ -154,11 +200,14 @@ def async_traffic(addr, syncer, notifier, is_server):
     :param syncer: multiprocessing.Barrier object for processes synchronization
     :param notifier: Notify parent process about any exceptions or success
     :param is_server: A flag which indicates if this is a server or not
+    :param with_ext_qp: If set, an external RC QP will be created and used by
+                        RDMACM (default: False)
     :return: None
     """
     try:
         if is_server:
-            server = CMResources(src=addr, is_async=True)
+            server = CMResources(src=addr, is_async=True,
+                                 with_ext_qp=with_ext_qp)
             listen_id = server.cmid
             listen_id.bind_addr(server.ai)
             listen_id.listen()
@@ -169,7 +218,8 @@ def async_traffic(addr, syncer, notifier, is_server):
             server_traffic(server, syncer)
             server.child_id.disconnect()
         else:
-            client = CMResources(src=addr, dst=addr, is_async=True)
+            client = CMResources(src=addr, dst=addr, is_async=True,
+                                 with_ext_qp=with_ext_qp)
             id = client.cmid
             id.resolve_addr(client.ai)
             syncer.wait()

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
 
-from tests.rdmacm_utils import sync_traffic, async_traffic
+from tests.rdmacm_utils import sync_traffic, async_traffic, \
+    async_traffic_with_ext_qp
 from pyverbs.pyverbs_error import PyverbsError
 from tests.base import RDMATestCase
 import multiprocessing as mp
@@ -57,10 +58,10 @@ class CMTestCase(RDMATestCase):
         ctx = mp.get_context('fork')
         syncer = ctx.Barrier(NUM_OF_PROCESSES, timeout=5)
         notifier = ctx.Queue()
-        passive = ctx.Process(target=traffic_func, args=[ip_addr, syncer,
-                                                         notifier, True])
-        active = ctx.Process(target=traffic_func, args=[ip_addr, syncer,
-                                                        notifier, False])
+        passive = ctx.Process(target=traffic_func,
+                              args=[ip_addr, syncer, notifier, True])
+        active = ctx.Process(target=traffic_func,
+                             args=[ip_addr, syncer, notifier, False])
         passive.start()
         active.start()
         while notifier.empty():
@@ -81,3 +82,6 @@ class CMTestCase(RDMATestCase):
 
     def test_rdmacm_async_traffic(self):
         self.two_nodes_rdmacm_traffic(self.ip_addr, async_traffic)
+
+    def test_rdmacm_async_traffic_external_qp(self):
+        self.two_nodes_rdmacm_traffic(self.ip_addr, async_traffic_with_ext_qp)


### PR DESCRIPTION
This series adds missing infrastructure to enable external QP usage with rdmacm.
It includes a simple rdmacm asynchronous traffic test that uses an external created QP.