### PR TITLE
redhat: Fix the condition for pyverbs enablement on Fedora 32 and up

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -28,7 +28,7 @@ BuildRequires: valgrind-devel
 BuildRequires: systemd
 BuildRequires: systemd-devel
 %if 0%{?fedora} >= 32
-%define with_pyverbs %{?_with_pyverbs: 0} %{?!_with_pyverbs: 1}
+%define with_pyverbs %{?_with_pyverbs: 1} %{?!_with_pyverbs: %{?!_without_pyverbs: 1} %{?_without_pyverbs: 0}}
 %else
 %define with_pyverbs %{?_with_pyverbs: 1} %{?!_with_pyverbs: 0}
 %endif


### PR DESCRIPTION
The cited commit enabled pyverbs build by default for Fedora 32 and up.
However, it broke enalbing pyverbs build when passing '--with pyverbs' flag.

Fix the condition so that now the behavior for Fedora 32 and up will be:
 * Default: pyverbs enabled.
 * --with pyverbs: pyverbs enabled.
 * --without pyverbs: pyverbs disabled.

Fixes: 07b304b75186 ("redhat: Build pyverbs for Fedora greater than release 31")
Signed-off-by: Alaa Hleihel <alaa@mellanox.com>
Reviewed-by: Leon Romanovsky <leonro@mellanox.com>
Tested-by: Edward Srouji <edwards@mellanox.com>
CC: Honggang Li <honli@redhat.com>
Acked-by: Honggang Li <honli@redhat.com>
Signed-off-by: Leon Romanovsky <leonro@mellanox.com>