### PR TITLE
libhns: Cleanups for post and poll

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -255,8 +255,6 @@ static void hns_roce_update_rq_db(struct hns_roce_context *ctx,
 	roce_set_field(rq_db.parameter, DB_PARAM_RQ_PRODUCER_IDX_M,
 		       DB_PARAM_RQ_PRODUCER_IDX_S, rq_head);
 
-	udma_to_device_barrier();
-
 	hns_roce_write64((uint32_t *)&rq_db, ctx, ROCEE_VF_DB_CFG0_OFFSET);
 }
 
@@ -274,8 +272,6 @@ static void hns_roce_update_sq_db(struct hns_roce_context *ctx,
 	roce_set_field(sq_db.parameter, DB_PARAM_SQ_PRODUCER_IDX_M,
 		       DB_PARAM_SQ_PRODUCER_IDX_S, sq_head);
 	roce_set_field(sq_db.parameter, DB_PARAM_SL_M, DB_PARAM_SL_S, sl);
-
-	udma_to_device_barrier();
 
 	hns_roce_write64((uint32_t *)&sq_db, ctx, ROCEE_VF_DB_CFG0_OFFSET);
 }
@@ -892,6 +888,8 @@ out:
 	if (likely(nreq)) {
 		qp->sq.head += nreq;
 		qp->next_sge = sge_info.start_idx;
+
+		udma_to_device_barrier();
 
 		hns_roce_update_sq_db(ctx, qp->ibv_qp.qp_num, qp->sl,
 				     qp->sq.head & ((qp->sq.wqe_cnt << 1) - 1));

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -811,7 +811,7 @@ static int set_rc_wqe(void *wqe, struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 				      dseg, sge_info);
 	}
 
-	if (wr->send_flags & IBV_SEND_INLINE) {
+	if (wr->send_flags & IBV_SEND_INLINE && sge_info->valid_num) {
 		if (wr->opcode == IBV_WR_RDMA_READ)
 			return EINVAL;
 


### PR DESCRIPTION
There are some codes need to be simplified or optimized on the processing path of post_send/recv and poll_cq.