### PR TITLE
tests: Change max_sge_rd verification

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -98,7 +98,7 @@ class DeviceTest(PyverbsAPITestCase):
         assert attr.max_qp > 0
         assert attr.max_qp_wr > 0
         assert attr.max_sge > 0
-        assert attr.max_sge_rd > 0
+        assert attr.max_sge_rd >= 0
         assert attr.max_cq > 0
         assert attr.max_cqe > 0
         assert attr.max_mr > 0


### PR DESCRIPTION
Some devices report zero max_sge_rd,
change query device test to check for '>=' instead of '>'.

Signed-off-by: Chen Brasch <cbrasch@amazon.com>
Signed-off-by: Gal Pressman <galpress@amazon.com>