### PR TITLE
Skip query gid tests on unsupported devices

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -106,6 +106,8 @@ class DeviceTest(PyverbsAPITestCase):
         """
         devs = self.get_device_list()
         with d.Context(name=devs[0].name.decode()) as ctx:
+            if u.is_unspecified(ctx, port_num=1):
+                raise unittest.SkipTest('ibv_query_gid_ex is not supported on this device')
             try:
                 ctx.query_gid_ex(port_num=1, gid_index=0)
             except PyverbsRDMAError as ex:

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -89,6 +89,8 @@ class DeviceTest(PyverbsAPITestCase):
         with d.Context(name=devs[0].name.decode()) as ctx:
             device_attr = ctx.query_device()
             port_attr = ctx.query_port(1)
+            if port_attr.link_layer == e.IBV_LINK_LAYER_UNSPECIFIED:
+                raise unittest.SkipTest('ibv_query_gid_table is not supported on this device')
             max_entries = device_attr.phys_port_cnt * port_attr.gid_tbl_len
             try:
                 ctx.query_gid_table(max_entries)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -794,5 +794,15 @@ def is_eth(ctx, port_num):
     return ctx.query_port(port_num).link_layer == e.IBV_LINK_LAYER_ETHERNET
 
 
+def is_unspecified(ctx, port_num):
+    """
+    Queries the device's context's <port_num> port for its link layer.
+    :param ctx: The Context to query
+    :param port_num: Which Context's port to query
+    :return: True if the port's link layer is Unspecified, else False
+    """
+    return ctx.query_port(port_num).link_layer == e.IBV_LINK_LAYER_UNSPECIFIED
+
+
 def is_root():
     return os.geteuid() == 0


### PR DESCRIPTION
Skip test_query_gid_table and test_query_gid_ex when the device link layer is unspecified.