### PR TITLE
mlx5: DR, enhance the device memory usage

### DIFF
--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -220,6 +220,9 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->hdr_modify_icm_addr = DEVX_GET64(query_hca_cap_out, out,
 					       capability.device_mem_cap.
 					       header_modify_sw_icm_start_address);
+	caps->log_modify_hdr_icm_size = DEVX_GET(query_hca_cap_out, out,
+						 capability.device_mem_cap.log_header_modify_sw_icm_size);
+
 	/* RoCE caps */
 	if (roce) {
 		DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -271,7 +271,10 @@ static int dr_domain_check_icm_memory_caps(struct mlx5dv_dr_domain *dmn)
 		return errno;
 	}
 
-	dmn->info.max_log_action_icm_sz = DR_CHUNK_SIZE_4K;
+	dmn->info.max_log_action_icm_sz = min_t(uint32_t,
+						DR_CHUNK_SIZE_1024K,
+						dmn->info.caps.log_modify_hdr_icm_size
+						- DR_MODIFY_ACTION_LOG_SIZE);
 
 	if (dmn->info.caps.log_icm_size < DR_CHUNK_SIZE_1024K +
 	    DR_STE_LOG_SIZE) {

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -337,7 +337,7 @@ static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
 		}
 
 		if ((pool->dmn->flags & DR_DOMAIN_FLAG_MEMORY_RECLAIM) &&
-		    pool->icm_type == DR_ICM_TYPE_STE && !buddy->used_memory)
+		    !buddy->used_memory)
 			dr_icm_buddy_destroy(buddy);
 	}
 

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -314,7 +314,7 @@ static bool dr_icm_pool_is_sync_required(struct dr_icm_pool *pool)
 	return false;
 }
 
-static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
+static int dr_icm_pool_sync_pool_buddies(struct dr_icm_pool *pool)
 {
 	struct dr_icm_buddy_mem *buddy, *tmp_buddy;
 	int err;
@@ -342,6 +342,17 @@ static int dr_icm_pool_sync_all_buddy_pools(struct dr_icm_pool *pool)
 	}
 
 	return 0;
+}
+
+int dr_icm_pool_sync_pool(struct dr_icm_pool *pool)
+{
+	int ret;
+
+	pthread_mutex_lock(&pool->mutex);
+	ret = dr_icm_pool_sync_pool_buddies(pool);
+	pthread_mutex_unlock(&pool->mutex);
+
+	return ret;
 }
 
 static int dr_icm_handle_buddies_get_mem(struct dr_icm_pool *pool,
@@ -433,7 +444,7 @@ void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 
 	/* Check if we have chunks that are waiting for sync-ste */
 	if (dr_icm_pool_is_sync_required(buddy->pool))
-		dr_icm_pool_sync_all_buddy_pools(buddy->pool);
+		dr_icm_pool_sync_pool_buddies(buddy->pool);
 
 	pthread_mutex_unlock(&buddy->pool->mutex);
 }

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -156,6 +156,8 @@ Default behavior: Forward packet to eSwitch manager vport.
 
 **MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW**: clear the steering HW cache to enforce next packet hits the latest rules, in addition to the SW SYNC handling.
 
+**MLX5DV_DR_DOMAIN_SYNC_FLAGS_MEM**: sync device memory to free cached memory.
+
 
 *mlx5dv_dr_domain_set_reclaim_device_memory()* is used to enable the reclaiming of device memory back to the system when not in use, by default this feature is disabled.
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -193,7 +193,9 @@ struct mlx5_ifc_device_mem_cap_bits {
 
 	u8         steering_sw_icm_start_address[0x40];
 
-	u8         reserved_at_100[0x12];
+	u8         reserved_at_100[0x8];
+	u8	   log_header_modify_sw_icm_size[0x8];
+	u8	   reserved_at_110[0x2];
 	u8         log_sw_icm_alloc_granularity[0x6];
 	u8         log_steering_sw_icm_size[0x8];
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1441,6 +1441,7 @@ enum mlx5dv_dr_domain_type {
 enum mlx5dv_dr_domain_sync_flags {
 	MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW		= 1 << 0,
 	MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW		= 1 << 1,
+	MLX5DV_DR_DOMAIN_SYNC_FLAGS_MEM		= 1 << 2,
 };
 
 struct mlx5dv_dr_flow_meter_attr {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -981,6 +981,7 @@ static inline bool dr_is_root_table(struct mlx5dv_dr_table *tbl)
 struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,
 				       enum dr_icm_type icm_type);
 void dr_icm_pool_destroy(struct dr_icm_pool *pool);
+int dr_icm_pool_sync_pool(struct dr_icm_pool *pool);
 
 struct dr_icm_chunk *dr_icm_alloc_chunk(struct dr_icm_pool *pool,
 					enum dr_icm_chunk_size chunk_size);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -109,6 +109,7 @@ enum {
 	DR_STE_SIZE_CTRL	= 32,
 	DR_STE_SIZE_TAG		= 16,
 	DR_STE_SIZE_MASK	= 16,
+	DR_STE_LOG_SIZE		= 6,
 };
 
 enum {
@@ -117,6 +118,7 @@ enum {
 
 enum {
 	DR_MODIFY_ACTION_SIZE	= 8,
+	DR_MODIFY_ACTION_LOG_SIZE	= 3,
 };
 
 enum dr_matcher_criteria {
@@ -615,6 +617,7 @@ struct dr_devx_caps {
 	uint64_t			esw_rx_drop_address;
 	uint64_t			esw_tx_drop_address;
 	uint32_t			log_icm_size;
+	uint8_t				log_modify_hdr_icm_size;
 	uint64_t			hdr_modify_icm_addr;
 	uint32_t			flex_protocols;
 	uint8_t				flex_parser_id_icmp_dw0;


### PR DESCRIPTION
This series enhances the device memory usage by increasing ICM action memory allocation size up-to 8MB based on capabilities.

In addition, it enables on demand sync to free the cached memory for both STE and actions.