### PR TITLE
pyverbs: Add mlx5 DC support

### DIFF
--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -76,6 +76,9 @@ cdef extern from 'infiniband/mlx5dv.h':
         long        mmap_off;
         uint64_t    comp_mask;
 
+    cdef struct mlx5dv_qp_ex:
+        uint64_t comp_mask
+
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)
@@ -99,3 +102,6 @@ cdef extern from 'infiniband/mlx5dv.h':
     mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(v.ibv_context *context,
                                            uint32_t flags)
     void mlx5dv_devx_free_uar(mlx5dv_devx_uar *devx_uar)
+    void mlx5dv_wr_set_dc_addr(mlx5dv_qp_ex *mqp, v.ibv_ah *ah,
+                               uint32_t remote_dctn, uint64_t remote_dc_key)
+    mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(v.ibv_qp_ex *qp_ex)

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -6,8 +6,8 @@
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsObject
 from pyverbs.device cimport Context
+from pyverbs.qp cimport QP, QPEx
 from pyverbs.cq cimport CQEX
-from pyverbs.qp cimport QP
 
 
 cdef class Mlx5Context(Context):
@@ -25,7 +25,7 @@ cdef class Mlx5DVDCInitAttr(PyverbsObject):
 cdef class Mlx5DVQPInitAttr(PyverbsObject):
     cdef dv.mlx5dv_qp_init_attr attr
 
