### PR TITLE
verbs: Misc items

### DIFF
--- a/libibverbs/man/ibv_create_flow.3
+++ b/libibverbs/man/ibv_create_flow.3
@@ -50,7 +50,6 @@ IBV_FLOW_ATTR_SNIFFER		= 0x3,		/* Sniffer rule - receive all port traffic */
 .nf
 enum ibv_flow_flags {
 .in +8
-IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK = 1 << 0,	/* Apply the rules on packets that were sent from the attached QP through loopback */
 IBV_FLOW_ATTR_FLAGS_DONT_TRAP       = 1 << 1,	/* Rule doesn't trap received packets, allowing them to match lower prioritized rules */
 IBV_FLOW_ATTR_FLAGS_EGRESS          = 1 << 2,	/* Match sent packets against EGRESS rules and carry associated actions if required */
 .in -8

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -3327,6 +3327,18 @@ static inline int ibv_read_counters(struct ibv_counters *counters,
 	return vctx->read_counters(counters, counters_value, ncounters, flags);
 }
 
+#define IB_ROCE_UDP_ENCAP_VALID_PORT_MIN (0xC000)
+#define IB_ROCE_UDP_ENCAP_VALID_PORT_MAX (0xFFFF)
+#define IB_GRH_FLOWLABEL_MASK (0x000FFFFF)
+
+static inline uint16_t ibv_flow_label_to_udp_sport(uint32_t fl)
+{
+	uint32_t fl_low = fl & 0x03FFF, fl_high = fl & 0xFC000;
+
+	fl_low ^= fl_high >> 14;
+	return (uint16_t)(fl_low | IB_ROCE_UDP_ENCAP_VALID_PORT_MIN);
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1601,7 +1601,7 @@ struct ibv_ah {
 };
 
 enum ibv_flow_flags {
-	IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK = 1 << 0,
+	/* First bit is deprecated and can't be used */
 	IBV_FLOW_ATTR_FLAGS_DONT_TRAP = 1 << 1,
 	IBV_FLOW_ATTR_FLAGS_EGRESS = 1 << 2,
 };

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -308,7 +308,6 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_RX_HASH_DST_PORT_UDP
 
     cpdef enum ibv_flow_flags:
-        IBV_FLOW_ATTR_FLAGS_ALLOW_LOOP_BACK
         IBV_FLOW_ATTR_FLAGS_DONT_TRAP
         IBV_FLOW_ATTR_FLAGS_EGRESS
 


### PR DESCRIPTION
This series includes two patches in verbs and mlx5 as follows.
The first one deprecated a non-used bit in the steering area from verbs, this bit is not in use at all not in kernel and not in userspace.
The second one introduces some verbs helper function to set flow_label and RoCEv2 UDP source port for datagram QP, this routine in used in mlx5 driver.