### PR TITLE
RDMA-CM disassociate support

### DIFF
--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -6,6 +6,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.6@IBVERBS_1.6 24
  IBVERBS_1.7@IBVERBS_1.7 25
  IBVERBS_1.8@IBVERBS_1.8 28
+ IBVERBS_1.9@IBVERBS_1.9 30
  (symver)IBVERBS_PRIVATE_25 25
  ibv_ack_async_event@IBVERBS_1.0 1.1.6
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
@@ -58,6 +59,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_get_cq_event@IBVERBS_1.1 1.1.6
  ibv_get_device_guid@IBVERBS_1.0 1.1.6
  ibv_get_device_guid@IBVERBS_1.1 1.1.6
+ ibv_get_device_index@IBVERBS_1.9 30
  ibv_get_device_list@IBVERBS_1.0 1.1.6
  ibv_get_device_list@IBVERBS_1.1 1.1.6
  ibv_get_device_name@IBVERBS_1.0 1.1.6

--- a/kernel-headers/rdma/rdma_user_cm.h
+++ b/kernel-headers/rdma/rdma_user_cm.h
@@ -164,6 +164,8 @@ struct rdma_ucm_query_route_resp {
 	__u32 num_paths;
 	__u8 port_num;
 	__u8 reserved[3];
+	__u32 ibdev_index;
+	__u32 reserved1;
 };
 
 struct rdma_ucm_query_addr_resp {
@@ -175,6 +177,8 @@ struct rdma_ucm_query_addr_resp {
 	__u16 dst_size;
 	struct __kernel_sockaddr_storage src_addr;
 	struct __kernel_sockaddr_storage dst_addr;
+	__u32 ibdev_index;
+	__u32 reserved1;
 };
 
 struct rdma_ucm_query_path_resp {

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file("libibverbs.map.in"
 
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
-  1 1.8.${PACKAGE_VERSION}
+  1 1.9.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
   cmd_ah.c

--- a/libibverbs/device.c
+++ b/libibverbs/device.c
@@ -150,6 +150,13 @@ LATEST_SYMVER_FUNC(ibv_get_device_guid, 1_1, "IBVERBS_1.1",
 	return htobe64(guid);
 }
 
+int ibv_get_device_index(struct ibv_device *device)
+{
+	struct verbs_sysfs_dev *sysfs_dev = verbs_get_device(device)->sysfs;
+
+	return sysfs_dev->ibdev_idx;
+}
+
 int ibv_get_fw_ver(char *value, size_t len, struct verbs_sysfs_dev *sysfs_dev)
 {
 	/*

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -126,6 +126,11 @@ IBVERBS_1.8 {
 		ibv_reg_mr_iova2;
 } IBVERBS_1.7;
 
+IBVERBS_1.9 {
+	global:
+		ibv_get_device_index;
+} IBVERBS_1.8;
+
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
    version. See the top level CMakeLists.txt for this setting. */
 

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -32,6 +32,7 @@ rdma_man_pages(
   ibv_get_async_event.3
   ibv_get_cq_event.3
   ibv_get_device_guid.3.md
+  ibv_get_device_index.3.md
   ibv_get_device_list.3.md
   ibv_get_device_name.3.md
   ibv_get_pkey_index.3.md

--- a/libibverbs/man/ibv_get_device_guid.3.md
+++ b/libibverbs/man/ibv_get_device_guid.3.md
@@ -22,7 +22,7 @@ uint64_t ibv_get_device_guid(struct ibv_device *device);
 
 # DESCRIPTION
 
-**ibv_get_device_name()** returns the Global Unique IDentifier (GUID) of the
+**ibv_get_device_guid()** returns the Global Unique IDentifier (GUID) of the
 RDMA device *device*.
 
 # RETURN VALUE

--- a/libibverbs/man/ibv_get_device_guid.3.md
+++ b/libibverbs/man/ibv_get_device_guid.3.md
@@ -31,7 +31,7 @@ RDMA device *device*.
 order.
 
 # SEE ALSO
-
+**ibv_get_device_index**(3),
 **ibv_get_device_list**(3),
 **ibv_get_device_name**(3),
 **ibv_open_device**(3)

--- a/libibverbs/man/ibv_get_device_index.3.md
+++ b/libibverbs/man/ibv_get_device_index.3.md
@@ -1,0 +1,40 @@
+---
+date: ' 2020-04-22'
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: IBV_GET_DEVICE_INDEX
+---
+
+# NAME
+
+ibv_get_device_index - get an RDMA device index
+
+# SYNOPSIS
+
+```c
+#include <infiniband/verbs.h>
+
+int ibv_get_device_index(struct ibv_device *device);
+```
+
+# DESCRIPTION
+
+**ibv_get_device_index()** returns stable IB device index as it is assigned by the kernel.
+
+# RETURN VALUE
+
+**ibv_get_device_index()** returns an index, or -1 if the kernel doesn't support device indexes.
+
+# SEE ALSO
+
+**ibv_get_device_name**(3),
+**ibv_get_device_guid**(3),
+**ibv_get_device_list**(3),
+**ibv_open_device**(3)
+
+# AUTHOR
+
+Leon Romanovsky <leonro@mellanox.com>

--- a/libibverbs/man/ibv_get_device_list.3.md
+++ b/libibverbs/man/ibv_get_device_list.3.md
@@ -88,6 +88,7 @@ recommended.
 **ibv_fork_init**(3),
 **ibv_get_device_guid**(3),
 **ibv_get_device_name**(3),
+**ibv_get_device_index**(3),
 **ibv_open_device**(3)
 
 # AUTHOR

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2203,6 +2203,15 @@ void ibv_free_device_list(struct ibv_device **list);
 const char *ibv_get_device_name(struct ibv_device *device);
 
 /**
+ * ibv_get_device_index - Return kernel device index
+ *
+ * Available for the kernel with support of IB device query
+ * over netlink interface. For the unsupported kernels, the
+ * relevant -1 will be returned.
+ */
+int ibv_get_device_index(struct ibv_device *device);
+
+/**
  * ibv_get_device_guid - Return device's node GUID
  */
 __be64 ibv_get_device_guid(struct ibv_device *device);

--- a/librdmacm/rdma_cma_abi.h
+++ b/librdmacm/rdma_cma_abi.h
@@ -180,6 +180,8 @@ struct ucma_abi_query_route_resp {
 	__u32 num_paths;
 	__u8 port_num;
 	__u8 reserved[3];
+	__u32 ibdev_index;
+	__u32 reserved1;
 };
 
 struct ucma_abi_query_addr_resp {
@@ -191,6 +193,8 @@ struct ucma_abi_query_addr_resp {
 	__u16 dst_size;
 	struct sockaddr_storage src_addr;
 	struct sockaddr_storage dst_addr;
+	__u32 ibdev_index;
+	__u32 reserved1;
 };
 
 struct ucma_abi_query_path_resp {


### PR DESCRIPTION
In current implementation of RDMA-CM, if IB device resets itself, the
application and librdmacm can't recognise that the device is different,
because device identification is done based on node_guid. That node_guid
is the same before and after reset, but the device is different from the
kernel perspective.
    
This disconnect between kernel and rdma-cm is the reason why users need
to actually restart applications.
    
In the following patches, we will connect kernel and rdma-cm differently.
his will allow them to be in-sync. Once device "disappears" from the kernel,
it will be removed from librdmacm too. The "addition" of new device, will
reflect in addition in librdmacm too.
 