### PR TITLE
Fix LTO support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,16 @@ CHECK_C_SOURCE_COMPILES("
   HAVE_FUNC_ATTRIBUTE_IFUNC
   FAIL_REGEX "warning")
 
+CHECK_C_SOURCE_COMPILES("
+ #include <unistd.h>
+
+ void _sym(void);
+ __attribute__((__symver__(\"sym@TEST_1.1\"))) void _sym(void) {}
+
+ int main(int argc,const char *argv[]) { _sym(); }"
+  HAVE_FUNC_ATTRIBUTE_SYMVER
+  FAIL_REGEX "warning")
+
 # The code does not do the racy fcntl if the various CLOEXEC's are not
 # supported so it really doesn't work right if this isn't available. Thus hard
 # require it.
@@ -699,6 +709,9 @@ if (NOT HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE)
 endif()
 if (NOT HAVE_FUNC_ATTRIBUTE_IFUNC)
   message(STATUS " Compiler attribute ifunc NOT supported")
+endif()
+if (NOT HAVE_FUNC_ATTRIBUTE_SYMVER)
+  message(STATUS " Compiler attribute symver NOT supported, can not use LTO")
 endif()
 if (NOT HAVE_COHERENT_DMA)
   message(STATUS " Architecture NOT able to do coherent DMA (check util/udma_barrier.h) some providers disabled!")

--- a/buildlib/FindLDSymVer.cmake
+++ b/buildlib/FindLDSymVer.cmake
@@ -27,15 +27,25 @@ else()
 endif()
 
 # And matching source, this also checks that .symver asm works
-check_c_source_compiles("
-void ibv_get_device_list_1(void);
-void ibv_get_device_list_1(void){}
-asm(\".symver ibv_get_device_list_1, ibv_get_device_list@IBVERBS_1.1\");
-void ibv_get_device_list_0(void);
-void ibv_get_device_list_0(void){}
-asm(\".symver ibv_get_device_list_0, ibv_get_device_list@@IBVERBS_1.0\");
-
-int main(int argc,const char *argv[]){return 0;}" _LDSYMVER_SUCCESS)
+if (HAVE_FUNC_ATTRIBUTE_SYMVER)
+  check_c_source_compiles("
+  void ibv_get_device_list_1(void);
+  __attribute((__symver__(\"ibv_get_device_list@IBVERBS_1.1\")))
+  void ibv_get_device_list_1(void){}
+  void ibv_get_device_list_0(void);
+  __attribute((__symver__(\"ibv_get_device_list@IBVERBS_1.0\")))
+  void ibv_get_device_list_0(void){}
+  int main(int argc,const char *argv[]){return 0;}" _LDSYMVER_SUCCESS)
+else()
+  check_c_source_compiles("
+  void ibv_get_device_list_1(void);
+  void ibv_get_device_list_1(void){}
+  asm(\".symver ibv_get_device_list_1, ibv_get_device_list@IBVERBS_1.1\");
+  void ibv_get_device_list_0(void);
+  void ibv_get_device_list_0(void){}
+  asm(\".symver ibv_get_device_list_0, ibv_get_device_list@@IBVERBS_1.0\");
+  int main(int argc,const char *argv[]){return 0;}" _LDSYMVER_SUCCESS)
+endif()
 
 file(REMOVE "${CMAKE_CURRENT_BINARY_DIR}/test.map")
 set(CMAKE_EXE_LINKER_FLAGS "${SAFE_CMAKE_EXE_LINKER_FLAGS}")

--- a/buildlib/config.h.in
+++ b/buildlib/config.h.in
@@ -46,6 +46,8 @@
 
 #cmakedefine HAVE_FUNC_ATTRIBUTE_IFUNC 1
 
+#cmakedefine HAVE_FUNC_ATTRIBUTE_SYMVER 1
+
 #cmakedefine HAVE_WORKING_IF_H 1
 
 // Operating mode for symbol versions

--- a/iwpmd/iwarp_pm_common.c
+++ b/iwpmd/iwarp_pm_common.c
@@ -570,6 +570,10 @@ void copy_iwpm_sockaddr(__u16 addr_family, struct sockaddr_storage *src_sockaddr
 		*dst = *src;
 		break;
 	}
+	default:
+	assert(false);
+	if (dst_sockaddr)
+		dst_sockaddr->ss_family = addr_family;
 	}
 }
 

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -973,7 +973,6 @@ int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 	int ether_len;
 	struct peer_address src;
 	struct peer_address dst;
-	uint16_t ret_vid;
 	int ret = -EINVAL;
 	int err;
 
@@ -1022,10 +1021,11 @@ int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 		goto free_resources;
 
 	if (vid) {
-		ret_vid = neigh_get_vlan_id_from_dev(&neigh_handler);
+		uint16_t ret_vid = neigh_get_vlan_id_from_dev(&neigh_handler);
 
 		if (ret_vid <= 0xfff)
 			neigh_set_vlan_id(&neigh_handler, ret_vid);
+		*vid = ret_vid;
 	}
 
 	/* We are using only Ethernet here */
@@ -1035,9 +1035,6 @@ int ibv_resolve_eth_l2_from_gid(struct ibv_context *context,
 
 	if (ether_len <= 0)
 		goto free_resources;
-
-	if (vid)
-		*vid = ret_vid;
 
 	ret = 0;
 

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -279,13 +279,6 @@ easy, object-oriented access to IB verbs.
 %setup
 
 %build
-# This package uses top level ASM constructs which are incompatible with LTO.
-# Top level ASMs are often used to implement symbol versioning.  gcc-10
-# introduces a new mechanism for symbol versioning which works with LTO.
-# Converting packages to use that mechanism instead of toplevel ASMs is
-# recommended.
-# Disable LTO
-%define _lto_cflags %{nil}
 
 # New RPM defines _rundir, usually as /run
 %if 0%{?_rundir:1}

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -389,8 +389,6 @@ Pyverbs is a Cython-based Python API over libibverbs, providing an
 easy, object-oriented access to IB verbs.
 
 %prep
-# Make sure LTO is disable as rdma-core fails to compile with LTO enabled
-%define _lto_cflags %{nil}
 %setup -q -n  %{name}-%{version}%{git_ver}
 
 %build

--- a/util/symver.h
+++ b/util/symver.h
@@ -58,11 +58,16 @@
   warnings.  See also Documentation/versioning.md
 */
 
+#if HAVE_FUNC_ATTRIBUTE_SYMVER
 #define _MAKE_SYMVER(_local_sym, _public_sym, _ver_str)                        \
-	asm(".symver " #_local_sym "," #_public_sym "@" _ver_str)
+	__attribute__((__symver__(#_public_sym "@" _ver_str)))
+#else
+#define _MAKE_SYMVER(_local_sym, _public_sym, _ver_str)                        \
+	asm(".symver " #_local_sym "," #_public_sym "@" _ver_str);
+#endif
 #define _MAKE_SYMVER_FUNC(_public_sym, _uniq, _ver_str, _ret, ...)             \
 	_ret __##_public_sym##_##_uniq(__VA_ARGS__);                           \
-	_MAKE_SYMVER(__##_public_sym##_##_uniq, _public_sym, _ver_str);        \
+	_MAKE_SYMVER(__##_public_sym##_##_uniq, _public_sym, _ver_str)         \
 	_ret __##_public_sym##_##_uniq(__VA_ARGS__)
 
 #if defined(HAVE_FULL_SYMBOL_VERSIONS) && !defined(_STATIC_LIBRARY_BUILD_)


### PR DESCRIPTION
Now that gcc has defined attribute symver we can make LTO support work on compilers that support the new attribute.

@nmorey @Honggang-LI 