### PR TITLE
pyverbs: ODP refactoring and extensions 

### DIFF
--- a/pyverbs/mr.pyx
+++ b/pyverbs/mr.pyx
@@ -129,11 +129,12 @@ cdef class MR(PyverbsCM):
             self.pd = None
             self.buf = NULL
 
-    def write(self, data, length):
+    def write(self, data, length, offset=0):
         """
         Write user data to the MR's buffer using memcpy
         :param data: User data to write
         :param length: Length of the data to write
+        :param offset: Writing offset
         :return: None
         """
         if not self.buf or length < 0:
@@ -141,9 +142,10 @@ cdef class MR(PyverbsCM):
                                    f' {length} is invalid')
         # If data is a string, cast it to bytes as Python3 doesn't
         # automatically convert it.
+        cdef int off = offset
         if isinstance(data, str):
             data = data.encode()
-        memcpy(self.buf, <char *>data, length)
+        memcpy(<char*>(self.buf + off), <char *>data, length)
 
     cpdef read(self, length, offset):
         """

--- a/tests/base.py
+++ b/tests/base.py
@@ -184,6 +184,8 @@ class RDMATestCase(unittest.TestCase):
             raise unittest.SkipTest('No port is up, can\'t run traffic')
         # Choose one combination and use it
         self._select_config()
+        self.dev_info = {'dev_name': self.dev_name, 'ib_port': self.ib_port,
+                         'gid_index': self.gid_index}
 
     def _add_gids_per_port(self, ctx, dev, port):
         # Don't add ports which are not active

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -634,6 +634,8 @@ def requires_odp(qp_type):
     def outer(func):
         def inner(instance):
             odp_supported(instance.ctx, qp_type)
+            if getattr(instance, 'is_implicit', False):
+                odp_implicit_supported(instance.ctx)
             return func(instance)
         return inner
     return outer
@@ -667,6 +669,18 @@ def odp_supported(ctx, qp_type):
         raise unittest.SkipTest('ODP is not supported - ODP send not supported')
     if has_odp_recv == 0:
         raise unittest.SkipTest('ODP is not supported - ODP recv not supported')
+
+
+def odp_implicit_supported(ctx):
+    """
+    Check device ODP implicit capability.
+    :param ctx: Device Context
+    :return: None
+    """
+    odp_caps = ctx.query_device_ex().odp_caps
+    has_odp_implicit = odp_caps.general_caps & e.IBV_ODP_SUPPORT_IMPLICIT
+    if has_odp_implicit == 0:
+        raise unittest.SkipTest('ODP implicit is not supported')
 
 
 def requires_huge_pages():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -630,10 +630,10 @@ def xrc_traffic(client, server, is_cq_ex=False, send_op=None):
 
 
 # Decorators
-def requires_odp(qp_type):
+def requires_odp(qp_type, required_odp_caps):
     def outer(func):
         def inner(instance):
-            odp_supported(instance.ctx, qp_type)
+            odp_supported(instance.ctx, qp_type, required_odp_caps)
             if getattr(instance, 'is_implicit', False):
                 odp_implicit_supported(instance.ctx)
             return func(instance)
@@ -651,24 +651,20 @@ def requires_root_on_eth(port_num=1):
     return outer
 
 
-def odp_supported(ctx, qp_type):
+def odp_supported(ctx, qp_type, required_odp_caps):
     """
     Check device ODP capabilities, support only send/recv so far.
     :param ctx: Device Context
     :param qp_type: QP type ('rc', 'ud' or 'uc')
+    :param required_odp_caps: ODP Capability mask of specified device
     :return: None
     """
     odp_caps = ctx.query_device_ex().odp_caps
     if odp_caps.general_caps == 0:
         raise unittest.SkipTest('ODP is not supported - No ODP caps')
     qp_odp_caps = getattr(odp_caps, '{}_odp_caps'.format(qp_type))
-    has_odp_send = qp_odp_caps & e.IBV_ODP_SUPPORT_SEND
-    has_odp_recv = qp_odp_caps & e.IBV_ODP_SUPPORT_SRQ_RECV if qp_type == 'xrc'\
-                else qp_odp_caps & e.IBV_ODP_SUPPORT_RECV
-    if has_odp_send == 0:
-        raise unittest.SkipTest('ODP is not supported - ODP send not supported')
-    if has_odp_recv == 0:
-        raise unittest.SkipTest('ODP is not supported - ODP recv not supported')
+    if required_odp_caps & qp_odp_caps != required_odp_caps:
+        raise unittest.SkipTest('ODP is not supported - ODP recv/send is not supported')
 
 
 def odp_implicit_supported(ctx):


### PR DESCRIPTION
This series introduces new tests for ODP, in addition to infrastructure extensions and a refactoring of the ODP tests, which allows more flexibility for adding new tests in the future.
This includes:
- Support for registering an implicit ODP MR (with a test)
- An ODP test with UD traffic
