### PR TITLE
tests: Extend SRQ and QP support

### DIFF
--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -38,6 +38,7 @@ cdef class QP(PyverbsCM):
     cdef object scq
     cdef object rcq
     cdef object mws
+    cdef object srq
     cdef add_ref(self, obj)
 
 cdef class DataBuffer(PyverbsCM):

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -951,6 +951,10 @@ cdef class QP(PyverbsCM):
                 self.pd = pd
                 pd.add_ref(self)
                 self.context = None
+        if init_attr.srq is not None:
+            srq = <SRQ>init_attr.srq
+            srq.add_ref(self)
+            self.srq = srq
 
         if qp_attr is not None:
             funcs = {e.IBV_QPT_RC: self.to_init, e.IBV_QPT_UC: self.to_init,

--- a/pyverbs/srq.pxd
+++ b/pyverbs/srq.pxd
@@ -21,4 +21,6 @@ cdef class SrqInitAttrEx(PyverbsObject):
 cdef class SRQ(PyverbsCM):
     cdef v.ibv_srq *srq
     cdef object cq
+    cdef object qps
+    cdef add_ref(self, obj)
     cpdef close(self)

--- a/tests/base.py
+++ b/tests/base.py
@@ -11,10 +11,10 @@ import json
 import os
 
 from pyverbs.qp import QPCap, QPInitAttrEx, QPInitAttr, QPAttr, QP
+from pyverbs.srq import SRQ, SrqInitAttrEx, SrqInitAttr, SrqAttr
 from pyverbs.pyverbs_error import PyverbsRDMAError
 from pyverbs.addr import AHAttr, GlobalRoute
 from pyverbs.xrcd import XRCD, XRCDInitAttr
-from pyverbs.srq import SRQ, SrqInitAttrEx
 from pyverbs.device import Context
 from args_parser import parser
 import pyverbs.device as d
@@ -267,32 +267,39 @@ class TrafficResources(BaseResources):
     Basic traffic class. It provides the basic RDMA resources and operations
     needed for traffic.
     """
-    def __init__(self, dev_name, ib_port, gid_index):
+    def __init__(self, dev_name, ib_port, gid_index, with_srq=False,
+                 qp_count=1):
         """
         Initializes a TrafficResources object with the given values and creates
         basic RDMA resources.
         :param dev_name: Device name to be used
         :param ib_port: IB port of the device to use
         :param gid_index: Which GID index to use
+        :param with_srq: If True, create SRQ and attach to QPs
+        :param qp_count: Number of QPs to create
         """
         super(TrafficResources, self).__init__(dev_name=dev_name,
                                                ib_port=ib_port,
                                                gid_index=gid_index)
-        self.psn = random.getrandbits(24)
         self.msg_size = 1024
         self.num_msgs = 1000
         self.port_attr = None
         self.mr = None
         self.use_mr_prefetch = None
+        self.srq = None
         self.cq = None
-        self.qp = None
-        self.rqpn = 0
-        self.rpsn = 0
+        self.qps = []
+        self.qps_num = []
+        self.psns = []
+        self.rqps_num = None
+        self.rpsns = None
+        self.with_srq = with_srq
+        self.qp_count = qp_count
         self.init_resources()
 
     @property
-    def qpn(self):
-        return self.qp.qp_num
+    def qp(self):
+        return self.qps[0]
 
     def init_resources(self):
         """
@@ -300,9 +307,11 @@ class TrafficResources(BaseResources):
         :return: None
         """
         self.port_attr = self.ctx.query_port(self.ib_port)
+        if self.with_srq:
+            self.create_srq()
         self.create_cq()
         self.create_mr()
-        self.create_qp()
+        self.create_qps()
 
     def create_cq(self):
         """
@@ -320,24 +329,51 @@ class TrafficResources(BaseResources):
         """
         self.mr = MR(self.pd, self.msg_size, e.IBV_ACCESS_LOCAL_WRITE)
 
-    def create_qp(self):
+    def create_qp_cap(self):
+        return QPCap(max_recv_wr=self.num_msgs)
+
+    def create_qp_init_attr(self):
+        return QPInitAttr(qp_type=e.IBV_QPT_RC, scq=self.cq, rcq=self.cq,
+                          srq=self.srq, cap=self.create_qp_cap())
+
+    def create_qp_attr(self):
+        return QPAttr(port_num=self.ib_port)
+
+    def create_qps(self):
         """
-        Initializes self.qp with an RC QP.
+        Initializes self.qps with RC QPs.
         :return: None
         """
-        qp_caps = QPCap(max_recv_wr=self.num_msgs)
-        qp_init_attr = QPInitAttr(qp_type=e.IBV_QPT_RC, scq=self.cq,
-                                  rcq=self.cq, cap=qp_caps)
-        qp_attr = QPAttr(port_num=self.ib_port)
-        self.qp = QP(self.pd, qp_init_attr, qp_attr)
+        qp_init_attr = self.create_qp_init_attr()
+        qp_attr = self.create_qp_attr()
+        for _ in range(self.qp_count):
+            try:
+                qp = QP(self.pd, qp_init_attr, qp_attr)
+                self.qps.append(qp)
+                self.qps_num.append(qp.qp_num)
+                self.psns.append(random.getrandbits(24))
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest(f'Create QP type {qp_init_attr.qp_type} is not supported')
+                raise ex
 
-    def pre_run(self, rpsn, rqpn):
+    def create_srq_attr(self):
+        return SrqAttr(max_wr=self.num_msgs*self.qp_count)
+
+    def create_srq_init_attr(self):
+        return SrqInitAttr(self.create_srq_attr())
+
+    def create_srq(self):
+        srq_init_attr = self.create_srq_init_attr()
+        self.srq = SRQ(self.pd, srq_init_attr)
+
+    def pre_run(self, rpsns, rqps_num):
         """
-        Modify the QP's state to RTS and fill receive queue with <num_msgs> work
+        Modify the QP's states to RTS and fill receive queue with <num_msgs> work
         requests.
         This method is not implemented in this class.
-        :param rpsn: Remote PSN
-        :param rqpn: Remote QPN
+        :param rpsns: Remote PSNs
+        :param rqps_num: Remote QPs Number
         :return: None
         """
         raise NotImplementedError()
@@ -351,13 +387,10 @@ class RCResources(TrafficResources):
         ibv_rc_pingpong).
         :return: None
         """
-        attr = QPAttr(port_num=self.ib_port)
-        attr.dest_qp_num = self.rqpn
+        attr = self.create_qp_attr()
         attr.path_mtu = PATH_MTU
         attr.max_dest_rd_atomic = MAX_DEST_RD_ATOMIC
         attr.min_rnr_timer = MIN_RNR_TIMER
-        attr.rq_psn = self.psn
-        attr.sq_psn = self.rpsn
         attr.timeout = TIMEOUT
         attr.retry_cnt = RETRY_CNT
         attr.rnr_retry = RNR_RETRY
@@ -367,17 +400,21 @@ class RCResources(TrafficResources):
         ah_attr = AHAttr(port_num=self.ib_port, is_global=1, gr=gr,
                          dlid=self.port_attr.lid)
         attr.ah_attr = ah_attr
-        self.qp.to_rts(attr)
+        for i in range(self.qp_count):
+            attr.dest_qp_num = self.rqps_num[i]
+            attr.rq_psn = self.psns[i]
+            attr.sq_psn = self.rpsns[i]
+            self.qps[i].to_rts(attr)
 
-    def pre_run(self, rpsn, rqpn):
+    def pre_run(self, rpsns, rqps_num):
         """
         Configure Resources before running traffic
-        :param rpsn: Remote PSN (packet serial number)
-        :param rqpn: Remote QP number
+        :param rpsns: Remote PSNs (packet serial number)
+        :param rqps_num: Remote QPs number
         :return: None
         """
-        self.rqpn = rqpn
-        self.rpsn = rpsn
+        self.rpsns = rpsns
+        self.rqps_num = rqps_num
         self.to_rts()
 
 
@@ -390,18 +427,24 @@ class UDResources(TrafficResources):
         self.mr = MR(self.pd, self.msg_size + self.GRH_SIZE,
                      e.IBV_ACCESS_LOCAL_WRITE)
 
-    def create_qp(self):
-        qp_caps = QPCap(max_recv_wr=self.num_msgs)
-        qp_init_attr = QPInitAttr(qp_type=e.IBV_QPT_UD, cap=qp_caps,
-                                  scq=self.cq, rcq=self.cq)
-        qp_attr = QPAttr(port_num=self.ib_port)
+    def create_qp_init_attr(self):
+        return QPInitAttr(qp_type=e.IBV_QPT_UD, scq=self.cq,
+                          rcq=self.cq, srq=self.srq, cap=self.create_qp_cap())
+
+    def create_qps(self):
+        qp_init_attr = self.create_qp_init_attr()
+        qp_attr = self.create_qp_attr()
         qp_attr.qkey = self.UD_QKEY
         qp_attr.pkey_index = self.UD_PKEY_INDEX
-        self.qp = QP(self.pd, qp_init_attr, qp_attr)
+        for _ in range(self.qp_count):
+            qp = QP(self.pd, qp_init_attr, qp_attr)
+            self.qps.append(qp)
+            self.qps_num.append(qp.qp_num)
+            self.psns.append(random.getrandbits(24))
 
-    def pre_run(self, rpsn, rqpn):
-        self.rqpn = rqpn
-        self.rpsn = rpsn
+    def pre_run(self, rpsns, rqps_num):
+        self.rpsns = rpsns
+        self.rqps_num = rqps_num
 
 
 class XRCResources(TrafficResources):
@@ -409,23 +452,18 @@ class XRCResources(TrafficResources):
         self.temp_file = None
         self.xrcd_fd = -1
         self.xrcd = None
-        self.srq = None
-        self.qp_count = qp_count
         self.sqp_lst = []
         self.rqp_lst = []
-        self.qps_num = []
-        self.psns = []
-        self.rqps_num = None
-        self.rpsns = None
-        super(XRCResources, self).__init__(dev_name, ib_port, gid_index)
+        super(XRCResources, self).__init__(dev_name, ib_port, gid_index,
+                                           qp_count=qp_count)
 
     def close(self):
         os.close(self.xrcd_fd)
         self.temp_file.close()
 
-    def create_qp(self):
+    def create_qps(self):
         """
-        Initializes self.qp with an XRC SEND/RECV QP.
+        Initializes self.qps with an XRC SEND/RECV QPs.
         :return: None
         """
         qp_attr = QPAttr(port_num=self.ib_port)

--- a/tests/test_cq_events.py
+++ b/tests/test_cq_events.py
@@ -41,8 +41,8 @@ class CqEventsTestCase(RDMATestCase):
             if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Create qp with attrs {} is not supported'.format(qp_type))
             raise ex
-        client.pre_run(server.psn, server.qpn)
-        server.pre_run(client.psn, client.qpn)
+        client.pre_run(server.psns, server.qps_num)
+        server.pre_run(client.psns, client.qps_num)
         return client, server
 
     def test_cq_events_ud(self):

--- a/tests/test_cqex.py
+++ b/tests/test_cqex.py
@@ -55,22 +55,12 @@ class CqExTestCase(RDMATestCase):
         self.qp_dict = {'ud': CqExUD, 'rc': CqExRC, 'xrc': CqExXRC}
 
     def create_players(self, qp_type):
-        try:
-            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest(f'Create player with {qp_type} is not supported')
-
-        if qp_type == 'xrc':
-            client.pre_run(server.psns, server.qps_num)
-            server.pre_run(client.psns, client.qps_num)
-        else:
-            client.pre_run(server.psn, server.qpn)
-            server.pre_run(client.psn, client.qpn)
+        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                       self.gid_index)
+        client.pre_run(server.psns, server.qps_num)
+        server.pre_run(client.psns, client.qps_num)
         return client, server
 
     def test_ud_traffic_cq_ex(self):

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -185,20 +185,11 @@ class MWRC(RCResources):
                 raise unittest.SkipTest('Reg MR with MW access is not supported')
             raise ex
 
