### PR TITLE
tests: Allow zero vendor_part_id

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -86,7 +86,6 @@ class DeviceTest(PyverbsAPITestCase):
         assert attr.max_mr_size > PAGE_SIZE
         assert attr.page_size_cap >= PAGE_SIZE
         assert attr.vendor_id != 0
-        assert attr.vendor_part_id != 0
         assert attr.max_qp > 0
         assert attr.max_qp_wr > 0
         assert attr.max_sge > 0


### PR DESCRIPTION
Removed a test case which requires vendor_part_id to be non zero.
Per IBTA A3.3.1 VENDOR INFORMATION it is not required that the
vendor part ID field be set to a non-zero value:

	The following components are vendor specific: VendorID, DeviceID, De-
	vice Version, Subsystem VendorID, SubsystemID, ID String.

	The vendor places its IEEE assigned Organization Unique Identifier
	(OUI) in the VendorId field and *MAY PLACE ANY VALUE IN THE DEVICEID* and
	Device Version fields. The vendor may also provide an ASCII string of its
	choice in the ID String field.

	The Subsystem VendorID and SubsystemID provide additional informa-
	tion when a subsystem vendor uses components provided by other ven-
	dors. In this case the subsystem vendor provides its OUI in the Subsystem
	VendorID field and may specify any value in the SubsystemD field.
	A vendor that produces a generic controller (i.e., one that supports a stan-
	dard I/O protocol such as SRP), which does not have vendor specific de-
	vice drivers, may use the value of 0xFFFFFF in the VendorID field.
	However, such a value prevents the vendor from ever providing vendor
	specific drivers for the product.

Fixes: 3a33260ce9e9 ("pyverbs: Move tests to a stand-alone directory")
Signed-off-by: Bob Pearson <rpearson@hpe.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>