### PR TITLE
add ${NL_LIBRARY_DIRS} to link_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -442,6 +442,7 @@ if (ENABLE_RESOLVE_NEIGH)
   # FIXME use of pkgconfig is discouraged
   pkg_check_modules(NL libnl-3.0 libnl-route-3.0 REQUIRED)
   include_directories(${NL_INCLUDE_DIRS})
+  link_directories(${NL_LIBRARY_DIRS})
   set(NL_KIND 3)
 else()
   set(NL_KIND 0)


### PR DESCRIPTION
Handles case where nl-route-3 and nl-3 libs are not installed in
a standard location.  pkg_check_modules() puts the location it
got from pkgconfig in the NL_LIBRARY_DIRS variable.

For example, I have a test copy of nl-route-3 and nl-3 in /tmp/test/lib.  There is no other version of these libs installed on my system.   I can configure rdma-core with:
<pre>
cmake -DCMAKE_PREFIX_PATH=/tmp/test -DCMAKE_INSTALL_PATH=/tmp/test -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=YES ../rdma-core
</pre>

Without the fix, the compile will fail with:
<pre>
[  7%] Linking C executable ../bin/rdma_rename
/usr/bin/ld: cannot find -lnl-route-3
/usr/bin/ld: cannot find -lnl-3
collect2: error: ld returned 1 exit status
</pre>

because the "-L" linking information returned by pkg_check_modules() in ${NL_LIBRARY_DIRS}  is ignored by the rdma-core CMakeLists.txt.  This is easy to fix by adding a call to link_directories().

(an alternate solution if you are using cmake 3.6 or newer to use an imported target created by pkg_check_modules() with the "IMPORTED_TARGET" argument that got added in cmake 3.6)