-    def create_qp(self):
-        qp_caps = QPCap(max_recv_wr=self.num_msgs)
-        qp_init_attr = QPInitAttr(qp_type=e.IBV_QPT_RC, scq=self.cq,
-                                  rcq=self.cq, cap=qp_caps)
+    def create_qp_attr(self):
         qp_attr = QPAttr(port_num=self.ib_port)
         qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
         qp_attr.qp_access_flags = qp_access
-        try:
-            self.qp = QP(self.pd, qp_init_attr, qp_attr)
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create RC QP is not supported')
-            raise ex
-
+        return qp_attr
 
 
 class MWTest(RDMATestCase):
@@ -221,8 +212,8 @@ class MWTest(RDMATestCase):
         """
         self.client = resource(**self.dev_info, **resource_arg)
         self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psn, self.server.qpn)
-        self.server.pre_run(self.client.psn, self.client.qpn)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
 
     def tearDown(self):
         if self.server:

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -51,6 +51,17 @@ class OdpRC(RCResources):
                      implicit=self.is_implicit)
 
 
+class OdpSrqRc(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index, qp_count=1):
+        super(OdpSrqRc, self).__init__(dev_name=dev_name, ib_port=ib_port,
+                                       gid_index=gid_index, with_srq=True,
+                                       qp_count=qp_count)
+
+    @requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
+    def create_mr(self):
+        self.mr = create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+
+
 class OdpXRC(XRCResources):
     @requires_odp('xrc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
     def create_mr(self):
@@ -110,6 +121,10 @@ class OdpTestCase(RDMATestCase):
     def test_odp_xrc_traffic(self):
         client, server = self.create_players(OdpXRC)
         xrc_traffic(client, server)
+
+    def test_odp_rc_srq_traffic(self):
+        client, server = self.create_players(OdpSrqRc, qp_count=2)
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     @requires_huge_pages()
     def test_odp_rc_huge_traffic(self):

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -74,10 +74,8 @@ class OdpTestCase(RDMATestCase):
         """
         client = resource(**self.dev_info, **resource_arg)
         server = resource(**self.dev_info, **resource_arg)
