### PR TITLE
More efadv pyverbs tests

### DIFF
--- a/pyverbs/providers/efa/efadv.pxd
+++ b/pyverbs/providers/efa/efadv.pxd
@@ -5,6 +5,7 @@
 
 cimport pyverbs.providers.efa.libefa as dv
 
+from pyverbs.addr cimport AH
 from pyverbs.base cimport PyverbsObject
 from pyverbs.device cimport Context
 
@@ -15,3 +16,11 @@ cdef class EfaContext(Context):
 
 cdef class EfaDVDeviceAttr(PyverbsObject):
     cdef dv.efadv_device_attr dv
+
+
+cdef class EfaAH(AH):
+    pass
+
+
+cdef class EfaDVAHAttr(PyverbsObject):
+    cdef dv.efadv_ah_attr ah_attr

--- a/pyverbs/providers/efa/efadv.pxd
+++ b/pyverbs/providers/efa/efadv.pxd
@@ -8,6 +8,7 @@ cimport pyverbs.providers.efa.libefa as dv
 from pyverbs.addr cimport AH
 from pyverbs.base cimport PyverbsObject
 from pyverbs.device cimport Context
+from pyverbs.qp cimport QP
 
 
 cdef class EfaContext(Context):
@@ -24,3 +25,7 @@ cdef class EfaAH(AH):
 
 cdef class EfaDVAHAttr(PyverbsObject):
     cdef dv.efadv_ah_attr ah_attr
+
+
+cdef class SRDQP(QP):
+    pass

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -100,3 +100,34 @@ cdef class EfaDVDeviceAttr(PyverbsObject):
             print_format.format('Inline buffer size', self.dv.inline_buf_size) + \
             print_format.format('Device Capabilities', dev_cap_to_str(self.dv.device_caps)) + \
             print_format.format('Max RDMA Size', self.dv.max_rdma_size)
+
+
+cdef class EfaDVAHAttr(PyverbsObject):
+    """
+    Represents efadv_ah_attr struct
+    """
+    @property
+    def comp_mask(self):
+        return self.ah_attr.comp_mask
+
+    @property
+    def ahn(self):
+        return self.ah_attr.ahn
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return print_format.format('comp_mask', self.ah_attr.comp_mask) + \
+            print_format.format('ahn', self.ah_attr.ahn)
+
+
+cdef class EfaAH(AH):
+    def query_efa_ah(self):
+        """
+        Queries the provider for EFA specific AH attributes.
+        :return: An EfaDVAHAttr containing the attributes.
+        """
+        ah_attr = EfaDVAHAttr()
+        err = dv.efadv_query_ah(self.ah, &ah_attr.ah_attr, sizeof(ah_attr.ah_attr))
+        if err:
+            raise PyverbsRDMAError('Failed to query efa ah', err)
+        return ah_attr

--- a/pyverbs/providers/efa/efadv_enums.pxd
+++ b/pyverbs/providers/efa/efadv_enums.pxd
@@ -8,3 +8,6 @@ cdef extern from 'infiniband/efadv.h':
     cpdef enum:
         EFADV_DEVICE_ATTR_CAPS_RDMA_READ
         EFADV_DEVICE_ATTR_CAPS_RNR_RETRY
+
+    cpdef enum:
+        EFADV_QP_DRIVER_TYPE_SRD

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -1,21 +1,22 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
 
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 cimport pyverbs.libibverbs as v
 
 
 cdef extern from 'infiniband/efadv.h':
 
     cdef struct efadv_device_attr:
-        unsigned long           comp_mask
-        unsigned int            max_sq_wr
-        unsigned int            max_rq_wr
-        unsigned short          max_sq_sge
-        unsigned short          max_rq_sge
-        unsigned short          inline_buf_size
-        unsigned char           reserved[2]
-        unsigned int            device_caps
-        unsigned int            max_rdma_size
+        uint64_t comp_mask;
+        uint32_t max_sq_wr;
+        uint32_t max_rq_wr;
+        uint16_t max_sq_sge;
+        uint16_t max_rq_sge;
+        uint16_t inline_buf_size;
+        uint8_t reserved[2];
+        uint32_t device_caps;
+        uint32_t max_rdma_size;
 
     int efadv_query_device(v.ibv_context *ibvctx, efadv_device_attr *attrs,
-                           unsigned int inlen)
+                           uint32_t inlen)

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -18,5 +18,12 @@ cdef extern from 'infiniband/efadv.h':
         uint32_t device_caps;
         uint32_t max_rdma_size;
 
+    cdef struct efadv_ah_attr:
+        uint64_t comp_mask;
+        uint16_t ahn;
+        uint8_t reserved[6];
+
     int efadv_query_device(v.ibv_context *ibvctx, efadv_device_attr *attrs,
                            uint32_t inlen)
+    int efadv_query_ah(v.ibv_ah *ibvah, efadv_ah_attr *attr,
+                       uint32_t inlen)

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -27,3 +27,5 @@ cdef extern from 'infiniband/efadv.h':
                            uint32_t inlen)
     int efadv_query_ah(v.ibv_ah *ibvah, efadv_ah_attr *attr,
                        uint32_t inlen)
