### PR TITLE
mlx5: DR, Introduce an action which replicates a packet to multiple destinations

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -107,6 +107,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_query_qp_lag_port@MLX5_1.14 30
  mlx5dv_dr_action_create_dest_devx_tir@MLX5_1.15 31
  mlx5dv_dr_action_create_flow_sampler@MLX5_1.16 32
+ mlx5dv_dr_action_create_dest_array@MLX5_1.16 32
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -65,6 +65,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -77,6 +78,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
@@ -86,6 +88,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -95,6 +98,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -148,6 +152,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -159,6 +164,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
@@ -167,6 +173,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
@@ -175,6 +182,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
@@ -193,6 +201,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -203,6 +212,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
@@ -210,6 +220,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -221,6 +232,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
@@ -469,6 +481,16 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				attr.final_icm_addr = action->vport.caps->icm_address_tx;
 			}
 			break;
+		case DR_ACTION_TYP_DEST_ARRAY:
+			if (action->dest_array.dmn != dmn) {
+				dr_dbg(dmn, "Destination array belongs to a different domain\n");
+				goto out_invalid_arg;
+			}
+
+			attr.final_icm_addr = rx_rule ?
+				action->dest_array.rx_icm_addr :
+				action->dest_array.tx_icm_addr;
+			break;
 		default:
 			goto out_invalid_arg;
 		}
@@ -525,6 +547,15 @@ int dr_actions_build_attr(struct mlx5dv_dr_matcher *matcher,
 			}
 			attr[i].type = MLX5DV_FLOW_ACTION_DEST_DEVX;
 			attr[i].obj = actions[i]->dest_tbl->devx_obj;
+			break;
+		case DR_ACTION_TYP_DEST_ARRAY:
+			if (actions[i]->dest_array.dmn != dmn) {
+				dr_dbg(dmn, "Destination array belongs to a different domain\n");
+				errno = EINVAL;
+				return errno;
+			}
+			attr[i].type = MLX5DV_FLOW_ACTION_DEST_DEVX;
+			attr[i].obj = actions[i]->dest_array.devx_tbl->ft_dvo;
 			break;
 		case DR_ACTION_TYP_TNL_L2_TO_L2:
 		case DR_ACTION_TYP_L2_TO_TNL_L2:
@@ -1543,6 +1574,75 @@ struct mlx5dv_dr_action
 	return action;
 }
 
+static int
+dr_action_convert_to_fte_dest(struct mlx5dv_dr_domain *dmn,
+			      struct mlx5dv_dr_action *dest,
+			      struct mlx5dv_dr_action *dest_reformat,
+			      struct dr_devx_flow_fte_attr *fte_attr)
+{
+	struct dr_devx_flow_dest_info *dest_info =
+		&fte_attr->dest_arr[fte_attr->dest_size];
+
+	switch (dest->action_type) {
+	case DR_ACTION_TYP_MISS:
+		if (dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB)
+			goto err_exit;
+
+		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
+		dest_info->type = MLX5_FLOW_DEST_TYPE_VPORT;
+		break;
+	case DR_ACTION_TYP_VPORT:
+		if (dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB)
+			goto err_exit;
+
+		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
+		dest_info->type = MLX5_FLOW_DEST_TYPE_VPORT;
+		dest_info->vport_num = dest->vport.num;
+		break;
+	case DR_ACTION_TYP_QP:
+		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
+		dest_info->type = MLX5_FLOW_DEST_TYPE_TIR;
+
+		if (dest->dest_qp.is_qp)
+			dest_info->tir_num = to_mqp(dest->dest_qp.qp)->tirn;
+		else
+			dest_info->tir_num = dest->dest_qp.devx_tir->object_id;
+
+		break;
+	case DR_ACTION_TYP_CTR:
+		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_COUNT;
+		dest_info->type = MLX5_FLOW_DEST_TYPE_COUNTER;
+		dest_info->counter_id =
+			dest->ctr.devx_obj->object_id + dest->ctr.offset;
+		break;
+	default:
+		goto err_exit;
+	}
+
+	if (dest_reformat) {
+		switch (dest_reformat->action_type) {
+		case DR_ACTION_TYP_L2_TO_TNL_L2:
+		case DR_ACTION_TYP_L2_TO_TNL_L3:
+			if (dest_reformat->reformat.is_root_level)
+				goto err_exit;
+
+			fte_attr->extended_dest = true;
+			dest_info->has_reformat = true;
+			dest_info->reformat_id = dest_reformat->reformat.dvo->object_id;
+			break;
+		default:
+			goto err_exit;
+		}
+	}
+
+	fte_attr->dest_size++;
+	return 0;
+
+err_exit:
+	errno = EOPNOTSUPP;
+	return errno;
+}
+
 static struct dr_devx_tbl_with_refs *
 dr_action_create_sampler_term_tbl(struct mlx5dv_dr_domain *dmn,
 				  struct mlx5dv_dr_flow_sampler_attr *attr)
