### PR TITLE
tests: Remove parametrize

### DIFF
--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -127,13 +127,6 @@ Ran 14 tests in 0.152s
 
 OK
 ```
-We're using 'parametrize' as it instantiates the TestCase for us.
-'parametrize' can accept arguments as well (device name, IB port, GID index and
-PKey index):
-```
-suite = unittest.TestSuite()
-suite.addTest(RDMATestCase.parametrize(YourTestCase, dev_name='devname'))
-```
 
 ## Writing Tests
 The following section explains how to add a new test, using tests/test_odp.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -78,16 +78,6 @@ class PyverbsAPITestCase(unittest.TestCase):
 
 
 class RDMATestCase(unittest.TestCase):
-    """
-    A base class for test cases which provides the option for user parameters.
-    These can be provided by manually adding the test case to the runner:
-    suite = unittest.TestSuite()
-    ... # Regular auto-detection of test cases, no parameters used.
-    # Now follows your manual addition of test cases e.g:
-    suite.addTest(RDMATestCase.parametrize(<TestCaseName>, dev_name='..',
-                                           ib_port=1, gid_index=3,
-                                           pkey_index=42))
-    """
     ZERO_GID = '0000:0000:0000:0000'
 
     def __init__(self, methodName='runTest', dev_name=None, ib_port=None,
@@ -115,22 +105,6 @@ class RDMATestCase(unittest.TestCase):
         vendor_pid = dev_attrs.vendor_part_id
         return port_attrs.link_layer == e.IBV_LINK_LAYER_ETHERNET and \
             has_roce_hw_bug(vendor_id, vendor_pid)
-
-    @staticmethod
-    def parametrize(testcase_klass, dev_name=None, ib_port=None, gid_index=None,
-                    pkey_index=None):
-        """
-        Create a test suite containing all the tests from the given subclass
-        with the given dev_name, port, gid index and pkey_index.
-        """
-        loader = unittest.TestLoader()
-        names = loader.getTestCaseNames(testcase_klass)
-        suite = unittest.TestSuite()
-        for n in names:
-            suite.addTest(testcase_klass(n, dev_name=dev_name, ib_port=ib_port,
-                                         gid_index=gid_index,
-                                         pkey_index=pkey_index))
-        return suite
 
     @staticmethod
     def get_net_name(dev):


### PR DESCRIPTION
As parametrize isn't used - remove it.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>