### PR TITLE
libhns: Optimize buffer calculating process

### DIFF
--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -39,6 +39,7 @@
 
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>
+#include <util/util.h>
 #include <infiniband/verbs.h>
 #include <ccan/bitmap.h>
 #include <ccan/container_of.h>
@@ -48,6 +49,10 @@
 #define HNS_ROCE_HW_VER2		('h' << 24 | 'i' << 16 | '0' << 8 | '8')
 
 #define PFX				"hns: "
+
+/* The minimum page size is 4K for hardware */
+#define HNS_HW_PAGE_SHIFT 12
+#define HNS_HW_PAGE_SIZE (1 << HNS_HW_PAGE_SHIFT)
 
 #define HNS_ROCE_MAX_INLINE_DATA_LEN	32
 #define HNS_ROCE_MAX_CQ_NUM		0x10000
@@ -262,6 +267,15 @@ struct hns_roce_u_hw {
 	uint32_t hw_version;
 	struct verbs_context_ops hw_ops;
 };
+
+/*
+ * The entries's buffer should be aligned to a multiple of the hardware's
+ * minimum page size.
+ */
+static inline unsigned int to_hr_hem_entries_size(int count, int buf_shift)
+{
+	return align(count << buf_shift, HNS_HW_PAGE_SIZE);
+}
 
 static inline struct hns_roce_device *to_hr_dev(struct ibv_device *ibv_dev)
 {

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -119,7 +119,7 @@ struct hns_roce_buf {
 };
 
 #define BIT_CNT_PER_BYTE       8
-#define BIT_CNT_PER_U64		64
+#define BIT_CNT_PER_LONG       (BIT_CNT_PER_BYTE * sizeof(unsigned long))
 
 /* the sw doorbell type; */
 enum hns_roce_db_type {
@@ -182,9 +182,9 @@ struct hns_roce_cq {
 
 struct hns_roce_idx_que {
 	struct hns_roce_buf		buf;
-	int				buf_size;
-	int				entry_sz;
+	int				entry_shift;
 	unsigned long			*bitmap;
+	int				bitmap_cnt;
 };
 
 struct hns_roce_srq {
@@ -193,7 +193,7 @@ struct hns_roce_srq {
 	pthread_spinlock_t		lock;
 	unsigned long			*wrid;
 	unsigned int			srqn;
-	unsigned int			max_wqe;
+	unsigned int			wqe_cnt;
 	unsigned int			max_gs;
 	unsigned int			wqe_shift;
 	int				head;


### PR DESCRIPTION
Calculating process of WQE buffer is not clear enough to understand, so
optimize the code to improve the readability.

Changelog:
v3:
- Use align() directly instead of defining a new macro hr_hw_page_align().

v2:
- Remove meaningless judgment of count in #1 as Leon suggests.
- Rewrite commit message of both patch.