### PR TITLE
Network type

### DIFF
--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -39,6 +39,11 @@
 #include <linux/in.h>
 #include <linux/in6.h>
 
+enum {
+	RXE_NETWORK_TYPE_IPV4 = 1,
+	RXE_NETWORK_TYPE_IPV6 = 2,
+};
+
 union rxe_gid {
 	__u8	raw[16];
 	struct {
@@ -57,6 +62,7 @@ struct rxe_global_route {
 
 struct rxe_av {
 	__u8			port_num;
+	/* From RXE_NETWORK_TYPE_* */
 	__u8			network_type;
 	__u8			dmac[6];
 	struct rxe_global_route	grh;

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -801,7 +801,7 @@ static struct ibv_ah *rxe_create_ah(struct ibv_pd *pd, struct ibv_ah_attr *attr)
 	memcpy(&av->grh, &attr->grh, sizeof(attr->grh));
 	av->network_type =
 		ipv6_addr_v4mapped((struct in6_addr *)attr->grh.dgid.raw) ?
-		RDMA_NETWORK_IPV4 : RDMA_NETWORK_IPV6;
+		RXE_NETWORK_TYPE_IPV4 : RXE_NETWORK_TYPE_IPV6;
 
 	rdma_gid2ip(&av->sgid_addr, &sgid);
 	rdma_gid2ip(&av->dgid_addr, &attr->grh.dgid);

--- a/providers/rxe/rxe.h
+++ b/providers/rxe/rxe.h
@@ -42,12 +42,6 @@
 #include <rdma/rdma_user_rxe.h> /* struct rxe_av */
 #include "rxe-abi.h"
 
-enum rdma_network_type {
-	RDMA_NETWORK_IB,
-	RDMA_NETWORK_IPV4,
-	RDMA_NETWORK_IPV6
-};
-
 struct rxe_device {
 	struct verbs_device	ibv_dev;
 	int	abi_version;


### PR DESCRIPTION
Cleanup rxe provider to support kernel commit referenced below.

Reference: e0d696d201dd ("RDMA/rxe: Move the definitions for rxe_av.network_type to uAPI")
