### PR TITLE
ibacm: Fix id_string pointers after end-point address re-allocation

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2082,11 +2082,19 @@ __acm_ep_insert_addr(struct acmc_ep *ep, const char *name, uint8_t *addr,
 		;
 	if (i == ep->nmbr_ep_addrs) {
 		struct acmc_addr *new_info;
+		int j;
+
 		new_info = realloc(ep->addr_info, (i + 1) * sizeof(*ep->addr_info));
 		if (!new_info) {
 			ret = ENOMEM;
 			goto out;
 		}
+
+		/* id_string needs to point to the reallocated string_buf */
+		for (j = 0; (j < ep->nmbr_ep_addrs); j++) {
+			new_info[j].addr.id_string = new_info[j].string_buf;
+		}
+
 		ep->addr_info = new_info;
 
 		/* Added memory is not initialized */


### PR DESCRIPTION
end-point addresses in acm are represented by an array of acmc_addr
structures. This array is reallocated each time a new address is
added to the endpoint. The acmc_addr structure, itself,  contains
an acm_address structure:

struct acm_address {
        struct acm_endpoint     *endpoint;
        union acm_ep_info       info;
        char                    *id_string;
        uint16_t                type;
};

struct acmc_addr {
        struct acm_address    addr;
        void                  *prov_addr_context;
        char                  string_buf[ACM_MAX_ADDRESS];
};

The id_string field in the acm_address structure points back to the
string_buf field in the acmc_addr structure.

After a realloc() of the array of acmc_addr structures, the id_string
pointers for each acm_address should be reset to point at the
reallocated string_buf field in its parent acmc_addr structure.

id_string is only used for logging purposes and therefore, this bug is
fairly innocuous unless parsing the log file.

Fixes: c5ebe32278d5 ("ibacm: Allocate end-point addresses dynamically")
Signed-off-by: Mark Haywood <mark.haywood@oracle.com>