-        psn = 'psns' if resource == OdpXRC else 'psn'
-        qpn = 'qps_num' if resource == OdpXRC else 'qpn'
-        client.pre_run(getattr(server, psn), getattr(server, qpn))
-        server.pre_run(getattr(client, psn), getattr(client, qpn))
+        client.pre_run(server.psns, server.qps_num)
+        server.pre_run(client.psns, client.qps_num)
         return client, server
 
     def tearDown(self):

--- a/tests/test_relaxed_ordering.py
+++ b/tests/test_relaxed_ordering.py
@@ -43,12 +43,8 @@ class RoTestCase(RDMATestCase):
            if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Create player with attrs {} is not supported'.format(qp_type))
            raise ex
-        if qp_type == 'xrc':
-            client.pre_run(server.psns, server.qps_num)
-            server.pre_run(client.psns, client.qps_num)
-        else:
-            client.pre_run(server.psn, server.qpn)
-            server.pre_run(client.psn, client.qpn)
+        client.pre_run(server.psns, server.qps_num)
+        server.pre_run(client.psns, client.qps_num)
         return client, server
 
     def test_ro_rc_traffic(self):

--- a/tests/test_shared_pd.py
+++ b/tests/test_shared_pd.py
@@ -85,8 +85,8 @@ class SharedPDTestCase(RDMATestCase):
             **setup_params)
         self.imported_res.append(server_import)
         client = QpExRCRDMAWrite(**setup_params)
