### PR TITLE
tests: Add test for ibv_query_pkey

### DIFF
--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -25,6 +25,7 @@ from pyverbs.qp cimport QP
 from libc.stdlib cimport free, malloc
 from libc.string cimport memset
 from libc.stdint cimport uint64_t
+from libc.stdint cimport uint16_t
 
 cdef extern from 'endian.h':
     unsigned long be64toh(unsigned long host_64bits);
@@ -202,6 +203,13 @@ cdef class Context(PyverbsCM):
             raise PyverbsRDMAError('Failed to query EX device {name}'.
                                    format(name=self.name), rc)
         return dev_attr_ex
+
+    def query_pkey(self, unsigned int port_num, int index):
+        cdef uint16_t pkey
+        rc = v.ibv_query_pkey(self.context, port_num, index, &pkey)
+        if rc != 0:
+            raise PyverbsRDMAError(f'Failed to query pkey {index} of port {port_num}')
+        return pkey
 
     def query_gid(self, unsigned int port_num, int index):
         gid = GID()

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -495,6 +495,8 @@ cdef extern from 'infiniband/verbs.h':
     unsigned long ibv_get_device_guid(ibv_device *device)
     int ibv_query_gid(ibv_context *context, unsigned int port_num,
                       int index, ibv_gid *gid)
+    int ibv_query_pkey(ibv_context *context, unsigned int port_num,
+                       int index, uint16_t *pkey)
     ibv_pd *ibv_alloc_pd(ibv_context *context)
     int ibv_dealloc_pd(ibv_pd *pd)
     ibv_mr *ibv_reg_mr(ibv_pd *pd, void *addr, size_t length, int access)

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -63,6 +63,15 @@ class DeviceTest(PyverbsAPITestCase):
                 attr = ctx.query_device()
                 self.verify_device_attr(attr, dev)
 
+    def test_query_pkey(self):
+        """
+        Test ibv_query_pkey()
+        """
+        for dev in self.get_device_list():
+            with d.Context(name=dev.name.decode()) as ctx:
+                if dev.node_type == e.IBV_NODE_CA:
+                    ctx.query_pkey(port_num=1, index=0)
+
     def test_query_gid(self):
         """
         Test ibv_query_gid()


### PR DESCRIPTION
Add test for testing ibv_query_pkey() to test_device.py.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>