### PR TITLE
mlx5: Add DEVX TIR support in the DR area

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -22,6 +22,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.12@MLX5_1.12 28
  MLX5_1.13@MLX5_1.13 29
  MLX5_1.14@MLX5_1.14 30
+ MLX5_1.15@MLX5_1.15 31
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -103,6 +104,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_domain_set_reclaim_device_memory@MLX5_1.14 30
  mlx5dv_modify_qp_lag_port@MLX5_1.14 30
  mlx5dv_query_qp_lag_port@MLX5_1.14 30
+ mlx5dv_dr_action_create_dest_devx_tir@MLX5_1.15 31
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.14.${PACKAGE_VERSION}
+  1 1.15.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -69,6 +69,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_VPORT = 3408,
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L2 = 3409,
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L3 = 3410,
+	DR_DUMP_REC_TYPE_ACTION_DEVX_TIR = 3411,
 	DR_DUMP_REC_TYPE_ACTION_METER = 3414,
 };
 
@@ -104,9 +105,14 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 			      (uint64_t)(uintptr_t)action->dest_tbl);
 		break;
 	case DR_ACTION_TYP_QP:
-		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
-			      DR_DUMP_REC_TYPE_ACTION_QP, action_id, rule_id,
-			      action->qp->qp_num);
+		if (action->dest_qp.is_qp)
+			ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+				      DR_DUMP_REC_TYPE_ACTION_QP, action_id,
+				      rule_id, action->dest_qp.qp->qp_num);
+		else
+			ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%" PRIx64 "\n",
+				      DR_DUMP_REC_TYPE_ACTION_DEVX_TIR, action_id,
+				      rule_id, action->dest_qp.devx_tir->rx_icm_addr);
 		break;
 	case DR_ACTION_TYP_CTR:
 		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -141,3 +141,8 @@ MLX5_1.14 {
 		mlx5dv_modify_qp_lag_port;
 		mlx5dv_query_qp_lag_port;
 } MLX5_1.13;
