### PR TITLE
mlx5: DR, Improve locking and memory usage

### DIFF
--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -292,11 +292,11 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule)
 	if (!fout || !rule)
 		return -EINVAL;
 
-	pthread_mutex_lock(&rule->matcher->tbl->dmn->mutex);
+	dr_domain_lock(rule->matcher->tbl->dmn);
 
 	ret = dr_dump_rule(fout, rule);
 
-	pthread_mutex_unlock(&rule->matcher->tbl->dmn->mutex);
+	dr_domain_unlock(rule->matcher->tbl->dmn);
 
 	return ret;
 }
@@ -477,11 +477,11 @@ int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher)
 	if (!fout || !matcher)
 		return -EINVAL;
 
-	pthread_mutex_lock(&matcher->tbl->dmn->mutex);
+	dr_domain_lock(matcher->tbl->dmn);
 
 	ret = dr_dump_matcher_all(fout, matcher);
 
-	pthread_mutex_unlock(&matcher->tbl->dmn->mutex);
+	dr_domain_unlock(matcher->tbl->dmn);
 
 	return ret;
 }
@@ -567,11 +567,11 @@ int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *tbl)
 	if (!fout || !tbl)
 		return -EINVAL;
 
-	pthread_mutex_lock(&tbl->dmn->mutex);
+	dr_domain_lock(tbl->dmn);
 
 	ret = dr_dump_table_all(fout, tbl);
 
-	pthread_mutex_unlock(&tbl->dmn->mutex);
+	dr_domain_unlock(tbl->dmn);
 
 	return ret;
 }
@@ -746,11 +746,11 @@ int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *dmn)
 	if (!fout || !dmn)
 		return -EINVAL;
 
-	pthread_mutex_lock(&dmn->mutex);
+	dr_domain_lock(dmn);
 
 	ret = dr_dump_domain_all(fout, dmn);
 
-	pthread_mutex_unlock(&dmn->mutex);
+	dr_domain_unlock(dmn);
 
 	return ret;
 }

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -321,6 +321,8 @@ mlx5dv_dr_domain_create(struct ibv_context *ctx,
 	dmn->type = type;
 	atomic_init(&dmn->refcount, 1);
 	list_head_init(&dmn->tbl_list);
+	pthread_mutex_init(&dmn->info.rx.mutex, NULL);
+	pthread_mutex_init(&dmn->info.tx.mutex, NULL);
 
 	if (dr_domain_caps_init(ctx, dmn)) {
 		dr_dbg(dmn, "Failed init domain, no caps\n");
@@ -367,12 +369,9 @@ int mlx5dv_dr_domain_sync(struct mlx5dv_dr_domain *dmn, uint32_t flags)
 	}
 
 	if (flags & MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW) {
-		pthread_mutex_lock(&dmn->mutex);
 		ret = dr_send_ring_force_drain(dmn);
 		if (ret)
-			goto out_unlock;
-
-		pthread_mutex_unlock(&dmn->mutex);
+			return ret;
 	}
 
 	if (flags & MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW) {
@@ -393,21 +392,17 @@ int mlx5dv_dr_domain_sync(struct mlx5dv_dr_domain *dmn, uint32_t flags)
 	}
 
 	return ret;
-
-out_unlock:
-	pthread_mutex_unlock(&dmn->mutex);
-	return ret;
 }
 
 void mlx5dv_dr_domain_set_reclaim_device_memory(struct mlx5dv_dr_domain *dmn,
 						bool enable)
 {
-	pthread_mutex_lock(&dmn->mutex);
+	dr_domain_lock(dmn);
 	if (enable)
 		dmn->flags |= DR_DOMAIN_FLAG_MEMORY_RECLAIM;
 	else
 		dmn->flags &= ~DR_DOMAIN_FLAG_MEMORY_RECLAIM;
-	pthread_mutex_unlock(&dmn->mutex);
+	dr_domain_unlock(dmn);
 }
 
 int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *dmn)

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -1170,6 +1170,8 @@ struct dr_send_ring {
 	uint32_t		max_post_send_size;
 	/* manage the send queue */
 	uint32_t		tx_head;
+	/* protect QP/CQ operations */
+	pthread_mutex_t         mutex;
 	void			*buf;
 	uint32_t		buf_size;
 	struct ibv_wc		wc[MAX_SEND_CQE];

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -156,6 +156,7 @@ struct dr_icm_buddy_mem;
 struct dr_ste_htbl;
 struct dr_match_param;
 struct dr_devx_caps;
+struct dr_rule_rx_tx;
 struct dr_matcher_rx_tx;
 struct dr_ste_ctx;
 
@@ -181,13 +182,13 @@ struct dr_ste {
 	/* attached to the miss_list head at each htbl entry */
 	struct list_node	miss_list_node;
 
-	/* each rule member that uses this ste attached here */
-	struct list_head	rule_list;
-
 	/* this ste is member of htbl */
 	struct dr_ste_htbl	*htbl;
 
 	struct dr_ste_htbl	*next_htbl;
+
+	/* The rule this STE belongs to */
+	struct dr_rule_rx_tx    *rule_rx_tx;
 
 	/* this ste is part of a rule, located in ste's chain */
 	uint8_t			ste_chain_location;
@@ -798,14 +799,6 @@ struct mlx5dv_dr_matcher {
 	struct list_head		rule_list;
 };
 
-struct dr_rule_member {
-	struct dr_ste		*ste;
-	/* attached to dr_rule via this */
-	struct list_node	list;
-	/* attached to dr_ste via this */
-	struct list_node	use_ste_list;
-};
-
 struct dr_ste_action_modify_field {
 	uint16_t hw_field;
 	uint8_t start;
@@ -926,10 +919,9 @@ struct dr_htbl_connect_info {
 	};
 };
 
-
 struct dr_rule_rx_tx {
-	struct list_head		rule_members_list;
 	struct dr_matcher_rx_tx		*nic_matcher;
+	struct dr_ste			*last_rule_ste;
 };
 
 struct mlx5dv_dr_rule {
@@ -945,7 +937,13 @@ struct mlx5dv_dr_rule {
 	struct list_node	rule_list;
 };
 
-void dr_rule_update_rule_member(struct dr_ste *new_ste, struct dr_ste *ste);
+void dr_rule_set_last_member(struct dr_rule_rx_tx *nic_rule,
+			     struct dr_ste *ste,
+			     bool force);
+
+void dr_rule_get_reverse_rule_members(struct dr_ste **ste_arr,
+				      struct dr_ste *curr_ste,
+				      int *num_of_stes);
 
 struct dr_icm_chunk {
 	struct dr_icm_buddy_mem *buddy_mem;


### PR DESCRIPTION
This series improves the internal DR locking to enable parallel rule insertions in FDB mode.
In addition, it improves the rule tracking which dramatically reduces its memory consumption.