### PR TITLE
mlx5: DR, Add support for push / pop VLAN actions

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -110,6 +110,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_flow_sampler@MLX5_1.16 32
  mlx5dv_dr_action_create_dest_array@MLX5_1.16 32
  mlx5dv_dr_action_create_pop_vlan@MLX5_1.17 33
+ mlx5dv_dr_action_create_push_vlan@MLX5_1.17 33
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -24,6 +24,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.14@MLX5_1.14 30
  MLX5_1.15@MLX5_1.15 31
  MLX5_1.16@MLX5_1.16 32
+ MLX5_1.17@MLX5_1.17 33
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -108,6 +109,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_dest_devx_tir@MLX5_1.15 31
  mlx5dv_dr_action_create_flow_sampler@MLX5_1.16 32
  mlx5dv_dr_action_create_dest_array@MLX5_1.16 32
+ mlx5dv_dr_action_create_pop_vlan@MLX5_1.17 33
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.16.${PACKAGE_VERSION}
+  1 1.17.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -48,6 +48,7 @@ enum dr_action_valid_state {
 	DR_ACTION_STATE_NO_ACTION,
 	DR_ACTION_STATE_REFORMAT,
 	DR_ACTION_STATE_MODIFY_HDR,
+	DR_ACTION_STATE_MODIFY_VLAN,
 	DR_ACTION_STATE_NON_TERM,
 	DR_ACTION_STATE_TERM,
 	DR_ACTION_STATE_MAX,
@@ -69,6 +70,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_REFORMAT] = {
@@ -80,6 +82,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -89,6 +92,17 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
+		},
+		[DR_ACTION_STATE_MODIFY_VLAN] = {
+			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -102,6 +116,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
@@ -156,6 +171,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
@@ -166,6 +182,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
@@ -175,6 +192,16 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+		},
+		[DR_ACTION_STATE_MODIFY_VLAN] = {
+			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -186,6 +213,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TNL_L2_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
@@ -363,6 +391,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 
 	for (i = 0; i < num_actions; i++) {
 		struct mlx5dv_dr_action *action;
+		int max_actions_type = 1;
 		uint32_t action_type;
 
 		action = actions[i];
@@ -491,13 +520,18 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				action->dest_array.rx_icm_addr :
 				action->dest_array.tx_icm_addr;
 			break;
+		case DR_ACTION_TYP_POP_VLAN:
+			max_actions_type = MAX_VLANS;
+			attr.vlans.count++;
+			break;
 		default:
 			goto out_invalid_arg;
 		}
 
 		/* Check action duplication */
-		if (++action_type_set[action_type] > 1) {
-			dr_dbg(dmn, "Duplicate action type provided\n");
+		if (++action_type_set[action_type] > max_actions_type) {
+			dr_dbg(dmn, "Action type %d supports only max %d time(s)\n",
+			       action_type, max_actions_type);
 			goto out_invalid_arg;
 		}
 
@@ -935,6 +969,11 @@ free_action:
 dec_ref:
 	atomic_fetch_sub(&dmn->refcount, 1);
 	return NULL;
+}
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_pop_vlan(void)
+{
+	return dr_action_create_generic(DR_ACTION_TYP_POP_VLAN);
 }
 
 static int

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -72,6 +72,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L2 = 3409,
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L3 = 3410,
 	DR_DUMP_REC_TYPE_ACTION_DEVX_TIR = 3411,
+	DR_DUMP_REC_TYPE_ACTION_POP_VLAN = 3413,
 	DR_DUMP_REC_TYPE_ACTION_METER = 3414,
 	DR_DUMP_REC_TYPE_ACTION_SAMPLER = 3415,
 	DR_DUMP_REC_TYPE_ACTION_DEST_ARRAY = 3416,
@@ -188,6 +189,11 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 			      action->dest_array.devx_tbl->ft_dvo->object_id,
 			      action->dest_array.rx_icm_addr,
 			      action->dest_array.tx_icm_addr);
+		break;
+	case DR_ACTION_TYP_POP_VLAN:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
+			      DR_DUMP_REC_TYPE_ACTION_POP_VLAN, action_id,
+			      rule_id);
 		break;
 	default:
 		return 0;

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -72,6 +72,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L2 = 3409,
 	DR_DUMP_REC_TYPE_ACTION_DECAP_L3 = 3410,
 	DR_DUMP_REC_TYPE_ACTION_DEVX_TIR = 3411,
