### PR TITLE
verbs: Introduce verbs_cq for extended CQ operations

### DIFF
--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -135,7 +135,7 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 
 int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ibv_cq_init_attr_ex *cq_attr,
-			 struct ibv_cq_ex *cq,
+			 struct verbs_cq *cq,
 			 struct ibv_create_cq_ex *cmd,
 			 size_t cmd_size,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
@@ -157,7 +157,7 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 
 	return ibv_icmd_create_cq(context, cq_attr->cqe, cq_attr->channel,
 				  cq_attr->comp_vector, flags,
-				  ibv_cq_ex_to_cq(cq), cmdb);
+				  &cq->cq, cmdb);
 }
 
 int ibv_cmd_destroy_cq(struct ibv_cq *cq)

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -102,6 +102,13 @@ struct verbs_qp {
 };
 static_assert(offsetof(struct ibv_qp_ex, qp_base) == 0, "Invalid qp layout");
 
+struct verbs_cq {
+	union {
+		struct ibv_cq cq;
+		struct ibv_cq_ex cq_ex;
+	};
+};
+
 enum ibv_flow_action_type {
 	IBV_FLOW_ACTION_UNSPECIFIED,
 	IBV_FLOW_ACTION_ESP = 1,
@@ -484,7 +491,7 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 		      struct ib_uverbs_create_cq_resp *resp, size_t resp_size);
 int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ibv_cq_init_attr_ex *cq_attr,
-			 struct ibv_cq_ex *cq,
+			 struct verbs_cq *cq,
 			 struct ibv_create_cq_ex *cmd,
 			 size_t cmd_size,
 			 struct ib_uverbs_ex_create_cq_resp *resp,

--- a/providers/mlx4/cq.c
+++ b/providers/mlx4/cq.c
@@ -58,11 +58,11 @@ static struct mlx4_cqe *get_cqe(struct mlx4_cq *cq, int entry)
 
 static void *get_sw_cqe(struct mlx4_cq *cq, int n)
 {
-	struct mlx4_cqe *cqe = get_cqe(cq, n & cq->ibv_cq.cqe);
+	struct mlx4_cqe *cqe = get_cqe(cq, n & cq->verbs_cq.cq.cqe);
 	struct mlx4_cqe *tcqe = cq->cqe_size == 64 ? cqe + 1 : cqe;
 
 	return (!!(tcqe->owner_sr_opcode & MLX4_CQE_OWNER_MASK) ^
-		!!(n & (cq->ibv_cq.cqe + 1))) ? NULL : cqe;
+		!!(n & (cq->verbs_cq.cq.cqe + 1))) ? NULL : cqe;
 }
 
 static struct mlx4_cqe *next_cqe_sw(struct mlx4_cq *cq)
