### PR TITLE
redhat: allow blacklisting of hardware modules

### DIFF
--- a/redhat/rdma.kernel-init
+++ b/redhat/rdma.kernel-init
@@ -84,7 +84,7 @@ load_modules()
 	    continue
 	fi
 	if ! is_loaded $module; then
-	    /sbin/modprobe $module
+	    /sbin/modprobe -b $module
 	    res=$?
 	    RC=$[ $RC + $res ]
 	    if [ $res -ne 0 ]; then


### PR DESCRIPTION
For Fedora based distros which use systemd, the rdma hardware
driver loading are triggered by udev. That means the driver will
be loaded even when the rdma.service disabled, in case there is
rdma hardware installed in the machine.

As all rdma hardware drivers are leaf modules, which means no modules
depend on them. They will not be loaded as dependency of other
modules while they are blacklisted.

This patch will not allow blacklisting via the kernel command line,
because modprobe only apply the blacklist commands in the configuration
files. For Linux installation over PXE, you have to alter the initramfs
and add the modprobe configure file to blacklist a rdma hardware module.

Signed-off-by: Honggang Li <honli@redhat.com>