### PR TITLE
pyverbs: Memset the memory after posix_memalign

### DIFF
--- a/pyverbs/mem_alloc.pyx
+++ b/pyverbs/mem_alloc.pyx
@@ -7,6 +7,7 @@ from posix.stdlib cimport posix_memalign as c_posix_memalign
 from libc.stdlib cimport malloc as c_malloc, free as c_free
 from posix.mman cimport mmap as c_mmap, munmap as c_munmap
 from libc.stdint cimport uintptr_t
+from libc.string cimport memset
 cimport posix.mman as mm
 
 cdef extern from 'sys/mman.h':
@@ -58,7 +59,8 @@ def malloc(size):
 
 def posix_memalign(size, alignment=8):
     """
-    Python wrapper for the stdlib posix_memalign function
+    Python wrapper for the stdlib posix_memalign function.
+    The function calls posix_memalign and memsets the memory to 0.
     :param size: The size of the memory block in bytes
     :param alignment: Alignment of the allocated memory, must be a power of two
     :return: The address of the allocated memory, which is a multiple of
@@ -68,6 +70,7 @@ def posix_memalign(size, alignment=8):
     ret = c_posix_memalign(&ptr, alignment, size)
     if ret:
         raise MemoryError('Failed to allocate memory ({err}'.format(ret))
+    memset(ptr, 0, size)
     return <uintptr_t>ptr
 
 


### PR DESCRIPTION
Initialize the allocated memory with zeros in posix_memalign pyverbs
wrapper. Otherwise, the parent domain allocators that were using
posix_memalign were not fulfilling the requirement of the parent
domain callbacks (allocated buffers must be initialized with zeros).