@@ -206,7 +206,7 @@ static inline int mlx4_parse_cqe(struct mlx4_cq *cq,
 	int is_send;
 	enum ibv_wc_status *pstatus;
 
-	mctx = to_mctx(cq->ibv_cq.context);
+	mctx = to_mctx(cq->verbs_cq.cq.context);
 	qpn = be32toh(cqe->vlan_my_qpn) & MLX4_CQE_QPN_MASK;
 	if (lazy) {
 		cq->cqe = cqe;
@@ -243,7 +243,7 @@ static inline int mlx4_parse_cqe(struct mlx4_cq *cq,
 			to_msrq((*cur_qp)->verbs_qp.qp.srq) : NULL;
 	}
 
-	pwr_id = lazy ? &cq->ibv_cq.wr_id : &wc->wr_id;
+	pwr_id = lazy ? &cq->verbs_cq.cq_ex.wr_id : &wc->wr_id;
 	if (is_send) {
 		wq = &(*cur_qp)->sq;
 		wqe_index = be16toh(cqe->wqe_index);
@@ -260,7 +260,7 @@ static inline int mlx4_parse_cqe(struct mlx4_cq *cq,
 		++wq->tail;
 	}
 
-	pstatus = lazy ? &cq->ibv_cq.status : &wc->status;
+	pstatus = lazy ? &cq->verbs_cq.cq_ex.status : &wc->status;
 	if (is_error) {
 		ecqe = (struct mlx4_err_cqe *)cqe;
 		*pstatus = mlx4_handle_error_cqe(ecqe);
@@ -610,33 +610,33 @@ void mlx4_cq_fill_pfns(struct mlx4_cq *cq, const struct ibv_cq_init_attr_ex *cq_
 {
 
 	if (cq->flags & MLX4_CQ_FLAGS_SINGLE_THREADED) {
-		cq->ibv_cq.start_poll = mlx4_start_poll;
-		cq->ibv_cq.end_poll = mlx4_end_poll;
+		cq->verbs_cq.cq_ex.start_poll = mlx4_start_poll;
+		cq->verbs_cq.cq_ex.end_poll = mlx4_end_poll;
 	} else {
-		cq->ibv_cq.start_poll = mlx4_start_poll_lock;
-		cq->ibv_cq.end_poll = mlx4_end_poll_lock;
+		cq->verbs_cq.cq_ex.start_poll = mlx4_start_poll_lock;
+		cq->verbs_cq.cq_ex.end_poll = mlx4_end_poll_lock;
 	}
-	cq->ibv_cq.next_poll = mlx4_next_poll;
+	cq->verbs_cq.cq_ex.next_poll = mlx4_next_poll;
 
-	cq->ibv_cq.read_opcode = mlx4_cq_read_wc_opcode;
-	cq->ibv_cq.read_vendor_err = mlx4_cq_read_wc_vendor_err;
-	cq->ibv_cq.read_wc_flags = mlx4_cq_read_wc_flags;
+	cq->verbs_cq.cq_ex.read_opcode = mlx4_cq_read_wc_opcode;
+	cq->verbs_cq.cq_ex.read_vendor_err = mlx4_cq_read_wc_vendor_err;
+	cq->verbs_cq.cq_ex.read_wc_flags = mlx4_cq_read_wc_flags;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_BYTE_LEN)
-		cq->ibv_cq.read_byte_len = mlx4_cq_read_wc_byte_len;
+		cq->verbs_cq.cq_ex.read_byte_len = mlx4_cq_read_wc_byte_len;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_IMM)
-		cq->ibv_cq.read_imm_data = mlx4_cq_read_wc_imm_data;
+		cq->verbs_cq.cq_ex.read_imm_data = mlx4_cq_read_wc_imm_data;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_QP_NUM)
-		cq->ibv_cq.read_qp_num = mlx4_cq_read_wc_qp_num;
+		cq->verbs_cq.cq_ex.read_qp_num = mlx4_cq_read_wc_qp_num;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SRC_QP)
-		cq->ibv_cq.read_src_qp = mlx4_cq_read_wc_src_qp;
+		cq->verbs_cq.cq_ex.read_src_qp = mlx4_cq_read_wc_src_qp;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SLID)
-		cq->ibv_cq.read_slid = mlx4_cq_read_wc_slid;
+		cq->verbs_cq.cq_ex.read_slid = mlx4_cq_read_wc_slid;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SL)
-		cq->ibv_cq.read_sl = mlx4_cq_read_wc_sl;
+		cq->verbs_cq.cq_ex.read_sl = mlx4_cq_read_wc_sl;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_DLID_PATH_BITS)
-		cq->ibv_cq.read_dlid_path_bits = mlx4_cq_read_wc_dlid_path_bits;
+		cq->verbs_cq.cq_ex.read_dlid_path_bits = mlx4_cq_read_wc_dlid_path_bits;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)
-		cq->ibv_cq.read_completion_ts = mlx4_cq_read_wc_completion_ts;
+		cq->verbs_cq.cq_ex.read_completion_ts = mlx4_cq_read_wc_completion_ts;
 }
 
 int mlx4_arm_cq(struct ibv_cq *ibvcq, int solicited)
