### PR TITLE
libhns: Add support for CQE in size of 64 Bytes

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -135,6 +135,13 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 			goto db_free;
 	}
 
+	if (!resp.cqe_size)
+		context->cqe_size = HNS_ROCE_CQE_SIZE;
+	else if (resp.cqe_size <= HNS_ROCE_V3_CQE_SIZE)
+		context->cqe_size = resp.cqe_size;
+	else
+		context->cqe_size = HNS_ROCE_V3_CQE_SIZE;
+
 	pthread_spin_init(&context->uar_lock, PTHREAD_PROCESS_PRIVATE);
 
 	verbs_set_ops(&context->ibv_ctx, &hns_common_ops);

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -63,7 +63,9 @@
 #define HNS_ROCE_V1_MIN_WQE_NUM		0x20
 #define HNS_ROCE_V2_MIN_WQE_NUM		0x40
 
-#define HNS_ROCE_CQE_ENTRY_SIZE		0x20
+#define HNS_ROCE_CQE_SIZE 0x20
+#define HNS_ROCE_V3_CQE_SIZE 0x40
+
 #define HNS_ROCE_SQWQE_SHIFT		6
 #define HNS_ROCE_SGE_IN_WQE		2
 #define HNS_ROCE_SGE_SIZE		16
@@ -160,6 +162,7 @@ struct hns_roce_context {
 	unsigned int			max_qp_wr;
 	unsigned int			max_sge;
 	int				max_cqe;
+	unsigned int			cqe_size;
 };
 
 struct hns_roce_pd {
@@ -178,6 +181,7 @@ struct hns_roce_cq {
 	unsigned int			*arm_db;
 	int				arm_sn;
 	unsigned long			flags;
+	unsigned int			cqe_size;
 };
 
 struct hns_roce_idx_que {
@@ -272,9 +276,11 @@ struct hns_roce_u_hw {
  * The entries's buffer should be aligned to a multiple of the hardware's
  * minimum page size.
  */
+#define hr_hw_page_align(x) align(x, HNS_HW_PAGE_SIZE)
+
 static inline unsigned int to_hr_hem_entries_size(int count, int buf_shift)
 {
-	return align(count << buf_shift, HNS_HW_PAGE_SIZE);
+	return hr_hw_page_align(count << buf_shift);
 }
 
 static inline struct hns_roce_device *to_hr_dev(struct ibv_device *ibv_dev)

--- a/providers/hns/hns_roce_u_hw_v1.c
+++ b/providers/hns/hns_roce_u_hw_v1.c
@@ -157,7 +157,7 @@ static void hns_roce_handle_error_cqe(struct hns_roce_cqe *cqe,
 
 static struct hns_roce_cqe *get_cqe(struct hns_roce_cq *cq, int entry)
 {
-	return cq->buf.buf + entry * HNS_ROCE_CQE_ENTRY_SIZE;
+	return cq->buf.buf + entry * HNS_ROCE_CQE_SIZE;
 }
 
 static void *get_sw_cqe(struct hns_roce_cq *cq, int n)

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -193,7 +193,7 @@ static void hns_roce_v2_handle_error_cqe(struct hns_roce_v2_cqe *cqe,
 
 static struct hns_roce_v2_cqe *get_cqe_v2(struct hns_roce_cq *cq, int entry)
 {
-	return cq->buf.buf + entry * HNS_ROCE_CQE_ENTRY_SIZE;
+	return cq->buf.buf + entry * cq->cqe_size;
 }
 
 static void *get_sw_cqe_v2(struct hns_roce_cq *cq, int n)

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -179,6 +179,7 @@ struct hns_roce_v2_cqe {
 	__le32	smac;
 	__le32	byte_28;
 	__le32	byte_32;
+	__le32	rsv[8];
 };
 
 #define CQE_BYTE_4_OPCODE_S 0


### PR DESCRIPTION
The new version of RoCEE supports using CQE in size of 32B or 64B. The performance of bus can be improved by using larger size of CQE. 

The kernel parts ("RDMA/hns: Add support for CQE in size of 64 Bytes") has been merged and the ABI related changes has been synchronized by ad9987ed8e6f ("Update kernel headers").