### PR TITLE
mlx5: Improve memory usage in the DR area

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -21,6 +21,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.11@MLX5_1.11 25
  MLX5_1.12@MLX5_1.12 28
  MLX5_1.13@MLX5_1.13 29
+ MLX5_1.14@MLX5_1.14 30
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -98,6 +99,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_free_var@MLX5_1.12 28
  mlx5dv_pp_alloc@MLX5_1.13 29
  mlx5dv_pp_free@MLX5_1.13 29
+ mlx5dv_dr_domain_set_reclaim_device_memory@MLX5_1.14 30
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.13.${PACKAGE_VERSION}
+  1 1.14.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -344,6 +344,17 @@ out_unlock:
 	return ret;
 }
 
+void mlx5dv_dr_domain_set_reclaim_device_memory(struct mlx5dv_dr_domain *dmn,
+						bool enable)
+{
+	pthread_mutex_lock(&dmn->mutex);
+	if (enable)
+		dmn->flags |= DR_DOMAIN_FLAG_MEMORY_RECLAIM;
+	else
+		dmn->flags &= ~DR_DOMAIN_FLAG_MEMORY_RECLAIM;
+	pthread_mutex_unlock(&dmn->mutex);
+}
+
 int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *dmn)
 {
 	if (atomic_load(&dmn->refcount) > 1)

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -33,7 +33,7 @@
 #include "mlx5dv_dr.h"
 
 #define DR_ICM_MODIFY_HDR_ALIGN_BASE	64
-#define DR_ICM_SYNC_THRESHOLD (64 * 1024 * 1024)
+#define DR_ICM_SYNC_THRESHOLD_POOL (64 * 1024 * 1024)
 
 struct dr_icm_pool {
 	enum dr_icm_type	icm_type;
@@ -42,6 +42,7 @@ struct dr_icm_pool {
 	/* memory management */
 	pthread_mutex_t		mutex;
 	struct list_head	buddy_mem_list;
+	uint64_t		hot_memory_size;
 };
 
 struct dr_icm_mr {
@@ -307,18 +308,8 @@ out_free_chunk:
 
 static bool dr_icm_pool_is_sync_required(struct dr_icm_pool *pool)
 {
-	uint64_t allow_hot_size, all_hot_mem = 0;
-	struct dr_icm_buddy_mem *buddy;
-
-	list_for_each(&pool->buddy_mem_list, buddy, list_node) {
-		allow_hot_size = dr_icm_pool_chunk_size_to_byte((buddy->max_order - 2),
-								pool->icm_type);
-		all_hot_mem += buddy->hot_memory_size;
-
-		if ((buddy->hot_memory_size > allow_hot_size) ||
-		    (all_hot_mem > DR_ICM_SYNC_THRESHOLD))
-			return true;
-	}
+	if (pool->hot_memory_size > DR_ICM_SYNC_THRESHOLD_POOL)
+		return true;
 
 	return false;
 }
@@ -340,8 +331,8 @@ static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
 		list_for_each_safe(&buddy->hot_list, chunk, tmp_chunk, chunk_list) {
 			dr_buddy_free_mem(buddy, chunk->seg,
 					  ilog32(chunk->num_of_entries - 1));
-			buddy->hot_memory_size -= chunk->byte_size;
 			buddy->used_memory -= chunk->byte_size;
+			pool->hot_memory_size -= chunk->byte_size;
 			dr_icm_chunk_destroy(chunk);
 		}
 
@@ -438,7 +429,7 @@ void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 	pthread_mutex_lock(&buddy->pool->mutex);
 	list_del_init(&chunk->chunk_list);
 	list_add_tail(&buddy->hot_list, &chunk->chunk_list);
-	buddy->hot_memory_size += chunk->byte_size;
+	buddy->pool->hot_memory_size += chunk->byte_size;
 
 	/* Check if we have chunks that are waiting for sync-ste */
 	if (dr_icm_pool_is_sync_required(buddy->pool))

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -291,6 +291,7 @@ dr_icm_chunk_create(struct dr_icm_pool *pool,
 		goto out_free_chunk;
 	}
 
+	buddy_mem_pool->used_memory += chunk->byte_size;
 	chunk->buddy_mem = buddy_mem_pool;
 	list_node_init(&chunk->chunk_list);
 
@@ -340,8 +341,13 @@ static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
 			dr_buddy_free_mem(buddy, chunk->seg,
 					  ilog32(chunk->num_of_entries - 1));
 			buddy->hot_memory_size -= chunk->byte_size;
+			buddy->used_memory -= chunk->byte_size;
 			dr_icm_chunk_destroy(chunk);
 		}
+
+		if ((pool->dmn->flags & DR_DOMAIN_FLAG_MEMORY_RECLAIM) &&
+		    pool->icm_type == DR_ICM_TYPE_STE && !buddy->used_memory)
+			dr_icm_buddy_destroy(buddy);
 	}
 
 	return 0;
@@ -355,10 +361,6 @@ static int dr_icm_handle_buddies_get_mem(struct dr_icm_pool *pool,
 	struct dr_icm_buddy_mem *buddy_mem_pool;
 	bool new_mem = false;
 	int err = 0;
-
-	/* Check if we have chunks that are waiting for sync-ste */
-	if (dr_icm_pool_is_sync_required(pool))
-		dr_icm_pool_sync_all_buddy_pools(pool);
 
 	*seg = -1;
 
@@ -437,6 +439,11 @@ void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 	list_del_init(&chunk->chunk_list);
 	list_add_tail(&buddy->hot_list, &chunk->chunk_list);
 	buddy->hot_memory_size += chunk->byte_size;
+
+	/* Check if we have chunks that are waiting for sync-ste */
+	if (dr_icm_pool_is_sync_required(buddy->pool))
+		dr_icm_pool_sync_all_buddy_pools(buddy->pool);
+
 	pthread_mutex_unlock(&buddy->pool->mutex);
 }
 

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -133,3 +133,8 @@ MLX5_1.13 {
 		mlx5dv_pp_alloc;
 		mlx5dv_pp_free;
 } MLX5_1.12;
+
+MLX5_1.14 {
+	global:
+		mlx5dv_dr_domain_set_reclaim_device_memory;
+} MLX5_1.13;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -67,6 +67,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_sync.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_domain_set_reclaim_device_memory.3
  mlx5dv_dr_flow.3 mlx5dv_dr_matcher_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_matcher_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_create.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -10,7 +10,7 @@ footer: mlx5
 
 # NAME
 
-mlx5dv_dr_domain_create, mlx5dv_dr_domain_sync, mlx5dv_dr_domain_destroy - Manage flow domains
+mlx5dv_dr_domain_create, mlx5dv_dr_domain_sync, mlx5dv_dr_domain_destroy, mlx5dv_dr_domain_set_reclaim_device_memory - Manage flow domains
 
 mlx5dv_dr_table_create, mlx5dv_dr_table_destroy - Manage flow tables
 
@@ -48,6 +48,10 @@ int mlx5dv_dr_domain_sync(
 		uint32_t flags);
 
 int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *domain);
