### PR TITLE
mlx5: Add a man page note regarding DV indirect MKEY

### DIFF
--- a/providers/mlx5/man/mlx5dv_create_mkey.3.md
+++ b/providers/mlx5/man/mlx5dv_create_mkey.3.md
@@ -66,9 +66,11 @@ Upon success destroy 0 is returned or the value of errno on a failure.
 
 To let this functionality works a DEVX context should be opened by using *mlx5dv_open_device*.
 
+The created indirect mkey can`t work with scatter to CQE feature, consider *mlx5dv_create_qp()* with MLX5DV_QP_CREATE_DISABLE_SCATTER_TO_CQE for small messages.
+
 # SEE ALSO
 
-**mlx5dv_open_device**
+**mlx5dv_open_device**(3), **mlx5dv_create_qp**(3)
 
 #AUTHOR
 


### PR DESCRIPTION
Scatter to CQE shouldn't be used while receive buffer SGE points to an indirect MKEY, add a man page note for.