### PR TITLE
libibverbs: Fix reporting link_layer for efa devices

### DIFF
--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -231,6 +231,7 @@ static const char *link_layer_str(uint8_t link_layer)
 {
 	switch (link_layer) {
 	case IBV_LINK_LAYER_UNSPECIFIED:
+		return "Unspecified";
 	case IBV_LINK_LAYER_INFINIBAND:
 		return "InfiniBand";
 	case IBV_LINK_LAYER_ETHERNET:


### PR DESCRIPTION
Avoid reporting link_layer "InfiniBand" for efa devices.

Before:

$ ibv_devinfo
hca_id:	efa_0
	transport:			unspecified (4)
	fw_ver:				0.0.0.0
	node_guid:			0000:0000:0000:0000
	sys_image_guid:			0000:0000:0000:0000
	vendor_id:			0x1d0f
	vendor_part_id:			61344
	hw_ver:				0xEFA0
	phys_port_cnt:			1
		port:	1
			state:			PORT_ACTIVE (4)
			max_mtu:		4096 (5)
			active_mtu:		4096 (5)
			sm_lid:			0
			port_lid:		0
			port_lmc:		0x01
			link_layer:		InfiniBand

After:

$ ibv_devinfo
hca_id:	efa_0
	transport:			unspecified (4)
	fw_ver:				0.0.0.0
	node_guid:			0000:0000:0000:0000
	sys_image_guid:			0000:0000:0000:0000
	vendor_id:			0x1d0f
	vendor_part_id:			61344
	hw_ver:				0xEFA0
	phys_port_cnt:			1
		port:	1
			state:			PORT_ACTIVE (4)
			max_mtu:		4096 (5)
			active_mtu:		4096 (5)
			sm_lid:			0
			port_lid:		0
			port_lmc:		0x01
			link_layer:		Unknown

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>