### PR TITLE
Add support for passing device name as command-line argument

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 
 rdma_python_test(tests
   __init__.py
+  args_parser.py
   base.py
   rdmacm_utils.py
   test_addr.py

--- a/tests/args_parser.py
+++ b/tests/args_parser.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Kamal Heib <kamalheib1@gmail.com>, All rights reserved.  See COPYING file
+
+import argparse
+import sys
+
+
+class ArgsParser(object):
+    def __init__(self):
+        self.args = None
+
+    def get_config(self):
+        return self.args
+
+    def parse_args(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument('--dev',
+                            help='RDMA device to run the tests on')
+        parser.add_argument('-v', '--verbose', dest='verbosity',
+                            action='store_const',
+                            const=2, help='Verbose output')
+        ns, args = parser.parse_known_args()
+        self.args = vars(ns)
+        if self.args['verbosity']:
+            args += ['--verbose']
+        sys.argv[1:] = args
+
+
+parser = ArgsParser()

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
 
+from args_parser import parser
 import unittest
 import os
 from importlib.machinery import SourceFileLoader
@@ -9,4 +10,5 @@ from importlib.machinery import SourceFileLoader
 
 module_path = os.path.join(os.path.dirname(__file__), '__init__.py')
 tests = SourceFileLoader('tests', module_path).load_module()
+parser.parse_args()
 unittest.main(module=tests)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -15,23 +15,36 @@ import pyverbs.device as d
 PAGE_SIZE = resource.getpagesize()
 
 
-class DeviceTest(unittest.TestCase):
+class DeviceTest(PyverbsAPITestCase):
     """
     Test various functionalities of the Device class.
     """
+
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def get_device_list(self):
+        lst = d.get_device_list()
+        if len(lst) == 0:
+            raise unittest.SkipTest('No IB device found')
+        dev_name = self.config['dev']
+        if dev_name:
+            for dev in lst:
+                if dev.name.decode() == dev_name:
+                    lst = [dev]
+                    break
+            if len(lst) == 0:
+                raise PyverbsRDMAError(f'No IB device with name {dev_name} found')
+        return lst
 
     def test_dev_list(self):
         """
         Verify that it's possible to get IB devices list.
         """
-        d.get_device_list()
-
-    @staticmethod
-    def get_device_list():
-        lst = d.get_device_list()
-        if len(lst) == 0:
-            raise unittest.SkipTest('No IB device found')
-        return lst
+        self.get_device_list()
 
     def test_open_dev(self):
         """


### PR DESCRIPTION
Add support for passing the device name command-line arguments to the test cases, This is needed to give the users the ability to run the tests on a specific device on systems with multiple devices.