### PR TITLE
verbs: Prevent dontfork on ODP MR

### DIFF
--- a/libibverbs/cmd.c
+++ b/libibverbs/cmd.c
@@ -344,6 +344,7 @@ int ibv_cmd_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	vmr->ibv_mr.rkey    = resp->rkey;
 	vmr->ibv_mr.context = pd->context;
 	vmr->mr_type        = IBV_MR_TYPE_MR;
+	vmr->access = access;
 
 	return 0;
 }

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -86,6 +86,7 @@ enum ibv_mr_type {
 struct verbs_mr {
 	struct ibv_mr		ibv_mr;
 	enum ibv_mr_type        mr_type;
+	int access;
 };
 
 static inline struct verbs_mr *verbs_get_mr(struct ibv_mr *mr)


### PR DESCRIPTION
ODP is immune to the COW problem because it directly tracks the page tables.
As such prevents dontfork on ODP MR which might fail in case by the registration time there is still no physical memory mapping.