### PR TITLE
mlx5: DR, Introduce ASO actions

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -109,8 +109,10 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_dest_devx_tir@MLX5_1.15 31
  mlx5dv_dr_action_create_flow_sampler@MLX5_1.16 32
  mlx5dv_dr_action_create_dest_array@MLX5_1.16 32
+ mlx5dv_dr_action_create_aso@MLX5_1.17 33
  mlx5dv_dr_action_create_pop_vlan@MLX5_1.17 33
  mlx5dv_dr_action_create_push_vlan@MLX5_1.17 33
+ mlx5dv_dr_action_modify_aso@MLX5_1.17 33
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -51,6 +51,7 @@ enum dr_action_valid_state {
 	DR_ACTION_STATE_MODIFY_VLAN,
 	DR_ACTION_STATE_NON_TERM,
 	DR_ACTION_STATE_TERM,
+	DR_ACTION_STATE_ASO_METER,
 	DR_ACTION_STATE_MAX,
 };
 
@@ -72,6 +73,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TNL_L3_TO_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FLOW_METER]	= DR_ACTION_STATE_ASO_METER,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_REFORMAT] = {
@@ -85,6 +87,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -95,6 +98,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_MODIFY_VLAN] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -107,6 +111,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -123,6 +128,15 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
+		},
+		[DR_ACTION_STATE_ASO_METER] = {
+			[DR_ACTION_TYP_QP]              = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_FT]              = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_SAMPLER]         = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]      = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_CTR]             = DR_ACTION_STATE_ASO_METER,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -139,6 +153,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_REFORMAT] = {
@@ -176,6 +191,18 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
+		},
+		[DR_ACTION_STATE_ASO_METER] = {
+			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_MODIFY_HDR]      = DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_PUSH_VLAN]       = DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_CTR]             = DR_ACTION_STATE_ASO_METER,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO_METER,
+			[DR_ACTION_TYP_DROP]            = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_FT]              = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_MISS]            = DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -195,6 +222,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_REFORMAT] = {
@@ -207,6 +235,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -216,6 +245,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_MODIFY_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -227,6 +257,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -242,6 +273,15 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
+		},
+		[DR_ACTION_STATE_ASO_METER] = {
+			[DR_ACTION_TYP_VPORT]           = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_FT]              = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_SAMPLER]         = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]      = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_CTR]             = DR_ACTION_STATE_ASO_METER,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -261,6 +301,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_REFORMAT] = {
@@ -310,6 +351,15 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO_METER,
+		},
+		[DR_ACTION_STATE_ASO_METER] = {
+			[DR_ACTION_TYP_VPORT]           = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_FT]              = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_SAMPLER]         = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_DEST_ARRAY]      = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_CTR]             = DR_ACTION_STATE_ASO_METER,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO_METER,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -474,6 +524,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			attr.ctr_id = action->ctr.devx_obj->object_id +
 				action->ctr.offset;
 			break;
