### PR TITLE
libhns: Refactor process about opcode in set_rc_wqe()

### DIFF
--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -41,6 +41,7 @@
 #include <util/udma_barrier.h>
 #include <util/util.h>
 #include <infiniband/verbs.h>
+#include <ccan/array_size.h>
 #include <ccan/bitmap.h>
 #include <ccan/container_of.h>
 

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -37,6 +37,30 @@
 #include "hns_roce_u_db.h"
 #include "hns_roce_u_hw_v2.h"
 
+#define HR_IBV_OPC_MAP(ib_key, hr_key) \
+		[IBV_WR_ ## ib_key] = HNS_ROCE_WQE_OP_ ## hr_key
+
+static const uint32_t hns_roce_opcode[] = {
+	HR_IBV_OPC_MAP(RDMA_WRITE,		RDMA_WRITE),
+	HR_IBV_OPC_MAP(RDMA_WRITE_WITH_IMM,	RDMA_WRITE_WITH_IMM),
+	HR_IBV_OPC_MAP(SEND,			SEND),
+	HR_IBV_OPC_MAP(SEND_WITH_IMM,		SEND_WITH_IMM),
+	HR_IBV_OPC_MAP(RDMA_READ,		RDMA_READ),
+	HR_IBV_OPC_MAP(ATOMIC_CMP_AND_SWP,	ATOMIC_COM_AND_SWAP),
+	HR_IBV_OPC_MAP(ATOMIC_FETCH_AND_ADD,	ATOMIC_FETCH_AND_ADD),
+	HR_IBV_OPC_MAP(LOCAL_INV,		LOCAL_INV),
+	HR_IBV_OPC_MAP(BIND_MW,			BIND_MW_TYPE),
+	HR_IBV_OPC_MAP(SEND_WITH_INV,		SEND_WITH_INV),
+};
+
+static inline uint32_t to_hr_opcode(enum ibv_wr_opcode ibv_opcode)
+{
+	if (ibv_opcode >= ARRAY_SIZE(hns_roce_opcode))
+		return HNS_ROCE_WQE_OP_MASK;
+
+	return hns_roce_opcode[ibv_opcode];
+}
+
 static void *get_send_sge_ex(struct hns_roce_qp *qp, int n);
 
 static void set_data_seg_v2(struct hns_roce_v2_wqe_data_seg *dseg,
@@ -61,13 +85,11 @@ static void set_extend_atomic_seg(struct hns_roce_qp *qp,
 }
 
 static int set_atomic_seg(struct hns_roce_qp *qp, struct ibv_send_wr *wr,
-			  unsigned int msg_len, void *dseg,
-			  struct hns_roce_sge_info *sge_info)
+			  void *dseg, struct hns_roce_sge_info *sge_info)
 {
-	struct hns_roce_wqe_atomic_seg *aseg;
+	struct hns_roce_wqe_atomic_seg *aseg = dseg;
+	unsigned int msg_len = sge_info->total_len;
 	unsigned int ext_sg_num;
-
-	aseg = dseg;
 
 	if (msg_len == STANDARD_ATOMIC_U_BYTE_8) {
 		if (wr->opcode == IBV_WR_ATOMIC_CMP_AND_SWP) {
@@ -684,93 +706,95 @@ static void set_sge(struct hns_roce_v2_wqe_data_seg *dseg,
 	}
 }
 
+static __le32 get_immtdata(enum ibv_wr_opcode opcode, const struct ibv_send_wr *wr)
+{
+	switch (opcode) {
+	case IBV_WR_SEND_WITH_IMM:
+	case IBV_WR_RDMA_WRITE_WITH_IMM:
+		return htole32(be32toh(wr->imm_data));
+	default:
+		return 0;
+	}
+}
+
+static void set_bind_mw_seg(struct hns_roce_rc_sq_wqe *wqe,
+			    const struct ibv_send_wr *wr)
+{
+	roce_set_bit(wqe->byte_4, RC_SQ_WQE_BYTE_4_MW_TYPE_S,
+		     wr->bind_mw.mw->type - 1);
+	roce_set_bit(wqe->byte_4, RC_SQ_WQE_BYTE_4_ATOMIC_S,
+		     (wr->bind_mw.bind_info.mw_access_flags &
+		     IBV_ACCESS_REMOTE_ATOMIC) ? 1 : 0);
+	roce_set_bit(wqe->byte_4, RC_SQ_WQE_BYTE_4_RDMA_READ_S,
+		     (wr->bind_mw.bind_info.mw_access_flags &
+		     IBV_ACCESS_REMOTE_READ) ? 1 : 0);
+	roce_set_bit(wqe->byte_4, RC_SQ_WQE_BYTE_4_RDMA_WRITE_S,
+		     (wr->bind_mw.bind_info.mw_access_flags &
+		     IBV_ACCESS_REMOTE_WRITE) ? 1 : 0);
+	wqe->new_rkey = htole32(wr->bind_mw.rkey);
+	wqe->byte_16 = htole32(wr->bind_mw.bind_info.length &
+			       HNS_ROCE_ADDRESS_MASK);
+	wqe->byte_20 = htole32(wr->bind_mw.bind_info.length >>
+			       HNS_ROCE_ADDRESS_SHIFT);
+	wqe->rkey = htole32(wr->bind_mw.bind_info.mr->rkey);
+	wqe->va = htole64(wr->bind_mw.bind_info.addr);
+}
+
+static int check_rc_opcode(struct hns_roce_rc_sq_wqe *wqe,
+			   const struct ibv_send_wr *wr)
+{
+	int ret = 0;
+
+	wqe->immtdata = get_immtdata(wr->opcode, wr);
+
+	switch (wr->opcode) {
+	case IBV_WR_RDMA_READ:
+	case IBV_WR_RDMA_WRITE:
+	case IBV_WR_RDMA_WRITE_WITH_IMM:
+		wqe->va = htole64(wr->wr.rdma.remote_addr);
+		wqe->rkey = htole32(wr->wr.rdma.rkey);
+		break;
+	case IBV_WR_SEND:
+	case IBV_WR_SEND_WITH_IMM:
+		break;
+	case IBV_WR_ATOMIC_CMP_AND_SWP:
+	case IBV_WR_ATOMIC_FETCH_AND_ADD:
+		wqe->rkey = htole32(wr->wr.atomic.rkey);
+		wqe->va = htole64(wr->wr.atomic.remote_addr);
+		break;
+	case IBV_WR_LOCAL_INV:
+		wqe->inv_key = htole32(wr->invalidate_rkey);
+		/* fallthrough */
+	case IBV_WR_SEND_WITH_INV:
+		roce_set_bit(wqe->byte_4, RC_SQ_WQE_BYTE_4_SO_S, 1);
+		break;
+	case IBV_WR_BIND_MW:
+		set_bind_mw_seg(wqe, wr);
+		break;
+	default:
+		ret = EINVAL;
+		break;
+	}
+
+	roce_set_field(wqe->byte_4, RC_SQ_WQE_BYTE_4_OPCODE_M,
+		       RC_SQ_WQE_BYTE_4_OPCODE_S, to_hr_opcode(wr->opcode));
+
+	return ret;
+}
+
 static int set_rc_wqe(void *wqe, struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 		      int nreq, struct hns_roce_sge_info *sge_info)
 {
 	struct hns_roce_rc_sq_wqe *rc_sq_wqe = wqe;
 	struct hns_roce_v2_wqe_data_seg *dseg;
-	int hr_op;
+	int ret;
 	int i;
 
 	memset(rc_sq_wqe, 0, sizeof(struct hns_roce_rc_sq_wqe));
 
-	switch (wr->opcode) {
-	case IBV_WR_RDMA_READ:
-		hr_op = HNS_ROCE_WQE_OP_RDMA_READ;
-		rc_sq_wqe->va = htole64(wr->wr.rdma.remote_addr);
-		rc_sq_wqe->rkey = htole32(wr->wr.rdma.rkey);
-		break;
-	case IBV_WR_RDMA_WRITE:
-		hr_op = HNS_ROCE_WQE_OP_RDMA_WRITE;
-		rc_sq_wqe->va = htole64(wr->wr.rdma.remote_addr);
-		rc_sq_wqe->rkey = htole32(wr->wr.rdma.rkey);
-		break;
-	case IBV_WR_RDMA_WRITE_WITH_IMM:
-		hr_op = HNS_ROCE_WQE_OP_RDMA_WRITE_WITH_IMM;
-		rc_sq_wqe->va = htole64(wr->wr.rdma.remote_addr);
-		rc_sq_wqe->rkey = htole32(wr->wr.rdma.rkey);
-		rc_sq_wqe->immtdata = htole32(be32toh(wr->imm_data));
-		break;
-	case IBV_WR_SEND:
-		hr_op = HNS_ROCE_WQE_OP_SEND;
-		break;
-	case IBV_WR_SEND_WITH_INV:
-		hr_op = HNS_ROCE_WQE_OP_SEND_WITH_INV;
-		rc_sq_wqe->inv_key = htole32(wr->invalidate_rkey);
-		break;
-	case IBV_WR_SEND_WITH_IMM:
-		hr_op = HNS_ROCE_WQE_OP_SEND_WITH_IMM;
-		rc_sq_wqe->immtdata = htole32(be32toh(wr->imm_data));
-		break;
-	case IBV_WR_LOCAL_INV:
-		hr_op = HNS_ROCE_WQE_OP_LOCAL_INV;
-		roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_SO_S, 1);
-		rc_sq_wqe->inv_key = htole32(wr->invalidate_rkey);
-		break;
-	case IBV_WR_BIND_MW:
-		hr_op = HNS_ROCE_WQE_OP_BIND_MW_TYPE;
-		roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_MW_TYPE_S,
-			     wr->bind_mw.mw->type - 1);
-		roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_ATOMIC_S,
-			     (wr->bind_mw.bind_info.mw_access_flags &
-			     IBV_ACCESS_REMOTE_ATOMIC) ? 1 : 0);
-		roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_RDMA_READ_S,
-			     (wr->bind_mw.bind_info.mw_access_flags &
-			     IBV_ACCESS_REMOTE_READ) ? 1 : 0);
-		roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_RDMA_WRITE_S,
-			     (wr->bind_mw.bind_info.mw_access_flags &
-			     IBV_ACCESS_REMOTE_WRITE) ? 1 : 0);
-		rc_sq_wqe->new_rkey = htole32(wr->bind_mw.rkey);
-		rc_sq_wqe->byte_16 = htole32(wr->bind_mw.bind_info.length &
-					     HNS_ROCE_ADDRESS_MASK);
-		rc_sq_wqe->byte_20 = htole32(wr->bind_mw.bind_info.length >>
-					     HNS_ROCE_ADDRESS_SHIFT);
-		rc_sq_wqe->rkey = htole32(wr->bind_mw.bind_info.mr->rkey);
-		rc_sq_wqe->va = htole64(wr->bind_mw.bind_info.addr);
-		break;
-	case IBV_WR_ATOMIC_CMP_AND_SWP:
-		hr_op = HNS_ROCE_WQE_OP_ATOMIC_COM_AND_SWAP;
-		rc_sq_wqe->rkey = htole32(wr->wr.atomic.rkey);
-		rc_sq_wqe->va = htole64(wr->wr.atomic.remote_addr);
-		roce_set_field(rc_sq_wqe->byte_16, RC_SQ_WQE_BYTE_16_SGE_NUM_M,
-			       RC_SQ_WQE_BYTE_16_SGE_NUM_S,
-			       sge_info->valid_num);
-		break;
-	case IBV_WR_ATOMIC_FETCH_AND_ADD:
-		hr_op = HNS_ROCE_WQE_OP_ATOMIC_FETCH_AND_ADD;
-		rc_sq_wqe->rkey = htole32(wr->wr.atomic.rkey);
-		rc_sq_wqe->va = htole64(wr->wr.atomic.remote_addr);
-		roce_set_field(rc_sq_wqe->byte_16, RC_SQ_WQE_BYTE_16_SGE_NUM_M,
-			       RC_SQ_WQE_BYTE_16_SGE_NUM_S,
-			       sge_info->valid_num);
-		break;
-	default:
-		hr_op = HNS_ROCE_WQE_OP_MASK;
-		return EINVAL;
-	}
-
-	roce_set_field(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_OPCODE_M,
-		       RC_SQ_WQE_BYTE_4_OPCODE_S, hr_op);
+	ret = check_rc_opcode(rc_sq_wqe, wr);
+	if (ret)
+		return ret;
 
 	roce_set_bit(rc_sq_wqe->byte_4, RC_SQ_WQE_BYTE_4_CQE_S,
 		     (wr->send_flags & IBV_SEND_SIGNALED) ? 1 : 0);
@@ -805,9 +829,11 @@ static int set_rc_wqe(void *wqe, struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 	if (wr->opcode == IBV_WR_ATOMIC_FETCH_AND_ADD ||
 	    wr->opcode == IBV_WR_ATOMIC_CMP_AND_SWP) {
 		dseg++;
-		return set_atomic_seg(qp, wr, le32toh(rc_sq_wqe->msg_len),
-				      dseg, sge_info);
+		ret = set_atomic_seg(qp, wr, dseg, sge_info);
 	}
+
+	if (ret)
+		return ret;
 
 	if (wr->send_flags & IBV_SEND_INLINE && sge_info->valid_num) {
 		if (wr->opcode == IBV_WR_RDMA_READ)


### PR DESCRIPTION
According to the IB Specifications, the verbs should return an immediate error when the users set an unsupported opcode. Furthermore, refactor codes about opcode in process of set_rc_wqe() to make the differences between opcodes clearer.