+	DR_DUMP_REC_TYPE_ACTION_PUSH_VLAN = 3412,
 	DR_DUMP_REC_TYPE_ACTION_POP_VLAN = 3413,
 	DR_DUMP_REC_TYPE_ACTION_METER = 3414,
 	DR_DUMP_REC_TYPE_ACTION_SAMPLER = 3415,
@@ -194,6 +195,11 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
 			      DR_DUMP_REC_TYPE_ACTION_POP_VLAN, action_id,
 			      rule_id);
+		break;
+	case DR_ACTION_TYP_PUSH_VLAN:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_PUSH_VLAN, action_id,
+			      rule_id, action->push_vlan.vlan_hdr);
 		break;
 	default:
 		return 0;

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -170,6 +170,8 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 		return err;
 	}
 
+	caps->prio_tag_required = DEVX_GET(query_hca_cap_out, out,
+					   capability.cmd_hca_cap.prio_tag_required);
 	caps->eswitch_manager = DEVX_GET(query_hca_cap_out, out,
 					 capability.cmd_hca_cap.eswitch_manager);
 	caps->gvmi = DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.vhca_id);

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -152,3 +152,8 @@ MLX5_1.16 {
 		mlx5dv_dr_action_create_dest_array;
 		mlx5dv_dr_action_create_flow_sampler;
 } MLX5_1.15;
+
+MLX5_1.17 {
+	global:
+		mlx5dv_dr_action_create_pop_vlan;
+} MLX5_1.16;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -156,4 +156,5 @@ MLX5_1.16 {
 MLX5_1.17 {
 	global:
 		mlx5dv_dr_action_create_pop_vlan;
+		mlx5dv_dr_action_create_push_vlan;
 } MLX5_1.16;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -68,6 +68,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_modify_header.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_packet_reformat.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_pop_vlan.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_push_vlan.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_tag.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -67,6 +67,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_flow_meter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_modify_header.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_packet_reformat.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_pop_vlan.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_tag.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -38,6 +38,8 @@ mlx5dv_dr_action_create_flow_meter, mlx5dv_dr_action_modify_flow_meter - Create 
 
 mlx5dv_dr_action_create_flow_sampler - Create flow sampler action
 
+mlx5dv_dr_action_create_pop_vlan - Create pop vlan action
+
 mlx5dv_dr_action_destroy - Destroy actions
 
 # SYNOPSIS
@@ -131,6 +133,8 @@ struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_dest_array(struct mlx5dv_dr_domain *domain,
 				   size_t num_dest,
 				   struct mlx5dv_dr_action_dest_attr *dests[]);
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_pop_vlan(void);
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 ```
@@ -230,6 +234,9 @@ All original packets will be steered to default_next_table in **attr**.
 A modify header format SET_ACTION data can be provided in action of **attr**, which can be executed on packets before going to default flow table. On some devices, this is required to set register value.
 
 Action Flags: action **flags** can be set to one of the types of *enum mlx5dv_dr_action_flags*:
+
+Action: Pop Vlan
+*mlx5dv_dr_action_create_pop_vlan* creates a pop vlan action which removes VLAN tags from packets layer 2.
 
 **MLX5DV_DR_ACTION_FLAGS_ROOT_LEVEL**: is used to indicate the action is targeted for flow table in level=0 (ROOT) of the specific domain.
 

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -40,6 +40,8 @@ mlx5dv_dr_action_create_flow_sampler - Create flow sampler action
 
 mlx5dv_dr_action_create_pop_vlan - Create pop vlan action
 
+mlx5dv_dr_action_create_push_vlan- Create push vlan action
+
 mlx5dv_dr_action_destroy - Destroy actions
 
 # SYNOPSIS
@@ -135,6 +137,10 @@ mlx5dv_dr_action_create_dest_array(struct mlx5dv_dr_domain *domain,
 				   struct mlx5dv_dr_action_dest_attr *dests[]);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_pop_vlan(void);
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_push_vlan(
+		struct mlx5dv_dr_domain *dmn,
+		__be32 vlan_hdr)
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 ```
@@ -237,6 +243,9 @@ Action Flags: action **flags** can be set to one of the types of *enum mlx5dv_dr
 
 Action: Pop Vlan
 *mlx5dv_dr_action_create_pop_vlan* creates a pop vlan action which removes VLAN tags from packets layer 2.
+
+Action: Push Vlan
+*mlx5dv_dr_action_create_push_vlan* creates a push vlan action which adds VLAN tags to packets layer 2.
 
 **MLX5DV_DR_ACTION_FLAGS_ROOT_LEVEL**: is used to indicate the action is targeted for flow table in level=0 (ROOT) of the specific domain.
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -602,7 +602,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 
 	u8         log_max_srq_sz[0x8];
 	u8         log_max_qp_sz[0x8];
-	u8         reserved_at_90[0xb];
+	u8         reserved_at_90[0x8];
+	u8         prio_tag_required[0x1];
+	u8         reserved_at_99[0x2];
 	u8         log_max_qp[0x5];
 
 	u8         reserved_at_a0[0xa];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1564,6 +1564,9 @@ int mlx5dv_dr_action_modify_flow_meter(struct mlx5dv_dr_action *action,
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_sampler(struct mlx5dv_dr_flow_sampler_attr *attr);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_pop_vlan(void);
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
 int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *domain);

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1567,6 +1567,10 @@ mlx5dv_dr_action_create_flow_sampler(struct mlx5dv_dr_flow_sampler_attr *attr);
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_pop_vlan(void);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_push_vlan(struct mlx5dv_dr_domain *domain,
+				  __be32 vlan_hdr);
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
 int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *domain);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -46,6 +46,8 @@
 #define WIRE_PORT		0xFFFF
 #define DR_STE_SVLAN		0x1
 #define DR_STE_CVLAN		0x2
