### PR TITLE
pyverbs: Extend rdmacm support in Pyverbs

### DIFF
--- a/pyverbs/cmid.pxd
+++ b/pyverbs/cmid.pxd
@@ -12,6 +12,8 @@ cdef class CMID(PyverbsCM):
     cdef object event_channel
     cdef object ctx
     cdef object pd
+    cdef object mrs
+    cdef add_ref(self, obj)
     cpdef close(self)
 
 

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -481,6 +481,7 @@ cdef extern from 'infiniband/verbs.h':
         uint32_t comp_mask
 
     ibv_device **ibv_get_device_list(int *n)
+    int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)
     ibv_context *ibv_open_device(ibv_device *device)
     int ibv_close_device(ibv_context *context)

--- a/pyverbs/librdmacm.pxd
+++ b/pyverbs/librdmacm.pxd
@@ -93,6 +93,8 @@ cdef extern from '<rdma/rdma_cma.h>':
 
     rdma_event_channel *rdma_create_event_channel()
     void rdma_destroy_event_channel(rdma_event_channel *channel)
+    ibv_context **rdma_get_devices(int *num_devices)
+    void rdma_free_devices (ibv_context **list);
     int rdma_get_cm_event(rdma_event_channel *channel, rdma_cm_event **event)
     int rdma_ack_cm_event(rdma_cm_event *event)
     char *rdma_event_str(rdma_cm_event_type event)

--- a/pyverbs/librdmacm.pxd
+++ b/pyverbs/librdmacm.pxd
@@ -137,7 +137,15 @@ cdef extern from '<rdma/rdma_verbs.h>':
     int rdma_post_ud_send(rdma_cm_id *id, void *context, void *addr,
                           size_t length, ibv_mr *mr, int flags, ibv_ah *ah,
                           uint32_t remote_qpn)
+    int rdma_post_read(rdma_cm_id *id, void *context, void *addr,
+                       size_t length, ibv_mr *mr, int flags,
+                       uint64_t remote_addr, uint32_t rkey)
+    int rdma_post_write(rdma_cm_id *id, void *context, void *addr,
+                        size_t length, ibv_mr *mr, int flags,
+                        uint64_t remote_addr, uint32_t rkey)
     int rdma_get_send_comp(rdma_cm_id *id, ibv_wc *wc)
     int rdma_get_recv_comp(rdma_cm_id *id, ibv_wc *wc)
     ibv_mr *rdma_reg_msgs(rdma_cm_id *id, void *addr, size_t length)
+    ibv_mr *rdma_reg_read(rdma_cm_id *id, void *addr, size_t length)
+    ibv_mr *rdma_reg_write(rdma_cm_id *id, void *addr, size_t length)
     int rdma_dereg_mr(ibv_mr *mr)

--- a/pyverbs/mr.pxd
+++ b/pyverbs/mr.pxd
@@ -4,11 +4,13 @@
 #cython: language_level=3
 
 from pyverbs.base cimport PyverbsCM
+cimport pyverbs.librdmacm as cm
 from . cimport libibverbs as v
 
 
 cdef class MR(PyverbsCM):
     cdef object pd
+    cdef object cmid
     cdef v.ibv_mr *mr
     cdef int mmap_length
     cdef object is_huge


### PR DESCRIPTION
The series adds:
- Support for rdma_get_devices and ibv_get_device_index.
- rdmacm remote read/write APIs which allow reading/writing using internal QPs and registering memory buffers using the rdmacm APIs.
- rdmacm remote traffic tests.