### PR TITLE
Fix spelling mistake and acute accent in manual pages

### DIFF
--- a/libibnetdisc/man/ibnd_discover_fabric.3
+++ b/libibnetdisc/man/ibnd_discover_fabric.3
@@ -28,7 +28,7 @@ Indicate that the library should print debug output which shows it's progress
 through the fabric.
 
 .B ibnd_set_max_smps_on_wire()
-Set the number of SMP\'s which will be issued on the wire simultaneously.
+Set the number of SMP's which will be issued on the wire simultaneously.
 
 .SH "RETURN VALUE"
 .B ibnd_discover_fabric()

--- a/libibumad/man/umad_addr_dump.3
+++ b/libibumad/man/umad_addr_dump.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_ADDR_DUMP 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_ADDR_DUMP 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_addr_dump \- dump addr structure to stderr
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_alloc.3
+++ b/libibumad/man/umad_alloc.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_ALLOC 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_ALLOC 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_alloc \- allocate memory for umad buffers
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_class_str.3
+++ b/libibumad/man/umad_class_str.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_CLASS_STR 3  "Feb 15, 2013" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_CLASS_STR 3  "Feb 15, 2013" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_*_str \- class of functions to return string representations of enums
 

--- a/libibumad/man/umad_close_port.3
+++ b/libibumad/man/umad_close_port.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_OPEN_PORT 3  "May 11, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_OPEN_PORT 3  "May 11, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_close_port \- close InfiniBand device port for umad access
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_debug.3
+++ b/libibumad/man/umad_debug.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_DEBUG 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_DEBUG 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_debug \- set debug level
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_dump.3
+++ b/libibumad/man/umad_dump.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_DUMP 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_DUMP 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_dump \- dump umad buffer to stderr
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_free.3
+++ b/libibumad/man/umad_free.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_FREE 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_FREE 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_free \- frees memory of umad buffers
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_ca.3
+++ b/libibumad/man/umad_get_ca.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_CA 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_CA 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_ca, umad_release_ca \- get and release InfiniBand device port attributes
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_ca_portguids.3
+++ b/libibumad/man/umad_get_ca_portguids.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_CA_PORTGUIDS 3  "August 8, 2016" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_CA_PORTGUIDS 3  "August 8, 2016" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_ca_portguids \- get the InfiniBand device ports GUIDs
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_cas_names.3
+++ b/libibumad/man/umad_get_cas_names.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_CAS_NAMES 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_CAS_NAMES 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_cas_names \- get list of available InfiniBand device names
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_fd.3
+++ b/libibumad/man/umad_get_fd.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_FD 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_FD 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_fd \- get the umad fd for the requested port
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_issm_path.3
+++ b/libibumad/man/umad_get_issm_path.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_ISSM_PATH 3  "Oct 18, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_ISSM_PATH 3  "Oct 18, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_issm_path \- get path of issm device
 .SH "SYNOPSIS"
@@ -27,7 +27,7 @@ Opening issm device sets PortInfo:CapMask IsSM bit and closing clears it.
 .SH "RETURN VALUE"
 .B umad_open_port()
 returns 0 on success and a negative value on error as follows:
- -ENODEV IB device can\'t be resolved
+ -ENODEV IB device can't be resolved
  -EINVAL port is not valid (bad
 .I portnum\fR
 or no umad device)

--- a/libibumad/man/umad_get_mad.3
+++ b/libibumad/man/umad_get_mad.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_MAD 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_MAD 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_mad \- get the MAD pointer of a umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_mad_addr.3
+++ b/libibumad/man/umad_get_mad_addr.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_MAD_ADDR 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_MAD_ADDR 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_mad_addr \- get the address of the ib_mad_addr from a umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_pkey.3
+++ b/libibumad/man/umad_get_pkey.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_PKEY 3  "Jan 15, 2008" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_PKEY 3  "Jan 15, 2008" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_pkey \- get pkey index from umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_get_port.3
+++ b/libibumad/man/umad_get_port.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_GET_PORT 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_GET_PORT 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_get_port, umad_release_port \- open and close an InfiniBand port
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_open_port.3
+++ b/libibumad/man/umad_open_port.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_OPEN_PORT 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_OPEN_PORT 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_open_port \- open InfiniBand device port for umad access
 .SH "SYNOPSIS"
@@ -24,12 +24,12 @@ for details).
 .SH "RETURN VALUE"
 .B umad_open_port()
 returns 0 or an unique positive value of umad device descriptor on success, and a negative value on error as follows:
- -EOPNOTSUPP ABI version doesn\'t match
- -ENODEV     IB device can\'t be resolved
+ -EOPNOTSUPP ABI version doesn't match
+ -ENODEV     IB device can't be resolved
  -EINVAL     port is not valid (bad
 .I portnum\fR
 or no umad device)
- -EIO        umad device for this port can\'t be opened
+ -EIO        umad device for this port can't be opened
 .SH "SEE ALSO"
 .BR umad_close_port (3),
 .BR umad_get_cas_names (3),

--- a/libibumad/man/umad_poll.3
+++ b/libibumad/man/umad_poll.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_POLL 3  "October 23, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_POLL 3  "October 23, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_poll \- poll umad
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_recv.3
+++ b/libibumad/man/umad_recv.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_RECV 3  "May 11, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_RECV 3  "May 11, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_recv \- receive umad
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_register.3
+++ b/libibumad/man/umad_register.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_REGISTER 3  "May 11, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_REGISTER 3  "May 11, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_register \- register the specified management class and version for port
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_register2.3
+++ b/libibumad/man/umad_register2.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_REGISTER2 3  "March 25, 2014" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_REGISTER2 3  "March 25, 2014" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_register2 \- register the specified management class and version for port
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_register_oui.3
+++ b/libibumad/man/umad_register_oui.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_REGISTER_OUI 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_REGISTER_OUI 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_register_oui \- register the specified class in vendor range 2 for port
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_send.3
+++ b/libibumad/man/umad_send.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SEND 3  "May 11, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SEND 3  "May 11, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_send \- send umad
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_set_addr.3
+++ b/libibumad/man/umad_set_addr.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SET_ADDR 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SET_ADDR 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_set_addr \- set MAD address fields within umad buffer using host ordering
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_set_addr_net.3
+++ b/libibumad/man/umad_set_addr_net.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SET_ADDR_NET 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SET_ADDR_NET 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_set_addr_net \- set MAD address fields within umad buffer using network ordering
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_set_grh.3
+++ b/libibumad/man/umad_set_grh.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SET_GRH 3  "May 24, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SET_GRH 3  "May 24, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_set_grh \- set GRH fields within umad buffer using host ordering
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_set_grh_net.3
+++ b/libibumad/man/umad_set_grh_net.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SET_GRH_NET 3  "May 24, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SET_GRH_NET 3  "May 24, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_set_grh_net \- set GRH fields within umad buffer using network ordering
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_set_pkey.3
+++ b/libibumad/man/umad_set_pkey.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SET_PKEY 3  "June 20, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SET_PKEY 3  "June 20, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_set_pkey \- set pkey index within umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_size.3
+++ b/libibumad/man/umad_size.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_SIZE 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_SIZE 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_size \- get the size of umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_status.3
+++ b/libibumad/man/umad_status.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_STATUS 3  "May 17, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_STATUS 3  "May 17, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_status \- get the status of a umad buffer
 .SH "SYNOPSIS"

--- a/libibumad/man/umad_unregister.3
+++ b/libibumad/man/umad_unregister.3
@@ -1,7 +1,7 @@
 .\" -*- nroff -*-
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
 .\"
-.TH UMAD_UNREGISTER 3  "May 21, 2007" "OpenIB" "OpenIB Programmer\'s Manual"
+.TH UMAD_UNREGISTER 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
 .SH "NAME"
 umad_unregister \- unregister umad agent
 .SH "SYNOPSIS"

--- a/libibverbs/man/ibv_import_device.3.md
+++ b/libibverbs/man/ibv_import_device.3.md
@@ -10,7 +10,7 @@ title: ibv_import_device
 
 # NAME
 
-ibv_import_device - import a device from a given comamnd FD
+ibv_import_device - import a device from a given command FD
 
 # SYNOPSIS
 


### PR DESCRIPTION
This pull request addresses issues found by lintian:

* verbs: Fix spelling mistake of command
* libibumad/libibnetdisc: Fix acute accent in manual pages

linitan reports `acute-accent-in-manual-page`:

> This manual page uses the \' groff sequence. Usually, the intent to generate an apostrophe, but that sequence actually renders as a an acute accent.
>
> For an apostrophe or a single closing quote, use plain '. For single opening quote, i.e. a straight downward line ' like the one used in shell commands, use &#92;(aq.