+#define CVLAN_ETHERTYPE	0x8100
+#define SVLAN_ETHERTYPE	0x88a8
 
 #define dr_dbg(dmn, arg...) dr_dbg_ctx((dmn)->ctx, ##arg)
 
@@ -148,6 +150,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_SAMPLER,
 	DR_ACTION_TYP_DEST_ARRAY,
 	DR_ACTION_TYP_POP_VLAN,
+	DR_ACTION_TYP_PUSH_VLAN,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -296,6 +299,7 @@ struct dr_ste_actions_attr {
 	uint16_t	hit_gvmi;
 	uint32_t	reformat_id;
 	uint32_t	reformat_size;
+	bool		prio_tag_required;
 	struct {
 		int		count;
 		uint32_t	headers[MAX_VLANS];
@@ -649,6 +653,7 @@ struct dr_devx_caps {
 	uint32_t			num_vports;
 	struct dr_devx_vport_cap	*vports_caps;
 	struct dr_devx_roce_cap		roce_caps;
+	bool				prio_tag_required;
 };
 
 struct dr_devx_flow_table_attr {
@@ -880,6 +885,9 @@ struct mlx5dv_dr_action {
 			struct dr_devx_vport_cap	*caps;
 			uint32_t			num;
 		} vport;
+		struct {
+			uint32_t	vlan_hdr;
+		} push_vlan;
 		struct {
 			bool    is_qp;
 			union {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -42,7 +42,7 @@
 #include "mlx5.h"
 
 #define DR_RULE_MAX_STES	17
-#define DR_ACTION_MAX_STES	3
+#define DR_ACTION_MAX_STES	5
 #define WIRE_PORT		0xFFFF
 #define DR_STE_SVLAN		0x1
 #define DR_STE_CVLAN		0x2
@@ -147,6 +147,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_MISS,
 	DR_ACTION_TYP_SAMPLER,
 	DR_ACTION_TYP_DEST_ARRAY,
+	DR_ACTION_TYP_POP_VLAN,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -280,6 +281,8 @@ uint64_t dr_ste_get_icm_addr(struct dr_ste *ste);
 uint64_t dr_ste_get_mr_addr(struct dr_ste *ste);
 struct list_head *dr_ste_get_miss_list(struct dr_ste *ste);
 
+#define MAX_VLANS 2
+
 struct dr_ste_actions_attr {
 	uint32_t	modify_index;
 	uint16_t	modify_actions;
@@ -293,6 +296,10 @@ struct dr_ste_actions_attr {
 	uint16_t	hit_gvmi;
 	uint32_t	reformat_id;
 	uint32_t	reformat_size;
+	struct {
+		int		count;
+		uint32_t	headers[MAX_VLANS];
+	} vlans;
 };
 
 void dr_ste_set_actions_rx(struct dr_ste_ctx *ste_ctx,


### PR DESCRIPTION
This series adds support for push / pop VLAN actions, this will allow HW offloading of those actions.