### PR TITLE
Documentation: Fix formatting of shell commands

### DIFF
--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -51,8 +51,10 @@ valid RDMA resources for proper functioning.
 ## How to run rdma-core's tests
 #### Developers
 The tests can be executed from ./build/bin:
+```
 ./build.sh
 ./build/bin/run_tests.py
+```
 #### Users
 The tests are not a Python package, as such they can be found under
 /usr/share/doc/rdma-core-{version}/tests.


### PR DESCRIPTION
The shell commands to execute the tests were formatted incorrectly, add
the missing ```.

Signed-off-by: Gal Pressman <galpress@amazon.com>