### PR TITLE
tests: Add a dry run option

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -4,6 +4,8 @@
 import importlib
 import os
 
+from args_parser import parser
+
 # Load every test as a module in the system so that unittest's loader can find it
 def _load_tests():
     res = []
@@ -20,8 +22,23 @@ __test_modules__ = _load_tests()
 # a single test.
 tests = importlib.import_module(".", __name__)
 
+
+def _show_tests_and_exit(loader, standard_tests, pattern):
+    """
+    Prints the full test names that are loaded with the current modules via
+    loadTestsFromModule protocol, without modifying standard_tests.
+    """
+    for mod in __test_modules__:
+        for test in loader.loadTestsFromModule(mod, pattern):
+            for test_case in test:
+                print(test_case.id())
+    return standard_tests
+
+
 def load_tests(loader, standard_tests, pattern):
     """Implement the loadTestsFromModule protocol"""
+    if parser.args['list_tests']:
+        return _show_tests_and_exit(loader, standard_tests, pattern)
     for mod in __test_modules__:
         standard_tests.addTests(loader.loadTestsFromModule(mod, pattern))
     return standard_tests

--- a/tests/args_parser.py
+++ b/tests/args_parser.py
@@ -19,6 +19,10 @@ class ArgsParser(object):
         parser.add_argument('-v', '--verbose', dest='verbosity',
                             action='store_const',
                             const=2, help='Verbose output')
+        parser.add_argument('--list-tests', action='store_true', default=False,
+                            help='Print a list of the full test names that are '
+                                 'loaded by default and exit without running '
+                                 'them.')
         ns, args = parser.parse_known_args()
         self.args = vars(ns)
         if self.args['verbosity']:


### PR DESCRIPTION
Add a --dry_run command-line argument that prints a list of the full
test names that are loaded by default and exit without running them.