### PR TITLE
libibverbs/man/ibv_create_wq.3 replace verbs_exp.h with verbs.h

### DIFF
--- a/libibverbs/man/ibv_create_wq.3
+++ b/libibverbs/man/ibv_create_wq.3
@@ -6,7 +6,7 @@
 ibv_create_wq, ibv_destroy_wq \- create or destroy a Work Queue (WQ).
 .SH "SYNOPSIS"
 .nf
-.B #include <infiniband/verbs_exp.h>
+.B #include <infiniband/verbs.h>
 .sp
 .BI "struct ibv_wq *ibv_create_wq(struct ibv_context " "*context,"
 .BI "                                     struct ibv_wq_init_attr " "*wq_init_attr" );


### PR DESCRIPTION
It seems "verbs_exp.h" is OFED only, so replace it with "verbs.h".

Signed-off-by: Honggang Li <honli@redhat.com>