### PR TITLE
mlx5: Misc items

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -82,6 +82,7 @@ static const struct verbs_match_ent hca_table[] = {
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
 	HCA(MELLANOX, 0xa2d6),  /* BlueField-2 integrated ConnectX-6 Dx network controller */
+	HCA(MELLANOX, 0xa2dc),  /* BlueField-3 integrated ConnectX-7 network controller */
 	{}
 };
 

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -368,7 +368,7 @@ static int set_data_inl_seg(struct mlx5_qp *qp, struct ibv_send_wr *wr,
 
 static uint8_t wq_sig(struct mlx5_wqe_ctrl_seg *ctrl)
 {
-	return calc_sig(ctrl, be32toh(ctrl->qpn_ds));
+	return calc_sig(ctrl, (be32toh(ctrl->qpn_ds) & 0x3f) << 4);
 }
 
 #ifdef MLX5_DEBUG


### PR DESCRIPTION
This series includes the below two items:
- Adds Bluefield-3 to the list of supported devices.
- Fixes the wqe signature calculation.