### PR TITLE
mlx5: Misc items

### DIFF
--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -718,7 +718,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	if (cq_attr->comp_mask & IBV_CQ_INIT_ATTR_MASK_PD) {
 		if (!(to_mparent_domain(cq_attr->parent_domain))) {
 			errno = EINVAL;
-			return NULL;
+			goto err;
 		}
 		cq->parent_domain = cq_attr->parent_domain;
 	}


### PR DESCRIPTION
This series includes two patches as follows:
The first one enables devx by default in case supported by the underlay mlx5 device. 
The second one fixes a memory leak in some bad flow of CQ creation.