### PR TITLE
Fixup AZP compilations and update to newer everything

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -30,7 +30,7 @@ stages:
               set -e
               mkdir build-pandoc artifacts
               cd build-pandoc
-              CC=gcc-9 cmake -GNinja ..
+              CC=gcc-10 cmake -GNinja ..
               ninja docs
 
               cd ..

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -117,17 +117,17 @@ stages:
               set -e
               mkdir build-arm64
               cd build-arm64
-              CC=aarch64-linux-gnu-gcc-8 cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
+              CC=aarch64-linux-gnu-gcc-9 cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
               ninja
-            displayName: gcc 8.3 ARM64 Compile
+            displayName: gcc 9.3 ARM64 Compile
 
           - bash: |
               set -e
               mkdir build-ppc64el
               cd build-ppc64el
-              CC=powerpc64le-linux-gnu-gcc-8 cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
+              CC=powerpc64le-linux-gnu-gcc-9 cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
               ninja
-            displayName: gcc 8.3 PPC64EL Compile
+            displayName: gcc 9.3 PPC64EL Compile
 
           - bash: |
               set -e

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -98,9 +98,9 @@ stages:
               set -e
               mkdir build-clang
               cd build-clang
-              CC=clang-9 CFLAGS="-m32" cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
+              CC=clang-10 CFLAGS="-m32" cmake -GNinja .. -DIOCTL_MODE=both -DNO_PYVERBS=1 -DENABLE_WERROR=1
               ninja
-            displayName: clang 9.0 32-bit Compile
+            displayName: clang 10.0 32-bit Compile
 
           - bash: |
               set -e
@@ -132,12 +132,12 @@ stages:
           - bash: |
               set -e
               sed -i -e 's/ninja \(.*\)-v/ninja \1/g' debian/rules
-              debian/rules CC=clang-9 EXTRA_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DENABLE_WERROR=1" build
-            displayName: clang 9.0 Bionic Build
+              debian/rules CC=clang-10 EXTRA_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DENABLE_WERROR=1" build
+            displayName: clang 10.0 Bionic Build
           - bash: |
               set -e
               fakeroot debian/rules binary