-        client.pre_run(server_import.psn, server_import.qpn)
-        server_import.pre_run(client.psn, client.qpn)
+        client.pre_run(server_import.psns, server_import.qps_num)
+        server_import.pre_run(client.psns, client.qps_num)
         client.rkey = server_import.mr.rkey
         server_import.rkey = client.mr.rkey
         client.raddr = server_import.mr.buf

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -322,51 +322,52 @@ def get_global_ah(agr_obj, gid_index, port):
 
 
 def xrc_post_send(agr_obj, qp_num, send_object, gid_index, port, send_op=None):
-    agr_obj.qp = agr_obj.sqp_lst[qp_num]
+    agr_obj.qps = agr_obj.sqp_lst
     if send_op:
         post_send_ex(agr_obj, send_object, gid_index, port, send_op)
     else:
         post_send(agr_obj, send_object, gid_index, port)
 
 
-def post_send_ex(agr_obj, send_object, gid_index, port, send_op=None):
-    qp_type = agr_obj.qp.qp_type
-    agr_obj.qp.wr_start()
-    agr_obj.qp.wr_id = 0x123
-    agr_obj.qp.wr_flags = e.IBV_SEND_SIGNALED
+def post_send_ex(agr_obj, send_object, gid_index, port, send_op=None, qp_idx=0):
+    qp = agr_obj.qps[qp_idx]
+    qp_type = qp.qp_type
+    qp.wr_start()
+    qp.wr_id = 0x123
+    qp.wr_flags = e.IBV_SEND_SIGNALED
     if send_op == e.IBV_QP_EX_WITH_SEND:
