### PR TITLE
Fix return value of ibv_destroy_flow when not supported

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2370,7 +2370,7 @@ static inline int ibv_destroy_flow(struct ibv_flow *flow_id)
 	struct verbs_context *vctx = verbs_get_ctx_op(flow_id->context,
 						      ibv_destroy_flow);
 	if (!vctx)
-		return -EOPNOTSUPP;
+		return EOPNOTSUPP;
 	return vctx->ibv_destroy_flow(flow_id);
 }
 


### PR DESCRIPTION
It is supposed to return an errno value, but was returning -EOPNOTSUPP
(note the negative).