### PR TITLE
tests: Fix calculate gid max_entries

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -88,8 +88,10 @@ class DeviceTest(PyverbsAPITestCase):
         devs = self.get_device_list()
         with d.Context(name=devs[0].name.decode()) as ctx:
             device_attr = ctx.query_device()
-            port_attr = ctx.query_port(1)
-            max_entries = device_attr.phys_port_cnt * port_attr.gid_tbl_len
+            max_entries = 0
+            for port_num in range(1, device_attr.phys_port_cnt + 1):
+                port_attr = ctx.query_port(port_num)
+                max_entries += port_attr.gid_tbl_len
             try:
                 ctx.query_gid_table(max_entries)
             except PyverbsRDMAError as ex:


### PR DESCRIPTION
Avoid the following failure over devices with multiple ports (like mlx4)
by calculating the max_entries for both ports.

$ ./build/bin/run_tests.py -v test_device -k test_query_gid_table
test_query_gid_table (tests.test_device.DeviceTest)
Test ibv_query_gid_table() ... ERROR

======================================================================
ERROR: test_query_gid_table (tests.test_device.DeviceTest)
Test ibv_query_gid_table()
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rdma-core/tests/test_device.py", line 99, in test_query_gid_table
    raise ex
  File "/home/rdma-core/tests/test_device.py", line 94, in test_query_gid_table
    ctx.query_gid_table(max_entries)
  File "device.pyx", line 261, in pyverbs.device.Context.query_gid_table
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to query gid tables of the device. Errno: -22, Unknown error -22

----------------------------------------------------------------------
Ran 1 test in 0.006s

FAILED (errors=1)

Fixes: bbbdd13fe356 ("tests: Add tests for ibv_query_gid_table and ibv_query_gid_ex")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>