### PR TITLE
tests: Extend parent domain tests

### DIFF
--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -36,3 +36,4 @@ cdef class ParentDomainContext(PyverbsObject):
     cdef object p_alloc
     cdef object p_free
     cdef object pd
+    cdef object user_data

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -171,7 +171,7 @@ cdef void pd_free(v.ibv_pd *pd, void *pd_context, void *ptr,
 
 
 cdef class ParentDomainContext(PyverbsObject):
-    def __init__(self, PD pd, alloc_func, free_func):
+    def __init__(self, PD pd, alloc_func, free_func, user_data=None):
         """
         Initializes ParentDomainContext object which is used as a pd_context.
         It contains the relevant fields in order to allow the user to write
@@ -180,11 +180,21 @@ cdef class ParentDomainContext(PyverbsObject):
                   creation of the Parent Domain
         :param alloc_func: Python alloc function
         :param free_func: Python free function
+        :param user_data: Additional user-specific data
         """
         super().__init__()
         self.pd = pd
         self.p_alloc = alloc_func
         self.p_free = free_func
+        self.user_data = user_data
+
+    @property
+    def user_data(self):
+        return self.user_data
+
+    @user_data.setter
+    def user_data(self, val):
+        self.user_data = val
 
 
 cdef class ParentDomainInitAttr(PyverbsObject):

--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -4,84 +4,152 @@
 Test module for Pyverbs' ParentDomain.
 """
 from pyverbs.pd import ParentDomainInitAttr, ParentDomain, ParentDomainContext
+from tests.base import RCResources, UDResources, RDMATestCase
 from pyverbs.pyverbs_error import PyverbsRDMAError
-from pyverbs.srq import SrqAttr, SrqInitAttr, SRQ
-from pyverbs.cq import CqInitAttrEx, CQEX, CQ
-from pyverbs.qp import QPInitAttr, QP
-from tests.base import BaseResources
-from tests.base import RDMATestCase
+from tests.test_cqex import create_ex_cq
 import pyverbs.mem_alloc as mem
 import pyverbs.enums as e
 import tests.utils as u
+
 import unittest
 import errno
 
 
-class ParentDomainRes(BaseResources):
-    def __init__(self, dev_name, ib_port=None, gid_index=None):
+def default_allocator(pd, context, size, alignment, resource_type):
+    return e._IBV_ALLOCATOR_USE_DEFAULT
+
+
+def default_free(pd, context, ptr, resource_type):
+    return e._IBV_ALLOCATOR_USE_DEFAULT
+
+
+def mem_align_allocator(pd, context, size, alignment, resource_type):
+    p = mem.posix_memalign(size, alignment)
+    return p
+
+
+def free_func(pd, context, ptr, resource_type):
+    mem.free(ptr)
+
+
+def create_parent_domain_with_allocators(res):
+    """
+    Creates parent domain for res instance. The allocators themselves are taken
+    from res.allocator_func and res.free_func.
+    :param res: The resources instance to work on (an instance of BaseResources)
+    """
+    if res.allocator_func and res.free_func:
+        res.pd_ctx = ParentDomainContext(res.pd, res.allocator_func,
+                                         res.free_func)
+    pd_attr = ParentDomainInitAttr(pd=res.pd, pd_context=res.pd_ctx)
+    try:
+        res.pd = ParentDomain(res.ctx, attr=pd_attr)
+    except PyverbsRDMAError as ex:
+        if ex.error_code == errno.EOPNOTSUPP:
+            raise unittest.SkipTest('Parent Domain is not supported on this device')
+        raise ex
+
+
+def parent_domain_res_cls(base_class):
+    """
+    This is a factory function which creates a class that inherits base_class of
+    any BaseResources type. Its purpose is to behave exactly as base_class does,
+    except for creating a parent domain with custom allocators.
+    Hence the returned class must be initialized with (alloc_func, free_func,
+    **kwargs), while kwargs are the arguments needed (if any) for base_class.
+    :param base_class: The base resources class to inherit from
+    :return: ParentDomainRes(alloc_func=None, free_func=None, **kwargs) class
+    """
+    class ParentDomainRes(base_class):
+        def __init__(self, alloc_func=None, free_func=None, **kwargs):
+            self.pd_ctx = None
+            self.protection_domain = None
+            self.allocator_func = alloc_func
+            self.free_func = free_func
+            super().__init__(**kwargs)
+
+        def create_pd(self):
+            super().create_pd()
+            self.protection_domain = self.pd
+            create_parent_domain_with_allocators(self)
+
+    return ParentDomainRes
+
+
+class ParentDomainCqExSrqRes(parent_domain_res_cls(RCResources)):
+    """
+    Parent domain resources. Based on RCResources.
+    This includes a parent domain created with the given allocators, in addition
+    it creates an extended CQ and a SRQ for RC traffic.
+    :param dev_name: Device name to be used
+    :param ib_port: IB port of the device to use
+    :param gid_index: Which GID index to use
+    :param alloc_func: Custom allocator function
+    :param free_func: Custom free function
+    """
+    def __init__(self, dev_name, ib_port=None, gid_index=None, alloc_func=None,
+                 free_func=None):
         super().__init__(dev_name=dev_name, ib_port=ib_port,
-                         gid_index=gid_index)
-        # Parent Domain will be created according to the test
-        self.pd_ctx = None
-        self.parent_domain = None
+                         gid_index=gid_index, alloc_func=alloc_func,
+                         free_func=free_func, with_srq=True)
+
+    def create_cq(self):
+        create_ex_cq(self)
 
 
-class ParentDomainTestCase(RDMATestCase):
+class ParentDomainTrafficTest(RDMATestCase):
     def setUp(self):
         super().setUp()
-        self.pd_res = ParentDomainRes(self.dev_name)
+        self.iters = 10
+        self.server = None
+        self.client = None
 
-    def _create_parent_domain_with_allocators(self, alloc_func, free_func):
-        if alloc_func and free_func:
-            self.pd_res.pd_ctx = ParentDomainContext(self.pd_res.pd, alloc_func,
-                                                     free_func)
-        pd_attr = ParentDomainInitAttr(pd=self.pd_res.pd,
-                                       pd_context=self.pd_res.pd_ctx)
-        try:
-            self.pd_res.parent_domain = ParentDomain(self.pd_res.ctx,
-                                                     attr=pd_attr)
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Parent Domain is not supported on this device')
-            raise ex
+    def tearDown(self):
+        if self.server:
+            self.server.pd.close()
+        if self.client:
+            self.client.pd.close()
 
-    def _create_rdma_objects(self):
-        cq = CQ(self.pd_res.ctx, 100, None, None, 0)
-        dev_attr = self.pd_res.ctx.query_device()
-        qp_cap = u.random_qp_cap(dev_attr)
-        qia = QPInitAttr(scq=cq, rcq=cq, cap=qp_cap)
-        qia.qp_type = e.IBV_QPT_RC
-        QP(self.pd_res.parent_domain, qia)
-        srq_init_attr = SrqInitAttr(SrqAttr())
-        SRQ(self.pd_res.parent_domain, srq_init_attr)
-        cq_init_attrs_ex = CqInitAttrEx(comp_mask=e.IBV_CQ_INIT_ATTR_MASK_PD,
-                                        parent_domain=self.pd_res.parent_domain)
-        CQEX(self.pd_res.ctx, cq_init_attrs_ex)
+    def create_players(self, resource, **resource_arg):
+        """
+        Init Parent Domain tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
 
-    def test_without_allocators(self):
-        self._create_parent_domain_with_allocators(None, None)
-        self._create_rdma_objects()
-        self.pd_res.parent_domain.close()
+    def test_without_allocators_rc_traffic(self):
+        parent_domain_rc_res = parent_domain_res_cls(RCResources)
+        self.create_players(parent_domain_rc_res)
+        u.traffic(**self.traffic_args)
 
-    def test_default_allocators(self):
-        def alloc_p_func(pd, context, size, alignment, resource_type):
-            return e._IBV_ALLOCATOR_USE_DEFAULT
+    def test_default_allocators_rc_traffic(self):
+        parent_domain_rc_res = parent_domain_res_cls(RCResources)
+        self.create_players(parent_domain_rc_res, alloc_func=default_allocator,
+                            free_func=default_free)
+        u.traffic(**self.traffic_args)
 
-        def free_p_func(pd, context, ptr, resource_type):
-            return e._IBV_ALLOCATOR_USE_DEFAULT
+    def test_mem_align_rc_traffic(self):
+        parent_domain_rc_res = parent_domain_res_cls(RCResources)
+        self.create_players(parent_domain_rc_res,
+                            alloc_func=mem_align_allocator, free_func=free_func)
+        u.traffic(**self.traffic_args)
 
-        self._create_parent_domain_with_allocators(alloc_p_func, free_p_func)
-        self._create_rdma_objects()
-        self.pd_res.parent_domain.close()
+    def test_mem_align_ud_traffic(self):
+        parent_domain_ud_res = parent_domain_res_cls(UDResources)
+        self.create_players(parent_domain_ud_res,
+                            alloc_func=mem_align_allocator, free_func=free_func)
+        u.traffic(**self.traffic_args)
 
-    def test_mem_align_allocators(self):
-        def alloc_p_func(pd, context, size, alignment, resource_type):
-            p = mem.posix_memalign(size, alignment)
-            return p
-
-        def free_p_func(pd, context, ptr, resource_type):
-            mem.free(ptr)
-
-        self._create_parent_domain_with_allocators(alloc_p_func, free_p_func)
-        self._create_rdma_objects()
-        self.pd_res.parent_domain.close()
+    def test_mem_align_srq_excq_rc_traffic(self):
+        self.create_players(ParentDomainCqExSrqRes,
+                            alloc_func=mem_align_allocator, free_func=free_func)
+        u.traffic(**self.traffic_args, is_cq_ex=True)


### PR DESCRIPTION
Extend parent domain tests to include traffic.
The series includes: UD traffic, RC traffic with/without SRQ
extended CQ and huge pages.