### PR TITLE
tests: Fix check for providers that do not support query_gid_table

### DIFF
--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -93,7 +93,7 @@ class DeviceTest(PyverbsAPITestCase):
             try:
                 ctx.query_gid_table(max_entries)
             except PyverbsRDMAError as ex:
-                if ex.error_code in [errno.EOPNOTSUPP, errno.EPROTONOSUPPORT]:
+                if ex.error_code in [-errno.EOPNOTSUPP, -errno.EPROTONOSUPPORT]:
                     raise unittest.SkipTest('ibv_query_gid_table is not'\
                                             ' supported on this device')
                 raise ex


### PR DESCRIPTION
ibv_query_gid_table() returns the number of entries that were read on
success or negative errno value on error - fix the check when the
query_gid_table() is not supported by the providers.

Fixes: bbbdd13fe356 ("tests: Add tests for ibv_query_gid_table and ibv_query_gid_ex")
Reported-by: Edward Srouji <edwards@nvidia.com>
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>