### PR TITLE
srp_daemon: Avoid extra permissions for the lock file

### DIFF
--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -142,7 +142,6 @@ static int check_process_uniqueness(struct config_t *conf)
 		return -1;
 	}
 
-	fchmod(fd, S_IRUSR|S_IRGRP|S_IROTH|S_IWUSR|S_IWGRP|S_IWOTH);
 	if (0 != lockf(fd, F_TLOCK, 0)) {
 		pr_err("failed to lock %s (errno: %d). possibly another "
 		       "srp_daemon is locking it\n", path, errno);


### PR DESCRIPTION
There is no need to create a world-writable lock file.
It's enough to have an RW permission for the file owner only.

Fixes: ee138ce1e40d ("Cause srp_daemon launch to fail if another srp_daemon is already working on the same HCA port.")
Signed-off-by: Sergey Gorenko <sergeygo@nvidia.com>
Reviewed-by: Max Gurtovoy <mgurtovoy@nvidia.com>
Reviewed-by: Bart Van Assche <bvanassche@acm.org>