### PR TITLE
mlx5: DR, Improve rule insertion rate

### DIFF
--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -175,8 +175,9 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->gvmi = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.vhca_id);
 	caps->flex_protocols = DEVX_GET(query_hca_cap_out, out,
 					capability.cmd_hca_cap.flex_parser_protocols);
-	roce = DEVX_GET(query_hca_cap_out, out,
-			capability.cmd_hca_cap.roce);
+	caps->isolate_vl_tc = DEVX_GET(query_hca_cap_out, out,
+				       capability.cmd_hca_cap.isolate_vl_tc);
+	roce = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.roce);
 
 	caps->sw_format_ver = DEVX_GET(query_hca_cap_out, out,
 				       capability.cmd_hca_cap.steering_format_version);
@@ -766,6 +767,7 @@ struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, log_rq_stride, attr->rq_wqe_shift - 4);
 	DEVX_SET(qpc, qpc, log_rq_size, ilog32(attr->rq_wqe_cnt - 1));
 	DEVX_SET(qpc, qpc, dbr_umem_id, attr->db_umem_id);
+	DEVX_SET(qpc, qpc, isolate_vl_tc, attr->isolate_vl_tc);
 
 	DEVX_SET(create_qp_in, in, wq_umem_id, attr->buff_umem_id);
 

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -273,6 +273,8 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 			dr_dbg_ctx(ctx, "Query RoCE capabilities failed %d\n", err);
 			return err;
 		}
+		caps->roce_caps.fl_rc_qp_when_roce_disabled = DEVX_GET(query_hca_cap_out, out,
+					      capability.roce_caps.fl_rc_qp_when_roce_disabled);
 		caps->roce_caps.fl_rc_qp_when_roce_enabled = DEVX_GET(query_hca_cap_out, out,
 					      capability.roce_caps.fl_rc_qp_when_roce_enabled);
 	}

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -66,6 +66,26 @@ int dr_devx_query_esw_vport_context(struct ibv_context *ctx,
 	return 0;
 }
 
