### PR TITLE
verbs: Set attributes to zero if query_device_ex() is not supported

### DIFF
--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -396,7 +396,7 @@ static int query_device_ex(struct ibv_context *context,
 	if (attr_size < sizeof(attr->orig_attr))
 		return EOPNOTSUPP;
 
-	memset(&attr->orig_attr, 0, sizeof(attr->orig_attr));
+	memset(attr, 0, attr_size);
 
 	return ibv_query_device(context, &attr->orig_attr);
 }

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -495,7 +495,7 @@ static void print_raw_packet_caps(uint32_t raw_packet_caps)
 static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)
 {
 	struct ibv_context *ctx;
-	struct ibv_device_attr_ex device_attr;
+	struct ibv_device_attr_ex device_attr = {};
 	struct ibv_port_attr port_attr;
 	int rc = 0;
 	uint8_t port;


### PR DESCRIPTION
All of structrue ibv_device_attr_ex should be set to zero if a provider don't support query_device_ex(), or the fields which are not included in attr->orig_attr will get a random value.

Fixes: 58ccb638b540 ("libibverbs: Fix query_device_ex dummy function not to return EOPNOTSUPP")