### PR TITLE
Add a dot to kernel headers update script commit message

### DIFF
--- a/kernel-headers/update
+++ b/kernel-headers/update
@@ -151,7 +151,7 @@ def make_commit(args,ntree,kernel_desc):
 
     # And now create the commit
     msg="Update kernel headers\n\n";
-    p = textwrap.fill("To commit %s"%(kernel_desc.decode()),
+    p = textwrap.fill("To commit %s."%(kernel_desc.decode()),
                       width=74)
     msg = msg + p;
     msg = msg + "\n\nSigned-off-by: %s\n"%(emaila);


### PR DESCRIPTION
Commit messages usually end with a dot, do that in the script as well.

Signed-off-by: Gal Pressman <galpress@amazon.com>