### PR TITLE
efa: Update correct errno return on create extended QP function

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -927,7 +927,7 @@ struct ibv_qp *efa_create_qp_ex(struct ibv_context *ibvctx,
 				struct ibv_qp_init_attr_ex *attr_ex)
 {
 	if (attr_ex->qp_type != IBV_QPT_UD) {
-		errno = EINVAL;
+		errno = EOPNOTSUPP;
 		return NULL;
 	}
 


### PR DESCRIPTION
EFA device only supports UD QP, therefore in case QP type is not UD
an errno of EOPNUTSUPP should be returned.

Signed-off-by: Chen Brasch <cbrasch@amazon.com>
Signed-off-by: Gal Pressman <galpress@amazon.com>