### PR TITLE
mlx5: Fix an issue on P9 with legacy UAR

### DIFF
--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -323,7 +323,7 @@ static void mlx5_insert_dyn_uuars(struct mlx5_context *ctx,
 		list_node_init(&bf->uar_entry);
 		list_add_tail(head, &bf->uar_entry);
 		if (!bf_uar->dyn_alloc_uar)
-			bf->bfreg_dyn_index = (ctx->curr_legacy_dyn_sys_uar_page - 1) * num_bfregs_per_page;
+			bf->bfreg_dyn_index = (ctx->curr_legacy_dyn_sys_uar_page - 1) * num_bfregs_per_page + j;
 		bf->dyn_alloc_uar = bf_uar->dyn_alloc_uar;
 		bf->need_lock = bf_uar->qp_shared;
 		mlx5_spinlock_init(&bf->lock, bf->need_lock);


### PR DESCRIPTION
The index of the uuar inside the UAR need to be considered when working with the legacy dynamic UAR mode.
Without that on P9 where there are more than two uuars the third one won't be set correctly.