### PR TITLE
ibacm: Fix move of man page from section 1 to section 8

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Build-Depends: cmake (>= 2.8.11),
                python3-docutils,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Rules-Requires-Root: no
-Standards-Version: 4.4.1
+Standards-Version: 4.5.0
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
 Homepage: https://github.com/linux-rdma/rdma-core

--- a/ibacm/man/ibacm.8
+++ b/ibacm/man/ibacm.8
@@ -1,5 +1,5 @@
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
-.TH "ibacm" 1 "2014-06-16" "ibacm" "ibacm" ibacm
+.TH "ibacm" 8 "2014-06-16" "ibacm" "ibacm" ibacm
 .SH NAME
 ibacm \- address and route resolution services for InfiniBand.
 .SH SYNOPSIS


### PR DESCRIPTION
The man page of ibacm was moved from section 1 to section 8, but the man page itself still claimed to be in section 1.

Also Bump Standards-Version of the Debian package to 4.5.0.