### PR TITLE
srp_daemon: srp_daemon.service should wait for network.target

### DIFF
--- a/srp_daemon/srp_daemon.service.in
+++ b/srp_daemon/srp_daemon.service.in
@@ -3,6 +3,7 @@ Description=Daemon that discovers and logs in to SRP target systems
 Documentation=man:srp_daemon file:/etc/srp_daemon.conf
 DefaultDependencies=false
 Conflicts=emergency.target emergency.service
+After=network.target
 Before=remote-fs-pre.target
 
 [Service]


### PR DESCRIPTION
srp_daemon.service runs the start_on_all_ports script. This script
enumerates files under /sys/class/infiniband/*/ports/* to start an
srp_daemon_port service for each port. The files under
/sys/class/infiniband/*/ports/* are created during boot and do not
exist until after network.target. When started at boottime, srp_daemon
is not starting any port services as expected. For srp_daemon to work
as designed, it should wait for network.target.

Fixes: 1c7fe513e3e9 ("srp_daemon: One systemd service per port")
Signed-off-by: Mark Haywood <mark.haywood@oracle.com>