+
+void mlx5dv_dr_domain_set_reclaim_device_memory(
+		struct mlx5dv_dr_domain *dmn,
+		bool enable);
 
 struct mlx5dv_dr_table *mlx5dv_dr_table_create(
 		struct mlx5dv_dr_domain *domain,
@@ -144,6 +148,9 @@ Default behavior: Forward packet to eSwitch manager vport.
 **MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW**: block until completion of all software queued tasks.
 
 **MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW**: clear the steering HW cache to enforce next packet hits the latest rules, in addition to the SW SYNC handling.
+
+
+*mlx5dv_dr_domain_set_reclaim_device_memory()* is used to enable the reclaiming of device memory back to the system when not in use, by default this feature is disabled.
 
 ## Table
 *mlx5dv_dr_table_create()* creates a DR table in the **domain**, at the appropriate **level**, and can be used with *mlx5dv_dr_matcher_create()* and *mlx5dv_dr_action_create_dest_table()*.

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1456,6 +1456,9 @@ int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *domain);
 
 int mlx5dv_dr_domain_sync(struct mlx5dv_dr_domain *domain, uint32_t flags);
 
+void mlx5dv_dr_domain_set_reclaim_device_memory(struct mlx5dv_dr_domain *dmn,
+						bool enable);
+
 struct mlx5dv_dr_table *
 mlx5dv_dr_table_create(struct mlx5dv_dr_domain *domain, uint32_t level);
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -615,6 +615,10 @@ struct dr_domain_info {
 	struct dr_devx_caps	caps;
 };
 
+enum dr_domain_flags {
+	 DR_DOMAIN_FLAG_MEMORY_RECLAIM = 1 << 0,
+};
+
 struct mlx5dv_dr_domain {
 	struct ibv_context		*ctx;
 	struct ibv_pd			*pd;
@@ -627,6 +631,7 @@ struct mlx5dv_dr_domain {
 	struct dr_send_ring		*send_ring;
 	struct dr_domain_info		info;
 	struct list_head		tbl_list;
+	uint32_t			flags;
 };
 
 struct dr_table_rx_tx {
@@ -1042,6 +1047,7 @@ struct dr_icm_buddy_mem {
 
 	/* This is the list of used chunks. HW may be accessing this memory */
 	struct list_head	used_list;
+	size_t			used_memory;
 
 	/* hardware may be accessing this memory but at some future,
 	 * undetermined time, it might cease to do so.

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -1054,8 +1054,6 @@ struct dr_icm_buddy_mem {
 	 * sync_ste command sets them free.
 	 */
 	struct list_head	hot_list;
-	/* indicates the byte size of hot mem */
-	unsigned int		hot_memory_size;
 };
 
 int dr_buddy_init(struct dr_icm_buddy_mem *buddy, uint32_t max_order);


### PR DESCRIPTION
This series improves the memory usage in the DR area by enabling an option to reclaim device memory which is not in use.

In addition, the hot memory calculations to consider whether sync call is required was refactored to prevent redundant checks and improve performance.