### PR TITLE
Add conditionals for systemd in rdma-core.spec file

### DIFF
--- a/buildlib/cbuild
+++ b/buildlib/cbuild
@@ -189,7 +189,7 @@ class amazonlinux1(YumEnvironment):
     use_make = True;
     pandoc = False;
     build_pyverbs = False;
-    specfile = "buildlib/centos6.spec";
+    specfile = "redhat/rdma-core.spec";
     python_cmd = "python";
     to_azp = False;
 


### PR DESCRIPTION
Add conditionals to build rdma-core packages for a system which does not have systemd.
Amazon Linux 1 cbuild packaging is modified to use rdma-core.spec file as well.