### PR TITLE
mlx5:  Enable SW Steering RX/TX domains

### DIFF
--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -133,6 +133,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 {
 	uint32_t out[DEVX_ST_SZ_DW(query_hca_cap_out)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(query_hca_cap_in)] = {};
+	bool roce;
 	int err;
 
 	DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
@@ -151,6 +152,8 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->gvmi = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.vhca_id);
 	caps->flex_protocols = DEVX_GET(query_hca_cap_out, out,
 					capability.cmd_hca_cap.flex_parser_protocols);
+	roce = DEVX_GET(query_hca_cap_out, out,
+			capability.cmd_hca_cap.roce);
 
 	if (dr_matcher_supp_flex_parser_icmp_v4(caps)) {
 		caps->flex_parser_id_icmp_dw0 =
@@ -217,6 +220,21 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->hdr_modify_icm_addr = DEVX_GET64(query_hca_cap_out, out,
 					       capability.device_mem_cap.
 					       header_modify_sw_icm_start_address);
+	/* RoCE caps */
+	if (roce) {
+		DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
+		DEVX_SET(query_hca_cap_in, in, op_mod,
+			 MLX5_SET_HCA_CAP_OP_MOD_ROCE |
+			 HCA_CAP_OPMOD_GET_CUR);
+
+		err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
+		if (err) {
+			dr_dbg_ctx(ctx, "Query RoCE capabilities failed %d\n", err);
+			return err;
+		}
+		caps->roce_caps.fl_rc_qp_when_roce_enabled = DEVX_GET(query_hca_cap_out, out,
+					      capability.roce_caps.fl_rc_qp_when_roce_enabled);
+	}
 
 	return 0;
 }

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -485,16 +485,20 @@ int dr_devx_modify_qp_init2rtr(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, mtu, attr->mtu);
 	DEVX_SET(qpc, qpc, log_msg_max, DR_CHUNK_SIZE_MAX - 1);
 	DEVX_SET(qpc, qpc, remote_qpn, attr->qp_num);
-	memcpy(DEVX_ADDR_OF(qpc, qpc, primary_address_path.rmac_47_32),
-	       attr->dgid_attr.mac, sizeof(attr->dgid_attr.mac));
-	memcpy(DEVX_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
-	       attr->dgid_attr.gid.raw, sizeof(attr->dgid_attr.gid.raw));
-	DEVX_SET(qpc, qpc, primary_address_path.src_addr_index,
-		 attr->sgid_index);
 
-	if (attr->dgid_attr.roce_ver == MLX5_ROCE_VERSION_2)
-		DEVX_SET(qpc, qpc, primary_address_path.udp_sport,
-			 DR_DEVX_ICM_UDP_PORT);
+	if (attr->fl) {
+		DEVX_SET(qpc, qpc, primary_address_path.fl, attr->fl);
+	} else {
+		memcpy(DEVX_ADDR_OF(qpc, qpc, primary_address_path.rmac_47_32),
+		       attr->dgid_attr.mac, sizeof(attr->dgid_attr.mac));
+		memcpy(DEVX_ADDR_OF(qpc, qpc, primary_address_path.rgid_rip),
+		       attr->dgid_attr.gid.raw, sizeof(attr->dgid_attr.gid.raw));
+		DEVX_SET(qpc, qpc, primary_address_path.src_addr_index,
+			 attr->sgid_index);
+		if (attr->dgid_attr.roce_ver == MLX5_ROCE_VERSION_2)
+			DEVX_SET(qpc, qpc, primary_address_path.udp_sport,
+				 DR_DEVX_ICM_UDP_PORT);
+	}
 
 	DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, attr->port_num);
 	DEVX_SET(qpc, qpc, min_rnr_nak, 1);

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -188,15 +188,18 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 	if (ret)
 		return ret;
 
-	/* Non FDB type is supported only over root table */
-	if (dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB)
-		return 0;
-
 	ret = dr_devx_query_device(ctx, &dmn->info.caps);
 	if (ret)
 		/* Ignore devx query failure to allow steering on root level
 		 * tables in case devx is not supported over mlx5dv_dr API
 		 */
+		return 0;
+
+	/* Non FDB type is supported over root table or when we can enable
+	 * force-loopback.
+	 */
+	if ((dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB) &&
+	    !dmn->info.caps.roce_caps.fl_rc_qp_when_roce_enabled)
 		return 0;
 
 	ret = dr_domain_query_fdb_caps(ctx, dmn);

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -92,6 +92,14 @@ struct mlx5_ifc_atomic_caps_bits {
 	u8         reserved_at_2b0[0x550];
 };
 
+struct mlx5_ifc_roce_cap_bits {
+	u8         reserved_0[0x6];
+	u8         fl_rc_qp_when_roce_enabled[0x1];
+	u8         reserved_at_7[0x19];
+
+	u8         reserved_at_20[0x7e0];
+};
+
 struct mlx5_ifc_flow_table_context_bits {
 	u8         reformat_en[0x1];
 	u8         decap_en[0x1];
@@ -1034,6 +1042,7 @@ union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_flow_table_eswitch_cap_bits flow_table_eswitch_cap;
 	struct mlx5_ifc_device_mem_cap_bits device_mem_cap;
 	struct mlx5_ifc_odp_cap_bits odp_cap;
+	struct mlx5_ifc_roce_cap_bits roce_caps;
 	u8         reserved_at_0[0x8000];
 };
 
@@ -1069,6 +1078,7 @@ enum mlx5_cap_type {
 
 enum {
 	MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE        = 0x0 << 1,
+	MLX5_SET_HCA_CAP_OP_MOD_ROCE                  = 0x4 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_NIC_FLOW_TABLE        = 0x7 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_ESW_FLOW_TABLE        = 0x8 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY         = 0xf << 1,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -918,6 +918,7 @@ struct dr_devx_qp_rtr_attr {
 	uint16_t		port_num;
 	uint8_t			min_rnr_timer;
 	uint8_t			sgid_index;
+	bool			fl;
 };
 
 int dr_devx_modify_qp_init2rtr(struct ibv_context *ctx,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -575,6 +575,10 @@ struct dr_devx_vport_cap {
 	uint64_t icm_address_tx;
 };
 
+struct dr_devx_roce_cap {
+	bool fl_rc_qp_when_roce_enabled;
+};
+
 struct dr_devx_caps {
 	uint16_t			gvmi;
 	uint64_t			nic_rx_drop_address;
@@ -596,6 +600,7 @@ struct dr_devx_caps {
 	bool				fdb_sw_owner;
 	uint32_t			num_vports;
 	struct dr_devx_vport_cap	*vports_caps;
+	struct dr_devx_roce_cap		roce_caps;
 };
 
 struct dr_domain_rx_tx {


### PR DESCRIPTION
This series enables SW Steering RX/TX domains when force-loopback is supported while RoCE is enabled.

When using loopback QP the gid index is not required and the code is safe from any gid change scenario, this enables opening the RX/TX domains paths.