-        agr_obj.qp.wr_send()
+        qp.wr_send()
     elif send_op == e.IBV_QP_EX_WITH_RDMA_WRITE:
-        agr_obj.qp.wr_rdma_write(agr_obj.rkey, agr_obj.raddr)
+        qp.wr_rdma_write(agr_obj.rkey, agr_obj.raddr)
     elif send_op == e.IBV_QP_EX_WITH_SEND_WITH_IMM:
-        agr_obj.qp.wr_send_imm(IMM_DATA)
+        qp.wr_send_imm(IMM_DATA)
     elif send_op == e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM:
-        agr_obj.qp.wr_rdma_write_imm(agr_obj.rkey, agr_obj.raddr, IMM_DATA)
+        qp.wr_rdma_write_imm(agr_obj.rkey, agr_obj.raddr, IMM_DATA)
     elif send_op == e.IBV_QP_EX_WITH_RDMA_READ:
-        agr_obj.qp.wr_rdma_read(agr_obj.rkey, agr_obj.raddr)
+        qp.wr_rdma_read(agr_obj.rkey, agr_obj.raddr)
     elif send_op == e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP:
         # We're checking the returned value (remote's content), so cmp/swp
         # values are of no importance.
-        agr_obj.qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr, 42, 43)
+        qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr, 42, 43)
     elif send_op == e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD:
-        agr_obj.qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr, 1)
+        qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr, 1)
     elif send_op == e.IBV_QP_EX_WITH_BIND_MW:
         bind_info = MWBindInfo(agr_obj.mr, agr_obj.mr.buf, agr_obj.mr.rkey,
                                e.IBV_ACCESS_REMOTE_WRITE)
         mw = MW(agr_obj.pd, mw_type=e.IBV_MW_TYPE_2)
         # A new rkey is needed to be set into bind_info, modify rkey
-        agr_obj.qp.wr_bind_mw(mw, agr_obj.mr.rkey + 12, bind_info)
-        agr_obj.qp.wr_send()
+        qp.wr_bind_mw(mw, agr_obj.mr.rkey + 12, bind_info)
+        qp.wr_send()
     if qp_type == e.IBV_QPT_UD:
         ah = get_global_ah(agr_obj, gid_index, port)
