### PR TITLE
mlx5: Memory improvements in the DR area 

### DIFF
--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -16,6 +16,7 @@ rdma_shared_provider(mlx5 libmlx5.map
   cq.c
   dbrec.c
   dr_action.c
+  dr_buddy.c
   dr_crc32.c
   dr_dbg.c
   dr_devx.c

--- a/providers/mlx5/dr_buddy.c
+++ b/providers/mlx5/dr_buddy.c
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2004 Topspin Communications.  All rights reserved.
+ * Copyright (c) 2005, 2006, 2007, 2008 Mellanox Technologies. All rights reserved.
+ * Copyright (c) 2006, 2007 Cisco Systems, Inc.  All rights reserved.
+ * Copyright (c) 2019, Mellanox Technologies. All rights reserved.
+ *
+ * This software is available to you under a choice of one of two
+ * licenses.  You may choose to be licensed under the terms of the GNU
+ * General Public License (GPL) Version 2, available from the file
+ * COPYING in the main directory of this source tree, or the
+ * OpenIB.org BSD license below:
+ *
+ *	Redistribution and use in source and binary forms, with or
+ *	without modification, are permitted provided that the following
+ *	conditions are met:
+ *
+ *	- Redistributions of source code must retain the above
+ *	  copyright notice, this list of conditions and the following
+ *	  disclaimer.
+ *
+ *	- Redistributions in binary form must reproduce the above
+ *	  copyright notice, this list of conditions and the following
+ *	  disclaimer in the documentation and/or other materials
+ *	  provided with the distribution.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <ccan/bitmap.h>
+#include "mlx5dv_dr.h"
+
+struct dr_icm_pool;
+struct dr_icm_buddy_mem;
+
+static int dr_find_first_bit(const bitmap *set_addr,
+			     const bitmap *addr,
+			     unsigned int size)
+{
+	unsigned int set_size = (size - 1) / BITS_PER_LONG + 1;
+	unsigned long set_idx;
+
+	/* find the first free in the first level */
+	set_idx =  bitmap_ffs(set_addr, 0, set_size);
+	/* find the next level */
+	return bitmap_ffs(addr, set_idx * BITS_PER_LONG, size);
+}
+
+int dr_buddy_init(struct dr_icm_buddy_mem *buddy, uint32_t max_order)
+{
+	int i, s;
+
+	buddy->max_order = max_order;
+
+	list_node_init(&buddy->list_node);
+	list_head_init(&buddy->used_list);
+	list_head_init(&buddy->hot_list);
+
+	buddy->bits = calloc(buddy->max_order + 1, sizeof(long *));
+	if (!buddy->bits) {
+		errno = ENOMEM;
+		return ENOMEM;
+	}
+
+	buddy->num_free = calloc(buddy->max_order + 1, sizeof(*buddy->num_free));
+	if (!buddy->num_free)
+		goto err_out_free_bits;
+
+	buddy->set_bit = calloc(buddy->max_order + 1, sizeof(long *));
+	if (!buddy->set_bit)
+		goto err_out_free_num_free;
+
+	/* Allocating max_order bitmaps, one for each order.
+	 * only the bitmap for the maximum size will be available for use and
+	 * the first bit there will be set.
+	 */
+	for (i = 0; i <= buddy->max_order; ++i) {
+		s = 1 << (buddy->max_order - i);
+		buddy->bits[i] = bitmap_alloc0(s);
+		if (!buddy->bits[i])
+			goto err_out_free_each_bit_per_order;
+	}
+
+	for (i = 0; i <= buddy->max_order; ++i) {
+		s = BITS_TO_LONGS(1 << (buddy->max_order - i));
+		buddy->set_bit[i] = bitmap_alloc0(s);
+		if (!buddy->set_bit[i])
+			goto err_out_free_set;
+	}
+
+	bitmap_set_bit(buddy->bits[buddy->max_order], 0);
+	bitmap_set_bit(buddy->set_bit[buddy->max_order], 0);
+
+	buddy->num_free[buddy->max_order] = 1;
+
+	return 0;
+
+err_out_free_set:
+	for (i = 0; i <= buddy->max_order; ++i)
+		free(buddy->set_bit[i]);
+
+err_out_free_each_bit_per_order:
+	free(buddy->set_bit);
+
+	for (i = 0; i <= buddy->max_order; ++i)
+		free(buddy->bits[i]);
+
+err_out_free_num_free:
+	free(buddy->num_free);
+
+err_out_free_bits:
+	free(buddy->bits);
+	errno = ENOMEM;
+	return ENOMEM;
+}
+
+void dr_buddy_cleanup(struct dr_icm_buddy_mem *buddy)
+{
+	int i;
+
+	list_del(&buddy->list_node);
+
+	for (i = 0; i <= buddy->max_order; ++i) {
+		free(buddy->bits[i]);
+		free(buddy->set_bit[i]);
+	}
+
+	free(buddy->set_bit);
+	free(buddy->num_free);
+	free(buddy->bits);
+}
+
+/*
+ * Find the borders (high and low) of specific seg (segment location)
+ * of the lower level of the bitmap in order to mark the upper layer
+ * of bitmap.
+ */
+static void dr_buddy_get_seg_borders(uint32_t seg,
+				     uint32_t *low,
+				     uint32_t *high)
+{
+	*low = (seg / BITS_PER_LONG) * BITS_PER_LONG;
+	*high = ((seg / BITS_PER_LONG) + 1) * BITS_PER_LONG;
+}
+
+/*
+ * We have two layers of searching in the bitmaps, so when needed update the
+ * second layer of search.
+ */
+static void dr_buddy_update_upper_bitmap(struct dr_icm_buddy_mem *buddy,
+					 uint32_t seg, int order)
+{
+	uint32_t h, l, m;
+
+	/* clear upper layer of search if needed */
+	dr_buddy_get_seg_borders(seg, &l, &h);
+	m = bitmap_ffs(buddy->bits[order], l, h);
+	if (m == h) /* nothing in the long that includes seg */
+		bitmap_clear_bit(buddy->set_bit[order], seg / BITS_PER_LONG);
+}
+
+/*
+ * This function finds the first area of the managed memory by the buddy.
+ * It uses the data structures of the buddy-system in order to find the first
+ * area of free place, starting from the current order till the maximum order
+ * in the system.
+ * The function returns the location (seg) in the whole buddy memory area, this
+ * indicates the place of the memory to use, it is the index of the mem segment.
+ */
+int dr_buddy_alloc_mem(struct dr_icm_buddy_mem *buddy, int order)
+{
+	int seg;
+	int o, m;
+
+	for (o = order; o <= buddy->max_order; ++o)
+		if (buddy->num_free[o]) {
+			m = 1 << (buddy->max_order - o);
+			seg = dr_find_first_bit(buddy->set_bit[o], buddy->bits[o], m);
+			if (m <= seg) {
+				/* not found free mem, but there are free mem */
+				assert(false);
+				return -1;
+			}
+			goto found;
+		}
+
+	return -1;
+
+found:
+	bitmap_clear_bit(buddy->bits[o], seg);
+	/* clear upper layer of search if needed */
+	dr_buddy_update_upper_bitmap(buddy, seg, o);
+	--buddy->num_free[o];
+	/* if we find free memory in some order that it is bigger than the
+	 * required order, we need to devied each order between the required to
+	 * the found one to 2, and mark accordingly.
+	 */
+	while (o > order) {
+		--o;
+		seg <<= 1;
+		bitmap_set_bit(buddy->bits[o], seg ^ 1);
+		bitmap_set_bit(buddy->set_bit[o], (seg ^ 1) / BITS_PER_LONG);
+
+		++buddy->num_free[o];
+	}
+
+	seg <<= order;
+
+	return seg;
+}
+
+void
+dr_buddy_free_mem(struct dr_icm_buddy_mem *buddy, uint32_t seg, int order)
+{
+	seg >>= order;
+
+	/* whenever a segment is free, the mem is added to the buddy that gave it */
+	while (bitmap_test_bit(buddy->bits[order], seg ^ 1)) {
+		bitmap_clear_bit(buddy->bits[order], seg ^ 1);
+		dr_buddy_update_upper_bitmap(buddy, seg ^ 1, order);
+		--buddy->num_free[order];
+		seg >>= 1;
+		++order;
+	}
+	bitmap_set_bit(buddy->bits[order], seg);
+	bitmap_set_bit(buddy->set_bit[order], seg / BITS_PER_LONG);
+
+	++buddy->num_free[order];
+}
+

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -33,60 +33,21 @@
 #include "mlx5dv_dr.h"
 
 #define DR_ICM_MODIFY_HDR_ALIGN_BASE	64
-
-struct dr_icm_pool;
-
 #define DR_ICM_SYNC_THRESHOLD (64 * 1024 * 1024)
 
-struct dr_icm_bucket {
-	struct dr_icm_pool	*pool;
-
-	/* It is safe to allocate chunks from this list, now HW is guaranteed
-	 * to not access this memory
-	 */
-	struct list_head	free_list;
-	unsigned int		free_list_count;
-
-	/* This is the list of used chunks, HW may be accessing this memory */
-	struct list_head	used_list;
-	unsigned int		used_list_count;
-
-	/* HW may be accessing this memory but at some future,
-	 * undetermined time, it might cease to do so. Before deciding to call
-	 * sync_ste, this list is moved to tmp_list
-	 */
-	struct list_head	hot_list;
-	unsigned int		hot_list_count;
-
-	/* Temporary list, entries from the hot list are moved to this list.
-	 * sync_ste is executed and then tmp_list is concatenated to the free list
-	 */
-	struct list_head	tmp_list;
-	unsigned int		tmp_list_count;
-
-	uint32_t		total_chunks;
-	uint32_t		num_of_entries;
-	uint32_t		entry_size;
-	pthread_mutex_t		mutex;
-};
-
 struct dr_icm_pool {
-	struct dr_icm_bucket	*buckets;
 	enum dr_icm_type	icm_type;
-	enum dr_icm_chunk_size	max_log_chunk_sz;
-	enum dr_icm_chunk_size	num_of_buckets;
-	struct list_head	icm_mr_list;
-	pthread_mutex_t		mr_mutex;
 	struct mlx5dv_dr_domain	*dmn;
+	enum dr_icm_chunk_size	max_log_chunk_sz;
+	/* memory management */
+	pthread_mutex_t		mutex;
+	struct list_head	buddy_mem_list;
 };
 
 struct dr_icm_mr {
-	struct dr_icm_pool	*pool;
 	struct ibv_mr		*mr;
 	struct ibv_dm		*dm;
-	size_t			used_length;
 	uint64_t		icm_start_addr;
-	struct list_node	mr_list;
 };
 
 static int
@@ -136,7 +97,9 @@ alloc_dm:
 		if (fallback) {
 			align_base = 1UL << log_align_base;
 			align_diff = icm_mr->icm_start_addr % align_base;
-			icm_mr->used_length = align_base - align_diff;
+			/* increase the address to start from aligned size */
+			icm_mr->icm_start_addr = icm_mr->icm_start_addr +
+				(align_base - align_diff);
 			return 0;
 		}
 
@@ -177,8 +140,6 @@ dr_icm_pool_mr_create(struct dr_icm_pool *pool)
 		goto free_dm;
 	}
 
