### PR TITLE
Grammar-related fixes

### DIFF
--- a/Documentation/udev.md
+++ b/Documentation/udev.md
@@ -26,7 +26,7 @@ This can happen in several spots along the bootup:
    This happens asynchronously in the boot process, systemd does not wait for
    udev to finish loading modules before it continues on.
 
-   This path makes it very likely the system will experience a RDMA 'hot plug'
+   This path makes it very likely the system will experience an RDMA 'hot plug'
    scenario.
 
  - From systemd's fixed module loader systemd-modules-load.service, e.g. from
@@ -41,7 +41,7 @@ This is triggered automatically by udev rules that match the master devices
 and load the protocol module with udev's module loader. This happens
 asynchronously to the rest of the systemd startup.
 
-Once a RDMA device is created by the kernel then udev will cause systemd to
+Once an RDMA device is created by the kernel then udev will cause systemd to
 schedule ULP module loading services (e.g. rdma-load-modules@.service) specific
 to the plugged hardware. If sysinit.target has not yet been passed then these
 loaders will defer sysinit.target until they complete, otherwise this is a hot

--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -165,7 +165,7 @@ stages:
 
           - task: PublishPipelineArtifact@0
             inputs:
-              # Contains a rdma-core-XX.tar.gz file
+              # Contains an rdma-core-XX.tar.gz file
               artifactName: source_tar
               targetPath: artifacts
 

--- a/debian/control
+++ b/debian/control
@@ -87,7 +87,7 @@ Description: User space provider drivers for libibverbs
  hardware access from userspace (kernel bypass), and libibverbs
  supports this when available.
  .
- A RDMA driver consists of a kernel portion and a user space portion.
+ An RDMA driver consists of a kernel portion and a user space portion.
  This package contains the user space verbs drivers:
  .
   - bnxt_re: Broadcom NetXtreme-E RoCE HCAs

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -190,7 +190,7 @@ enum {
 	VSYSFS_READ_FW_VER = 1 << 2,
 };
 
-/* A rdma device detected in sysfs */
+/* An rdma device detected in sysfs */
 struct verbs_sysfs_dev {
 	struct list_node entry;
 	void *provider_data;

--- a/libibverbs/man/ibv_query_gid_table.3.md
+++ b/libibverbs/man/ibv_query_gid_table.3.md
@@ -37,7 +37,7 @@ to the size of *entries* array.
 *entries* array must be allocated such that it can contain all the valid
 GID table entries of the device. If there are more valid GID entries than
 the provided value of *max_entries* and *entries* array, the call will fail.
-For example, if a RDMA device *context* has a total of 10 valid
+For example, if an RDMA device *context* has a total of 10 valid
 GID entries, *entries* should be allocated for at least 10 entries, and
 *max_entries* should be set appropriately.
 

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -1119,7 +1119,7 @@ static int rping_connect_client(struct rping_cb *cb)
 		}
 	}
 
-	DEBUG_LOG("rmda_connect successful\n");
+	DEBUG_LOG("rdma_connect successful\n");
 	return 0;
 }
 

--- a/librdmacm/man/rdma_init_qp_attr.3.md
+++ b/librdmacm/man/rdma_init_qp_attr.3.md
@@ -10,7 +10,7 @@ title: RDMA_INIT_QP_ATTR
 
 # NAME
 
-rdma_init_qp_attr - Returns qp attributes of a rdma_cm_id.
+rdma_init_qp_attr - Returns qp attributes of an rdma_cm_id.
 
 # SYNOPSIS
 
@@ -23,7 +23,7 @@ int rdma_init_qp_attr(struct rdma_cm_id *id,
 ```
 # DESCRIPTION
 
-**rdma_init_qp_attr()** returns qp attributes of a rdma_cm_id.
+**rdma_init_qp_attr()** returns qp attributes of an rdma_cm_id.
 
 Information about qp attributes and qp attributes mask is returned through the *qp_attr* and *qp_attr_mask* parameters.
 

--- a/tests/base_rdmacm.py
+++ b/tests/base_rdmacm.py
@@ -91,7 +91,7 @@ class CMResources(abc.ABC):
 
     def create_qp(self):
         """
-        Create a rdmacm QP. If self.with_ext_qp is set, then an external CQ and
+        Create an rdmacm QP. If self.with_ext_qp is set, then an external CQ and
         RC QP will be created and set in self.cq and self.qp
         respectively.
         """

--- a/tests/rdmacm_utils.py
+++ b/tests/rdmacm_utils.py
@@ -267,7 +267,7 @@ class CMAsyncConnection(CMConnection):
 
     def establish_connection(self):
         """
-        Establish RMDACM connection between two Async CMIDs.
+        Establish RDMACM connection between two Async CMIDs.
         """
         if self.cm_res.passive:
             self.cm_res.cmid.bind_addr(self.cm_res.ai)
@@ -378,7 +378,7 @@ class CMSyncConnection(CMConnection):
 
     def establish_connection(self):
         """
-        Establish RMDACM connection between two Sync CMIDs.
+        Establish RDMACM connection between two Sync CMIDs.
         """
         if self.cm_res.passive:
             self.cm_res.cmid.listen()


### PR DESCRIPTION
The patch only makes grammar-related fixes. It fixes misspelled abbreviations for Remote Direct Memory Access and incorrect use of the article "a" with "RDMA".

The changes include:
 * Changed "a RDMA" to "an RDMA"
 * Changed "RMDA" to "RDMA".