### PR TITLE
tests: Verify max_pkeys only for CA

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -103,7 +103,8 @@ class DeviceTest(PyverbsAPITestCase):
         assert attr.max_cqe > 0
         assert attr.max_mr > 0
         assert attr.max_pd > 0
-        assert attr.max_pkeys > 0
+        if device.node_type == e.IBV_NODE_CA:
+            assert attr.max_pkeys > 0
 
     def test_query_device_ex(self):
         """


### PR DESCRIPTION
As max_pkeys attr is not required by all providers, verify it only when
the node type is CA.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>