### PR TITLE
mlx5: Add support for steering default miss

### DIFF
--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -241,6 +241,10 @@ enum mlx5_ib_flow_type {
 	MLX5_IB_FLOW_TYPE_MC_DEFAULT,
 };
 
+enum mlx5_ib_create_flow_flags {
+	MLX5_IB_ATTR_CREATE_FLOW_FLAGS_DEFAULT_MISS = 1 << 0,
+};
+
 enum mlx5_ib_create_flow_attrs {
 	MLX5_IB_ATTR_CREATE_FLOW_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
 	MLX5_IB_ATTR_CREATE_FLOW_MATCH_VALUE,
@@ -251,6 +255,7 @@ enum mlx5_ib_create_flow_attrs {
 	MLX5_IB_ATTR_CREATE_FLOW_TAG,
 	MLX5_IB_ATTR_CREATE_FLOW_ARR_COUNTERS_DEVX,
 	MLX5_IB_ATTR_CREATE_FLOW_ARR_COUNTERS_DEVX_OFFSET,
+	MLX5_IB_ATTR_CREATE_FLOW_FLAGS,
 };
 
 enum mlx5_ib_destoy_flow_attrs {

--- a/providers/mlx5/man/mlx5dv_create_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_create_flow.3.md
@@ -61,6 +61,8 @@ struct mlx5dv_flow_action_attr {
 		The DEVX destination object for the matched packets.
 	MLX5DV_FLOW_ACTION_COUNTERS_DEVX
 		The DEVX counter object for the matched packets.
+	MLX5DV_FLOW_ACTION_DEFAULT_MISS
+		Steer the packet to the default miss destination.
 
 *qp*
 :	QP passed, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_IBV_QP*.

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -335,6 +335,7 @@ enum mlx5dv_flow_action_type {
 	MLX5DV_FLOW_ACTION_TAG,
 	MLX5DV_FLOW_ACTION_DEST_DEVX,
 	MLX5DV_FLOW_ACTION_COUNTERS_DEVX,
+	MLX5DV_FLOW_ACTION_DEFAULT_MISS,
 };
 
 struct mlx5dv_flow_action_attr {


### PR DESCRIPTION
Add support for steering default miss.
When packet matched the default miss rule then it's steered to the default miss of the verbs steering domain.