-        agr_obj.qp.wr_set_ud_addr(ah, agr_obj.rqpn, agr_obj.UD_QKEY)
+        qp.wr_set_ud_addr(ah, agr_obj.rqps_num[qp_idx], agr_obj.UD_QKEY)
     if qp_type == e.IBV_QPT_XRC_SEND:
-        agr_obj.qp.wr_set_xrc_srqn(agr_obj.remote_srqn)
-    agr_obj.qp.wr_set_sge(send_object)
-    agr_obj.qp.wr_complete()
+        qp.wr_set_xrc_srqn(agr_obj.remote_srqn)
+    qp.wr_set_sge(send_object)
+    qp.wr_complete()
 
 
-def post_send(agr_obj, send_wr, gid_index, port):
+def post_send(agr_obj, send_wr, gid_index, port, qp_idx=0):
     """
     Post a single send WR to the QP. Post_send's second parameter (send bad wr)
     is ignored for simplicity. For UD traffic an address vector is added as
@@ -375,26 +376,28 @@ def post_send(agr_obj, send_wr, gid_index, port):
     :param send_wr: Send work request to post send
     :param gid_index: Local gid index
     :param port: IB port number
+    :param qp_idx: QP index to use
     :return: None
     """
     qp_type = agr_obj.qp.qp_type
     if qp_type == e.IBV_QPT_UD:
         ah = get_global_ah(agr_obj, gid_index, port)
-        send_wr.set_wr_ud(ah, agr_obj.rqpn, agr_obj.UD_QKEY)
-    agr_obj.qp.post_send(send_wr, None)
+        send_wr.set_wr_ud(ah, agr_obj.rqps_num[qp_idx], agr_obj.UD_QKEY)
+    agr_obj.qps[qp_idx].post_send(send_wr, None)
 
 
-def post_recv(qp, recv_wr, num_wqes=1):
+def post_recv(agr_obj, recv_wr, qp_idx=0 ,num_wqes=1):
     """
     Call the QP's post_recv() method <num_wqes> times. Post_recv's second
     parameter (recv bad wr) is ignored for simplicity.
-    :param qp: QP which posts receive work request
     :param recv_wr: Receive work request to post
+    :param qp_idx: QP index which posts receive work request
     :param num_wqes: Number of WQEs to post
     :return: None
     """
+    receive_queue = agr_obj.srq if agr_obj.srq else agr_obj.qps[qp_idx]
     for _ in range(num_wqes):
-        qp.post_recv(recv_wr, None)
+        receive_queue.post_recv(recv_wr, None)
 
 
 def poll_cq(cq, count=1, data=None):
@@ -492,10 +495,10 @@ def validate(received_str, is_server, msg_size):
                 format(exp=expected_str, rcv=received_str))
 
 
-def send(agr_obj, send_object, gid_index, port, send_op=None, new_send=False):
+def send(agr_obj, send_object, gid_index, port, send_op=None, new_send=False, qp_idx=0):
     if new_send:
-        return post_send_ex(agr_obj, send_object, gid_index, port, send_op)
-    return post_send(agr_obj, send_object, gid_index, port)
+        return post_send_ex(agr_obj, send_object, gid_index, port, send_op, qp_idx)
+    return post_send(agr_obj, send_object, gid_index, port, qp_idx)
 
 
 def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
@@ -520,30 +523,41 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
         imm_data = None
     s_recv_wr = get_recv_wr(server)
     c_recv_wr = get_recv_wr(client)
-    post_recv(client.qp, c_recv_wr, client.num_msgs)
-    post_recv(server.qp, s_recv_wr, server.num_msgs)
+    for qp_idx in range(server.qp_count):
+        # prepare the receive queue with RecvWR
+        post_recv(client, c_recv_wr, qp_idx=qp_idx)
+        post_recv(server, s_recv_wr, qp_idx=qp_idx)
     read_offset = GRH_SIZE if client.qp.qp_type == e.IBV_QPT_UD else 0
     for _ in range(iters):