+		case DR_ACTION_TYP_ASO_FLOW_METER:
 		case DR_ACTION_TYP_ASO_FIRST_HIT:
 			if (dmn->ctx != action->aso.devx_obj->context) {
 				dr_dbg(dmn, "ASO belongs to a different IB ctx\n");
@@ -843,6 +894,57 @@ dr_action_aso_first_hit_init(struct mlx5dv_dr_action *action,
 	return 0;
 }
 
+static int
+dr_action_aso_flow_meter_init(struct mlx5dv_dr_action *action,
+			      uint32_t offset,
+			      uint32_t flags,
+			      uint8_t return_reg_c)
+{
+	if (!flags ||
+	    (flags > MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_UNDEFINED)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	if ((offset / MLX5_ASO_FLOW_METER_NUM_PER_OBJ) >=
+				(1 << action->aso.devx_obj->log_obj_range)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	if ((return_reg_c > 5) || (return_reg_c % 2 == 0)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	switch (flags) {
+	case MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_RED:
+		action->aso.flow_meter.initial_color =
+			MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_RED;
+		break;
+	case MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_YELLOW:
+		action->aso.flow_meter.initial_color =
+			MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_YELLOW;
+		break;
+	case MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_GREEN:
+		action->aso.flow_meter.initial_color =
+			MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_GREEN;
+		break;
+	case MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_UNDEFINED:
+		action->aso.flow_meter.initial_color =
+			MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_UNDEFINED;
+		break;
+	default:
+		errno = EINVAL;
+		return errno;
+	}
+
+	action->aso.offset = offset;
+	action->aso.dest_reg_id = return_reg_c;
+
+	return 0;
+}
+
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *dmn,
 			    struct mlx5dv_devx_obj *devx_obj,
@@ -868,6 +970,16 @@ mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *dmn,
 		if (dr_action_aso_first_hit_init(action, offset,
 						 flags, return_reg_c))
 			goto out_free;
+	} else if (devx_obj->type == MLX5_DEVX_ASO_FLOW_METER) {
+		action = dr_action_create_generic(DR_ACTION_TYP_ASO_FLOW_METER);
+		if (!action)
+			return NULL;
+
+		action->aso.devx_obj = devx_obj;
+
+		if (dr_action_aso_flow_meter_init(action, offset,
+						  flags, return_reg_c))
+			goto out_free;
 	} else {
 		errno = EOPNOTSUPP;
 		return NULL;
@@ -888,6 +1000,9 @@ int mlx5dv_dr_action_modify_aso(struct mlx5dv_dr_action *action,
 	if (action->action_type == DR_ACTION_TYP_ASO_FIRST_HIT)
 		return dr_action_aso_first_hit_init(action, offset,
 						    flags, return_reg_c);
+	else if (action->action_type == DR_ACTION_TYP_ASO_FLOW_METER)
+		return dr_action_aso_flow_meter_init(action, offset,
+						     flags, return_reg_c);
 
 	errno = EINVAL;
 	return errno;

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -64,6 +64,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -78,6 +79,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -89,6 +91,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -98,6 +101,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
@@ -110,6 +114,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -128,6 +133,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
@@ -138,11 +144,13 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
@@ -152,6 +160,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
@@ -160,6 +169,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
@@ -176,6 +186,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -189,6 +200,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -199,6 +211,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -208,6 +221,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_POP_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
@@ -218,6 +232,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -237,6 +252,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
@@ -250,6 +266,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_REFORMAT] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_REFORMAT,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -258,6 +275,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_HDR,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
@@ -270,6 +288,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_MODIFY_VLAN,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_MODIFY_VLAN,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_REFORMAT,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
@@ -281,6 +300,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_NON_TERM,
+			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_NON_TERM,
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
@@ -453,6 +473,13 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 		case DR_ACTION_TYP_CTR:
 			attr.ctr_id = action->ctr.devx_obj->object_id +
 				action->ctr.offset;
+			break;
+		case DR_ACTION_TYP_ASO_FIRST_HIT:
+			if (dmn->ctx != action->aso.devx_obj->context) {
+				dr_dbg(dmn, "ASO belongs to a different IB ctx\n");
+				goto out_invalid_arg;
+			}
+			attr.aso = &action->aso;
 			break;
 		case DR_ACTION_TYP_TAG:
 			attr.flow_tag = action->flow_tag;
@@ -785,6 +812,85 @@ mlx5dv_dr_action_create_flow_counter(struct mlx5dv_devx_obj *devx_obj,
 	action->ctr.offset = offset;
 
 	return action;
+}
+
+static int
+dr_action_aso_first_hit_init(struct mlx5dv_dr_action *action,
+			     uint32_t offset,
+			     uint32_t flags,
+			     uint8_t return_reg_c)
+{
+	if (!check_comp_mask(flags, MLX5DV_DR_ACTION_FLAGS_ASO_FIRST_HIT_SET)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	if ((offset / MLX5_ASO_FIRST_HIT_NUM_PER_OBJ) >=
+				(1 << action->aso.devx_obj->log_obj_range)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	if ((return_reg_c > 5) || (return_reg_c % 2 == 0)) {
+		errno = EINVAL;
+		return errno;
+	}
+
+	action->aso.offset = offset;
+	action->aso.first_hit.set = flags & MLX5DV_DR_ACTION_FLAGS_ASO_FIRST_HIT_SET;
+	action->aso.dest_reg_id = return_reg_c;
+
+	return 0;
+}
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *dmn,
+			    struct mlx5dv_devx_obj *devx_obj,
+			    uint32_t offset,
+			    uint32_t flags,
+			    uint8_t return_reg_c)
+{
+	struct mlx5dv_dr_action *action = NULL;
+
+	if (!dmn->info.supp_sw_steering ||
+	    dmn->info.caps.sw_format_ver != MLX5_HW_CONNECTX_6DX) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	if (devx_obj->type == MLX5_DEVX_ASO_FIRST_HIT) {
+		action = dr_action_create_generic(DR_ACTION_TYP_ASO_FIRST_HIT);
+		if (!action)
+			return NULL;
+
+		action->aso.devx_obj = devx_obj;
+
+		if (dr_action_aso_first_hit_init(action, offset,
+						 flags, return_reg_c))
+			goto out_free;
+	} else {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	return action;
+
+out_free:
+	free(action);
+	return NULL;
+}
+
+int mlx5dv_dr_action_modify_aso(struct mlx5dv_dr_action *action,
+				uint32_t offset,
+				uint32_t flags,
+				uint8_t return_reg_c)
+{
+	if (action->action_type == DR_ACTION_TYP_ASO_FIRST_HIT)
+		return dr_action_aso_first_hit_init(action, offset,
+						    flags, return_reg_c);
+
+	errno = EINVAL;
+	return errno;
 }
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value)

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -77,6 +77,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_METER = 3414,
 	DR_DUMP_REC_TYPE_ACTION_SAMPLER = 3415,
 	DR_DUMP_REC_TYPE_ACTION_DEST_ARRAY = 3416,
+	DR_DUMP_REC_TYPE_ACTION_ASO_FIRST_HIT = 3417,
 };
 
 static uint64_t dr_dump_icm_to_idx(uint64_t icm_addr)
@@ -200,6 +201,11 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
 			      DR_DUMP_REC_TYPE_ACTION_PUSH_VLAN, action_id,
 			      rule_id, action->push_vlan.vlan_hdr);
+		break;
+	case DR_ACTION_TYP_ASO_FIRST_HIT:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_ASO_FIRST_HIT, action_id,
+			      rule_id, action->aso.devx_obj->object_id);
 		break;
 	default:
 		return 0;

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -78,6 +78,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_SAMPLER = 3415,
 	DR_DUMP_REC_TYPE_ACTION_DEST_ARRAY = 3416,
 	DR_DUMP_REC_TYPE_ACTION_ASO_FIRST_HIT = 3417,
+	DR_DUMP_REC_TYPE_ACTION_ASO_FLOW_METER = 3418,
 };
 
 static uint64_t dr_dump_icm_to_idx(uint64_t icm_addr)
@@ -205,6 +206,11 @@ static int dr_dump_rule_action_mem(FILE *f, const uint64_t rule_id,
 	case DR_ACTION_TYP_ASO_FIRST_HIT:
 		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
 			      DR_DUMP_REC_TYPE_ACTION_ASO_FIRST_HIT, action_id,
+			      rule_id, action->aso.devx_obj->object_id);
+		break;
+	case DR_ACTION_TYP_ASO_FLOW_METER:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_ASO_FLOW_METER, action_id,
 			      rule_id, action->aso.devx_obj->object_id);
 		break;
 	default:

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -157,6 +157,7 @@ enum {
 };
 
 enum dr_ste_v1_aso_ctx_type {
+	DR_STE_V1_ASO_CTX_TYPE_POLICERS = 0x2,
 	DR_STE_V1_ASO_CTX_TYPE_FIRST_HIT = 0x4,
 };
 