-	list_add_tail(&pool->icm_mr_list, &icm_mr->mr_list);
-
 	return icm_mr;
 
 free_dm:
@@ -190,35 +151,34 @@ free_icm_mr:
 
 static  void dr_icm_pool_mr_destroy(struct dr_icm_mr *icm_mr)
 {
-	list_del(&icm_mr->mr_list);
 	ibv_dereg_mr(icm_mr->mr);
 	mlx5_free_dm(icm_mr->dm);
 	free(icm_mr);
 }
 
+static enum dr_icm_type
+get_chunk_icm_type(struct dr_icm_chunk *chunk)
+{
+	return chunk->buddy_mem->pool->icm_type;
+}
+
 static int dr_icm_chunk_ste_init(struct dr_icm_chunk *chunk)
 {
-	struct dr_icm_bucket *bucket = chunk->bucket;
-	struct dr_icm_pool *pool = bucket->pool;
-
-	chunk->ste_arr = calloc(bucket->num_of_entries, sizeof(struct dr_ste));
+	chunk->ste_arr = calloc(chunk->num_of_entries, sizeof(struct dr_ste));
 	if (!chunk->ste_arr) {
-		dr_dbg(pool->dmn, "Failed allocating ste_arr for chunk\n");
 		errno = ENOMEM;
 		return errno;
 	}
 
-	chunk->hw_ste_arr = calloc(bucket->num_of_entries, DR_STE_SIZE_REDUCED);
+	chunk->hw_ste_arr = calloc(chunk->num_of_entries, DR_STE_SIZE_REDUCED);
 	if (!chunk->hw_ste_arr) {
-		dr_dbg(pool->dmn, "Failed allocating hw_ste_arr for chunk\n");
 		errno = ENOMEM;
 		goto out_free_ste_arr;
 	}
 
-	chunk->miss_list = malloc(bucket->num_of_entries *
+	chunk->miss_list = malloc(chunk->num_of_entries *
 				  sizeof(struct list_head));
 	if (!chunk->miss_list) {
-		dr_dbg(pool->dmn, "Failed allocating miss_list for chunk\n");
 		errno = ENOMEM;
 		goto out_free_hw_ste_arr;
 	}
@@ -232,64 +192,6 @@ out_free_ste_arr:
 	return errno;
 }
 
-static int dr_icm_chunks_create(struct dr_icm_bucket *bucket)
-{
-	size_t mr_free_size, mr_req_size, mr_row_size;
-	struct dr_icm_pool *pool = bucket->pool;
-	struct dr_icm_chunk *chunk;
-	struct dr_icm_mr *icm_mr;
-	int i;
-
-	mr_req_size = bucket->num_of_entries * bucket->entry_size;
-	mr_row_size = dr_icm_pool_chunk_size_to_byte(pool->max_log_chunk_sz,
-						     pool->icm_type);
-
-	pthread_mutex_lock(&pool->mr_mutex);
-	icm_mr = list_tail(&pool->icm_mr_list, struct dr_icm_mr, mr_list);
-	if (icm_mr)
-		mr_free_size = icm_mr->mr->length - icm_mr->used_length;
-
-	if (!icm_mr || mr_free_size < mr_row_size) {
-		icm_mr = dr_icm_pool_mr_create(pool);
-		if (!icm_mr)
-			goto out_err;
-	}
-
-	/* Create memory aligned chunks */
-	for (i = 0; i < mr_row_size / mr_req_size; i++) {
-		chunk = calloc(1, sizeof(struct dr_icm_chunk));
-		if (!chunk) {
-			errno = ENOMEM;
-			goto out_err;
-		}
-
-		chunk->bucket = bucket;
-		chunk->rkey = icm_mr->mr->rkey;
-		chunk->mr_addr = (uintptr_t)icm_mr->mr->addr + icm_mr->used_length;
-		chunk->icm_addr = (uintptr_t)icm_mr->icm_start_addr + icm_mr->used_length;
-		icm_mr->used_length += mr_req_size;
-		chunk->num_of_entries = bucket->num_of_entries;
-		chunk->byte_size = chunk->num_of_entries * bucket->entry_size;
-
-		if (pool->icm_type == DR_ICM_TYPE_STE)
-			if (dr_icm_chunk_ste_init(chunk))
-				goto out_free_chunk;
-
-		list_node_init(&chunk->chunk_list);
-		list_add(&bucket->free_list, &chunk->chunk_list);
-		bucket->free_list_count++;
-		bucket->total_chunks++;
-	}
-	pthread_mutex_unlock(&pool->mr_mutex);
-	return 0;
-
-out_free_chunk:
-	free(chunk);
-out_err:
-	pthread_mutex_unlock(&pool->mr_mutex);
-	return errno;
-}
-
 static void dr_icm_chunk_ste_cleanup(struct dr_icm_chunk *chunk)
 {
 	free(chunk->miss_list);
@@ -299,164 +201,196 @@ static void dr_icm_chunk_ste_cleanup(struct dr_icm_chunk *chunk)
 
 static void dr_icm_chunk_destroy(struct dr_icm_chunk *chunk)
 {
-	struct dr_icm_bucket *bucket = chunk->bucket;
+	enum dr_icm_type icm_type = get_chunk_icm_type(chunk);
 
 	list_del(&chunk->chunk_list);
-	bucket->total_chunks--;
 
-	if (bucket->pool->icm_type == DR_ICM_TYPE_STE)
+	if (icm_type == DR_ICM_TYPE_STE)
 		dr_icm_chunk_ste_cleanup(chunk);
 
 	free(chunk);
 }
 
-static void dr_icm_bucket_init(struct dr_icm_pool *pool,
-			       struct dr_icm_bucket *bucket,
-			       enum dr_icm_chunk_size chunk_size)
+static int dr_icm_buddy_create(struct dr_icm_pool *pool)
 {
-	if (pool->icm_type == DR_ICM_TYPE_STE)
-		bucket->entry_size = DR_STE_SIZE;
-	else
-		bucket->entry_size = DR_MODIFY_ACTION_SIZE;
+	struct dr_icm_buddy_mem *buddy;
+	struct dr_icm_mr *icm_mr;
 
-	bucket->num_of_entries = dr_icm_pool_chunk_size_to_entries(chunk_size);
-	bucket->pool = pool;
-	pthread_mutex_init(&bucket->mutex, NULL);
-	list_head_init(&bucket->free_list);
-	list_head_init(&bucket->used_list);
-	list_head_init(&bucket->hot_list);
-	list_head_init(&bucket->tmp_list);
+	icm_mr = dr_icm_pool_mr_create(pool);
+	if (!icm_mr)
+		return ENOMEM;
+
+	buddy = calloc(1, sizeof(*buddy));
+	if (!buddy) {
+		errno = ENOMEM;
+		goto free_mr;
+	}
+
+	if (dr_buddy_init(buddy, pool->max_log_chunk_sz))
+		goto err_free_buddy;
+
+	buddy->icm_mr = icm_mr;
+	buddy->pool = pool;
+
+	/* add it to the -start- of the list in order to search in it first */
+	list_add(&pool->buddy_mem_list, &buddy->list_node);
+
+	return 0;
+
+err_free_buddy:
+	free(buddy);
+free_mr:
+	dr_icm_pool_mr_destroy(icm_mr);
+	return errno;
 }
 
-static void dr_icm_bucket_cleanup(struct dr_icm_bucket *bucket)
+static void dr_icm_buddy_destroy(struct dr_icm_buddy_mem *buddy)
 {
 	struct dr_icm_chunk *chunk, *next;
 
-	pthread_mutex_destroy(&bucket->mutex);
-	list_append_list(&bucket->free_list, &bucket->tmp_list);
-	list_append_list(&bucket->free_list, &bucket->hot_list);
-
-	list_for_each_safe(&bucket->free_list, chunk, next, chunk_list)
+	list_for_each_safe(&buddy->hot_list, chunk, next, chunk_list)
 		dr_icm_chunk_destroy(chunk);
 
-	assert(bucket->total_chunks == 0);
-
-	/* Cleanup of unreturned chunks */
-	list_for_each_safe(&bucket->used_list, chunk, next, chunk_list)
+	list_for_each_safe(&buddy->used_list, chunk, next, chunk_list)
 		dr_icm_chunk_destroy(chunk);
+
+	dr_icm_pool_mr_destroy(buddy->icm_mr);
+
+	dr_buddy_cleanup(buddy);
+
+	free(buddy);
 }
 
-static uint64_t dr_icm_hot_mem_size(struct dr_icm_pool *pool)
+static struct dr_icm_chunk *
+dr_icm_chunk_create(struct dr_icm_pool *pool,
+		    enum dr_icm_chunk_size chunk_size,
+		    struct dr_icm_buddy_mem *buddy_mem_pool,
+		    int seg)
 {
-	uint64_t hot_size = 0;
-	int i;
+	struct dr_icm_chunk *chunk;
+	int offset;
 
-	for (i = 0; i < pool->num_of_buckets; i++)
-		hot_size += pool->buckets[i].hot_list_count *
-			    dr_icm_pool_chunk_size_to_byte(i, pool->icm_type);
+	chunk = calloc(1, sizeof(struct dr_icm_chunk));
+	if (!chunk) {
+		errno = ENOMEM;
+		return NULL;
+	}
 
-	return hot_size;
+	offset = dr_icm_pool_dm_type_to_entry_size(pool->icm_type) * seg;
+
+	chunk->rkey = buddy_mem_pool->icm_mr->mr->rkey;
+	chunk->mr_addr = (uintptr_t)buddy_mem_pool->icm_mr->mr->addr + offset;
+	chunk->icm_addr = (uintptr_t)buddy_mem_pool->icm_mr->icm_start_addr + offset;
+	chunk->num_of_entries = dr_icm_pool_chunk_size_to_entries(chunk_size);
+	chunk->byte_size = dr_icm_pool_chunk_size_to_byte(chunk_size, pool->icm_type);
+	chunk->seg = seg;
+
+	if (pool->icm_type == DR_ICM_TYPE_STE && dr_icm_chunk_ste_init(chunk)) {
+		dr_dbg(pool->dmn, "Failed init ste arrays: order: %d\n",
+		       chunk_size)
+		goto out_free_chunk;
+	}
+
+	chunk->buddy_mem = buddy_mem_pool;
+	list_node_init(&chunk->chunk_list);
+
+	/* chunk now is part of the used_list */
+	list_add_tail(&buddy_mem_pool->used_list, &chunk->chunk_list);
+
+	return chunk;
+
+out_free_chunk:
+	free(chunk);
+	return NULL;
 }
 
-static bool dr_icm_reuse_hot_entries(struct dr_icm_pool *pool,
-				     struct dr_icm_bucket *bucket)
+static bool dr_icm_pool_is_sync_required(struct dr_icm_pool *pool)
 {
-	uint64_t bytes_for_sync;
+	uint64_t allow_hot_size, all_hot_mem = 0;
+	struct dr_icm_buddy_mem *buddy;
 
-	bytes_for_sync = dr_icm_hot_mem_size(pool);
-	if (bytes_for_sync < DR_ICM_SYNC_THRESHOLD || !bucket->hot_list_count)
-		return false;
+	list_for_each(&pool->buddy_mem_list, buddy, list_node) {
+		allow_hot_size = dr_icm_pool_chunk_size_to_byte((buddy->max_order - 2),
+								pool->icm_type);
+		all_hot_mem += buddy->hot_memory_size;
 
-	return true;
+		if ((buddy->hot_memory_size > allow_hot_size) ||
+		    (all_hot_mem > DR_ICM_SYNC_THRESHOLD))
+			return true;
+	}
+
+	return false;
 }
 
-static void dr_icm_chill_bucket_start(struct dr_icm_bucket *bucket)
+static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
 {
-	list_append_list(&bucket->tmp_list, &bucket->hot_list);
-	bucket->tmp_list_count += bucket->hot_list_count;
-	bucket->hot_list_count = 0;
-}
+	struct dr_icm_buddy_mem *buddy, *tmp_buddy;
+	int err;
 
-static void dr_icm_chill_bucket_end(struct dr_icm_bucket *bucket)
-{
-	list_append_list(&bucket->free_list, &bucket->tmp_list);
-	bucket->free_list_count += bucket->tmp_list_count;
-	bucket->tmp_list_count = 0;
-}
+	err = dr_devx_sync_steering(pool->dmn->ctx);
+	if (err) {
+		dr_dbg(pool->dmn, "Failed devx sync hw\n");
+		return err;
+	}
 
-static void dr_icm_chill_bucket_abort(struct dr_icm_bucket *bucket)
-{
-	list_append_list(&bucket->hot_list, &bucket->tmp_list);
-	bucket->hot_list_count += bucket->tmp_list_count;
-	bucket->tmp_list_count = 0;
-}
+	list_for_each_safe(&pool->buddy_mem_list, buddy, tmp_buddy, list_node) {
+		struct dr_icm_chunk *chunk, *tmp_chunk;
 
-static void dr_icm_chill_buckets_start(struct dr_icm_pool *pool,
-				       struct dr_icm_bucket *cb,
-				       bool bucks[DR_CHUNK_SIZE_MAX])
-{
-	struct dr_icm_bucket *bucket;
-	int i;
-
-	for (i = 0; i < pool->num_of_buckets; i++) {
-		bucket = &pool->buckets[i];
-		if (bucket == cb) {
-			dr_icm_chill_bucket_start(bucket);
-			continue;
-		}
-
-		/* Freeing the mutex is done at the end of that process, after
-		 * sync_ste was executed at dr_icm_chill_buckets_end func.
-		 */
-		if (!pthread_mutex_trylock(&bucket->mutex)) {
-			dr_icm_chill_bucket_start(bucket);
-			bucks[i] = true;
+		list_for_each_safe(&buddy->hot_list, chunk, tmp_chunk, chunk_list) {
+			dr_buddy_free_mem(buddy, chunk->seg,
+					  ilog32(chunk->num_of_entries - 1));
+			buddy->hot_memory_size -= chunk->byte_size;
+			dr_icm_chunk_destroy(chunk);
 		}
 	}
+
+	return 0;
 }
 
-static void dr_icm_chill_buckets_end(struct dr_icm_pool *pool,
-				     struct dr_icm_bucket *cb,
-				     bool bucks[DR_CHUNK_SIZE_MAX])
+static int dr_icm_handle_buddies_get_mem(struct dr_icm_pool *pool,
+					 enum dr_icm_chunk_size chunk_size,
+					 struct dr_icm_buddy_mem **buddy,
+					 int *seg)
 {
-	struct dr_icm_bucket *bucket;
-	int i;
+	struct dr_icm_buddy_mem *buddy_mem_pool;
+	bool new_mem = false;
+	int err = 0;
 
-	for (i = 0; i < pool->num_of_buckets; i++) {
-		bucket = &pool->buckets[i];
-		if (bucket == cb) {
-			dr_icm_chill_bucket_end(bucket);
-			continue;
+	/* Check if we have chunks that are waiting for sync-ste */
+	if (dr_icm_pool_is_sync_required(pool))
+		dr_icm_pool_sync_all_buddy_pools(pool);
+
+	*seg = -1;
+
+	/* find the next free place from the buddy list */
+	while (*seg == -1) {
+		list_for_each(&pool->buddy_mem_list, buddy_mem_pool, list_node) {
+			*seg = dr_buddy_alloc_mem(buddy_mem_pool, chunk_size);
+			if (*seg != -1)
+				goto found;
+
+			if (new_mem) {
+				/* We have new memory pool, first in the list */
+				assert(false);
+				dr_dbg(pool->dmn, "No memory for order: %d\n",
+				       chunk_size);
+				errno = ENOMEM;
+				err = ENOMEM;
+				goto out;
+			}
 		}
-
-		if (!bucks[i])
-			continue;
-
-		dr_icm_chill_bucket_end(bucket);
-		pthread_mutex_unlock(&bucket->mutex);
+		/* no more available allocators in that pool, create new */
+		err = dr_icm_buddy_create(pool);
+		if (err)
+			goto out;
+		/* mark we have new memory, first in list */
+		new_mem = true;
 	}
-}
 
-static void dr_icm_chill_buckets_abort(struct dr_icm_pool *pool,
-				       struct dr_icm_bucket *cb,
-				       bool bucks[DR_CHUNK_SIZE_MAX])
-{
-	struct dr_icm_bucket *bucket;
-	int i;
-
-	for (i = 0; i < pool->num_of_buckets; i++) {
-		bucket = &pool->buckets[i];
-		if (bucket == cb) {
-			dr_icm_chill_bucket_abort(bucket);
-			continue;
-		}
-
-		if (!bucks[i])
-			continue;
-
-		dr_icm_chill_bucket_abort(bucket);
-		pthread_mutex_unlock(&bucket->mutex);
-	}
+found:
+	*buddy = buddy_mem_pool;
+out:
+	return err;
 }
 
 /* Allocate an ICM chunk, each chunk holds a piece of ICM memory and
@@ -465,66 +399,45 @@ static void dr_icm_chill_buckets_abort(struct dr_icm_pool *pool,
 struct dr_icm_chunk *dr_icm_alloc_chunk(struct dr_icm_pool *pool,
 					enum dr_icm_chunk_size chunk_size)
 {
-	bool bucks[DR_CHUNK_SIZE_MAX] = {};
-	struct dr_icm_bucket *bucket;
-	struct dr_icm_chunk *chunk;
-	int err;
+	struct dr_icm_buddy_mem *buddy;
+	struct dr_icm_chunk *chunk = NULL;
+	int ret;
+	int seg;
 
 	if (chunk_size > pool->max_log_chunk_sz) {
 		errno = EINVAL;
 		return NULL;
 	}
 
-	bucket = &pool->buckets[chunk_size];
+	pthread_mutex_lock(&pool->mutex);
+	/* find mem, get back the relevant buddy pool and seg in that mem */
+	ret = dr_icm_handle_buddies_get_mem(pool, chunk_size, &buddy, &seg);
+	if (ret)
+		goto out;
 
-	pthread_mutex_lock(&bucket->mutex);
+	chunk = dr_icm_chunk_create(pool, chunk_size, buddy, seg);
+	if (!chunk)
+		goto out_err;
 
-	/* Take chunk from pool if available, otherwise allocate new chunks */
-	if (list_empty(&bucket->free_list)) {
-		if (dr_icm_reuse_hot_entries(pool, bucket)) {
-			dr_icm_chill_buckets_start(pool, bucket, bucks);
-			err = dr_devx_sync_steering(pool->dmn->ctx);
-			if (err) {
-				dr_icm_chill_buckets_abort(pool, bucket, bucks);
-				dr_dbg(pool->dmn, "Sync_steering failed\n");
-				chunk = NULL;
-				goto out;
-			}
-			dr_icm_chill_buckets_end(pool, bucket, bucks);
-		} else {
-			dr_icm_chunks_create(bucket);
-		}
-	}
+	goto out;
 
-	chunk = list_tail(&bucket->free_list, struct dr_icm_chunk, chunk_list);
-	if (chunk) {
-		list_del_init(&chunk->chunk_list);
-		list_add_tail(&bucket->used_list, &chunk->chunk_list);
-		bucket->free_list_count--;
-		bucket->used_list_count++;
-	}
+out_err:
+	dr_buddy_free_mem(buddy, seg, chunk_size);
 out:
-	pthread_mutex_unlock(&bucket->mutex);
+	pthread_mutex_unlock(&pool->mutex);
 	return chunk;
 }
 
 void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 {
-	struct dr_icm_bucket *bucket = chunk->bucket;
+	struct dr_icm_buddy_mem *buddy = chunk->buddy_mem;
 
-	if (bucket->pool->icm_type == DR_ICM_TYPE_STE) {
-		memset(chunk->ste_arr, 0,
-		       bucket->num_of_entries * sizeof(struct dr_ste));
-		memset(chunk->hw_ste_arr, 0,
-		       bucket->num_of_entries * DR_STE_SIZE_REDUCED);
-	}
-
-	pthread_mutex_lock(&bucket->mutex);
+	/* move the memory to the waiting list AKA "hot" */
+	pthread_mutex_lock(&buddy->pool->mutex);
 	list_del_init(&chunk->chunk_list);
-	list_add_tail(&bucket->hot_list, &chunk->chunk_list);
-	bucket->hot_list_count++;
-	bucket->used_list_count--;
-	pthread_mutex_unlock(&bucket->mutex);
+	list_add_tail(&buddy->hot_list, &chunk->chunk_list);
+	buddy->hot_memory_size += chunk->byte_size;
+	pthread_mutex_unlock(&buddy->pool->mutex);
 }
 
 struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,
@@ -532,7 +445,6 @@ struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,
 {
 	enum dr_icm_chunk_size max_log_chunk_sz;
 	struct dr_icm_pool *pool;
-	int i;
 
 	if (icm_type == DR_ICM_TYPE_STE)
 		max_log_chunk_sz = dmn->info.max_log_sw_icm_sz;
@@ -545,43 +457,25 @@ struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,
 		return NULL;
 	}
 
-	pool->buckets = calloc(max_log_chunk_sz + 1, sizeof(struct dr_icm_bucket));
-	if (!pool->buckets) {
-		errno = ENOMEM;
-		goto free_pool;
-	}
-
 	pool->dmn = dmn;
 	pool->icm_type = icm_type;
 	pool->max_log_chunk_sz = max_log_chunk_sz;
-	pool->num_of_buckets = max_log_chunk_sz + 1;
-	list_head_init(&pool->icm_mr_list);
 
-	for (i = 0; i < pool->num_of_buckets; i++)
-		dr_icm_bucket_init(pool, &pool->buckets[i], i);
+	list_head_init(&pool->buddy_mem_list);
 
-	pthread_mutex_init(&pool->mr_mutex, NULL);
+	pthread_mutex_init(&pool->mutex, NULL);
 
 	return pool;
-
-free_pool:
-	free(pool);
-	return NULL;
 }
 
 void dr_icm_pool_destroy(struct dr_icm_pool *pool)
 {
-	struct dr_icm_mr *icm_mr, *next;
-	int i;
+	struct dr_icm_buddy_mem *buddy, *tmp_buddy;
 
-	pthread_mutex_destroy(&pool->mr_mutex);
+	list_for_each_safe(&pool->buddy_mem_list, buddy, tmp_buddy, list_node)
+		dr_icm_buddy_destroy(buddy);
 
-	list_for_each_safe(&pool->icm_mr_list, icm_mr, next, mr_list)
-		dr_icm_pool_mr_destroy(icm_mr);
+	pthread_mutex_destroy(&pool->mutex);
 
-	for (i = 0; i < pool->num_of_buckets; i++)
-		dr_icm_bucket_cleanup(&pool->buckets[i]);
-
-	free(pool->buckets);
 	free(pool);
 }


### PR DESCRIPTION
This series includes few memory improvements in the DR area as follows.

The first patch changes to allocate an accurate aligned DM memory size instead of wasting some memory by allocating double size as was done before.

The next two patches introduce and use a buddy system memory allocation algorithm, this enables a flexible way to manage the ICM memory which reduces the memory consumption comparing the bucket management that was used before. 
