### PR TITLE
 tests: Add more ODP tests

### DIFF
--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -23,19 +23,22 @@ class OdpUD(UDResources):
 
 class OdpRC(RCResources):
     def __init__(self, dev_name, ib_port, gid_index, is_huge=False,
-                 user_addr=None, use_mr_prefetch=None, is_implicit=False):
+                 user_addr=None, use_mr_prefetch=None, is_implicit=False,
+                 prefetch_advice=e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE):
         """
         Initialize an OdpRC object.
         :param dev_name: Device name to be used
         :param ib_port: IB port of the device to use
         :param gid_index: Which GID index to use
-        :param use_mr_prefetch: Describes the properties of the prefetch
-                                operation. The options are 'sync', 'async'
-                                and None to skip the prefetch operation.
         :param is_huge: If True, use huge pages for MR registration
         :param user_addr: The MR's buffer address. If None, the buffer will be
                           allocated by pyverbs.
+        :param use_mr_prefetch: Describes the properties of the prefetch
+                                operation. The options are 'sync', 'async'
+                                and None to skip the prefetch operation.
         :param is_implicit: If True, register implicit MR.
+        :param prefetch_advice: The advice of the prefetch request (ignored
+                                if use_mr_prefetch is None).
         """
         self.is_huge = is_huge
         self.user_addr = user_addr
@@ -43,6 +46,7 @@ class OdpRC(RCResources):
         super(OdpRC, self).__init__(dev_name=dev_name, ib_port=ib_port,
                                     gid_index=gid_index)
         self.use_mr_prefetch = use_mr_prefetch
+        self.prefetch_advice = prefetch_advice
 
     @requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
     def create_mr(self):
@@ -142,12 +146,18 @@ class OdpTestCase(RDMATestCase):
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_sync_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch='sync')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
+                       e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
+            client, server = self.create_players(OdpRC, use_mr_prefetch='sync',
+                                                 prefetch_advice=advice)
+            traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_async_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch='async')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
+                       e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
+            client, server = self.create_players(OdpRC, use_mr_prefetch='async',
+                                                 prefetch_advice=advice)
+            traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_implicit_sync_prefetch_rc_traffic(self):
         client, server = self.create_players(OdpRC, use_mr_prefetch='sync', is_implicit=True)

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -23,13 +23,15 @@ class OdpUD(UDResources):
 
 class OdpRC(RCResources):
     def __init__(self, dev_name, ib_port, gid_index, is_huge=False,
-                 user_addr=None, use_mr_prefetch=False, is_implicit=False):
+                 user_addr=None, use_mr_prefetch=None, is_implicit=False):
         """
         Initialize an OdpRC object.
         :param dev_name: Device name to be used
         :param ib_port: IB port of the device to use
         :param gid_index: Which GID index to use
-        :param use_mr_prefetch: If True, prefetch the MRs
+        :param use_mr_prefetch: Describes the properties of the prefetch
+                                operation. The options are 'sync', 'async'
+                                and None to skip the prefetch operation.
         :param is_huge: If True, use huge pages for MR registration
         :param user_addr: The MR's buffer address. If None, the buffer will be
                           allocated by pyverbs.
@@ -139,10 +141,18 @@ class OdpTestCase(RDMATestCase):
                                               user_addr=self.user_addr)
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
-    def test_odp_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch=True)
+    def test_odp_sync_prefetch_rc_traffic(self):
+        client, server = self.create_players(OdpRC, use_mr_prefetch='sync')
         traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
-    def test_odp_implicit_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch=True, is_implicit=True)
+    def test_odp_async_prefetch_rc_traffic(self):
+        client, server = self.create_players(OdpRC, use_mr_prefetch='async')
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+
+    def test_odp_implicit_sync_prefetch_rc_traffic(self):
+        client, server = self.create_players(OdpRC, use_mr_prefetch='sync', is_implicit=True)
+        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+
+    def test_odp_implicit_async_prefetch_rc_traffic(self):
+        client, server = self.create_players(OdpRC, use_mr_prefetch='async', is_implicit=True)
         traffic(client, server, self.iters, self.gid_index, self.ib_port)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -721,17 +721,22 @@ def huge_pages_supported():
             raise unittest.SkipTest('There are no huge pages of size 2M allocated')
 
 
-def prefetch_mrs(agr_obj, sg_list, advise=e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
+def prefetch_mrs(agr_obj, sg_list, advice=e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
                  flags=e._IBV_ADVISE_MR_FLAG_FLUSH):
     """
     Pre-fetch a range of an on-demand paging MR.
     :param agr_obj: Aggregation object which contains all resources necessary
     :param sg_list: SGE list
-    :param advise: The requested advise value
-    :param flags: Describes the properties of the advise operation
+    :param advice: The requested advice value
+    :param flags: Describes the properties of the advice operation
     :return: None
     """
-    agr_obj.pd.advise_mr(advise, flags, sg_list)
+    try:
+        agr_obj.pd.advise_mr(advice, flags, sg_list)
+    except PyverbsRDMAError as ex:
+        if ex.error_code == errno.EOPNOTSUPP:
+            raise unittest.SkipTest(f'Advise MR with flags ({flags}) and advice ({advice}) is not supported')
+        raise ex
 
 
 def is_eth(ctx, port_num):


### PR DESCRIPTION
This mini-series contains two commits that extend the ODP tests with implicit and explicit ODP MRs and more advice options.