### PR TITLE
mlx5: NC UAR improvements

### DIFF
--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -57,7 +57,13 @@ static int dr_domain_init_resources(struct mlx5dv_dr_domain *dmn)
 		return ret;
 	}
 
-	dmn->uar = mlx5dv_devx_alloc_uar(dmn->ctx, 0);
+	dmn->uar = mlx5dv_devx_alloc_uar(dmn->ctx,
+					 MLX5_IB_UAPI_UAR_ALLOC_TYPE_NC);
+
+	if (!dmn->uar)
+		dmn->uar = mlx5dv_devx_alloc_uar(dmn->ctx,
+						 MLX5_IB_UAPI_UAR_ALLOC_TYPE_BF);
+
 	if (!dmn->uar) {
 		dr_dbg(dmn, "Can't allocate UAR\n");
 		goto clean_pd;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1415,7 +1415,6 @@ static int mlx5_set_context(struct mlx5_context *context,
 	context->cmds_supp_uhw = resp->cmds_supp_uhw;
 	context->vendor_cap_flags = 0;
 	list_head_init(&context->dyn_uar_bf_list);
-	list_head_init(&context->dyn_uar_nc_list);
 	list_head_init(&context->dyn_uar_qp_shared_list);
 	list_head_init(&context->dyn_uar_qp_dedicated_list);
 
@@ -1536,9 +1535,8 @@ bf_done:
 		}
 	}
 
-	context->cq_uar = mlx5_attach_dedicated_uar(&v_ctx->context,
-						    MLX5_IB_UAPI_UAR_ALLOC_TYPE_NC);
-	context->cq_uar_reg = context->cq_uar ? context->cq_uar->uar : context->uar[0].reg;
+	mlx5_set_singleton_nc_uar(&v_ctx->context);
+	context->cq_uar_reg = context->nc_uar ? context->nc_uar->uar : context->uar[0].reg;
 
 	return 0;
 

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -325,14 +325,13 @@ struct mlx5_context {
 	__be32                          dump_fill_mkey_be;
 	uint32_t			flags;
 	struct list_head		dyn_uar_bf_list;
-	struct list_head		dyn_uar_nc_list;
 	struct list_head		dyn_uar_qp_shared_list;
 	struct list_head		dyn_uar_qp_dedicated_list;
 	uint16_t			qp_max_dedicated_uuars;
 	uint16_t			qp_alloc_dedicated_uuars;
 	uint16_t			qp_max_shared_uuars;
 	uint16_t			qp_alloc_shared_uuars;
-	struct mlx5_bf			*cq_uar;
+	struct mlx5_bf			*nc_uar;
 	void				*cq_uar_reg;
 };
 
@@ -1057,8 +1056,7 @@ int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
 			 const struct ibv_qp_init_attr_ex *attr,
 			 const struct mlx5dv_qp_init_attr *mlx5_attr);
 void clean_dyn_uars(struct ibv_context *context);
-struct mlx5_bf *mlx5_attach_dedicated_uar(struct ibv_context *context,
-					  uint32_t flags);
+void mlx5_set_singleton_nc_uar(struct ibv_context *context);
 
 int mlx5_set_ece(struct ibv_qp *qp, struct ibv_ece *ece);
 int mlx5_query_ece(struct ibv_qp *qp, struct ibv_ece *ece);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -1142,6 +1142,7 @@ struct dr_qp {
 	struct mlx5dv_devx_uar		*uar;
 	struct mlx5dv_devx_umem		*buf_umem;
 	struct mlx5dv_devx_umem		*db_umem;
+	uint8_t nc_uar : 1;
 };
 
 struct dr_cq {


### PR DESCRIPTION
This series fixes the DR send flow to use NC UAR with its matching locking as currently the DB mode is in use.
In addition, as there is no real need for dedicated NC UARs, the driver code was refactored to use a singleton one.