### PR TITLE
verbs: Set default gid type for unspecified link layer

### DIFF
--- a/libibverbs/cmd_device.c
+++ b/libibverbs/cmd_device.c
@@ -356,8 +356,8 @@ static int query_sysfs_gid_entry(struct ibv_context *context, uint32_t port_num,
 			} else if (link_layer == IBV_LINK_LAYER_ETHERNET) {
 				entry->gid_type = IBV_GID_TYPE_ROCE_V1;
 			} else {
-				ret = EINVAL;
-				goto out;
+				/* Unspecified link layer is IB by default */
+				entry->gid_type = IBV_GID_TYPE_IB;
 			}
 		} else {
 			entry->gid_type = IBV_GID_TYPE_ROCE_V2;


### PR DESCRIPTION
The gid type is IB by default, remove the error code return.

Signed-off-by: Gal Pressman <galpress@amazon.com>