+
+MLX5_1.15 {
+	global:
+		mlx5dv_dr_action_create_dest_devx_tir;
+} MLX5_1.14;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -57,6 +57,7 @@ rdma_alias_man_pages(
  mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_dereg.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_table.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ibv_qp.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_devx_tir.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_vport.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_flow_counter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_drop.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -24,7 +24,7 @@ mlx5dv_dr_action_create_default_miss - Create default miss action
 
 mlx5dv_dr_action_create_tag - Create tag actions
 
-mlx5dv_dr_action_create_dest_ibv_qp, mlx5dv_dr_action_create_dest_table, mlx5dv_dr_action_create_dest_vport - Create packet destination actions
+mlx5dv_dr_action_create_dest_ibv_qp, mlx5dv_dr_action_create_dest_table, mlx5dv_dr_action_create_dest_vport, mlx5dv_dr_action_create_dest_devx_tir - Create packet destination actions
 
 mlx5dv_dr_action_create_packet_reformat - Create packet reformat actions
 
@@ -93,6 +93,9 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_table(
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_vport(
 		struct mlx5dv_dr_domain *domain,
 		uint32_t vport);
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_devx_tir(
+		struct mlx5dv_devx_obj *devx_obj);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_packet_reformat(
 		struct mlx5dv_dr_domain *domain,
@@ -187,6 +190,7 @@ Action: Destination
 *mlx5dv_dr_action_create_dest_ibv_qp* creates a terminating action delivering the packet to a QP, defined by **ibqp**. Valid only on domain type NIC_RX.
 *mlx5dv_dr_action_create_dest_table* creates a forwarding action to another flow table, defined by **table**. The destination **table** must be from the same domain with a level higher than zero.
 *mlx5dv_dr_action_create_dest_vport* creates a forwarding action to a **vport** on the same **domain**. Valid only on domain type FDB.
+*mlx5dv_dr_action_create_dest_devx_tir* creates a terminating action delivering the packet to a TIR, defined by **devx_obj**. Valid only on domain type NIC_RX.
 
 Action: Packet Reformat
 *mlx5dv_dr_action_create_packet_reformat* create a packet reformat context and action in the **domain**. The **reformat_type**, **data_sz** and **data** are defined in *man mlx5dv_create_flow_action_packet_reformat*.

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -667,6 +667,7 @@ enum mlx5_devx_obj_type {
 	MLX5_DEVX_FLOW_METER		= 3,
 	MLX5_DEVX_QP			= 4,
 	MLX5_DEVX_PKT_REFORMAT_CTX	= 5,
+	MLX5_DEVX_TIR			= 6,
 };
 
 struct mlx5dv_devx_obj {
@@ -674,6 +675,7 @@ struct mlx5dv_devx_obj {
 	uint32_t handle;
 	enum mlx5_devx_obj_type type;
 	uint32_t object_id;
+	uint64_t rx_icm_addr;
 };
 
 struct mlx5_var_obj {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -51,6 +51,7 @@ enum {
 	MLX5_CMD_OP_QUERY_ESW_VPORT_CONTEXT = 0x752,
 	MLX5_CMD_OP_QUERY_ROCE_ADDRESS = 0x760,
 	MLX5_CMD_OP_QUERY_LAG = 0x842,
+	MLX5_CMD_OP_CREATE_TIR = 0x900,
 	MLX5_CMD_OP_MODIFY_TIS = 0x913,
 	MLX5_CMD_OP_QUERY_TIS = 0x915,
 	MLX5_CMD_OP_CREATE_FLOW_TABLE = 0x930,
@@ -2144,6 +2145,18 @@ struct mlx5_ifc_qpc_bits {
 	u8         reserved_at_684[0x9c];
 
 	u8         dbr_umem_id[0x20];
+};
+
+struct mlx5_ifc_create_tir_out_bits {
+	u8         status[0x8];
+	u8         icm_address_63_40[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         icm_address_39_32[0x8];
+	u8         tirn[0x18];
+
+	u8         icm_address_31_0[0x20];
 };
 
 struct mlx5_ifc_create_qp_out_bits {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1497,6 +1497,9 @@ struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_dest_vport(struct mlx5dv_dr_domain *domain,
 				   uint32_t vport);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_devx_tir(struct mlx5dv_devx_obj *devx_obj);
+
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_drop(void);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_default_miss(void);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -734,7 +734,13 @@ struct mlx5dv_dr_action {
 			struct dr_devx_vport_cap	*caps;
 			uint32_t			num;
 		} vport;
-		struct ibv_qp		*qp;
+		struct {
+			bool    is_qp;
+			union {
+				struct mlx5dv_devx_obj  *devx_tir;
+				struct ibv_qp           *qp;
+			};
+		} dest_qp;
 		struct mlx5dv_devx_obj	*devx_obj;
 		uint32_t		flow_tag;
 	};

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4746,6 +4746,13 @@ static void set_devx_obj_info(const void *in, const void *out,
 		obj->type = MLX5_DEVX_QP;
 		obj->object_id = DEVX_GET(create_qp_out, out, qpn);
 		break;
+	case MLX5_CMD_OP_CREATE_TIR:
+		obj->type = MLX5_DEVX_TIR;
+		obj->object_id = DEVX_GET(create_tir_out, out, tirn);
+		obj->rx_icm_addr = DEVX_GET(create_tir_out, out, icm_address_31_0);
+		obj->rx_icm_addr |= (uint64_t)DEVX_GET(create_tir_out, out, icm_address_39_32) << 32;
+		obj->rx_icm_addr |= (uint64_t)DEVX_GET(create_tir_out, out, icm_address_63_40) << 40;
+		break;
 	case MLX5_CMD_OP_ALLOC_PACKET_REFORMAT_CONTEXT:
 		obj->type = MLX5_DEVX_PKT_REFORMAT_CTX;
 		obj->object_id = DEVX_GET(alloc_packet_reformat_context_out,


### PR DESCRIPTION
This series adds an action to enable creating rules that steer packets to a DEVX TIR object.