+    v.ibv_qp *efadv_create_driver_qp(v.ibv_pd *ibvpd, v.ibv_qp_init_attr *attr,
+                                     uint32_t driver_qp_type)

--- a/tests/base.py
+++ b/tests/base.py
@@ -339,7 +339,12 @@ class TrafficResources(BaseResources):
 
     def create_srq(self):
         srq_init_attr = self.create_srq_init_attr()
-        self.srq = SRQ(self.pd, srq_init_attr)
+        try:
+            self.srq = SRQ(self.pd, srq_init_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create SRQ is not supported')
+            raise ex
 
     def pre_run(self, rpsns, rqps_num):
         """

--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -9,6 +9,7 @@ from pyverbs.addr import GlobalRoute, AHAttr, AH
 from tests.base import PyverbsAPITestCase
 import pyverbs.enums as e
 from pyverbs.pd import PD
+import tests.utils as u
 
 
 class AHTest(PyverbsAPITestCase):
@@ -26,7 +27,7 @@ class AHTest(PyverbsAPITestCase):
                 state = ctx.query_port(port_num).state
                 if state != e.IBV_PORT_ACTIVE and state != e.IBV_PORT_INIT:
                     continue
-                gr = get_global_route(ctx, port_num=port_num)
+                gr = u.get_global_route(ctx, port_num=port_num)
                 ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
                 try:
                     with AH(pd, attr=ah_attr):
@@ -77,7 +78,7 @@ class AHTest(PyverbsAPITestCase):
                 state = ctx.query_port(port_num).state
                 if state != e.IBV_PORT_ACTIVE and state != e.IBV_PORT_INIT:
                     continue
-                gr = get_global_route(ctx)
+                gr = u.get_global_route(ctx)
                 ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
                 try:
                     with AH(pd, attr=ah_attr) as ah:
@@ -89,18 +90,3 @@ class AHTest(PyverbsAPITestCase):
                     raise ex
         if done == 0:
             raise unittest.SkipTest('No port is up, can\'t create AH')
-
-
-def get_global_route(ctx, gid_index=0, port_num=1):
-    """
-    Queries the provided Context's gid <gid_index> and creates a GlobalRoute
-    object with sgid_index <gid_index> and the queried GID as dgid.
-    :param ctx: Context object to query
-    :param gid_index: GID index to query and use. Default: 0, as it's always
-                      valid
-    :param port_num: Number of the port to query. Default: 1
-    :return: GlobalRoute object
-    """
-    gid = ctx.query_gid(port_num, gid_index)
-    gr = GlobalRoute(dgid=gid, sgid_index=gid_index)
-    return gr

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -7,6 +7,8 @@ Test module for efa direct-verbs.
 import errno
 from pyverbs.addr import AHAttr
 from pyverbs.base import PyverbsRDMAError
+from pyverbs.cq import CQ
+import pyverbs.enums as e
 from pyverbs.pd import PD
 import pyverbs.providers.efa.efadv as efa
 from tests.base import PyverbsAPITestCase
@@ -55,3 +57,24 @@ class EfaAHTest(PyverbsAPITestCase):
                 if ex.error_code == errno.EOPNOTSUPP:
                     raise unittest.SkipTest('Not supported on non EFA devices')
                 raise ex
+
+
+class EfaQPTest(PyverbsAPITestCase):
+    """
+    Test SRD QP class
+    """
+    def test_efadv_create_driver_qp(self):
+        """
+        Test efadv_create_driver_qp()
+        """
+        for ctx, attr, attr_ex in self.devices:
+            with PD(ctx) as pd:
+                with CQ(ctx, 100) as cq:
+                    qia = u.get_qp_init_attr(cq, attr)
+                    qia.qp_type = e.IBV_QPT_DRIVER
+                    try:
+                        qp = efa.SRDQP(pd, qia)
+                    except PyverbsRDMAError as ex:
+                        if ex.error_code == errno.EOPNOTSUPP:
+                            raise unittest.SkipTest("Create SRD QP is not supported")
+                        raise ex

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -11,7 +11,7 @@ from tests.base import PyverbsAPITestCase
 import unittest
 
 
-class EfaDvTest(PyverbsAPITestCase):
+class EfaQueryDeviceTest(PyverbsAPITestCase):
     """
     Test various functionalities of the direct verbs class.
     """

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -5,9 +5,12 @@ Test module for efa direct-verbs.
 """
 
 import errno
+from pyverbs.addr import AHAttr
 from pyverbs.base import PyverbsRDMAError
+from pyverbs.pd import PD
 import pyverbs.providers.efa.efadv as efa
 from tests.base import PyverbsAPITestCase
+import tests.utils as u
 import unittest
 
 
@@ -29,3 +32,26 @@ class EfaQueryDeviceTest(PyverbsAPITestCase):
                     if ex.error_code == errno.EOPNOTSUPP:
                         raise unittest.SkipTest('Not supported on non EFA devices')
                     raise ex
+
+
+class EfaAHTest(PyverbsAPITestCase):
+    """
+    Test functionality of the EfaAH class
+    """
+    def test_efadv_query_ah(self):
+        """
+        Test efadv_query_ah()
+        """
+        for ctx, attr, attr_ex in self.devices:
+            pd = PD(ctx)
+            try:
+                gr = u.get_global_route(ctx, port_num=1)
+                ah_attr = AHAttr(gr=gr, is_global=1, port_num=1)
+                ah = efa.EfaAH(pd, attr=ah_attr)
+                query_ah_attr = ah.query_efa_ah()
+                if self.config['verbosity']:
+                    print(f'\n{query_ah_attr}')
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Not supported on non EFA devices')
+                raise ex

--- a/tests/test_qp.py
+++ b/tests/test_qp.py
@@ -59,7 +59,7 @@ class QPTest(PyverbsAPITestCase):
                         qia = get_qp_init_attr_ex(cq, pd, attr, attr_ex, qp_type)
                         creator = ctx
                     else:
-                        qia = get_qp_init_attr(cq, attr)
+                        qia = u.get_qp_init_attr(cq, attr)
                         qia.qp_type = qp_type
                         creator = pd
 
@@ -197,7 +197,7 @@ class QPTest(PyverbsAPITestCase):
                             raise unittest.SkipTest('To Create RAW QP must be done by root on Ethernet link layer')
 
                     # Legacy QP
-                    qia = get_qp_init_attr(cq, attr)
+                    qia = u.get_qp_init_attr(cq, attr)
                     qia.qp_type = qp_type
                     caps = qia.cap
                     qp = self.create_qp(pd, qia, False, False)
@@ -249,7 +249,7 @@ class QPTest(PyverbsAPITestCase):
             with PD(ctx) as pd:
                 with CQ(ctx, 100, None, None, 0) as cq:
                     # Legacy QP
-                    qia = get_qp_init_attr(cq, attr)
+                    qia = u.get_qp_init_attr(cq, attr)
                     qia.qp_type = e.IBV_QPT_UD
                     qp = self.create_qp(pd, qia, False, False)
                     qa = QPAttr()
@@ -281,19 +281,6 @@ class QPTest(PyverbsAPITestCase):
                     qa.qp_state = e.IBV_QPS_RESET
                     qp.modify(qa, e.IBV_QP_STATE)
                     assert qp.qp_state == e.IBV_QPS_RESET, 'Extended QP, QP state is not as expected'
-
-
-def get_qp_init_attr(cq, attr):
-    """
-    Creates a QPInitAttr object with a QP type of the provided <qpts> array and
-    other random values.
-    :param cq: CQ to be used as send and receive CQ
-    :param attr: Device attributes for capability checks
-    :return: An initialized QPInitAttr object
-    """
-    qp_cap = u.random_qp_cap(attr)
-    sig = random.randint(0, 1)
-    return QPInitAttr(scq=cq, rcq=cq, cap=qp_cap, sq_sig_all=sig)
 
 
 def get_qp_init_attr_ex(cq, pd, attr, attr_ex, qpt):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -321,6 +321,21 @@ def get_global_ah(agr_obj, gid_index, port):
     return AH(agr_obj.pd, attr=ah_attr)
 
 
+def get_global_route(ctx, gid_index=0, port_num=1):
+    """
+    Queries the provided Context's gid <gid_index> and creates a GlobalRoute
+    object with sgid_index <gid_index> and the queried GID as dgid.
+    :param ctx: Context object to query
+    :param gid_index: GID index to query and use. Default: 0, as it's always
+                      valid
+    :param port_num: Number of the port to query. Default: 1
+    :return: GlobalRoute object
+    """
+    gid = ctx.query_gid(port_num, gid_index)
+    gr = GlobalRoute(dgid=gid, sgid_index=gid_index)
+    return gr
+
+
 def xrc_post_send(agr_obj, qp_num, send_object, gid_index, port, send_op=None):
     agr_obj.qps = agr_obj.sqp_lst
     if send_op:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,7 +13,7 @@ import os
 from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
 from pyverbs.addr import AHAttr, AH, GlobalRoute
 from pyverbs.wr import SGE, SendWR, RecvWR
-from pyverbs.qp import QPCap, QPInitAttrEx
+from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx
 from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.mr import MW, MWBindInfo
 from tests.base import XRCResources
@@ -237,6 +237,19 @@ def random_qp_init_attr_ex(attr_ex, attr, qpt=None):
         # TSO increases send WQE size, let's be on the safe side
         qia.cap.max_send_sge = 2
     return qia
+
+
+def get_qp_init_attr(cq, attr):
+    """
+    Creates a QPInitAttr object with a QP type of the provided <qpts> array and
+    other random values.
+    :param cq: CQ to be used as send and receive CQ
+    :param attr: Device attributes for capability checks
+    :return: An initialized QPInitAttr object
+    """
+    qp_cap = random_qp_cap(attr)
+    sig = random.randint(0, 1)
+    return QPInitAttr(scq=cq, rcq=cq, cap=qp_cap, sq_sig_all=sig)
 
 
 def wc_status_to_str(status):


### PR DESCRIPTION
This series contains a small fix to skip SRQ tests on unsupported devices and adds more efadv functionality to the testing infra.