### PR TITLE
azp: Fix azp image build

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -257,7 +257,7 @@ class APTEnvironment(Environment):
     build_python = True;
     def get_docker_file(self,tmpdir):
         res = DockerFile(self.docker_parent);
-        res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
+        res.lines.append("RUN apt-get update; apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
             " ".join(sorted(self.pkgs))));
         return res;
 


### PR DESCRIPTION
For some reason the apt-get update command fails with the following
error message:
W: http://apt.llvm.org/bionic/dists/llvm-toolchain-bionic-8/InRelease: No system certificates available. Try installing ca-certificates.
W: http://apt.llvm.org/bionic/dists/llvm-toolchain-bionic-8/Release: No system certificates available. Try installing ca-certificates.
E: The repository 'http://apt.llvm.org/bionic llvm-toolchain-bionic-8 Release' does not have a Release file.

Which fails the entire build.
However, everything else works correctly if continuing instead of
exiting because of the &&.

Signed-off-by: Gal Pressman <galpress@amazon.com>