### PR TITLE
EFA RNR retry

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -105,6 +105,7 @@ struct efa_ibv_create_ah_resp {
 
 enum {
 	EFA_QUERY_DEVICE_CAPS_RDMA_READ = 1 << 0,
+	EFA_QUERY_DEVICE_CAPS_RNR_RETRY = 1 << 1,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -144,6 +144,11 @@ static inline bool is_rdma_read_cap(struct efa_context *ctx)
 	return ctx->device_caps & EFA_QUERY_DEVICE_CAPS_RDMA_READ;
 }
 
+static inline bool is_rnr_retry_cap(struct efa_context *ctx)
+{
+	return ctx->device_caps & EFA_QUERY_DEVICE_CAPS_RNR_RETRY;
+}
+
 static inline struct efa_dev *to_efa_dev(struct ibv_device *ibvdev)
 {
 	return container_of(ibvdev, struct efa_dev, vdev.device);

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -139,16 +139,6 @@ struct efa_dev {
 	uint32_t pg_sz;
 };
 
-static inline bool is_rdma_read_cap(struct efa_context *ctx)
-{
-	return ctx->device_caps & EFA_QUERY_DEVICE_CAPS_RDMA_READ;
-}
-
-static inline bool is_rnr_retry_cap(struct efa_context *ctx)
-{
-	return ctx->device_caps & EFA_QUERY_DEVICE_CAPS_RNR_RETRY;
-}
-
 static inline struct efa_dev *to_efa_dev(struct ibv_device *ibvdev)
 {
 	return container_of(ibvdev, struct efa_dev, vdev.device);

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef __EFADV_H__
@@ -37,6 +37,7 @@ struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
 
 enum {
 	EFADV_DEVICE_ATTR_CAPS_RDMA_READ = 1 << 0,
+	EFADV_DEVICE_ATTR_CAPS_RNR_RETRY = 1 << 1,
 };
 
 struct efadv_device_attr {

--- a/providers/efa/man/efadv_query_device.3.md
+++ b/providers/efa/man/efadv_query_device.3.md
@@ -69,6 +69,9 @@ struct efadv_device_attr {
 	EFADV_DEVICE_ATTR_CAPS_RDMA_READ:
 		RDMA read is supported.
 
+	EFADV_DEVICE_ATTR_CAPS_RNR_RETRY:
+		RNR retry is supported for SRD QPs.
+
 *max_rdma_size*
 :	Maximum RDMA transfer size in bytes.
 

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -144,6 +144,9 @@ int efadv_query_device(struct ibv_context *ibvctx,
 
 		if (is_rdma_read_cap(ctx))
 			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
+
+		if (is_rnr_retry_cap(ctx))
+			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
 	}
 
 	attr->comp_mask = comp_mask_out;

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -22,6 +22,9 @@
 #include "efadv.h"
 #include "verbs.h"
 
+#define EFA_DEV_CAP(ctx, cap) \
+	((ctx)->device_caps & EFA_QUERY_DEVICE_CAPS_##cap)
+
 static bool is_buf_cleared(void *buf, size_t len)
 {
 	int i;
@@ -142,10 +145,10 @@ int efadv_query_device(struct ibv_context *ibvctx,
 	if (vext_field_avail(typeof(*attr), max_rdma_size, inlen)) {
 		attr->max_rdma_size = ctx->max_rdma_size;
 
-		if (is_rdma_read_cap(ctx))
+		if (EFA_DEV_CAP(ctx, RDMA_READ))
 			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
 
-		if (is_rnr_retry_cap(ctx))
+		if (EFA_DEV_CAP(ctx, RNR_RETRY))
 			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
 	}
 
@@ -1006,7 +1009,7 @@ static int efa_check_qp_attr(struct efa_context *ctx,
 		IBV_QP_EX_WITH_SEND_WITH_IMM;
 	uint64_t supp_srd_send_ops_mask =
 		IBV_QP_EX_WITH_SEND | IBV_QP_EX_WITH_SEND_WITH_IMM |
-		(is_rdma_read_cap(ctx) ? IBV_QP_EX_WITH_RDMA_READ : 0);
+		(EFA_DEV_CAP(ctx, RDMA_READ) ? IBV_QP_EX_WITH_RDMA_READ : 0);
 
 #define EFA_CREATE_QP_SUPP_ATTR_MASK \
 	(IBV_QP_INIT_ATTR_PD | IBV_QP_INIT_ATTR_SEND_OPS_FLAGS)

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -8,7 +8,10 @@ from pyverbs.base import PyverbsRDMAError
 
 
 def dev_cap_to_str(flags):
-    l = {dve.EFADV_DEVICE_ATTR_CAPS_RDMA_READ: 'RDMA Read'}
+    l = {
+            dve.EFADV_DEVICE_ATTR_CAPS_RDMA_READ: 'RDMA Read',
+            dve.EFADV_DEVICE_ATTR_CAPS_RNR_RETRY: 'RNR Retry',
+    }
     return bitmask_to_str(flags, l)
 
 

--- a/pyverbs/providers/efa/efadv_enums.pxd
+++ b/pyverbs/providers/efa/efadv_enums.pxd
@@ -7,3 +7,4 @@ cdef extern from 'infiniband/efadv.h':
 
     cpdef enum:
         EFADV_DEVICE_ATTR_CAPS_RDMA_READ
+        EFADV_DEVICE_ATTR_CAPS_RNR_RETRY


### PR DESCRIPTION
This series adds support for RNR retry counter on SRD QPs through the modify QP verb.

Kernel submission:
https://lore.kernel.org/linux-rdma/20200731060420.17053-1-galpress@amazon.com/