-            displayName: clang 9.0 Bionic .deb Build
+            displayName: clang 10.0 Bionic .deb Build
           - bash: |
               set -e
               lintian ../*.deb

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -22,7 +22,7 @@ pr:
 resources:
   containers:
     - container: azp
-      image: ucfconsort.azurecr.io/rdma-core/azure_pipelines:28.0
+      image: ucfconsort.azurecr.io/rdma-core/azure_pipelines:29.0
       endpoint: ucfconsort_registry
     - container: centos6
       image: ucfconsort.azurecr.io/rdma-core/centos6:25.0
@@ -64,18 +64,18 @@ stages:
 
           - bash: |
               set -e
-              mkdir build-gcc9
-              cd build-gcc9
-              CC=gcc-9 cmake -GNinja .. -DIOCTL_MODE=both -DENABLE_STATIC=1 -DENABLE_WERROR=1
+              mkdir build-gcc10
+              cd build-gcc10
+              CC=gcc-10 cmake -GNinja .. -DIOCTL_MODE=both -DENABLE_STATIC=1 -DENABLE_WERROR=1
               ninja
-            displayName: gcc 9.1 Compile
+            displayName: gcc 10.0 Compile
 
           - task: PythonScript@0
             displayName: Check Build Script
             inputs:
               scriptPath: buildlib/check-build
-              arguments: --src .. --cc gcc-9
-              workingDirectory: build-gcc9
+              arguments: --src .. --cc gcc-10
+              workingDirectory: build-gcc10
               pythonInterpreter: /usr/bin/python3
 
           # Run sparse on the subdirectories which are sparse clean
@@ -106,9 +106,9 @@ stages:
               set -e
               mv util/udma_barrier.h util/udma_barrier.h.old
               echo "#error Fail" >> util/udma_barrier.h
-              cd build-gcc9
+              cd build-gcc10
               rm CMakeCache.txt
-              CC=gcc-9 cmake -GNinja .. -DIOCTL_MODE=both -DENABLE_WERROR=1
+              CC=gcc-10 cmake -GNinja .. -DIOCTL_MODE=both -DENABLE_WERROR=1
               ninja
               mv ../util/udma_barrier.h.old ../util/udma_barrier.h
             displayName: Simulate non-coherent DMA Platform Compile
@@ -156,7 +156,7 @@ stages:
               set -e
               mkdir build-pandoc artifacts
               cd build-pandoc
-              CC=gcc-9 cmake -GNinja ..
+              CC=gcc-10 cmake -GNinja ..
               ninja docs
               cd ../artifacts
               # FIXME: Check Build.SourceBranch for tag consistency

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -39,6 +39,9 @@ resources:
     - container: xenial
       image: ucfconsort.azurecr.io/rdma-core/ubuntu-16.04:28.0
       endpoint: ucfconsort_registry
+    - container: bionic
+      image: ucfconsort.azurecr.io/rdma-core/ubuntu-18.04:29.0
+      endpoint: ucfconsort_registry
     - container: leap
       image: ucfconsort.azurecr.io/rdma-core/opensuse-15.0:25.0
       endpoint: ucfconsort_registry
@@ -220,6 +223,8 @@ stages:
           matrix:
             xenial:
               CONTAINER: xenial
+            bionic:
+              CONTAINER: bionic
         container: $[ variables['CONTAINER'] ]
         steps:
           - checkout: none

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -257,7 +257,7 @@ class APTEnvironment(Environment):
     build_python = True;
     def get_docker_file(self,tmpdir):
         res = DockerFile(self.docker_parent);
-        res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
+        res.lines.append("RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
             " ".join(sorted(self.pkgs))));
         return res;
 
@@ -333,6 +333,15 @@ class bionic(APTEnvironment):
     };
     name = "ubuntu-18.04";
     aliases = {"bionic", "ubuntu"};
+    to_azp = True
+
+class focal(APTEnvironment):
+    docker_parent = "ubuntu:20.04"
+    pkgs = bionic.pkgs | {
+        'dh-python',
+    }
+    name = "ubuntu-20.04";
+    aliases = {"focal", "ubuntu"};
 
 class jessie(APTEnvironment):
     docker_parent = "debian:8"
@@ -507,6 +516,7 @@ environments = [centos6(),
                 amazonlinux2(),
                 xenial(),
                 bionic(),
+                focal(),
                 jessie(),
                 stretch(),
                 fc31(),

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -489,6 +489,12 @@ deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic-updates main universe""
                          "dpkg --add-architecture ppc64el &&"
                          "dpkg --add-architecture arm64 &&"
                          "sed -i -e 's/^deb /deb [arch=amd64,i386] /g' /etc/apt/sources.list");
+
+        # There is some bug in APT where it doesn't order the install
+        # properly. Probably related to multi-arch..  Resolve it by early
+        # installing these two packages.
+        res.lines[-1] = res.lines[-1].replace("update && apt-get",
+                                              "update && apt-get install -y --no-install-recommends libgcc-s1:i386 libgcc-s1:ppc64el && apt-get")
         return res;
 
 # -------------------------------------------------------------------------

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -428,7 +428,7 @@ class azure_pipelines(APTEnvironment):
         "dh-systemd",
         "dpkg-dev",
         "fakeroot",
-        "gcc-9",
+        "gcc-10",
         "git",
         "python2.7",
         "libc6-dev",
@@ -450,7 +450,7 @@ class azure_pipelines(APTEnvironment):
         "valgrind",
     } | {
         # 32 bit build support
-        "libgcc-9-dev:i386",
+        "libgcc-10-dev:i386",
         "libc6-dev:i386",
         "libnl-3-dev:i386",
         "libnl-route-3-dev:i386",

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -416,7 +416,7 @@ class tumbleweed(ZypperEnvironment):
 # -------------------------------------------------------------------------
 
 class azure_pipelines(APTEnvironment):
-    docker_parent = "ubuntu:18.04"
+    docker_parent = "ubuntu:20.04"
     pkgs = {
         "abi-compliance-checker",
         "abi-dumper",
@@ -425,12 +425,12 @@ class azure_pipelines(APTEnvironment):
         "cmake",
         "cython3",
         "debhelper",
+        "dh-python",
         "dh-systemd",
         "dpkg-dev",
         "fakeroot",
         "gcc-10",
         "git",
-        "python2.7",
         "libc6-dev",
         "libnl-3-dev",
         "libnl-route-3-dev",
@@ -458,8 +458,8 @@ class azure_pipelines(APTEnvironment):
         "libudev-dev:i386",
     } | {
         # ARM 64 cross compiler
-        "gcc-8-aarch64-linux-gnu",
-        "libgcc-8-dev:arm64",
+        "gcc-9-aarch64-linux-gnu",
+        "libgcc-9-dev:arm64",
         "libc6-dev:arm64",
         "libnl-3-dev:arm64",
         "libnl-route-3-dev:arm64",
@@ -467,8 +467,8 @@ class azure_pipelines(APTEnvironment):
         "libudev-dev:arm64",
     } | {
         # PPC 64 cross compiler
-        "gcc-8-powerpc64le-linux-gnu",
-        "libgcc-8-dev:ppc64el",
+        "gcc-9-powerpc64le-linux-gnu",
+        "libgcc-9-dev:ppc64el",
         "libc6-dev:ppc64el",
         "libnl-3-dev:ppc64el",
         "libnl-route-3-dev:ppc64el",
@@ -480,18 +480,18 @@ class azure_pipelines(APTEnvironment):
     aliases = {"azp"}
 
     def get_docker_file(self,tmpdir):
-        res = bionic.get_docker_file(self,tmpdir);
+        res = focal.get_docker_file(self,tmpdir);
         self.fix_https(tmpdir)
         self.add_ppa(tmpdir,
-                     "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main",
+                     "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu focal main",
                      "60C317803A41BA51845E371A1E9377A2BA9EF27F");
         self.add_ppa(tmpdir,
-                     "deb [arch=amd64] https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main",
+                     "deb [arch=amd64] https://apt.llvm.org/focal/ llvm-toolchain-focal-10 main",
                      "15CF4D18AF4F7421");
         self.add_source_list(tmpdir,"arm64.list",
-                             """deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic main universe
-deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic-security main universe
-deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic-updates main universe""");
+                             """deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ focal main universe
+deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ focal-security main universe
+deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ focal-updates main universe""");
 
         res.lines.insert(1,"ADD etc/ /etc/");
         res.lines.insert(1,"RUN dpkg --add-architecture i386 &&"
@@ -499,11 +499,13 @@ deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic-updates main universe""
                          "dpkg --add-architecture arm64 &&"
                          "sed -i -e 's/^deb /deb [arch=amd64,i386] /g' /etc/apt/sources.list");
 
+
         # There is some bug in APT where it doesn't order the install
         # properly. Probably related to multi-arch..  Resolve it by early
         # installing these two packages.
-        res.lines[-1] = res.lines[-1].replace("update && apt-get",
-                                              "update && apt-get install -y --no-install-recommends libgcc-s1:i386 libgcc-s1:ppc64el && apt-get")
+        res.lines[-1] = res.lines[-1].replace("update && DEBIAN_FRONTEND=noninteractive apt-get",
+                                              "update && apt-get install -y --no-install-recommends libgcc-s1:i386 libgcc-s1:ppc64el && DEBIAN_FRONTEND=noninteractive apt-get")
+
         return res;
 
 # -------------------------------------------------------------------------

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -421,7 +421,7 @@ class azure_pipelines(APTEnvironment):
         "abi-compliance-checker",
         "abi-dumper",
         "ca-certificates",
-        "clang-9",
+        "clang-10",
         "cmake",
         "cython3",
         "debhelper",
@@ -486,7 +486,7 @@ class azure_pipelines(APTEnvironment):
                      "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main",
                      "60C317803A41BA51845E371A1E9377A2BA9EF27F");
         self.add_ppa(tmpdir,
-                     "deb [arch=amd64] http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main",
+                     "deb [arch=amd64] https://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main",
                      "15CF4D18AF4F7421");
         self.add_source_list(tmpdir,"arm64.list",
                              """deb [arch=arm64,ppc64el] http://ports.ubuntu.com/ bionic main universe

--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -257,7 +257,7 @@ class APTEnvironment(Environment):
     build_python = True;
     def get_docker_file(self,tmpdir):
         res = DockerFile(self.docker_parent);
-        res.lines.append("RUN apt-get update; apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
+        res.lines.append("RUN apt-get update && apt-get install -y --no-install-recommends %s && apt-get clean && rm -rf /usr/share/doc/ /usr/lib/debug /var/lib/apt/lists/"%(
             " ".join(sorted(self.pkgs))));
         return res;
 
@@ -267,6 +267,15 @@ class APTEnvironment(Environment):
             os.makedirs(sld);
         with open(os.path.join(sld,name),"w") as F:
             F.write(content + "\n");
+
+    def fix_https(self,tmpdir):
+        """The ubuntu image does not include ca-certificates, so if we want to use
+        HTTPS disable certificate validation."""
+        cfgd = os.path.join(tmpdir,"etc","apt","apt.conf.d")
+        if not os.path.isdir(cfgd):
+            os.makedirs(cfgd)
+        with open(os.path.join(cfgd,"01nossl"),"w") as F:
+            F.write('Acquire::https { Verify-Peer "false"; };')
 
     def add_ppa(self,tmpdir,srcline,keyid):
         gpgd = os.path.join(tmpdir,"etc","apt","trusted.gpg.d");
@@ -463,6 +472,7 @@ class azure_pipelines(APTEnvironment):
 
     def get_docker_file(self,tmpdir):
         res = bionic.get_docker_file(self,tmpdir);
+        self.fix_https(tmpdir)
         self.add_ppa(tmpdir,
                      "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu bionic main",
                      "60C317803A41BA51845E371A1E9377A2BA9EF27F");

--- a/buildlib/check-build
+++ b/buildlib/check-build
@@ -84,7 +84,7 @@ def get_symbol_vers(fn,exported=True):
 def check_lib_symver(args,fn):
     g = re.match(r"lib([^.]+)\.so\.(\d+)\.(\d+)\.(.*)",fn);
     if g.group(4) != args.PACKAGE_VERSION:
-        raise ValueError("Shared Library filename %r does not have the package version %r (%r)%"(
+        raise ValueError("Shared Library filename %r does not have the package version %r (%r)"%(
             fn,args.PACKAGE_VERSION,g.groups()));
 
     # umad/etc used the wrong symbol version name when they moved to soname 3.0

--- a/buildlib/gen-sparse.py
+++ b/buildlib/gen-sparse.py
@@ -70,6 +70,8 @@ def get_buildlib_patches(dfn):
     def add_to_dict(d,lst):
         for I in lst:
             nh = norm_header(I)
+            if nh is None:
+                continue;
             assert nh not in d
             d[nh] = (I, find_system_header(args,nh))
 

--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -23,7 +23,7 @@ function(rdma_cython_module PY_MODULE LINKER_FLAGS)
     string(REGEX REPLACE "\\.so$" "" SONAME "${FILENAME}${CMAKE_PYTHON_SO_SUFFIX}")
     add_library(${SONAME} SHARED ${CFILE})
     set_target_properties(${SONAME} PROPERTIES
-      COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option ${NO_VAR_TRACKING_FLAGS}"
+      COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option -Wno-deprecated-declarations ${NO_VAR_TRACKING_FLAGS}"
       LIBRARY_OUTPUT_DIRECTORY "${BUILD_PYTHON}/${PY_MODULE}"
       PREFIX "")
     target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs rdmacm ${LINKER_FLAGS})

--- a/buildlib/sparse-include/31/bits-sysmacros.h.diff
+++ b/buildlib/sparse-include/31/bits-sysmacros.h.diff
@@ -1,0 +1,24 @@
+--- /usr/include/x86_64-linux-gnu/bits/sysmacros.h	2020-04-14 19:26:04.000000000 +0000
++++ include/bits/sysmacros.h	2020-05-05 19:03:23.910980758 +0000
+@@ -40,8 +40,8 @@
+   __SYSMACROS_DECLARE_MAJOR (DECL_TEMPL)			\
+   {								\
+     unsigned int __major;					\
+-    __major  = ((__dev & (__dev_t) 0x00000000000fff00u) >>  8); \
+-    __major |= ((__dev & (__dev_t) 0xfffff00000000000u) >> 32); \
++    __major  = ((__dev & (__dev_t) 0x00000000000fff00ul) >>  8); \
++    __major |= ((__dev & (__dev_t) 0xfffff00000000000ul) >> 32); \
+     return __major;						\
+   }
+ 
+@@ -52,8 +52,8 @@
+   __SYSMACROS_DECLARE_MINOR (DECL_TEMPL)			\
+   {								\
+     unsigned int __minor;					\
+-    __minor  = ((__dev & (__dev_t) 0x00000000000000ffu) >>  0); \
+-    __minor |= ((__dev & (__dev_t) 0x00000ffffff00000u) >> 12); \
++    __minor  = ((__dev & (__dev_t) 0x00000000000000fful) >>  0); \
++    __minor |= ((__dev & (__dev_t) 0x00000ffffff00000ul) >> 12); \
+     return __minor;						\
+   }
+ 

--- a/buildlib/sparse-include/31/netinet-in.h.diff
+++ b/buildlib/sparse-include/31/netinet-in.h.diff
@@ -1,0 +1,123 @@
+--- /usr/include/netinet/in.h	2020-04-14 19:26:04.000000000 +0000
++++ include/netinet/in.h	2020-05-05 19:11:08.250904392 +0000
+@@ -22,12 +22,12 @@
+ #include <bits/stdint-uintn.h>
+ #include <sys/socket.h>
+ #include <bits/types.h>
+-
++#include <linux/types.h>
+ 
+ __BEGIN_DECLS
+ 
+ /* Internet address.  */
+-typedef uint32_t in_addr_t;
++typedef __be32 in_addr_t;
+ struct in_addr
+   {
+     in_addr_t s_addr;
+@@ -116,7 +116,7 @@
+ #endif /* !__USE_KERNEL_IPV6_DEFS */
+ 
+ /* Type to represent a port.  */
+-typedef uint16_t in_port_t;
++typedef __be16 in_port_t;
+ 
+ /* Standard well-known ports.  */
+ enum
+@@ -175,37 +175,37 @@
+ #define	IN_CLASSB_HOST		(0xffffffff & ~IN_CLASSB_NET)
+ #define	IN_CLASSB_MAX		65536
+ 
+-#define	IN_CLASSC(a)		((((in_addr_t)(a)) & 0xe0000000) == 0xc0000000)
++#define	IN_CLASSC(a)		((((uint32_t)(a)) & 0xe0000000) == 0xc0000000)
+ #define	IN_CLASSC_NET		0xffffff00
+ #define	IN_CLASSC_NSHIFT	8
+ #define	IN_CLASSC_HOST		(0xffffffff & ~IN_CLASSC_NET)
+ 
+-#define	IN_CLASSD(a)		((((in_addr_t)(a)) & 0xf0000000) == 0xe0000000)
++#define	IN_CLASSD(a)		((((uint32_t)(a)) & 0xf0000000) == 0xe0000000)
+ #define	IN_MULTICAST(a)		IN_CLASSD(a)
+ 
+-#define	IN_EXPERIMENTAL(a)	((((in_addr_t)(a)) & 0xe0000000) == 0xe0000000)
+-#define	IN_BADCLASS(a)		((((in_addr_t)(a)) & 0xf0000000) == 0xf0000000)
++#define	IN_EXPERIMENTAL(a)	((((uint32_t)(a)) & 0xe0000000) == 0xe0000000)
++#define	IN_BADCLASS(a)		((((uint32_t)(a)) & 0xf0000000) == 0xf0000000)
+ 
+ /* Address to accept any incoming messages.  */
+-#define	INADDR_ANY		((in_addr_t) 0x00000000)
++#define	INADDR_ANY		((uint32_t) 0x00000000)
+ /* Address to send to all hosts.  */
+-#define	INADDR_BROADCAST	((in_addr_t) 0xffffffff)
++#define	INADDR_BROADCAST	((uint32_t) 0xffffffff)
+ /* Address indicating an error return.  */
+-#define	INADDR_NONE		((in_addr_t) 0xffffffff)
++#define	INADDR_NONE		((uint32_t) 0xffffffff)
+ 
+ /* Network number for local host loopback.  */
+ #define	IN_LOOPBACKNET		127
+ /* Address to loopback in software to local host.  */
+ #ifndef INADDR_LOOPBACK
+-# define INADDR_LOOPBACK	((in_addr_t) 0x7f000001) /* Inet 127.0.0.1.  */
++# define INADDR_LOOPBACK	((uint32_t) 0x7f000001) /* Inet 127.0.0.1.  */
+ #endif
+ 
+ /* Defines for Multicast INADDR.  */
+-#define INADDR_UNSPEC_GROUP	((in_addr_t) 0xe0000000) /* 224.0.0.0 */
+-#define INADDR_ALLHOSTS_GROUP	((in_addr_t) 0xe0000001) /* 224.0.0.1 */
+-#define INADDR_ALLRTRS_GROUP    ((in_addr_t) 0xe0000002) /* 224.0.0.2 */
+-#define INADDR_ALLSNOOPERS_GROUP ((in_addr_t) 0xe000006a) /* 224.0.0.106 */
+-#define INADDR_MAX_LOCAL_GROUP  ((in_addr_t) 0xe00000ff) /* 224.0.0.255 */
++#define INADDR_UNSPEC_GROUP	((uint32_t) 0xe0000000) /* 224.0.0.0 */
++#define INADDR_ALLHOSTS_GROUP	((uint32_t) 0xe0000001) /* 224.0.0.1 */
++#define INADDR_ALLRTRS_GROUP    ((uint32_t) 0xe0000002) /* 224.0.0.2 */
++#define INADDR_ALLSNOOPERS_GROUP ((uint32_t) 0xe000006a) /* 224.0.0.106 */
++#define INADDR_MAX_LOCAL_GROUP  ((uint32_t) 0xe00000ff) /* 224.0.0.255 */
+ 
+ #if !__USE_KERNEL_IPV6_DEFS
+ /* IPv6 address */
+@@ -214,8 +214,8 @@
+     union
+       {
+ 	uint8_t	__u6_addr8[16];
+-	uint16_t __u6_addr16[8];
+-	uint32_t __u6_addr32[4];
++	__be16 __u6_addr16[8];
++	__be32 __u6_addr32[4];
+       } __in6_u;
+ #define s6_addr			__in6_u.__u6_addr8
+ #ifdef __USE_MISC
+@@ -254,7 +254,7 @@
+   {
+     __SOCKADDR_COMMON (sin6_);
+     in_port_t sin6_port;	/* Transport layer port # */
+-    uint32_t sin6_flowinfo;	/* IPv6 flow information */
++    __be32 sin6_flowinfo;	/* IPv6 flow information */
+     struct in6_addr sin6_addr;	/* IPv6 address */
+     uint32_t sin6_scope_id;	/* IPv6 scope-id */
+   };
+@@ -372,12 +372,12 @@
+    this was a short-sighted decision since on different systems the types
+    may have different representations but the values are always the same.  */
+ 
+-extern uint32_t ntohl (uint32_t __netlong) __THROW __attribute__ ((__const__));
+-extern uint16_t ntohs (uint16_t __netshort)
++extern uint32_t ntohl (__be32 __netlong) __THROW __attribute__ ((__const__));
++extern uint16_t ntohs (__be16 __netshort)
+      __THROW __attribute__ ((__const__));
+-extern uint32_t htonl (uint32_t __hostlong)
++extern __be32 htonl (uint32_t __hostlong)
+      __THROW __attribute__ ((__const__));
+-extern uint16_t htons (uint16_t __hostshort)
++extern __be16 htons (uint16_t __hostshort)
+      __THROW __attribute__ ((__const__));
+ 
+ #include <endian.h>
+@@ -386,7 +386,7 @@
+ #include <bits/byteswap.h>
+ #include <bits/uintn-identity.h>
+ 
+-#ifdef __OPTIMIZE__
++#ifdef __disabled_OPTIMIZE__
+ /* We can optimize calls to the conversion functions.  Either nothing has
+    to be done or we are using directly the byte-swapping functions which
+    often can be inlined.  */

--- a/buildlib/sparse-include/31/stdlib.h.diff
+++ b/buildlib/sparse-include/31/stdlib.h.diff
@@ -1,0 +1,23 @@
+--- /usr/include/stdlib.h	2020-04-14 19:26:04.000000000 +0000
++++ include/stdlib.h	2020-05-05 19:03:23.910980758 +0000
+@@ -130,6 +130,20 @@
+ 
+ /* Likewise for '_FloatN' and '_FloatNx'.  */
+ 
++/* For whatever reason our sparse does not understand these new compiler types */
++#undef __GLIBC_USE_IEC_60559_TYPES_EXT
++#define __GLIBC_USE_IEC_60559_TYPES_EXT 0
++#undef __HAVE_FLOAT32
++#define __HAVE_FLOAT32 0
++#undef __HAVE_FLOAT32X
++#define __HAVE_FLOAT32X 0
++#undef __HAVE_FLOAT64
++#define __HAVE_FLOAT64 0
++#undef __HAVE_FLOAT64X
++#define __HAVE_FLOAT64X 0
++#undef __HAVE_FLOAT128
++#define __HAVE_FLOAT128 0
++
+ #if __HAVE_FLOAT16 && __GLIBC_USE (IEC_60559_TYPES_EXT)
+ extern _Float16 strtof16 (const char *__restrict __nptr,
+ 			  char **__restrict __endptr)

--- a/buildlib/sparse-include/31/sys-socket.h.diff
+++ b/buildlib/sparse-include/31/sys-socket.h.diff
@@ -1,0 +1,11 @@
+--- /usr/include/x86_64-linux-gnu/sys/socket.h	2020-04-14 19:26:04.000000000 +0000
++++ include/sys/socket.h	2020-05-05 19:03:23.910980758 +0000
+@@ -54,7 +54,7 @@
+    uses with any of the listed types to be allowed without complaint.
+    G++ 2.7 does not support transparent unions so there we want the
+    old-style declaration, too.  */
+-#if defined __cplusplus || !__GNUC_PREREQ (2, 7) || !defined __USE_GNU
++#if 1
+ # define __SOCKADDR_ARG		struct sockaddr *__restrict
+ # define __CONST_SOCKADDR_ARG	const struct sockaddr *
+ #else

--- a/ibacm/prov/acmp/src/acmp.c
+++ b/ibacm/prov/acmp/src/acmp.c
@@ -1230,8 +1230,10 @@ acmp_sa_resp(struct acm_sa_mad *mad)
 
 	req->msg.hdr.opcode |= ACM_OP_ACK;
 	if (!mad->umad.status) {
+		struct acm_ep_addr_data *resolve_data = req->msg.resolve_data;
+
 		req->msg.hdr.status = (uint8_t) (be16toh(sa_mad->status) >> 8);
-		memcpy(&req->msg.resolve_data[0].info.path, sa_mad->data,
+		memcpy(&resolve_data->info.path, sa_mad->data,
 		       sizeof(struct ibv_path_record));
 	} else {
 		req->msg.hdr.status = ACM_STATUS_ETIMEDOUT;

--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2116,7 +2116,9 @@ __acm_ep_insert_addr(struct acmc_ep *ep, const char *name, uint8_t *addr,
 		}
 	}
 	ep->addr_info[i].addr.type = addr_type;
-	strncpy(ep->addr_info[i].string_buf, name, ACM_MAX_ADDRESS);
+	if (!check_snprintf(ep->addr_info[i].string_buf,
+			    sizeof(ep->addr_info[i].string_buf), "%s", name))
+		return EINVAL;
 	memcpy(ep->addr_info[i].addr.info.addr, tmp, ACM_MAX_ADDRESS);
 	ret = ep->port->prov->add_address(&ep->addr_info[i].addr,
 					  ep->prov_ep_context,

--- a/ibacm/src/libacm.c
+++ b/ibacm/src/libacm.c
@@ -40,6 +40,8 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 
+#include <util/util.h>
+
 static pthread_mutex_t acm_lock = PTHREAD_MUTEX_INITIALIZER;
 static int sock = -1;
 static short server_port = 6125;
@@ -202,7 +204,9 @@ static int acm_format_ep_addr(struct acm_ep_addr_data *data, uint8_t *addr,
 
 	switch (type) {
 	case ACM_EP_INFO_NAME:
-		strncpy((char *) data->info.name,  (char *) addr,  ACM_MAX_ADDRESS);
+		if (!check_snprintf((char *)data->info.name,
+				   sizeof(data->info.name), "%s", (char *)addr))
+			return -1;
 		break;
 	case ACM_EP_INFO_ADDRESS_IP:
 		memcpy(data->info.addr, &((struct sockaddr_in *) addr)->sin_addr, 4);

--- a/librdmacm/acm.h
+++ b/librdmacm/acm.h
@@ -111,7 +111,7 @@ struct acm_ep_addr_data {
  */
 struct acm_resolve_msg {
 	struct acm_hdr          hdr;
-	struct acm_ep_addr_data data[0];
+	struct acm_ep_addr_data data[];
 };
 
 enum {
@@ -130,7 +130,7 @@ enum {
  */
 struct acm_perf_msg {
 	struct acm_hdr          hdr;
-	uint64_t                data[0];
+	uint64_t                data[];
 };
 
 /*
@@ -144,12 +144,12 @@ struct acm_ep_config_data {
 	uint16_t                pkey;
 	uint16_t                addr_cnt;
 	uint8_t                 prov_name[ACM_MAX_PROV_NAME];
-	union acm_ep_info       addrs[0];
+	union acm_ep_info       addrs[];
 };
 
 struct acm_ep_query_msg {
 	struct acm_hdr             hdr;
-	struct acm_ep_config_data  data[0];
+	struct acm_ep_config_data  data[];
 };
 
 struct acm_msg {


### PR DESCRIPTION
Various churn in Ubuntu and clang land broke building the azp image, fix it up, and update clang, gcc and base OSs.

Fedora should be updated too, but it is currently broken.