-        c_send_wr, c_sg = get_send_elements(client, False)
-        if client.use_mr_prefetch:
-            prefetch_mrs(client, [c_sg])
-        c_send_object = c_sg if send_op else c_send_wr
-        send(client, c_send_object, gid_idx, port, send_op, new_send)
-        poll(client.cq)
-        poll(server.cq, data=imm_data)
-        post_recv(server.qp, s_recv_wr)
-        msg_received = server.mr.read(server.msg_size, read_offset)
-        validate(msg_received, True, server.msg_size)
-        s_send_wr, s_sg = get_send_elements(server, True)
-        if server.use_mr_prefetch:
-            prefetch_mrs(server, [s_sg])
-        s_send_object = s_sg if send_op else s_send_wr
-        send(server, s_send_object, gid_idx, port, send_op, new_send)
-        poll(server.cq)
-        poll(client.cq, data=imm_data)
-        post_recv(client.qp, c_recv_wr)
-        msg_received = client.mr.read(client.msg_size, read_offset)
-        validate(msg_received, False, client.msg_size)
+        for qp_idx in range(server.qp_count):
+            c_send_wr, c_sg = get_send_elements(client, False)
+            if client.use_mr_prefetch:
+                flags = e._IBV_ADVISE_MR_FLAG_FLUSH
+                if client.use_mr_prefetch == 'async':
+                    flags = 0
+                prefetch_mrs(client, [c_sg], flags=flags)
+            c_send_object = c_sg if send_op else c_send_wr
+            send(client, c_send_object, gid_idx, port, send_op, new_send,
+                 qp_idx)
+            poll(client.cq)
+            poll(server.cq, data=imm_data)
+            post_recv(server, s_recv_wr, qp_idx=qp_idx)
+            msg_received = server.mr.read(server.msg_size, read_offset)
+            validate(msg_received, True, server.msg_size)
+            s_send_wr, s_sg = get_send_elements(server, True)
+            if server.use_mr_prefetch:
+                flags = e._IBV_ADVISE_MR_FLAG_FLUSH
+                if server.use_mr_prefetch == 'async':
+                    flags = 0
+                prefetch_mrs(server, [s_sg], flags=flags)
+            s_send_object = s_sg if send_op else s_send_wr
+            send(server, s_send_object, gid_idx, port, send_op, new_send,
+                 qp_idx)
+            poll(server.cq)
+            poll(client.cq, data=imm_data)
+            post_recv(client, c_recv_wr, qp_idx=qp_idx)
+            msg_received = client.mr.read(client.msg_size, read_offset)
+            validate(msg_received, False, client.msg_size)
 
 
 def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
@@ -611,8 +625,8 @@ def xrc_traffic(client, server, is_cq_ex=False, send_op=None):
     client.remote_srqn = server.srq.get_srq_num()
     s_recv_wr = get_recv_wr(server)
     c_recv_wr = get_recv_wr(client)
-    post_recv(client.srq, c_recv_wr, client.qp_count*client.num_msgs)
-    post_recv(server.srq, s_recv_wr, server.qp_count*server.num_msgs)
+    post_recv(client, c_recv_wr, num_wqes=client.qp_count*client.num_msgs)
+    post_recv(server, s_recv_wr, num_wqes=server.qp_count*server.num_msgs)
     # Using the new post send API, we need the SGE, not the SendWR
     send_element_idx = 1 if send_op else 0
     for _ in range(client.num_msgs):


### PR DESCRIPTION
This series supports the creation and usage of multiple QPs with SRQ in the rdma-core tests.
Up until now, each basic traffic resource (that inherits from the TrafficResources class) was able to create one QP. With this extension, it would be able to choose the number of QPs to be created and used for traffic.
In addition, a SRQ test that uses multiple QPs was added to the ODP test cases.