### PR TITLE
verbs: Remove incorrect comment on SQ PSN from documentation

### DIFF
--- a/libibverbs/man/ibv_modify_qp.3
+++ b/libibverbs/man/ibv_modify_qp.3
@@ -30,7 +30,7 @@ enum ibv_mtu            path_mtu;               /* Path MTU (valid only for RC/U
 enum ibv_mig_state      path_mig_state;         /* Path migration state (valid if HCA supports APM) */
 uint32_t                qkey;                   /* Q_Key for the QP (valid only for UD QPs) */
 uint32_t                rq_psn;                 /* PSN for receive queue (valid only for RC/UC QPs) */
-uint32_t                sq_psn;                 /* PSN for send queue (valid only for RC/UC QPs) */
+uint32_t                sq_psn;                 /* PSN for send queue */
 uint32_t                dest_qp_num;            /* Destination QP number (valid only for RC/UC QPs) */
 int                     qp_access_flags;        /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
 struct ibv_qp_cap       cap;                    /* QP capabilities (valid if HCA supports QP resizing) */

--- a/libibverbs/man/ibv_query_qp.3
+++ b/libibverbs/man/ibv_query_qp.3
@@ -35,7 +35,7 @@ enum ibv_mtu            path_mtu;            /* Path MTU (valid only for RC/UC Q
 enum ibv_mig_state      path_mig_state;      /* Path migration state (valid if HCA supports APM) */
 uint32_t                qkey;                /* Q_Key of the QP (valid only for UD QPs) */
 uint32_t                rq_psn;              /* PSN for receive queue (valid only for RC/UC QPs) */
-uint32_t                sq_psn;              /* PSN for send queue (valid only for RC/UC QPs) */
+uint32_t                sq_psn;              /* PSN for send queue */
 uint32_t                dest_qp_num;         /* Destination QP number (valid only for RC/UC QPs) */
 int                     qp_access_flags;     /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
 struct ibv_qp_cap       cap;                 /* QP capabilities */


### PR DESCRIPTION
The sq_psn field is valid for all QP types, not just RC/UC.

Signed-off-by: Gal Pressman <galpress@amazon.com>