@@ -532,6 +533,26 @@ static void dr_ste_v1_set_aso_first_hit(uint8_t *d_action,
 	DR_STE_SET(double_action_aso_v1, d_action, first_hit.set, !set);
 }
 
+static void dr_ste_v1_set_aso_flow_meter(uint8_t *d_action,
+					 uint32_t object_id,
+					 uint32_t offset,
+					 uint8_t dest_reg_id,
+					 uint8_t initial_color)
+{
+	DR_STE_SET(double_action_aso_v1, d_action, action_id,
+		   DR_STE_V1_ACTION_ID_ASO);
+	DR_STE_SET(double_action_aso_v1, d_action, aso_context_number,
+		   object_id + (offset / MLX5_ASO_FLOW_METER_NUM_PER_OBJ));
+	/* Convert reg_c index to HW 64bit index */
+	DR_STE_SET(double_action_aso_v1, d_action, dest_reg_id, (dest_reg_id - 1) / 2);
+	DR_STE_SET(double_action_aso_v1, d_action, aso_context_type,
+		   DR_STE_V1_ASO_CTX_TYPE_POLICERS);
+	DR_STE_SET(double_action_aso_v1, d_action, flow_meter.line_id,
+		   offset % MLX5_ASO_FLOW_METER_NUM_PER_OBJ);
+	DR_STE_SET(double_action_aso_v1, d_action, flow_meter.initial_color,
+		   initial_color);
+}
+
 static void dr_ste_v1_set_actions_tx(uint8_t *action_type_set,
 				     uint8_t *last_ste,
 				     struct dr_ste_actions_attr *attr,
@@ -541,10 +562,28 @@ static void dr_ste_v1_set_actions_tx(uint8_t *action_type_set,
 	uint8_t action_sz = DR_STE_ACTION_DOUBLE_SZ;
 	bool allow_encap = true;
 
+	if (action_type_set[DR_ACTION_TYP_ASO_FLOW_METER]) {
+		dr_ste_v1_set_aso_flow_meter(action,
+					     attr->aso->devx_obj->object_id,
+					     attr->aso->offset,
+					     attr->aso->dest_reg_id,
+					     attr->aso->flow_meter.initial_color);
+
+		action_sz -= DR_STE_ACTION_DOUBLE_SZ;
+		action += DR_STE_ACTION_DOUBLE_SZ;
+	}
+
 	if (action_type_set[DR_ACTION_TYP_CTR])
 		dr_ste_v1_set_counter_id(last_ste, attr->ctr_id);
 
 	if (action_type_set[DR_ACTION_TYP_MODIFY_HDR]) {
+		if (action_sz < DR_STE_ACTION_DOUBLE_SZ) {
+			dr_ste_v1_arr_init_next_match(&last_ste, added_stes,
+						      attr->gvmi);
+			action = DEVX_ADDR_OF(ste_mask_and_match_v1,
+					      last_ste, action);
+			action_sz = DR_STE_ACTION_TRIPLE_SZ;
+		}
 		dr_ste_v1_set_rewrite_actions(last_ste, action,
 					      attr->modify_actions,
 					      attr->modify_index);
@@ -705,6 +744,26 @@ static void dr_ste_v1_set_actions_rx(uint8_t *action_type_set,
 		dr_ste_v1_set_rewrite_actions(last_ste, action,
 					      attr->modify_actions,
 					      attr->modify_index);
+		action_sz -= DR_STE_ACTION_DOUBLE_SZ;
+		action += DR_STE_ACTION_DOUBLE_SZ;
+	}
+
+	if (action_type_set[DR_ACTION_TYP_ASO_FLOW_METER]) {
+		if (action_sz < DR_STE_ACTION_DOUBLE_SZ) {
+			dr_ste_v1_arr_init_next_match(&last_ste, added_stes,
+						      attr->gvmi);
+			action = DEVX_ADDR_OF(ste_mask_and_match_v1, last_ste,
+					      action);
+			action_sz = DR_STE_ACTION_TRIPLE_SZ;
+			allow_modify_hdr = false;
+			allow_ctr = true;
+		}
+		dr_ste_v1_set_aso_flow_meter(action,
+					     attr->aso->devx_obj->object_id,
+					     attr->aso->offset,
+					     attr->aso->dest_reg_id,
+					     attr->aso->flow_meter.initial_color);
+
 		action_sz -= DR_STE_ACTION_DOUBLE_SZ;
 		action += DR_STE_ACTION_DOUBLE_SZ;
 	}

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -155,6 +155,8 @@ MLX5_1.16 {
 
 MLX5_1.17 {
 	global:
+		mlx5dv_dr_action_create_aso;
 		mlx5dv_dr_action_create_pop_vlan;
 		mlx5dv_dr_action_create_push_vlan;
+		mlx5dv_dr_action_modify_aso;
 } MLX5_1.16;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -55,6 +55,7 @@ rdma_alias_man_pages(
  mlx5dv_devx_qp_modify.3 mlx5dv_devx_ind_tbl_query.3
  mlx5dv_devx_subscribe_devx_event.3 mlx5dv_devx_subscribe_devx_event_fd.3
  mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_dereg.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_table.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ibv_qp.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_devx_tir.3
@@ -71,6 +72,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_push_vlan.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_tag.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_destroy.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -252,8 +252,12 @@ After a packet hits the rule with the ASO object the value of the ASO object wil
 *mlx5dv_dr_action_modify_aso* modifies ASO action **action** with new values for **offset**, **return_reg_c** and **flags**.
 Only new DR rules using this **action** will use the modified values. Existing DR rules do not change the HW action values stored.
 
-**flags** can be set to one of the types of *mlx5dv_dr_action_aso_first_hit_flags*:
+**flags** can be set to one of the types of *mlx5dv_dr_action_aso_first_hit_flags* or *mlx5dv_dr_action_aso_flow_meter_flags*:
 **MLX5DV_DR_ACTION_ASO_FIRST_HIT_FLAGS_SET**: is used to set the ASO first hit object context, else the context is only copied to the return_reg_c.
+**MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_RED**: is used to indicate to update the initial color in ASO flow meter object value to red.
+**MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_YELLOW**: is used to indicate to update the initial color in ASO flow meter object value to yellow.
+**MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_GREEN**: is used to indicate to update the initial color in ASO flow meter object value to green.
+**MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_UNDEFINED**: is used to indicate to update the initial color in ASO flow meter object value to undefined.
 
 Action: Meter
 *mlx5dv_dr_action_create_flow_meter* creates a meter action based on the flow meter parameters. The paramertes are according to the device specification.

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -34,6 +34,8 @@ mlx5dv_dr_action_create_modify_header - Create modify header actions
 
 mlx5dv_dr_action_create_flow_counter - Create devx flow counter actions
 
+mlx5dv_dr_action_create_aso, mlx5dv_dr_action_modify_aso - Create and modify ASO actions
+
 mlx5dv_dr_action_create_flow_meter, mlx5dv_dr_action_modify_flow_meter - Create and modify meter action
 
 mlx5dv_dr_action_create_flow_sampler - Create flow sampler action
@@ -120,6 +122,18 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_modify_header(
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_flow_counter(
 		struct mlx5dv_devx_obj *devx_obj,
 		uint32_t offset);
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *domain,
+			    struct mlx5dv_devx_obj *devx_obj,
+			    uint32_t offset,
+			    uint32_t flags,
+			    uint8_t return_reg_c);
+
+int mlx5dv_dr_action_modify_aso(struct mlx5dv_dr_action *action,
+				uint32_t offset,
+				uint32_t flags,
+				uint8_t return_reg_c);
 
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_meter(struct mlx5dv_dr_flow_meter_attr *attr);
@@ -228,6 +242,18 @@ Action: Modify Header
 
 Action: Flow Count
 *mlx5dv_dr_action_create_flow_counter* creates a flow counter action from a DEVX flow counter object, based on **devx_obj** and specific counter index from **offset** in the counter bulk.
+
+Action: ASO
+*mlx5dv_dr_action_create_aso* receives a **domain** pointer and creates an ASO action from the DEVX ASO object, based on **devx_obj**.
+Use **offset** to select the specific ASO object in the **devx_obj** bulk.
+DR rules using this action can optionally update the ASO object value according to **flags** to choose the specific wanted behavior of this object.
+After a packet hits the rule with the ASO object the value of the ASO object will be copied into the chosen **return_reg_c** which can be used for match in following DR rules.
+
+*mlx5dv_dr_action_modify_aso* modifies ASO action **action** with new values for **offset**, **return_reg_c** and **flags**.
+Only new DR rules using this **action** will use the modified values. Existing DR rules do not change the HW action values stored.
+
+**flags** can be set to one of the types of *mlx5dv_dr_action_aso_first_hit_flags*:
+**MLX5DV_DR_ACTION_ASO_FIRST_HIT_FLAGS_SET**: is used to set the ASO first hit object context, else the context is only copied to the return_reg_c.
 
 Action: Meter
 *mlx5dv_dr_action_create_flow_meter* creates a meter action based on the flow meter parameters. The paramertes are according to the device specification.

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -671,6 +671,7 @@ enum mlx5_devx_obj_type {
 	MLX5_DEVX_FLOW_TABLE_ENTRY	= 8,
 	MLX5_DEVX_FLOW_SAMPLER		= 9,
 	MLX5_DEVX_ASO_FIRST_HIT		= 10,
+	MLX5_DEVX_ASO_FLOW_METER	= 11,
 };
 
 struct mlx5dv_devx_obj {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -670,6 +670,7 @@ enum mlx5_devx_obj_type {
 	MLX5_DEVX_FLOW_GROUP		= 7,
 	MLX5_DEVX_FLOW_TABLE_ENTRY	= 8,
 	MLX5_DEVX_FLOW_SAMPLER		= 9,
+	MLX5_DEVX_ASO_FIRST_HIT		= 10,
 };
 
 struct mlx5dv_devx_obj {
@@ -678,6 +679,7 @@ struct mlx5dv_devx_obj {
 	enum mlx5_devx_obj_type type;
 	uint32_t object_id;
 	uint64_t rx_icm_addr;
+	uint8_t log_obj_range;
 };
 
 struct mlx5_var_obj {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1485,6 +1485,27 @@ struct mlx5_ifc_ste_double_action_modify_action_list_v1_bits {
 	u8         modify_actions_argument_pointer[0x18];
 };
 
+struct mlx5_ifc_ste_aso_first_hit_action_v1_bits {
+	u8         reserved_at_0[0x6];
+	u8         set[0x1];
+	u8         line_id[0x9];
+};
+
+struct mlx5_ifc_ste_double_action_aso_v1_bits {
+	u8         action_id[0x8];
+	u8         aso_context_number[0x18];
+
+	u8         dest_reg_id[0x2];
+	u8         change_ordering_tag[0x1];
+	u8         aso_check_ordering[0x1];
+	u8         aso_context_type[0x4];
+	u8         reserved_at_28[0x8];
+	union {
+		u8	aso_fields[0x10];
+		struct mlx5_ifc_ste_aso_first_hit_action_v1_bits first_hit;
+	};
+};
+
 struct mlx5_ifc_ste_match_bwc_v1_bits {
 	u8         entry_format[0x8];
 	u8         counter_id[0x18];
@@ -2335,6 +2356,7 @@ struct mlx5_ifc_alloc_flow_counter_out_bits {
 enum {
 	MLX5_OBJ_TYPE_FLOW_METER = 0x000a,
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
+	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
 };
 
 struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
@@ -2346,7 +2368,9 @@ struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
 
 	u8         obj_id[0x20];
 
-	u8         reserved_at_60[0x20];
+	u8         reserved_at_60[0x3];
+	u8         log_obj_range[0x5];
+	u8         reserved_at_68[0x18];
 };
 
 struct mlx5_ifc_general_obj_out_cmd_hdr_bits {
@@ -3164,5 +3188,9 @@ enum {
 
 enum {
 	MLX5_QPC_PAGE_OFFSET_QUANTA = 64,
+};
+
+enum {
+	MLX5_ASO_FIRST_HIT_NUM_PER_OBJ = 512,
 };
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1485,10 +1485,24 @@ struct mlx5_ifc_ste_double_action_modify_action_list_v1_bits {
 	u8         modify_actions_argument_pointer[0x18];
 };
 
+enum {
+	MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_RED = 0x0,
+	MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_YELLOW = 0x1,
+	MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_GREEN = 0x2,
+	MLX5_IFC_ASO_FLOW_METER_INITIAL_COLOR_UNDEFINED = 0x3,
+};
+
 struct mlx5_ifc_ste_aso_first_hit_action_v1_bits {
 	u8         reserved_at_0[0x6];
 	u8         set[0x1];
 	u8         line_id[0x9];
+};
+
+struct mlx5_ifc_ste_aso_flow_meter_action_v1_bits {
+	u8         reserved_at_0[0xc];
+	u8         action[0x1];
+	u8         initial_color[0x2];
+	u8         line_id[0x1];
 };
 
 struct mlx5_ifc_ste_double_action_aso_v1_bits {
@@ -1503,6 +1517,7 @@ struct mlx5_ifc_ste_double_action_aso_v1_bits {
 	union {
 		u8	aso_fields[0x10];
 		struct mlx5_ifc_ste_aso_first_hit_action_v1_bits first_hit;
+		struct mlx5_ifc_ste_aso_flow_meter_action_v1_bits flow_meter;
 	};
 };
 
@@ -2356,6 +2371,7 @@ struct mlx5_ifc_alloc_flow_counter_out_bits {
 enum {
 	MLX5_OBJ_TYPE_FLOW_METER = 0x000a,
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
+	MLX5_OBJ_TYPE_ASO_FLOW_METER = 0x0024,
 	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
 };
 
@@ -3192,5 +3208,6 @@ enum {
 
 enum {
 	MLX5_ASO_FIRST_HIT_NUM_PER_OBJ = 512,
+	MLX5_ASO_FLOW_METER_NUM_PER_OBJ = 2,
 };
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1542,6 +1542,22 @@ struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_counter(struct mlx5dv_devx_obj *devx_obj,
 				     uint32_t offset);
 
+enum mlx5dv_dr_action_aso_first_hit_flags {
+	MLX5DV_DR_ACTION_FLAGS_ASO_FIRST_HIT_SET = 1 << 0,
+};
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *domain,
+			    struct mlx5dv_devx_obj *devx_obj,
+			    uint32_t offset,
+			    uint32_t flags,
+			    uint8_t return_reg_c);
+
+int mlx5dv_dr_action_modify_aso(struct mlx5dv_dr_action *action,
+				uint32_t offset,
+				uint32_t flags,
+				uint8_t return_reg_c);
+
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_packet_reformat(struct mlx5dv_dr_domain *domain,
 					uint32_t flags,

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1546,6 +1546,13 @@ enum mlx5dv_dr_action_aso_first_hit_flags {
 	MLX5DV_DR_ACTION_FLAGS_ASO_FIRST_HIT_SET = 1 << 0,
 };
 
+enum mlx5dv_dr_action_aso_flow_meter_flags {
+	MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_RED	= 1 << 0,
+	MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_YELLOW	= 1 << 1,
+	MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_GREEN	= 1 << 2,
+	MLX5DV_DR_ACTION_FLAGS_ASO_FLOW_METER_UNDEFINED	= 1 << 3,
+};
+
 struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_aso(struct mlx5dv_dr_domain *domain,
 			    struct mlx5dv_devx_obj *devx_obj,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -42,7 +42,7 @@
 #include "mlx5.h"
 
 #define DR_RULE_MAX_STES	17
-#define DR_ACTION_MAX_STES	5
+#define DR_ACTION_MAX_STES	6
 #define WIRE_PORT		0xFFFF
 #define DR_STE_SVLAN		0x1
 #define DR_STE_CVLAN		0x2
@@ -152,6 +152,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_POP_VLAN,
 	DR_ACTION_TYP_PUSH_VLAN,
 	DR_ACTION_TYP_ASO_FIRST_HIT,
+	DR_ACTION_TYP_ASO_FLOW_METER,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -292,9 +293,14 @@ struct dr_action_aso {
 	struct mlx5dv_devx_obj *devx_obj;
 	uint32_t offset;
 	uint8_t dest_reg_id;
-	struct {
-		bool set;
-	} first_hit;
+	union {
+		struct {
+			bool set;
+		} first_hit;
+		struct {
+			uint8_t initial_color;
+		} flow_meter;
+	};
 };
 
 struct dr_ste_actions_attr {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -151,6 +151,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_DEST_ARRAY,
 	DR_ACTION_TYP_POP_VLAN,
 	DR_ACTION_TYP_PUSH_VLAN,
+	DR_ACTION_TYP_ASO_FIRST_HIT,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -287,6 +288,15 @@ struct list_head *dr_ste_get_miss_list(struct dr_ste *ste);
 
 #define MAX_VLANS 2
 
+struct dr_action_aso {
+	struct mlx5dv_devx_obj *devx_obj;
+	uint32_t offset;
+	uint8_t dest_reg_id;
+	struct {
+		bool set;
+	} first_hit;
+};
+
 struct dr_ste_actions_attr {
 	uint32_t	modify_index;
 	uint16_t	modify_actions;
@@ -305,6 +315,7 @@ struct dr_ste_actions_attr {
 		int		count;
 		uint32_t	headers[MAX_VLANS];
 	} vlans;
+	struct dr_action_aso *aso;
 };
 
 void dr_ste_set_actions_rx(struct dr_ste_ctx *ste_ctx,
@@ -911,6 +922,7 @@ struct mlx5dv_dr_action {
 				struct ibv_qp           *qp;
 			};
 		} dest_qp;
+		struct dr_action_aso	aso;
 		struct mlx5dv_devx_obj	*devx_obj;
 		uint32_t		flow_tag;
 	};

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4814,6 +4814,8 @@ static void set_devx_obj_info(const void *in, const void *out,
 			obj->type = MLX5_DEVX_FLOW_SAMPLER;
 		else if (obj_type == MLX5_OBJ_TYPE_ASO_FIRST_HIT)
 			obj->type = MLX5_DEVX_ASO_FIRST_HIT;
+		else if (obj_type == MLX5_OBJ_TYPE_ASO_FLOW_METER)
+			obj->type = MLX5_DEVX_ASO_FLOW_METER;
 
 		obj->log_obj_range = DEVX_GET(general_obj_in_cmd_hdr, in, log_obj_range);
 		obj->object_id = DEVX_GET(general_obj_out_cmd_hdr, out, obj_id);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4812,7 +4812,10 @@ static void set_devx_obj_info(const void *in, const void *out,
 			obj->type = MLX5_DEVX_FLOW_METER;
 		else if (obj_type == MLX5_OBJ_TYPE_FLOW_SAMPLER)
 			obj->type = MLX5_DEVX_FLOW_SAMPLER;
+		else if (obj_type == MLX5_OBJ_TYPE_ASO_FIRST_HIT)
+			obj->type = MLX5_DEVX_ASO_FIRST_HIT;
 
+		obj->log_obj_range = DEVX_GET(general_obj_in_cmd_hdr, in, log_obj_range);
 		obj->object_id = DEVX_GET(general_obj_out_cmd_hdr, out, obj_id);
 		break;
 	case MLX5_CMD_OP_CREATE_QP:


### PR DESCRIPTION
This series Introduces few ASO actions as of first hit and flow metering.

The first hit action allows tracking when a rule is hit by a packet, the flow metering action allows monitoring the packet rate for specific flows.