### PR TITLE
tests: Skip test if multicast is not supported

### DIFF
--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -7,6 +7,7 @@ import os
 
 from tests.rdmacm_utils import  CMSyncConnection, CMAsyncConnection
 from pyverbs.pyverbs_error import PyverbsError
+from tests.utils import requires_mcast_support
 from tests.base import RDMATestCase
 import pyverbs.cm_enums as ce
 
@@ -148,11 +149,13 @@ class CMTestCase(RDMATestCase):
     def test_rdmacm_async_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection, self.rdmacm_traffic)
 
+    @requires_mcast_support()
     def test_rdmacm_async_multicast_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,
                                       self.rdmacm_multicast_traffic,
                                       port_space=ce.RDMA_PS_UDP)
 
+    @requires_mcast_support()
     def test_rdmacm_async_ex_multicast_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,
                                       self.rdmacm_multicast_traffic,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -671,6 +671,21 @@ def requires_root_on_eth(port_num=1):
     return outer
 
 
+def requires_mcast_support():
+    """
+    Check if the device support multicast
+    return: True if multicast is supported
+    """
+    def outer(func):
+        def inner(instance):
+            ctx = d.Context(name=instance.dev_name)
+            if ctx.query_device().max_mcast_grp == 0:
+                raise unittest.SkipTest('Multicast is not supported on this device')
+            return func(instance)
+        return inner
+    return outer
+
+
 def odp_supported(ctx, qp_type, required_odp_caps):
     """
     Check device ODP capabilities, support only send/recv so far.


### PR DESCRIPTION
Avoid test failure by skipping the test if multicast is not supported.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>