### PR TITLE
Misc pyverbs tests fixes round 2

### DIFF
--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -165,8 +165,8 @@ cdef class CQ(PyverbsCM):
         """
         rc = v.ibv_req_notify_cq(self.cq, solicited_only)
         if rc != 0:
-            raise PyverbsRDMAErrno('Request notify CQ returned {rc}'.
-                                   format(rc=rc))
+            raise PyverbsRDMAError('Request notify CQ returned {rc}'.
+                                   format(rc=rc), rc)
 
     def ack_events(self, num_events):
         """

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -21,6 +21,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_NODE_RNIC
         IBV_NODE_USNIC
         IBV_NODE_USNIC_UDP
+        IBV_NODE_UNSPECIFIED
 
     cpdef enum:
         IBV_LINK_LAYER_UNSPECIFIED

--- a/tests/base.py
+++ b/tests/base.py
@@ -203,6 +203,9 @@ class RDMATestCase(unittest.TestCase):
                     ctx.query_gid_type(port, idx) == e.IBV_GID_TYPE_ROCE_V2 and \
                     has_roce_hw_bug(vendor_id, vendor_pid):
                 continue
+            if not os.path.exists('/sys/class/infiniband/{}/device/net/'.format(dev)):
+                self.args.append([dev, port, idx, None])
+                continue
             net_name = self.get_net_name(dev)
             try:
                 ip_addr = self.get_ip_address(net_name)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -11,6 +11,7 @@ from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
 from tests.base import PyverbsAPITestCase
 import tests.utils as u
 import pyverbs.device as d
+import pyverbs.enums as e
 
 PAGE_SIZE = resource.getpagesize()
 
@@ -60,7 +61,7 @@ class DeviceTest(PyverbsAPITestCase):
         for dev in self.get_device_list():
             with d.Context(name=dev.name.decode()) as ctx:
                 attr = ctx.query_device()
-                self.verify_device_attr(attr)
+                self.verify_device_attr(attr, dev)
 
     def test_query_gid(self):
         """
@@ -71,15 +72,17 @@ class DeviceTest(PyverbsAPITestCase):
                 ctx.query_gid(port_num=1, index=0)
 
     @staticmethod
-    def verify_device_attr(attr):
+    def verify_device_attr(attr, device):
         """
         Helper method that verifies correctness of some members of DeviceAttr
         object.
         :param attr: A DeviceAttr object
+        :param device: A Device object
         :return: None
         """
-        assert attr.node_guid != 0
-        assert attr.sys_image_guid != 0
+        if device.node_type != e.IBV_NODE_UNSPECIFIED and device.node_type != e.IBV_NODE_UNKNOWN:
+            assert attr.node_guid != 0
+            assert attr.sys_image_guid != 0
         assert attr.max_mr_size > PAGE_SIZE
         assert attr.page_size_cap >= PAGE_SIZE
         assert attr.vendor_id != 0
@@ -101,7 +104,7 @@ class DeviceTest(PyverbsAPITestCase):
         for dev in self.get_device_list():
             with d.Context(name=dev.name.decode()) as ctx:
                 attr_ex = ctx.query_device_ex()
-                self.verify_device_attr(attr_ex.orig_attr)
+                self.verify_device_attr(attr_ex.orig_attr, dev)
 
     @staticmethod
     def verify_port_attr(attr):

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -219,8 +219,9 @@ class MWTest(PyverbsAPITestCase):
                 try:
                     mw_type = random.randint(3, 100)
                     MW(pd, mw_type)
-                except PyverbsRDMAError:
-                    pass
+                except PyverbsRDMAError as ex:
+                    if ex.error_code == errno.EOPNOTSUPP:
+                        raise unittest.SkipTest('Create memory window of type {} is not supported'.format(mw_type))
                 else:
                     raise PyverbsError('Created a MW with type {t}'.\
                                        format(t=mw_type))

--- a/tests/test_qp.py
+++ b/tests/test_qp.py
@@ -248,7 +248,7 @@ class QPTest(PyverbsAPITestCase):
                                 if ex.error_code == errno.EOPNOTSUPP:
                                     raise unittest.SkipTest('Create QP with extended attrs is not supported')
                                 raise ex
-                            qp_attr, qp_init_attr = qp.query(e.IBV_QP_CUR_STATE |
+                            qp_attr, qp_init_attr = qp.query(e.IBV_QP_STATE |
                                                              e.IBV_QP_CAP)
                             verify_qp_attrs(caps, e.IBV_QPS_RESET, qp_init_attr,
                                             qp_attr)
@@ -257,7 +257,7 @@ class QPTest(PyverbsAPITestCase):
                             qia.qp_type = qpt
                             caps = qia.cap  # Save them to verify values later
                             qp = QP(pd, qia)
-                            qp_attr, qp_init_attr = qp.query(e.IBV_QP_CUR_STATE |
+                            qp_attr, qp_init_attr = qp.query(e.IBV_QP_STATE |
                                                              e.IBV_QP_CAP)
                             verify_qp_attrs(caps, e.IBV_QPS_RESET, qp_init_attr,
                                             qp_attr)


### PR DESCRIPTION
Another set of pyverbs fixes which allow tests of unsupported devices to skip.