### PR TITLE
verbs: Try access the device before adding it to the device list

### DIFF
--- a/libibverbs/ibdev_nl.c
+++ b/libibverbs/ibdev_nl.c
@@ -206,7 +206,8 @@ int find_sysfs_devs_nl(struct list_head *tmp_sysfs_dev_list)
 		goto err;
 
 	list_for_each_safe (tmp_sysfs_dev_list, dev, dev_tmp, entry) {
-		if (find_uverbs_nl(nl, dev) && find_uverbs_sysfs(dev)) {
+		if ((find_uverbs_nl(nl, dev) && find_uverbs_sysfs(dev)) ||
+		    try_access_device(dev)) {
 			list_del(&dev->entry);
 			free(dev);
 		}

--- a/libibverbs/ibverbs.h
+++ b/libibverbs/ibverbs.h
@@ -91,4 +91,6 @@ enum ibv_node_type decode_knode_type(unsigned int knode_type);
 
 int find_sysfs_devs_nl(struct list_head *tmp_sysfs_dev_list);
 
+int try_access_device(const struct verbs_sysfs_dev *sysfs_dev);
+
 #endif /* IB_VERBS_H */

--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -64,7 +64,7 @@ struct ibv_driver {
 
 static LIST_HEAD(driver_list);
 
-static int try_access_device(const struct verbs_sysfs_dev *sysfs_dev)
+int try_access_device(const struct verbs_sysfs_dev *sysfs_dev)
 {
 	struct stat cdev_stat;
 	char *devpath;


### PR DESCRIPTION
We need to check that the device could be accessed before it is added to the device list.
Currently, it's done only in the sysfs fallback, do it in the netlink flow as well.