@@ -693,7 +693,7 @@ void __mlx4_cq_clean(struct mlx4_cq *cq, uint32_t qpn, struct mlx4_srq *srq)
 	 * from our QP and therefore don't need to be checked.
 	 */
 	for (prod_index = cq->cons_index; get_sw_cqe(cq, prod_index); ++prod_index)
-		if (prod_index == cq->cons_index + cq->ibv_cq.cqe)
+		if (prod_index == cq->cons_index + cq->verbs_cq.cq.cqe)
 			break;
 
 	/*
@@ -701,7 +701,7 @@ void __mlx4_cq_clean(struct mlx4_cq *cq, uint32_t qpn, struct mlx4_srq *srq)
 	 * that match our QP by copying older entries on top of them.
 	 */
 	while ((int) --prod_index - (int) cq->cons_index >= 0) {
-		cqe = get_cqe(cq, prod_index & cq->ibv_cq.cqe);
+		cqe = get_cqe(cq, prod_index & cq->verbs_cq.cq.cqe);
 		cqe += cqe_inc;
 		if (srq && srq->ext_srq &&
 		    (be32toh(cqe->g_mlpath_rqpn) & MLX4_CQE_QPN_MASK) == srq->verbs_srq.srq_num &&
@@ -713,7 +713,7 @@ void __mlx4_cq_clean(struct mlx4_cq *cq, uint32_t qpn, struct mlx4_srq *srq)
 				mlx4_free_srq_wqe(srq, be16toh(cqe->wqe_index));
 			++nfreed;
 		} else if (nfreed) {
-			dest = get_cqe(cq, (prod_index + nfreed) & cq->ibv_cq.cqe);
+			dest = get_cqe(cq, (prod_index + nfreed) & cq->verbs_cq.cq.cqe);
 			dest += cqe_inc;
 			owner_bit = dest->owner_sr_opcode & MLX4_CQE_OWNER_MASK;
 			memcpy(dest, cqe, sizeof *cqe);
@@ -762,8 +762,8 @@ void mlx4_cq_resize_copy_cqes(struct mlx4_cq *cq, void *buf, int old_cqe)
 
 	while ((mlx4dv_get_cqe_opcode(cqe)) != MLX4_CQE_OPCODE_RESIZE) {
 		cqe->owner_sr_opcode = (cqe->owner_sr_opcode & ~MLX4_CQE_OWNER_MASK) |
-			(((i + 1) & (cq->ibv_cq.cqe + 1)) ? MLX4_CQE_OWNER_MASK : 0);
-		memcpy(buf + ((i + 1) & cq->ibv_cq.cqe) * cq->cqe_size,
+			(((i + 1) & (cq->verbs_cq.cq.cqe + 1)) ? MLX4_CQE_OWNER_MASK : 0);
+		memcpy(buf + ((i + 1) & cq->verbs_cq.cq.cqe) * cq->cqe_size,
 		       cqe - cqe_inc, cq->cqe_size);
 		++i;
 		cqe = get_cqe(cq, (i & old_cqe));

--- a/providers/mlx4/mlx4.c
+++ b/providers/mlx4/mlx4.c
@@ -354,7 +354,7 @@ static int mlx4dv_get_cq(struct ibv_cq *cq_in,
 	cq_out->arm_db = mcq->arm_db;
 	cq_out->arm_sn = mcq->arm_sn;
 	cq_out->cqe_size = mcq->cqe_size;
-	cq_out->cqe_cnt = mcq->ibv_cq.cqe + 1;
+	cq_out->cqe_cnt = mcq->verbs_cq.cq.cqe + 1;
 
 	mcq->flags |= MLX4_CQ_FLAGS_DV_OWNED;
 

--- a/providers/mlx4/mlx4.h
+++ b/providers/mlx4/mlx4.h
@@ -159,7 +159,7 @@ enum {
 };
 
 struct mlx4_cq {
-	struct ibv_cq_ex		ibv_cq;
+	struct verbs_cq			verbs_cq;
 	struct mlx4_buf			buf;
 	struct mlx4_buf			resize_buf;
 	pthread_spinlock_t		lock;
@@ -268,7 +268,7 @@ static inline struct mlx4_pd *to_mpd(struct ibv_pd *ibpd)
 
 static inline struct mlx4_cq *to_mcq(struct ibv_cq *ibcq)
 {
-	return container_of((struct ibv_cq_ex *)ibcq, struct mlx4_cq, ibv_cq);
+	return container_of(ibcq, struct mlx4_cq, verbs_cq.cq);
 }
 
 static inline struct mlx4_srq *to_msrq(struct ibv_srq *ibsrq)

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -427,7 +427,7 @@ static int mlx4_cmd_create_cq(struct ibv_context *context,
 
 	ret = ibv_cmd_create_cq(context, cq_attr->cqe, cq_attr->channel,
 				cq_attr->comp_vector,
-				ibv_cq_ex_to_cq(&cq->ibv_cq),
+				&cq->verbs_cq.cq,
 				&cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp));
 	if (!ret)
@@ -449,7 +449,7 @@ static int mlx4_cmd_create_cq_ex(struct ibv_context *context,
 	cmd.db_addr  = (uintptr_t) cq->set_ci_db;
 
 	ret = ibv_cmd_create_cq_ex(context, cq_attr,
-				   &cq->ibv_cq, &cmd.ibv_cmd,
+				   &cq->verbs_cq, &cmd.ibv_cmd,
 				   sizeof(cmd),
 				   &resp.ibv_resp,
 				   sizeof(resp));
@@ -541,7 +541,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 	if (cq_alloc_flags & MLX4_CQ_FLAGS_EXTENDED)
 		mlx4_cq_fill_pfns(cq, cq_attr);
 
-	return &cq->ibv_cq;
+	return &cq->verbs_cq.cq_ex;
 
 err_db:
 	mlx4_free_db(to_mctx(context), MLX4_DB_TYPE_CQ, cq->set_ci_db);

--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -121,13 +121,13 @@ static void *get_cqe(struct mlx5_cq *cq, int n)
 
 static void *get_sw_cqe(struct mlx5_cq *cq, int n)
 {
-	void *cqe = get_cqe(cq, n & cq->ibv_cq.cqe);
+	void *cqe = get_cqe(cq, n & cq->verbs_cq.cq.cqe);
 	struct mlx5_cqe64 *cqe64;
 
 	cqe64 = (cq->cqe_sz == 64) ? cqe : cqe + 64;
 
 	if (likely(mlx5dv_get_cqe_opcode(cqe64) != MLX5_CQE_INVALID) &&
-	    !((cqe64->op_own & MLX5_CQE_OWNER_MASK) ^ !!(n & (cq->ibv_cq.cqe + 1)))) {
+	    !((cqe64->op_own & MLX5_CQE_OWNER_MASK) ^ !!(n & (cq->verbs_cq.cq.cqe + 1)))) {
 		return cqe;
 	} else {
 		return NULL;
@@ -191,7 +191,7 @@ static inline int handle_responder_lazy(struct mlx5_cq *cq, struct mlx5_cqe64 *c
 
 	if (srq) {
 		wqe_ctr = be16toh(cqe->wqe_counter);
-		cq->ibv_cq.wr_id = srq->wrid[wqe_ctr];
+		cq->verbs_cq.cq_ex.wr_id = srq->wrid[wqe_ctr];
 		mlx5_free_srq_wqe(srq, wqe_ctr);
 		if (cqe->op_own & MLX5_INLINE_SCATTER_32)
 			err = mlx5_copy_to_recv_srq(srq, wqe_ctr, cqe,
@@ -209,7 +209,7 @@ static inline int handle_responder_lazy(struct mlx5_cq *cq, struct mlx5_cqe64 *c
 		}
 
 		wqe_ctr = wq->tail & (wq->wqe_cnt - 1);
-		cq->ibv_cq.wr_id = wq->wrid[wqe_ctr];
+		cq->verbs_cq.cq_ex.wr_id = wq->wrid[wqe_ctr];
 		++wq->tail;
 		if (cqe->op_own & MLX5_INLINE_SCATTER_32)
 			err = mlx5_copy_to_recv_wqe(qp, wqe_ctr, cqe,
@@ -560,12 +560,12 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 	struct mlx5_srq_op *op;
 	uint16_t wqe_ctr;
 
-	cq->ibv_cq.status = IBV_WC_SUCCESS;
+	cq->verbs_cq.cq_ex.status = IBV_WC_SUCCESS;
 	switch (cqe64->app_op) {
 	case MLX5_CQE_APP_OP_TM_CONSUMED_MSG_SW_RDNV:
 	case MLX5_CQE_APP_OP_TM_CONSUMED_SW_RDNV:
 	case MLX5_CQE_APP_OP_TM_MSG_COMPLETION_CANCELED:
-		cq->ibv_cq.status = IBV_WC_TM_RNDV_INCOMPLETE;
+		cq->verbs_cq.cq_ex.status = IBV_WC_TM_RNDV_INCOMPLETE;
 		SWITCH_FALLTHROUGH;
 
 	case MLX5_CQE_APP_OP_TM_CONSUMED_MSG:
@@ -576,17 +576,17 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 		if (!tag->expect_cqe) {
 			mlx5_dbg(fp, MLX5_DBG_CQ, "got idx %d which wasn't added\n",
 				 be16toh(cqe64->app_info));
-			cq->ibv_cq.status = IBV_WC_GENERAL_ERR;
+			cq->verbs_cq.cq_ex.status = IBV_WC_GENERAL_ERR;
 			mlx5_spin_unlock(&srq->lock);
 			return CQ_OK;
 		}
-		cq->ibv_cq.wr_id = tag->wr_id;
+		cq->verbs_cq.cq_ex.wr_id = tag->wr_id;
 		if (mlx5_cqe_app_op_tm_is_complete(cqe64->app_op))
 			mlx5_tm_release_tag(srq, tag);
 		/* inline scatter 32 not supported for TM */
 		if (cqe64->op_own & MLX5_INLINE_SCATTER_64) {
 			if (be32toh(cqe64->byte_cnt) > tag->size)
-				cq->ibv_cq.status = IBV_WC_LOC_LEN_ERR;
+				cq->verbs_cq.cq_ex.status = IBV_WC_LOC_LEN_ERR;
 			else
 				memcpy(tag->ptr, cqe64 - 1,
 				       be32toh(cqe64->byte_cnt));
@@ -596,7 +596,7 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 
 	case MLX5_CQE_APP_OP_TM_REMOVE:
 		if (!(be32toh(cqe64->tm_cqe.success) & MLX5_TMC_SUCCESS))
-			cq->ibv_cq.status = IBV_WC_TM_ERR;
+			cq->verbs_cq.cq_ex.status = IBV_WC_TM_ERR;
 		SWITCH_FALLTHROUGH;
 
 	case MLX5_CQE_APP_OP_TM_APPEND:
@@ -615,7 +615,7 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 		if (op->tag) { /* APPEND or REMOVE */
 			mlx5_tm_release_tag(srq, op->tag);
 			if (cqe64->app_op == MLX5_CQE_APP_OP_TM_REMOVE &&
-			    cq->ibv_cq.status == IBV_WC_SUCCESS)
+			    cq->verbs_cq.cq_ex.status == IBV_WC_SUCCESS)
 				/*
 				 * If tag entry was successfully removed we
 				 * don't expect consumption completion for it
@@ -629,7 +629,7 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 		}
 
 		to_mqp(srq->cmd_qp)->sq.tail = op->wqe_head + 1;
-		cq->ibv_cq.wr_id = op->wr_id;
+		cq->verbs_cq.cq_ex.wr_id = op->wr_id;
 
 		mlx5_spin_unlock(&srq->lock);
 		break;
@@ -642,7 +642,7 @@ static int handle_tag_matching(struct mlx5_cq *cq,
 
 	case MLX5_CQE_APP_OP_TM_NO_TAG:
 		wqe_ctr = be16toh(cqe64->wqe_counter);
-		cq->ibv_cq.wr_id = srq->wrid[wqe_ctr];
+		cq->verbs_cq.cq_ex.wr_id = srq->wrid[wqe_ctr];
 		mlx5_free_srq_wqe(srq, wqe_ctr);
 		if (cqe64->op_own & MLX5_INLINE_SCATTER_32)
 			return mlx5_copy_to_recv_srq(srq, wqe_ctr, cqe64,
@@ -698,7 +698,7 @@ again:
 	is_srq = 0;
 	err = 0;
 
-	mctx = to_mctx(ibv_cq_ex_to_cq(&cq->ibv_cq)->context);
+	mctx = to_mctx(cq->verbs_cq.cq.context);
 	qpn = be32toh(cqe64->sop_drop_qpn) & 0xffffff;
 	if (lazy) {
 		cq->cqe64 = cqe64;
@@ -745,8 +745,8 @@ again:
 				break;
 			}
 
-			cq->ibv_cq.wr_id = wq->wrid[idx];
-			cq->ibv_cq.status = err;
+			cq->verbs_cq.cq_ex.wr_id = wq->wrid[idx];
+			cq->verbs_cq.cq_ex.status = err;
 		} else {
 			handle_good_req(wc, cqe64, wq, idx);
 
@@ -776,7 +776,7 @@ again:
 
 		if (lazy) {
 			if (likely(cqe64->app != MLX5_CQE_APP_TAG_MATCHING)) {
-				cq->ibv_cq.status = handle_responder_lazy
+				cq->verbs_cq.cq_ex.status = handle_responder_lazy
 					(cq, cqe64, *cur_rsc,
 					 is_srq ? *cur_srq : NULL);
 			} else {
@@ -813,7 +813,7 @@ again:
 		srqn_uidx = be32toh(cqe64->srqn_uidx) & 0xffffff;
 		ecqe = (struct mlx5_err_cqe *)cqe64;
 		{
-			enum ibv_wc_status *pstatus = lazy ? &cq->ibv_cq.status : &wc->status;
+			enum ibv_wc_status *pstatus = lazy ? &cq->verbs_cq.cq_ex.status : &wc->status;
 
 			*pstatus = mlx5_handle_error_cqe(ecqe);
 		}
@@ -844,7 +844,7 @@ again:
 			wqe_ctr = be16toh(cqe64->wqe_counter);
 			idx = wqe_ctr & (wq->wqe_cnt - 1);
 			if (lazy)
-				cq->ibv_cq.wr_id = wq->wrid[idx];
+				cq->verbs_cq.cq_ex.wr_id = wq->wrid[idx];
 			else
 				wc->wr_id = wq->wrid[idx];
 			wq->tail = wq->wqe_head[idx] + 1;
@@ -868,7 +868,7 @@ again:
 				}
 
 				if (lazy)
-					cq->ibv_cq.wr_id = (*cur_srq)->wrid[wqe_ctr];
+					cq->verbs_cq.cq_ex.wr_id = (*cur_srq)->wrid[wqe_ctr];
 				else
 					wc->wr_id = (*cur_srq)->wrid[wqe_ctr];
 				mlx5_free_srq_wqe(*cur_srq, wqe_ctr);
@@ -883,7 +883,7 @@ again:
 				}
 
 				if (lazy)
-					cq->ibv_cq.wr_id = wq->wrid[wq->tail & (wq->wqe_cnt - 1)];
+					cq->verbs_cq.cq_ex.wr_id = wq->wrid[wq->tail & (wq->wqe_cnt - 1)];
 				else
 					wc->wr_id = wq->wrid[wq->tail & (wq->wqe_cnt - 1)];
 				++wq->tail;
@@ -1608,39 +1608,39 @@ int mlx5_cq_fill_pfns(struct mlx5_cq *cq,
 					 ((cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK) ?
 							CLOCK_UPDATE : 0)];
 
-	cq->ibv_cq.start_poll = poll_ops->start_poll;
-	cq->ibv_cq.next_poll = poll_ops->next_poll;
-	cq->ibv_cq.end_poll = poll_ops->end_poll;
+	cq->verbs_cq.cq_ex.start_poll = poll_ops->start_poll;
+	cq->verbs_cq.cq_ex.next_poll = poll_ops->next_poll;
+	cq->verbs_cq.cq_ex.end_poll = poll_ops->end_poll;
 
-	cq->ibv_cq.read_opcode = mlx5_cq_read_wc_opcode;
-	cq->ibv_cq.read_vendor_err = mlx5_cq_read_wc_vendor_err;
-	cq->ibv_cq.read_wc_flags = mlx5_cq_read_wc_flags;
+	cq->verbs_cq.cq_ex.read_opcode = mlx5_cq_read_wc_opcode;
+	cq->verbs_cq.cq_ex.read_vendor_err = mlx5_cq_read_wc_vendor_err;
+	cq->verbs_cq.cq_ex.read_wc_flags = mlx5_cq_read_wc_flags;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_BYTE_LEN)
-		cq->ibv_cq.read_byte_len = mlx5_cq_read_wc_byte_len;
+		cq->verbs_cq.cq_ex.read_byte_len = mlx5_cq_read_wc_byte_len;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_IMM)
-		cq->ibv_cq.read_imm_data = mlx5_cq_read_wc_imm_data;
+		cq->verbs_cq.cq_ex.read_imm_data = mlx5_cq_read_wc_imm_data;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_QP_NUM)
-		cq->ibv_cq.read_qp_num = mlx5_cq_read_wc_qp_num;
+		cq->verbs_cq.cq_ex.read_qp_num = mlx5_cq_read_wc_qp_num;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SRC_QP)
-		cq->ibv_cq.read_src_qp = mlx5_cq_read_wc_src_qp;
+		cq->verbs_cq.cq_ex.read_src_qp = mlx5_cq_read_wc_src_qp;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SLID)
-		cq->ibv_cq.read_slid = mlx5_cq_read_wc_slid;
+		cq->verbs_cq.cq_ex.read_slid = mlx5_cq_read_wc_slid;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_SL)
-		cq->ibv_cq.read_sl = mlx5_cq_read_wc_sl;
+		cq->verbs_cq.cq_ex.read_sl = mlx5_cq_read_wc_sl;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_DLID_PATH_BITS)
-		cq->ibv_cq.read_dlid_path_bits = mlx5_cq_read_wc_dlid_path_bits;
+		cq->verbs_cq.cq_ex.read_dlid_path_bits = mlx5_cq_read_wc_dlid_path_bits;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)
-		cq->ibv_cq.read_completion_ts = mlx5_cq_read_wc_completion_ts;
+		cq->verbs_cq.cq_ex.read_completion_ts = mlx5_cq_read_wc_completion_ts;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_CVLAN)
-		cq->ibv_cq.read_cvlan = mlx5_cq_read_wc_cvlan;
+		cq->verbs_cq.cq_ex.read_cvlan = mlx5_cq_read_wc_cvlan;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_FLOW_TAG)
-		cq->ibv_cq.read_flow_tag = mlx5_cq_read_flow_tag;
+		cq->verbs_cq.cq_ex.read_flow_tag = mlx5_cq_read_flow_tag;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_TM_INFO)
-		cq->ibv_cq.read_tm_info = mlx5_cq_read_wc_tm_info;
+		cq->verbs_cq.cq_ex.read_tm_info = mlx5_cq_read_wc_tm_info;
 	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK) {
 		if (!mctx->clock_info_page)
 			return EOPNOTSUPP;
-		cq->ibv_cq.read_completion_wallclock_ns =
+		cq->verbs_cq.cq_ex.read_completion_wallclock_ns =
 		    mlx5_cq_read_wc_completion_wallclock_ns;
 	}
 
@@ -1750,21 +1750,21 @@ void __mlx5_cq_clean(struct mlx5_cq *cq, uint32_t rsn, struct mlx5_srq *srq)
 	 * from our QP and therefore don't need to be checked.
 	 */
 	for (prod_index = cq->cons_index; get_sw_cqe(cq, prod_index); ++prod_index)
-		if (prod_index == cq->cons_index + cq->ibv_cq.cqe)
+		if (prod_index == cq->cons_index + cq->verbs_cq.cq.cqe)
 			break;
 
 	/*
 	 * Now sweep backwards through the CQ, removing CQ entries
 	 * that match our QP by copying older entries on top of them.
 	 */
-	cqe_version = (to_mctx(cq->ibv_cq.context))->cqe_version;
+	cqe_version = (to_mctx(cq->verbs_cq.cq.context))->cqe_version;
 	while ((int) --prod_index - (int) cq->cons_index >= 0) {
-		cqe = get_cqe(cq, prod_index & cq->ibv_cq.cqe);
+		cqe = get_cqe(cq, prod_index & cq->verbs_cq.cq.cqe);
 		cqe64 = (cq->cqe_sz == 64) ? cqe : cqe + 64;
 		if (free_res_cqe(cqe64, rsn, srq, cqe_version)) {
 			++nfreed;
 		} else if (nfreed) {
-			dest = get_cqe(cq, (prod_index + nfreed) & cq->ibv_cq.cqe);
+			dest = get_cqe(cq, (prod_index + nfreed) & cq->verbs_cq.cq.cqe);
 			dest64 = (cq->cqe_sz == 64) ? dest : dest + 64;
 			owner_bit = dest64->op_own & MLX5_CQE_OWNER_MASK;
 			memcpy(dest, cqe, cq->cqe_sz);

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -871,7 +871,7 @@ static int mlx5dv_get_cq(struct ibv_cq *cq_in,
 
 	cq_out->comp_mask = 0;
 	cq_out->cqn       = mcq->cqn;
-	cq_out->cqe_cnt   = mcq->ibv_cq.cqe + 1;
+	cq_out->cqe_cnt   = mcq->verbs_cq.cq.cqe + 1;
 	cq_out->cqe_size  = mcq->cqe_sz;
 	cq_out->buf       = mcq->active_buf->buf;
 	cq_out->dbrec     = mcq->dbrec;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -402,8 +402,7 @@ enum {
 };
 
 struct mlx5_cq {
-	/* ibv_cq should always be subset of ibv_cq_ex */
-	struct ibv_cq_ex		ibv_cq;
+	struct verbs_cq			verbs_cq;
 	struct mlx5_buf			buf_a;
 	struct mlx5_buf			buf_b;
 	struct mlx5_buf		       *active_buf;
@@ -766,7 +765,7 @@ static inline struct mlx5_parent_domain *to_mparent_domain(struct ibv_pd *ibpd)
 
 static inline struct mlx5_cq *to_mcq(struct ibv_cq *ibcq)
 {
-	return container_of((struct ibv_cq_ex *)ibcq, struct mlx5_cq, ibv_cq);
+	return container_of(ibcq, struct mlx5_cq, verbs_cq.cq);
 }
 
 static inline struct mlx5_srq *to_msrq(struct ibv_srq *ibsrq)


### PR DESCRIPTION
Extended QP implementation has a nice verbs_qp abstraction which does
not exist for extended CQs, this patch modifies CQ to be similar.
The verbs_cq struct is a union of both CQ and extended CQ, which allows
access for both. In addition, converting a CQ to the provider's CQ can
now be done using container_of, without explicit casts.

Signed-off-by: Gal Pressman <galpress@amazon.com>