### PR TITLE
rdma.init-kernel: Do not load blacklisted modules

### DIFF
--- a/redhat/rdma.kernel-init
+++ b/redhat/rdma.kernel-init
@@ -84,7 +84,7 @@ load_modules()
 	    continue
 	fi
 	if ! is_loaded $module; then
-	    /sbin/modprobe $module
+	    /sbin/modprobe -b $module
 	    res=$?
 	    RC=$[ $RC + $res ]
 	    if [ $res -ne 0 ]; then


### PR DESCRIPTION
Add -b option to modprobe so blacklisted modules are not loaded.  This
makes it easier to prevent loading modules for certain Ethernet cards
with iWarp when only InfiniBand should be used for RDMA.