### PR TITLE
Misc pyverbs tests fixes

### DIFF
--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -51,8 +51,8 @@ class AHTest(PyverbsAPITestCase):
                 if port_attr.state != e.IBV_PORT_ACTIVE and \
                    port_attr.state != e.IBV_PORT_INIT:
                     continue
-                if port_attr.link_layer == e.IBV_LINK_LAYER_INFINIBAND:
-                    raise unittest.SkipTest('Can\'t run RoCE tests on IB link layer')
+                if port_attr.link_layer != e.IBV_LINK_LAYER_ETHERNET:
+                    raise unittest.SkipTest('RoCE tests are only supported on Ethernet link layer')
                 ah_attr = AHAttr(is_global=0, port_num=port_num)
                 try:
                     ah = AH(pd, attr=ah_attr)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -160,7 +160,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)
@@ -173,7 +173,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)
@@ -186,7 +186,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = attr_ex.max_dm_size + 1
             dm_attrs = u.get_dm_attrs(dm_len)
             try:
@@ -215,7 +215,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)
@@ -229,7 +229,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)
@@ -246,7 +246,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)
@@ -270,7 +270,7 @@ class DMTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,
                                       u.DM_ALIGNMENT)
             dm_attrs = u.get_dm_attrs(dm_len)

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -254,7 +254,7 @@ class DMMRTest(PyverbsAPITestCase):
         """
         for ctx, attr, attr_ex in self.devices:
             if attr_ex.max_dm_size == 0:
-                return
+                raise unittest.SkipTest('Device memory is not supported')
             with PD(ctx) as pd:
                 for i in range(10):
                     dm_len = random.randrange(u.MIN_DM_SIZE, attr_ex.max_dm_size/2,

--- a/tests/test_qp.py
+++ b/tests/test_qp.py
@@ -32,11 +32,21 @@ class QPTest(PyverbsAPITestCase):
                 with CQ(ctx, 100, None, None, 0) as cq:
                     qia = get_qp_init_attr(cq, attr)
                     qia.qp_type = e.IBV_QPT_RC
-                    with QP(pd, qia) as qp:
-                        assert qp.qp_state == e.IBV_QPS_RESET, 'RC QP should have been in RESET'
+                    try:
+                        with QP(pd, qia) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RESET, 'RC QP should have been in RESET'
+                    except PyverbsRDMAError as ex:
+                        if ex.error_code == errno.EOPNOTSUPP:
+                            raise unittest.SkipTest('Create QP with RC attrs is not supported')
+                        raise ex
                     qia.qp_type = e.IBV_QPT_UC
-                    with QP(pd, qia) as qp:
-                        assert qp.qp_state == e.IBV_QPS_RESET, 'UC QP should have been in RESET'
+                    try:
+                        with QP(pd, qia) as qp:
+                            assert qp.qp_state == e.IBV_QPS_RESET, 'UC QP should have been in RESET'
+                    except PyverbsRDMAError as ex:
+                        if ex.error_code == errno.EOPNOTSUPP:
+                            raise unittest.SkipTest('Create QP with UC attrs is not supported')
+                        raise ex
 
 
     def test_create_qp_no_attr(self):
@@ -68,11 +78,21 @@ class QPTest(PyverbsAPITestCase):
                 with CQ(ctx, 100, None, None, 0) as cq:
                     qia = get_qp_init_attr(cq, attr)
                     qia.qp_type = e.IBV_QPT_RC
-                    with QP(pd, qia, QPAttr()) as qp:
-                        assert qp.qp_state == e.IBV_QPS_INIT, 'RC QP should have been in INIT'
+                    try:
+                        with QP(pd, qia, QPAttr()) as qp:
+                            assert qp.qp_state == e.IBV_QPS_INIT, 'RC QP should have been in INIT'
+                    except PyverbsRDMAError as ex:
+                        if ex.error_code == errno.EOPNOTSUPP:
+                            raise unittest.SkipTest('Create QP with RC is not supported')
+                        raise ex
                     qia.qp_type = e.IBV_QPT_UC
-                    with QP(pd, qia, QPAttr()) as qp:
-                        assert qp.qp_state == e.IBV_QPS_INIT, 'UC QP should have been in INIT'
+                    try:
+                        with QP(pd, qia, QPAttr()) as qp:
+                            assert qp.qp_state == e.IBV_QPS_INIT, 'UC QP should have been in INIT'
+                    except PyverbsRDMAError as ex:
+                        if ex.error_code == errno.EOPNOTSUPP:
+                            raise unittest.SkipTest('Create QP with UC attrs is not supported')
+                        raise ex
 
     def test_create_qp_with_attr(self):
         """

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -164,10 +164,14 @@ class QpExTestCase(RDMATestCase):
                         'rc_bind_mw': QpExRCBindMw}
 
     def create_players(self, qp_type):
-        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
-        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
+        try:
+            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index)
+            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                           self.gid_index)
+        except PyverbsRDMAError as ex:
+           if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create player with {} is not supported'.format(qp_type))
         if 'xrc' in qp_type:
             client.pre_run(server.psns, server.qps_num)
             server.pre_run(client.psns, client.qps_num)


### PR DESCRIPTION
Misc fixes to make pyverbs tests skip on unsupported operations.