### PR TITLE
ibacm: check provider file ends with .so extension

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2832,6 +2832,17 @@ static void acm_load_prov_config(void)
 	}
 }
 
+static int acm_string_end_compare(const char *s1, const char *s2)
+{
+	size_t s1_len = strlen(s1);
+	size_t s2_len = strlen(s2);
+
+	if (s1_len < s2_len)
+		return -1;
+
+	return strcmp(s1 + s1_len - s2_len, s2);
+}
+
 static int acm_open_providers(void)
 {
 	DIR *shlib_dir;
@@ -2854,7 +2865,7 @@ static int acm_open_providers(void)
 	}
 
 	while ((dent = readdir(shlib_dir))) {
-		if (!strstr(dent->d_name, ".so"))
+		if (acm_string_end_compare(dent->d_name, ".so"))
 			continue;
 
 		if (!check_snprintf(file_name, sizeof(file_name), "%s/%s",


### PR DESCRIPTION
acm_open_providers() reads filenames and checks to see if the filenames
contain the .so (shared object) extension via strstr(). But this does
not verify that the extension is found at the end of the filename - only
that .so is a substring somewhere in the filename. This means filenames
of the sort "libibacmp.so.org" will be matched and loaded as providers.
The check should be modified to verify that the extension is at the end
of the filename.

Signed-off-by: Mark Haywood <mark.haywood@oracle.com>