-cdef class Mlx5QP(QP):
+cdef class Mlx5QP(QPEx):
     cdef object dc_type
 
 cdef class Mlx5DVCQInitAttr(PyverbsObject):

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -1260,9 +1260,12 @@ cdef class QPEx(QP):
         :return: An initialized QPEx object
         """
         super().__init__(creator, init_attr, qp_attr)
-        self.qp_ex = v.ibv_qp_to_qp_ex(self.qp)
-        if self.qp_ex == NULL:
-            raise PyverbsRDMAErrno('Failed to create extended QP')
+        if init_attr.comp_mask & v.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS:
+            self.qp_ex = v.ibv_qp_to_qp_ex(self.qp)
+            if self.qp_ex == NULL:
+                raise PyverbsRDMAErrno('Failed to create extended QP')
+        else:
+            self.logger.debug('qp_ex is not accessible since IBV_QP_INIT_ATTR_SEND_OPS_FLAGS was not passed.')
 
     @property
     def comp_mask(self):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rdma_python_test(tests
   args_parser.py
   base.py
   base_rdmacm.py
+  mlx5_base.py
   rdmacm_utils.py
   test_addr.py
   test_cq.py

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ rdma_python_test(tests
   test_cqex.py
   test_device.py
   test_efadv.py
+  test_mlx5_dc.py
   test_mlx5_lag_affinity.py
   test_mlx5_pp.py
   test_mlx5_uar.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -35,6 +35,7 @@ TIMEOUT = 14
 MLNX_VENDOR_ID = 0x02c9
 CX3_MLNX_PART_ID = 4099
 CX3Pro_MLNX_PART_ID = 4103
+DCT_KEY = 0xbadc0de
 # Dictionary: vendor_id -> array of part_ids of devices that lack RoCEv2 support
 ROCEV2_UNSUPPORTED_DEVS = {MLNX_VENDOR_ID: [CX3Pro_MLNX_PART_ID,
                                             CX3_MLNX_PART_ID]}
@@ -42,6 +43,18 @@ ROCEV2_UNSUPPORTED_DEVS = {MLNX_VENDOR_ID: [CX3Pro_MLNX_PART_ID,
 
 def has_roce_hw_bug(vendor_id, vendor_part_id):
     return vendor_part_id in ROCEV2_UNSUPPORTED_DEVS.get(vendor_id, [])
+
+
+def set_rnr_attributes(qp_attr):
+    """
+    Set default QP RNR attributes.
+    :param qp_attr: The QPAttr to set its attributes
+    :return: None
+    """
+    qp_attr.min_rnr_timer = MIN_RNR_TIMER
+    qp_attr.timeout = TIMEOUT
+    qp_attr.retry_cnt = RETRY_CNT
+    qp_attr.rnr_retry = RNR_RETRY
 
 
 class PyverbsAPITestCase(unittest.TestCase):
@@ -369,10 +382,7 @@ class RCResources(TrafficResources):
         attr = self.create_qp_attr()
         attr.path_mtu = PATH_MTU
         attr.max_dest_rd_atomic = MAX_DEST_RD_ATOMIC
-        attr.min_rnr_timer = MIN_RNR_TIMER
-        attr.timeout = TIMEOUT
-        attr.retry_cnt = RETRY_CNT
-        attr.rnr_retry = RNR_RETRY
+        set_rnr_attributes(attr)
         attr.max_rd_atomic = MAX_RD_ATOMIC
         gr = GlobalRoute(dgid=self.ctx.query_gid(self.ib_port, self.gid_index),
                          sgid_index=self.gid_index)
@@ -507,10 +517,7 @@ class XRCResources(TrafficResources):
                          gr=gr, dlid=self.port_attr.lid)
         qp_attr = QPAttr()
         qp_attr.path_mtu = PATH_MTU
-        qp_attr.timeout = TIMEOUT
-        qp_attr.retry_cnt = RETRY_CNT
-        qp_attr.rnr_retry = RNR_RETRY
-        qp_attr.min_rnr_timer = MIN_RNR_TIMER
+        set_rnr_attributes(qp_attr)
         qp_attr.ah_attr = ah_attr
         for i in range(self.qp_count):
             qp_attr.dest_qp_num = self.rqps_num[i][1]

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 NVIDIA Corporation . All rights reserved. See COPYING file
+
+import unittest
+import random
+import errno
+
+from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, \
+    Mlx5DVQPInitAttr, Mlx5QP, Mlx5DVDCInitAttr
+from tests.base import TrafficResources, set_rnr_attributes, DCT_KEY
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError
+from pyverbs.qp import QPCap, QPInitAttrEx, QPAttr
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from pyverbs.addr import AHAttr, GlobalRoute
+import pyverbs.enums as e
+from pyverbs.mr import MR
+
+
+class Mlx5DcResources(TrafficResources):
+    def __init__(self, dev_name, ib_port, gid_index, send_ops_flags,
+                 qp_count=1):
+        self.send_ops_flags = send_ops_flags
+        super().__init__(dev_name, ib_port, gid_index, with_srq=True,
+                         qp_count=qp_count)
+
+    def to_rts(self):
+        attr = self.create_qp_attr()
+        for i in range(self.qp_count):
+            self.qps[i].to_rts(attr)
+        self.dct_qp.to_rtr(attr)
+
+    def pre_run(self, rpsns, rqps_num):
+        self.rpsns = rpsns
+        self.rqps_num = rqps_num
+        self.to_rts()
+
+    def create_context(self):
+        mlx5dv_attr = Mlx5DVContextAttr()
+        try:
+            self.ctx = Mlx5Context(mlx5dv_attr, name=self.dev_name)
+        except PyverbsUserError as ex:
+            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
+        except PyverbsRDMAError:
+            raise unittest.SkipTest('Opening mlx5 context is not supported')
+
+    def create_mr(self):
+        access = e.IBV_ACCESS_REMOTE_WRITE | e.IBV_ACCESS_LOCAL_WRITE
+        self.mr = MR(self.pd, self.msg_size, access)
+
+    def create_qp_cap(self):
+        return QPCap(100, 0, 1, 0)
+
+    def create_qp_attr(self):
+        qp_attr = QPAttr(port_num=self.ib_port)
+        set_rnr_attributes(qp_attr)
+        qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
+        qp_attr.qp_access_flags = qp_access
+        gr = GlobalRoute(dgid=self.ctx.query_gid(self.ib_port, self.gid_index),
+                         sgid_index=self.gid_index)
+        ah_attr = AHAttr(port_num=self.ib_port, is_global=1, gr=gr,
+                         dlid=self.port_attr.lid)
+        qp_attr.ah_attr = ah_attr
+        return qp_attr
+
+    def create_qp_init_attr(self, send_ops_flags=0):
+        comp_mask = e.IBV_QP_INIT_ATTR_PD
+        if send_ops_flags:
+            comp_mask |= e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+        return QPInitAttrEx(cap=self.create_qp_cap(), pd=self.pd, scq=self.cq,
+                            rcq=self.cq, srq=self.srq, qp_type=e.IBV_QPT_DRIVER,
+                            send_ops_flags=send_ops_flags, comp_mask=comp_mask,
+                            sq_sig_all=1)
+
+    def create_qps(self):
+        # Create the DCI QPs.
+        qp_init_attr = self.create_qp_init_attr(self.send_ops_flags)
+        try:
+            for _ in range(self.qp_count):
+                comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_DC
+                attr = Mlx5DVQPInitAttr(comp_mask=comp_mask,
+                                        dc_init_attr=Mlx5DVDCInitAttr())
+                qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+                self.qps.append(qp)
+                self.qps_num.append(qp.qp_num)
+                self.psns.append(random.getrandbits(24))
+
+            # Create the DCT QP.
+            qp_init_attr = self.create_qp_init_attr()
+            dc_attr = Mlx5DVDCInitAttr(dc_type=dve.MLX5DV_DCTYPE_DCT,
+                                       dct_access_key=DCT_KEY)
+            attr = Mlx5DVQPInitAttr(comp_mask=dve.MLX5DV_QP_INIT_ATTR_MASK_DC,
+                                    dc_init_attr=dc_attr)
+            self.dct_qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Create DC QP is not supported')
+            raise ex

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 NVIDIA Corporation . All rights reserved. See COPYING file
+
+from tests.mlx5_base import Mlx5DcResources
+from tests.base import RDMATestCase
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class DCTest(RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+        self.traffic_args = None
+
+    def sync_remote_attr(self):
+        """
+        Exchange the remote attributes between the server and the client.
+        """
+        self.server.rkey = self.client.mr.rkey
+        self.server.raddr = self.client.mr.buf
+        self.client.rkey = self.server.mr.rkey
+        self.client.raddr = self.server.mr.buf
+        self.client.remote_dct_num = self.server.dct_qp.qp_num
+        self.server.remote_dct_num = self.client.dct_qp.qp_num
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init DC tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.sync_remote_attr()
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
+
+    def test_dc_rdma_write(self):
+        self.create_players(Mlx5DcResources, qp_count=2,
+                            send_ops_flags=e.IBV_QP_EX_WITH_RDMA_WRITE)
+        u.rdma_traffic(**self.traffic_args, new_send=True,
+                       send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+
+    def test_dc_send(self):
+        self.create_players(Mlx5DcResources, qp_count=2,
+                            send_ops_flags=e.IBV_QP_EX_WITH_SEND)
+        u.traffic(**self.traffic_args, new_send=True,
+                  send_op=e.IBV_QP_EX_WITH_SEND)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,11 +12,12 @@ import os
 
 from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
 from pyverbs.addr import AHAttr, AH, GlobalRoute
+from tests.base import XRCResources, DCT_KEY
 from pyverbs.wr import SGE, SendWR, RecvWR
 from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx
+from tests.mlx5_base import Mlx5DcResources
 from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.mr import MW, MWBindInfo
-from tests.base import XRCResources
 from pyverbs.cq import PollCqAttr
 import pyverbs.device as d
 import pyverbs.enums as e
@@ -391,6 +392,9 @@ def post_send_ex(agr_obj, send_object, gid_index, port, send_op=None, qp_idx=0):
         qp.wr_set_ud_addr(ah, agr_obj.rqps_num[qp_idx], agr_obj.UD_QKEY)
     if qp_type == e.IBV_QPT_XRC_SEND:
         qp.wr_set_xrc_srqn(agr_obj.remote_srqn)
+    if isinstance(agr_obj, Mlx5DcResources):
+        ah = get_global_ah(agr_obj, gid_index, port)
+        qp.wr_set_dc_addr(ah, agr_obj.remote_dct_num, DCT_KEY)
     qp.wr_set_sge(send_object)
     qp.wr_complete()
 


### PR DESCRIPTION
This series adds support to mlx5 DC QPs traffic usage.
In addition, two new DC traffic tests were added (Send and RDMA Write).