@@ -1553,7 +1653,6 @@ dr_action_create_sampler_term_tbl(struct mlx5dv_dr_domain *dmn,
 	struct dr_devx_flow_dest_info *dest_info;
 	struct dr_devx_tbl_with_refs *term_tbl;
 	struct mlx5dv_dr_action **ref_actions;
-	uint32_t dest_index = 0;
 	uint32_t ref_index = 0;
 	uint32_t tbl_type;
 	uint32_t i;
@@ -1580,6 +1679,11 @@ dr_action_create_sampler_term_tbl(struct mlx5dv_dr_domain *dmn,
 		goto free_term_tbl;
 	}
 
+	ft_attr.type = tbl_type;
+	ft_attr.level = dmn->info.caps.max_ft_level - 1;
+	ft_attr.term_tbl = true;
+	fte_attr.dest_arr = dest_info;
+
 	for (i = 0; i < attr->num_sample_actions; i++) {
 		enum dr_action_type action_type =
 			attr->sample_actions[i]->action_type;
@@ -1590,53 +1694,22 @@ dr_action_create_sampler_term_tbl(struct mlx5dv_dr_domain *dmn,
 		switch (action_type) {
 		case DR_ACTION_TYP_MISS:
 		case DR_ACTION_TYP_VPORT:
-			if (tbl_type != FS_FT_FDB) {
-				errno = EOPNOTSUPP;
+			if (dr_action_convert_to_fte_dest(dmn, attr->sample_actions[i],
+							  NULL, &fte_attr))
 				goto free_ref_actions;
-			}
 
-			fte_attr.action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
-			dest_info[dest_index].type = MLX5_FLOW_DEST_TYPE_VPORT;
-
-			if (action_type == DR_ACTION_TYP_MISS)
-				dest_info[dest_index].vport_num = 0;
-			else
-				dest_info[dest_index].vport_num =
-					attr->sample_actions[i]->vport.num;
-
-			dest_index++;
 			break;
 		case DR_ACTION_TYP_QP:
-			if (tbl_type != FS_FT_NIC_RX) {
-				errno = EOPNOTSUPP;
-				goto free_ref_actions;
-			}
-
-			fte_attr.action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
-			dest_info[dest_index].type = MLX5_FLOW_DEST_TYPE_TIR;
-
-			if (attr->sample_actions[i]->dest_qp.is_qp) {
-				struct mlx5_qp *mlx5_qp =
-					to_mqp(attr->sample_actions[i]->dest_qp.qp);
-				dest_info[dest_index].tir_num = mlx5_qp->tirn;
-			} else {
-				dest_info[dest_index].tir_num =
-					attr->sample_actions[i]->dest_qp.devx_tir->object_id;
-			}
-			dest_index++;
-			break;
 		case DR_ACTION_TYP_CTR:
 			if (tbl_type != FS_FT_NIC_RX) {
 				errno = EOPNOTSUPP;
 				goto free_ref_actions;
 			}
 
-			fte_attr.action |= MLX5_FLOW_CONTEXT_ACTION_COUNT;
-			dest_info[dest_index].type = MLX5_FLOW_DEST_TYPE_COUNTER;
-			dest_info[dest_index].counter_id =
-				attr->sample_actions[i]->ctr.devx_obj->object_id +
-				attr->sample_actions[i]->ctr.offset;
-			dest_index++;
+			if (dr_action_convert_to_fte_dest(dmn, attr->sample_actions[i],
+							  NULL, &fte_attr))
+				goto free_ref_actions;
+
 			break;
 		case DR_ACTION_TYP_TAG:
 			if (tbl_type != FS_FT_NIC_RX) {
@@ -1652,11 +1725,6 @@ dr_action_create_sampler_term_tbl(struct mlx5dv_dr_domain *dmn,
 		}
 	}
 
-	ft_attr.type = tbl_type;
-	ft_attr.level = dmn->info.caps.max_ft_level - 1;
-	ft_attr.term_tbl = true;
-	fte_attr.dest_size = dest_index;
-	fte_attr.dest_arr = dest_info;
 	term_tbl->devx_tbl = dr_devx_create_always_hit_ft(dmn->ctx, &ft_attr,
 							  &fg_attr, &fte_attr);
 	if (!term_tbl->devx_tbl)
@@ -1930,6 +1998,172 @@ dec_ref:
 	return NULL;
 }
 
+static int dr_action_add_action_member(struct list_head *ref_list,
+				       struct mlx5dv_dr_action *action)
+{
+	struct dr_rule_action_member *action_mem;
+
+	action_mem = calloc(1, sizeof(*action_mem));
+	if (!action_mem) {
+		errno = ENOMEM;
+		return errno;
+	}
+
+	action_mem->action = action;
+	list_node_init(&action_mem->list);
+	list_add_tail(ref_list, &action_mem->list);
+	atomic_fetch_add(&action_mem->action->refcount, 1);
+
+	return 0;
+}
+
+static void dr_action_remove_action_members(struct list_head *ref_list)
+{
+	struct dr_rule_action_member *action_mem;
+	struct dr_rule_action_member *tmp;
+
+	list_for_each_safe(ref_list, action_mem, tmp, list) {
+		list_del(&action_mem->list);
+		atomic_fetch_sub(&action_mem->action->refcount, 1);
+		free(action_mem);
+	}
+}
+
+static int
+dr_action_create_dest_array_tbl(struct mlx5dv_dr_action *action,
+				size_t num_dest,
+				struct mlx5dv_dr_action_dest_attr *dests[])
+{
+	struct mlx5dv_dr_domain *dmn = action->dest_array.dmn;
+	struct dr_devx_flow_table_attr ft_attr = {};
+	struct dr_devx_flow_group_attr fg_attr = {};
+	struct dr_devx_flow_fte_attr fte_attr = {};
+	uint32_t i;
+	int ret;
+
+	switch (dmn->type) {
+	case MLX5DV_DR_DOMAIN_TYPE_FDB:
+		ft_attr.type = FS_FT_FDB;
+		ft_attr.level = dmn->info.caps.max_ft_level - 1;
+		break;
+	case MLX5DV_DR_DOMAIN_TYPE_NIC_RX:
+		ft_attr.type = FS_FT_NIC_RX;
+		ft_attr.level = MLX5_MULTI_PATH_FT_MAX_LEVEL - 1;
+		break;
+	default:
+		errno = EOPNOTSUPP;
+		return errno;
+	}
+
+	fte_attr.dest_arr = calloc(num_dest, sizeof(struct dr_devx_flow_dest_info));
+	if (!fte_attr.dest_arr) {
+		errno = ENOMEM;
+		return errno;
+	}
+
+	for (i = 0; i < num_dest; i++) {
+		struct mlx5dv_dr_action *reformat_action;
+		struct mlx5dv_dr_action *dest_action;
+
+		switch (dests[i]->type) {
+		case MLX5DV_DR_ACTION_DEST_REFORMAT:
+			dest_action = dests[i]->dest_reformat->dest;
+			reformat_action = dests[i]->dest_reformat->reformat;
+			ft_attr.reformat_en = true;
+			break;
+		case MLX5DV_DR_ACTION_DEST:
+			dest_action = dests[i]->dest;
+			reformat_action = NULL;
+			break;
+		default:
+			errno = EINVAL;
+			goto clear_actions_list;
+		}
+
+		switch (dest_action->action_type) {
+		case DR_ACTION_TYP_MISS:
+		case DR_ACTION_TYP_VPORT:
+		case DR_ACTION_TYP_QP:
+		case DR_ACTION_TYP_CTR:
+			if (dr_action_add_action_member(&action->dest_array.actions_list,
+							dest_action))
+				goto clear_actions_list;
+
+			break;
+		default:
+			errno = EOPNOTSUPP;
+			goto clear_actions_list;
+		}
+
+		if (reformat_action)
+			if (dr_action_add_action_member(&action->dest_array.actions_list,
+							reformat_action))
+				goto clear_actions_list;
+
+		if (dr_action_convert_to_fte_dest(dmn, dest_action,
+						  reformat_action, &fte_attr))
+			goto clear_actions_list;
+	}
+
+	action->dest_array.devx_tbl = dr_devx_create_always_hit_ft(dmn->ctx,
+								   &ft_attr,
+								   &fg_attr,
+								   &fte_attr);
+	if (!action->dest_array.devx_tbl)
+		goto clear_actions_list;
+
+	ret = dr_devx_query_flow_table(action->dest_array.devx_tbl->ft_dvo,
+				       ft_attr.type,
+				       &action->dest_array.rx_icm_addr,
+				       &action->dest_array.tx_icm_addr);
+	if (ret)
+		goto destroy_devx_tbl;
+
+	free(fte_attr.dest_arr);
+	return 0;
+
+destroy_devx_tbl:
+	dr_devx_destroy_always_hit_ft(action->dest_array.devx_tbl);
+clear_actions_list:
+	dr_action_remove_action_members(&action->dest_array.actions_list);
+
+	free(fte_attr.dest_arr);
+	return errno;
+}
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_array(struct mlx5dv_dr_domain *dmn,
+				   size_t num_dest,
+				   struct mlx5dv_dr_action_dest_attr *dests[])
+{
+	struct mlx5dv_dr_action *action;
+
+	if (num_dest <= 1) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	atomic_fetch_add(&dmn->refcount, 1);
+
+	action = dr_action_create_generic(DR_ACTION_TYP_DEST_ARRAY);
+	if (!action)
+		goto dec_ref;
+
+	action->dest_array.dmn = dmn;
+	list_head_init(&action->dest_array.actions_list);
+
+	if (dr_action_create_dest_array_tbl(action, num_dest, dests))
+		goto free_action;
+
+	return action;
+
+free_action:
+	free(action);
+dec_ref:
+	atomic_fetch_sub(&dmn->refcount, 1);
+	return NULL;
+}
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action)
 {
 	if (atomic_load(&action->refcount) > 1)
@@ -1980,6 +2214,11 @@ int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action)
 		dr_action_destroy_sampler(action->sampler.sampler_default);
 		dr_action_destroy_sampler_term_tbl(action->sampler.term_tbl);
 		atomic_fetch_sub(&action->sampler.dmn->refcount, 1);
+		break;
+	case DR_ACTION_TYP_DEST_ARRAY:
+		dr_devx_destroy_always_hit_ft(action->dest_array.devx_tbl);
+		dr_action_remove_action_members(&action->dest_array.actions_list);
+		atomic_fetch_sub(&action->dest_array.dmn->refcount, 1);
 		break;
 	default:
 		break;

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -74,6 +74,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_DEVX_TIR = 3411,
 	DR_DUMP_REC_TYPE_ACTION_METER = 3414,
 	DR_DUMP_REC_TYPE_ACTION_SAMPLER = 3415,
+	DR_DUMP_REC_TYPE_ACTION_DEST_ARRAY = 3416,
 };
 
 static uint64_t dr_dump_icm_to_idx(uint64_t icm_addr)
@@ -180,6 +181,13 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 			      (action->sampler.sampler_restore) ?
 					action->sampler.sampler_restore->tx_icm_addr :
 					action->sampler.sampler_default->tx_icm_addr);
