### PR TITLE
tests: Avoid RoCEv2 GIDs on unsupported devices

### DIFF
--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -195,6 +195,14 @@ cdef class Context(PyverbsCM):
                                                                    format(idx=index, port=port_num))
         return gid
 
+    def query_gid_type(self, unsigned int port_num, unsigned int index):
+        cdef v.ibv_gid_type gid_type
+        rc = v.ibv_query_gid_type(self.context, port_num, index, &gid_type)
+        if rc != 0:
+            raise PyverbsRDMAErrno('Failed to query gid type of port {p} and gid index {g}'
+                                   .format(p=port_num, g=index))
+        return gid_type
+
     def query_port(self, unsigned int port_num):
         """
         Query port <port_num> of the device and returns its attributes.

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -594,3 +594,8 @@ cdef extern from 'infiniband/verbs.h':
     void ibv_wr_start(ibv_qp_ex *qp)
     int ibv_wr_complete(ibv_qp_ex *qp)
     void ibv_wr_abort(ibv_qp_ex *qp)
+
+
+cdef extern from 'infiniband/driver.h':
+    int ibv_query_gid_type(ibv_context *context, uint8_t port_num,
+                           unsigned int index, ibv_gid_type *type)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -431,3 +431,9 @@ cdef extern from '<infiniband/verbs.h>':
 _IBV_DEVICE_RAW_SCATTER_FCS = IBV_DEVICE_RAW_SCATTER_FCS
 _IBV_DEVICE_PCI_WRITE_END_PADDING = IBV_DEVICE_PCI_WRITE_END_PADDING
 _IBV_ALLOCATOR_USE_DEFAULT = <size_t>IBV_ALLOCATOR_USE_DEFAULT
+
+
+cdef extern from '<infiniband/driver.h>':
+    cpdef enum ibv_gid_type:
+        IBV_GID_TYPE_IB_ROCE_V1
+        IBV_GID_TYPE_ROCE_V2


### PR DESCRIPTION
Avoid RoCEv2 GIDs on unsupported devices.
To be able to do that, ibv_query_gid_type was added to Pyverbs' infrastructure.