### PR TITLE
pyverbs: Fixes and improvements

### DIFF
--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -20,6 +20,7 @@ cdef class Context(PyverbsCM):
     cdef object xrcds
     cdef object vars
     cdef object uars
+    cdef object pps
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr
@@ -63,7 +64,3 @@ cdef class DM(PyverbsCM):
 
 cdef class PortAttr(PyverbsObject):
     cdef v.ibv_port_attr attr
-
-cdef class VAR(PyverbsObject):
-    cdef object context
-    cpdef close(self)

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -102,6 +102,7 @@ cdef class Context(PyverbsCM):
         self.xrcds = weakref.WeakSet()
         self.vars = weakref.WeakSet()
         self.uars = weakref.WeakSet()
+        self.pps = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -230,8 +231,6 @@ cdef class Context(PyverbsCM):
             self.qps.add(obj)
         elif isinstance(obj, XRCD):
             self.xrcds.add(obj)
-        elif isinstance(obj, VAR):
-            self.vars.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 
@@ -980,19 +979,3 @@ def get_device_list():
     finally:
         v.ibv_free_device_list(dev_list)
     return devices
-
-
-cdef class VAR(PyverbsObject):
-    """
-    This is an abstract class of Virtio Access Region (VAR).
-    Each device specific VAR implementation should inherit this class
-    and initialize it according to the device attributes.
-    """
-    def __init__(self, Context context not None, **kwargs):
-        self.context = context
-
-    def __dealloc__(self):
-        self.close()
-
-    cpdef close(self):
-        pass

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -4,14 +4,13 @@
 #cython: language_level=3
 
 cimport pyverbs.providers.mlx5.libmlx5 as dv
-from pyverbs.device cimport Context, VAR
 from pyverbs.base cimport PyverbsObject
+from pyverbs.device cimport Context
 from pyverbs.cq cimport CQEX
 from pyverbs.qp cimport QP
 
 
 cdef class Mlx5Context(Context):
-    cdef object pps
     cpdef close(self)
 
 cdef class Mlx5DVContextAttr(PyverbsObject):
@@ -35,8 +34,9 @@ cdef class Mlx5DVCQInitAttr(PyverbsObject):
 cdef class Mlx5CQ(CQEX):
     pass
 
-cdef class Mlx5VAR(VAR):
+cdef class Mlx5VAR(PyverbsObject):
     cdef dv.mlx5dv_var *var
+    cdef object context
     cpdef close(self)
 
 cdef class Mlx5PP(PyverbsObject):

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -37,6 +37,8 @@ cdef class QP(PyverbsCM):
     cdef update_cqs(self, init_attr)
     cdef object scq
     cdef object rcq
+    cdef object mws
+    cdef add_ref(self, obj)
 
 cdef class DataBuffer(PyverbsCM):
     cdef v.ibv_data_buf data


### PR DESCRIPTION
This series includes the following fixes and improvements:
- Add Memory Windows (MWs) weakrefs to QPEx so they would be automatically closed upon closing the relevant QPs.
- Remove add_ref from Mlx5Context, so it can be used by non-mlx5-only objects