+		break;
+	case DR_ACTION_TYP_DEST_ARRAY:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x,0x%" PRIx64 ",0x%" PRIx64 "\n",
+			      DR_DUMP_REC_TYPE_ACTION_DEST_ARRAY, action_id, rule_id,
+			      action->dest_array.devx_tbl->ft_dvo->object_id,
+			      action->dest_array.rx_icm_addr,
+			      action->dest_array.tx_icm_addr);
 		break;
 	default:
 		return 0;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -149,5 +149,6 @@ MLX5_1.15 {
 
 MLX5_1.16 {
 	global:
+		mlx5dv_dr_action_create_dest_array;
 		mlx5dv_dr_action_create_flow_sampler;
 } MLX5_1.15;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -59,6 +59,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ibv_qp.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_devx_tir.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_vport.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_array.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_flow_counter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_drop.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_default_miss.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -26,6 +26,8 @@ mlx5dv_dr_action_create_tag - Create tag actions
 
 mlx5dv_dr_action_create_dest_ibv_qp, mlx5dv_dr_action_create_dest_table, mlx5dv_dr_action_create_dest_vport, mlx5dv_dr_action_create_dest_devx_tir - Create packet destination actions
 
+mlx5dv_dr_action_create_dest_array - Create destination array action
+
 mlx5dv_dr_action_create_packet_reformat - Create packet reformat actions
 
 mlx5dv_dr_action_create_modify_header - Create modify header actions
@@ -125,6 +127,11 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_sampler(struct mlx5dv_dr_flow_sampler_attr *attr);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_array(struct mlx5dv_dr_domain *domain,
+				   size_t num_dest,
+				   struct mlx5dv_dr_action_dest_attr *dests[]);
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 ```
 
@@ -198,6 +205,10 @@ Action: Destination
 *mlx5dv_dr_action_create_dest_table* creates a forwarding action to another flow table, defined by **table**. The destination **table** must be from the same domain with a level higher than zero.
 *mlx5dv_dr_action_create_dest_vport* creates a forwarding action to a **vport** on the same **domain**. Valid only on domain type FDB.
 *mlx5dv_dr_action_create_dest_devx_tir* creates a terminating action delivering the packet to a TIR, defined by **devx_obj**. Valid only on domain type NIC_RX.
+
+Action: Array
+*mlx5dv_dr_action_create_dest_array* creates an action which replicates a packet to multiple destinations. **num_dest** defines the number of replication destinations.
+Each **dests** destination array entry can be of different **type**. Use type MLX5DV_DR_ACTION_DEST for direct forwarding to an action destination. Use type MLX5DV_DR_ACTION_DEST_REFORMAT when reformat action should be performed on the packet before it is forwarding to the destination action.
 
 Action: Packet Reformat
 *mlx5dv_dr_action_create_packet_reformat* create a packet reformat context and action in the **domain**. The **reformat_type**, **data_sz** and **data** are defined in *man mlx5dv_create_flow_action_packet_reformat*.

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -104,6 +104,10 @@ struct mlx5_ifc_roce_cap_bits {
 	u8         reserved_at_20[0x7e0];
 };
 
+enum {
+	MLX5_MULTI_PATH_FT_MAX_LEVEL = 64,
+};
+
 struct mlx5_ifc_flow_table_context_bits {
 	u8         reformat_en[0x1];
 	u8         decap_en[0x1];

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -55,6 +55,7 @@ enum {
 	MLX5_CMD_OP_MODIFY_TIS = 0x913,
 	MLX5_CMD_OP_QUERY_TIS = 0x915,
 	MLX5_CMD_OP_CREATE_FLOW_TABLE = 0x930,
+	MLX5_CMD_OP_QUERY_FLOW_TABLE = 0x932,
 	MLX5_CMD_OP_CREATE_FLOW_GROUP = 0x933,
 	MLX5_CMD_OP_SET_FLOW_TABLE_ENTRY = 0x936,
 	MLX5_CMD_OP_CREATE_FLOW_COUNTER = 0x939,
@@ -157,6 +158,35 @@ struct mlx5_ifc_create_flow_table_out_bits {
 	u8         table_id[0x18];
 
 	u8         icm_address_31_0[0x20];
+};
+
+struct mlx5_ifc_query_flow_table_in_bits {
+	u8         opcode[0x10];
+	u8         reserved_at_10[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x40];
+
+	u8         table_type[0x8];
+	u8         reserved_at_88[0x18];
+
+	u8         reserved_at_a0[0x8];
+	u8         table_id[0x18];
+
+	u8         reserved_at_c0[0x140];
+};
+
+struct mlx5_ifc_query_flow_table_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x80];
+
+	struct mlx5_ifc_flow_table_context_bits flow_table_context;
 };
 
 struct mlx5_ifc_sync_steering_in_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -3036,7 +3036,17 @@ struct mlx5_ifc_dest_format_bits {
 	u8         destination_type[0x8];
 	u8         destination_id[0x18];
 
-	u8         reserved_at_20[0x20];
+	u8         reserved_at_20[0x1];
+	u8         packet_reformat[0x1];
+	u8         reserved_at_22[0x1e];
+};
+
+struct mlx5_ifc_extended_dest_format_bits {
+	struct mlx5_ifc_dest_format_bits destination_entry;
+
+	u8         packet_reformat_id[0x20];
+
+	u8         reserved_at_60[0x20];
 };
 
 struct mlx5_ifc_flow_counter_list_bits {
@@ -3062,7 +3072,8 @@ struct mlx5_ifc_flow_context_bits {
 	u8         reserved_at_60[0x10];
 	u8         action[0x10];
 
-	u8         reserved_at_80[0x8];
+	u8         extended_destination[0x1];
+	u8         reserved_at_81[0x7];
 	u8         destination_list_size[0x18];
 
 	u8         reserved_at_a0[0x8];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1509,6 +1509,29 @@ mlx5dv_dr_action_create_dest_vport(struct mlx5dv_dr_domain *domain,
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_dest_devx_tir(struct mlx5dv_devx_obj *devx_obj);
 
+enum mlx5dv_dr_action_dest_type {
+	MLX5DV_DR_ACTION_DEST,
+	MLX5DV_DR_ACTION_DEST_REFORMAT,
+};
+
+struct mlx5dv_dr_action_dest_reformat {
+	struct mlx5dv_dr_action *reformat;
+	struct mlx5dv_dr_action *dest;
+};
+
+struct mlx5dv_dr_action_dest_attr {
+	enum mlx5dv_dr_action_dest_type type;
+	union {
+		struct mlx5dv_dr_action *dest;
+		struct mlx5dv_dr_action_dest_reformat *dest_reformat;
+	};
+};
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_array(struct mlx5dv_dr_domain *domain,
+				   size_t num_dest,
+				   struct mlx5dv_dr_action_dest_attr *dests[]);
+
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_drop(void);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_default_miss(void);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -146,6 +146,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_METER,
 	DR_ACTION_TYP_MISS,
 	DR_ACTION_TYP_SAMPLER,
+	DR_ACTION_TYP_DEST_ARRAY,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -853,6 +854,13 @@ struct mlx5dv_dr_action {
 			struct dr_flow_sampler			*sampler_restore;
 		} sampler;
 		struct mlx5dv_dr_table	*dest_tbl;
+		struct {
+			struct mlx5dv_dr_domain		*dmn;
+			struct list_head		actions_list;
+			struct dr_devx_tbl		*devx_tbl;
+			uint64_t			rx_icm_addr;
+			uint64_t			tx_icm_addr;
+		} dest_array;
 		struct {
 			struct mlx5dv_devx_obj	*devx_obj;
 			uint32_t		offset;

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -645,6 +645,7 @@ struct dr_devx_flow_table_attr {
 	uint8_t		level;
 	bool		sw_owner;
 	bool		term_tbl;
+	bool		reformat_en;
 	uint64_t	icm_addr_rx;
 	uint64_t	icm_addr_tx;
 };
@@ -661,6 +662,8 @@ struct dr_devx_flow_dest_info {
 		uint32_t tir_num;
 		uint32_t counter_id;
 	};
+	bool has_reformat;
+	uint32_t reformat_id;
 };
 
 struct dr_devx_flow_fte_attr {
@@ -671,6 +674,7 @@ struct dr_devx_flow_fte_attr {
 	uint32_t			action;
 	uint32_t			dest_size;
 	struct dr_devx_flow_dest_info	*dest_arr;
+	bool				extended_dest;
 };
 
 struct dr_devx_tbl {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -983,7 +983,8 @@ int dr_devx_sync_steering(struct ibv_context *ctx);
 struct mlx5dv_devx_obj *
 dr_devx_create_flow_table(struct ibv_context *ctx,
 			  struct dr_devx_flow_table_attr *table_attr);
-
+int dr_devx_query_flow_table(struct mlx5dv_devx_obj *obj,  uint32_t type,
+			     uint64_t *rx_icm_addr, uint64_t *tx_icm_addr);
 struct dr_devx_tbl *
 dr_devx_create_always_hit_ft(struct ibv_context *ctx,
 			     struct dr_devx_flow_table_attr *ft_attr,


### PR DESCRIPTION
This series introduce an action which replicates a packet to multiple destinations, each destination can have an attached reformat action which will be applied to the packet before steered to this destination.