+static int dr_devx_query_nic_vport_context(struct ibv_context *ctx,
+					   bool *roce_en)
+{
+	uint32_t out[DEVX_ST_SZ_DW(query_nic_vport_context_out)] = {};
+	uint32_t in[DEVX_ST_SZ_DW(query_nic_vport_context_in)] = {};
+	int err;
+
+	DEVX_SET(query_nic_vport_context_in, in, opcode,
+		 MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT);
+	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
+	if (err) {
+		dr_dbg_ctx(ctx, "Query nic vport context failed %d\n", err);
+		return err;
+	}
+
+	*roce_en = DEVX_GET(query_nic_vport_context_out, out,
+			    nic_vport_context.roce_en);
+	return 0;
+}
+
 int dr_devx_query_gvmi(struct ibv_context *ctx, bool other_vport,
 		       uint16_t vport_number, uint16_t *gvmi)
 {
@@ -239,6 +259,10 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 	/* RoCE caps */
 	if (roce) {
+		err = dr_devx_query_nic_vport_context(ctx, &caps->roce_caps.roce_en);
+		if (err)
+			return err;
+
 		DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
 		DEVX_SET(query_hca_cap_in, in, op_mod,
 			 MLX5_SET_HCA_CAP_OP_MOD_ROCE |

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -207,7 +207,7 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 	 * force-loopback.
 	 */
 	if ((dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB) &&
-	    !dmn->info.caps.roce_caps.fl_rc_qp_when_roce_enabled)
+	    !dr_send_allow_fl(&dmn->info.caps))
 		return 0;
 
 	ret = dr_domain_query_fdb_caps(ctx, dmn);

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -832,6 +832,12 @@ int dr_send_postsend_action(struct mlx5dv_dr_domain *dmn,
 	return ret;
 }
 
+bool dr_send_allow_fl(struct dr_devx_caps *caps)
+{
+	return (caps->roce_caps.roce_en &&
+		caps->roce_caps.fl_rc_qp_when_roce_enabled);
+}
+
 static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn)
 {
 	struct dr_devx_qp_rts_attr rts_attr = {};
@@ -856,7 +862,7 @@ static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn)
 	rtr_attr.port_num	= port;
 
 	/* Enable force-loopback on the QP */
-	if (dmn->info.caps.roce_caps.fl_rc_qp_when_roce_enabled) {
+	if (dr_send_allow_fl(&dmn->info.caps)) {
 		rtr_attr.fl = true;
 	} else {
 		ret = dr_devx_query_gid(dmn->ctx, port, gid_index, &rtr_attr.dgid_attr);

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -834,8 +834,10 @@ int dr_send_postsend_action(struct mlx5dv_dr_domain *dmn,
 
 bool dr_send_allow_fl(struct dr_devx_caps *caps)
 {
-	return (caps->roce_caps.roce_en &&
-		caps->roce_caps.fl_rc_qp_when_roce_enabled);
+	return ((caps->roce_caps.roce_en &&
+		 caps->roce_caps.fl_rc_qp_when_roce_enabled) ||
+		(!caps->roce_caps.roce_en &&
+		 caps->roce_caps.fl_rc_qp_when_roce_disabled));
 }
 
 static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn)

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -605,7 +605,8 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         reserved_at_90[0xb];
 	u8         log_max_qp[0x5];
 
-	u8         reserved_at_a0[0xb];
+	u8         reserved_at_a0[0xa];
+	u8         isolate_vl_tc[0x1];
 	u8         log_max_srq[0x5];
 	u8         reserved_at_b0[0x10];
 
@@ -2548,7 +2549,8 @@ struct mlx5_ifc_qpc_bits {
 	u8         state[0x4];
 	u8         lag_tx_port_affinity[0x4];
 	u8         st[0x8];
-	u8         reserved_at_10[0x3];
+	u8         reserved_at_10[0x2];
+	u8         isolate_vl_tc[0x1];
 	u8         pm_state[0x2];
 	u8         reserved_at_15[0x1];
 	u8	   req_e2e_credit_mode[0x2];

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -98,7 +98,8 @@ struct mlx5_ifc_atomic_caps_bits {
 };
 
 struct mlx5_ifc_roce_cap_bits {
-	u8         reserved_0[0x6];
+	u8         reserved_0[0x5];
+	u8         fl_rc_qp_when_roce_disabled[0x1];
 	u8         fl_rc_qp_when_roce_enabled[0x1];
 	u8         reserved_at_7[0x19];
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -49,6 +49,7 @@ enum {
 	MLX5_CMD_OP_RTS2RTS_QP = 0x505,
 	MLX5_CMD_OP_QUERY_QP = 0x50b,
 	MLX5_CMD_OP_QUERY_ESW_VPORT_CONTEXT = 0x752,
+	MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT = 0x754,
 	MLX5_CMD_OP_QUERY_ROCE_ADDRESS = 0x760,
 	MLX5_CMD_OP_QUERY_LAG = 0x842,
 	MLX5_CMD_OP_CREATE_TIR = 0x900,
@@ -2462,6 +2463,34 @@ struct mlx5_ifc_query_esw_vport_context_in_bits {
 	u8         vport_number[0x10];
 
 	u8         reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_nic_vport_context_bits {
+	u8         reserved_at_0[0x1f];
+	u8         roce_en[0x1];
+
+	u8         reserved_at_20[0x7e0];
+};
+
+struct mlx5_ifc_query_nic_vport_context_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+
+	struct mlx5_ifc_nic_vport_context_bits nic_vport_context;
+};
+
+struct mlx5_ifc_query_nic_vport_context_in_bits {
+	u8         opcode[0x10];
+	u8         reserved_at_10[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x40];
 };
 
 enum {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -610,6 +610,7 @@ struct dr_devx_vport_cap {
 
 struct dr_devx_roce_cap {
 	bool roce_en;
+	bool fl_rc_qp_when_roce_disabled;
 	bool fl_rc_qp_when_roce_enabled;
 };
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -631,6 +631,7 @@ struct dr_devx_caps {
 	uint8_t				flex_parser_id_icmpv6_dw1;
 	uint8_t				max_ft_level;
 	uint8_t				sw_format_ver;
+	bool				isolate_vl_tc;
 	bool				eswitch_manager;
 	bool				rx_sw_owner;
 	bool				tx_sw_owner;
@@ -1041,6 +1042,7 @@ struct dr_devx_qp_create_attr {
 	uint32_t	sq_wqe_cnt;
 	uint32_t	rq_wqe_cnt;
 	uint32_t	rq_wqe_shift;
+	bool		isolate_vl_tc;
 };
 
 struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -609,6 +609,7 @@ struct dr_devx_vport_cap {
 };
 
 struct dr_devx_roce_cap {
+	bool roce_en;
 	bool fl_rc_qp_when_roce_enabled;
 };
 
@@ -1176,6 +1177,7 @@ struct dr_send_ring {
 int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn);
 void dr_send_ring_free(struct dr_send_ring *send_ring);
 int dr_send_ring_force_drain(struct mlx5dv_dr_domain *dmn);
+bool dr_send_allow_fl(struct dr_devx_caps *caps);
 int dr_send_postsend_ste(struct mlx5dv_dr_domain *dmn, struct dr_ste *ste,
 			 uint8_t *data, uint16_t size, uint16_t offset);
 int dr_send_postsend_htbl(struct mlx5dv_dr_domain *dmn, struct dr_ste_htbl *htbl,


### PR DESCRIPTION
This series improves rule insertion rate by using an isolated VL on the send QP.

This can be achieved only if force loop-back is supported and isolate_vl_tc cap is enabled.