### PR TITLE
verbs: Introduce ibv_is_fork_initialized verb

### DIFF
--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -10,6 +10,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.10@IBVERBS_1.10 31
  IBVERBS_1.11@IBVERBS_1.11 32
  IBVERBS_1.12@IBVERBS_1.12 34
+ IBVERBS_1.13@IBVERBS_1.13 35
  (symver)IBVERBS_PRIVATE_34 34
  _ibv_query_gid_ex@IBVERBS_1.11 32
  _ibv_query_gid_table@IBVERBS_1.11 32
@@ -75,6 +76,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_import_mr@IBVERBS_1.10 31
  ibv_import_pd@IBVERBS_1.10 31
  ibv_init_ah_from_wc@IBVERBS_1.1 1.1.6
+ ibv_is_fork_initialized@IBVERBS_1.13 35
  ibv_modify_qp@IBVERBS_1.0 1.1.6
  ibv_modify_qp@IBVERBS_1.1 1.1.6
  ibv_modify_srq@IBVERBS_1.0 1.1.6

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file("libibverbs.map.in"
 
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
-  1 1.12.${PACKAGE_VERSION}
+  1 1.13.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
   cmd_ah.c

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -153,6 +153,11 @@ IBVERBS_1.12 {
 		ibv_reg_dmabuf_mr;
 } IBVERBS_1.11;
 
+IBVERBS_1.13 {
+	global:
+		ibv_is_fork_initialized;
+} IBVERBS_1.12;
+
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
    version. See the top level CMakeLists.txt for this setting. */
 

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -41,6 +41,7 @@ rdma_man_pages(
   ibv_import_mr.3.md
   ibv_import_pd.3.md
   ibv_inc_rkey.3.md
+  ibv_is_fork_initialized.3.md
   ibv_modify_qp.3
   ibv_modify_qp_rate_limit.3
   ibv_modify_srq.3

--- a/libibverbs/man/ibv_is_fork_initialized.3.md
+++ b/libibverbs/man/ibv_is_fork_initialized.3.md
@@ -1,0 +1,48 @@
+---
+date: 2020-10-09
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: IBV_IS_FORK_INITIALIZED
+---
+
+# NAME
+
+ibv_is_fork_initialized - check if fork support (ibv_fork_init) is enabled
+
+# SYNOPSYS
+
+```c
+#include <infiniband/verbs.h>
+
+enum ibv_fork_status {
+	IBV_FORK_DISABLED,
+	IBV_FORK_ENABLED,
+	IBV_FORK_UNNEEDED,
+};
+
+enum ibv_fork_status ibv_is_fork_initialized(void);
+```
+
+# DESCRIPTION
+
+**ibv_is_fork_initialized()** checks whether libibverbs **fork()** support was
+enabled through the **ibv_fork_init()** verb.
+
+# RETURN VALUE
+
+**ibv_is_fork_initialized()** returns IBV_FORK_DISABLED if fork support is
+disabled, or IBV_FORK_ENABLED if enabled. IBV_FORK_UNNEEDED return value
+indicates that the kernel copies DMA pages on fork, hence a call to
+**ibv_fork_init()** is unneeded.
+
+# SEE ALSO
+
+**fork**(2),
+**ibv_fork_init**(3)
+
+# AUTHOR
+
+Gal Pressman <galpress@amazon.com>

--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -174,6 +174,11 @@ int ibv_fork_init(void)
 	return 0;
 }
 
+enum ibv_fork_status ibv_is_fork_initialized(void)
+{
+	return mm_root ? IBV_FORK_ENABLED : IBV_FORK_DISABLED;
+}
+
 static struct ibv_mem_node *__mm_prev(struct ibv_mem_node *node)
 {
 	if (node->left) {

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -139,6 +139,12 @@ enum ibv_device_cap_flags {
 	IBV_DEVICE_MANAGED_FLOW_STEERING = 1 << 29
 };
 
+enum ibv_fork_status {
+	IBV_FORK_DISABLED,
+	IBV_FORK_ENABLED,
+	IBV_FORK_UNNEEDED,
+};
+
 /*
  * Can't extended above ibv_device_cap_flags enum as in some systems/compilers
  * enum range is limited to 4 bytes.
@@ -3354,6 +3360,12 @@ int ibv_detach_mcast(struct ibv_qp *qp, const union ibv_gid *gid, uint16_t lid);
  * effect of an application calling fork() is undefined.
  */
 int ibv_fork_init(void);
+
+/**
+ * ibv_is_fork_initialized - Check if fork support
+ * (ibv_fork_init) was enabled.
+ */
+enum ibv_fork_status ibv_is_fork_initialized(void);
 
 /**
  * ibv_node_type_str - Return string describing node_type enum value


### PR DESCRIPTION
Add ibv_is_fork_initialized verb which allows the app to query whether
fork support (ibv_fork_init) is enabled/disabled.

The verb returns an enum with the disabled/enabled value, and could
later be extended to return a "not required" value if in the future a call
to ibv_fork_init() will not be required.

Motivation and more information:
https://lists.openfabrics.org/pipermail/ofiwg/2020-October/001969.html
https://lists.openfabrics.org/pipermail/ofiwg/2020-October/001978.html

Signed-off-by: Gal Pressman <galpress@amazon.com>