### PR TITLE
mlx5: Add mlx5_err() wrapper to control output

### DIFF
--- a/providers/mlx5/buf.c
+++ b/providers/mlx5/buf.c
@@ -269,8 +269,6 @@ static int alloc_huge_buf(struct mlx5_context *mctx, struct mlx5_buf *buf,
 		buf->base = bitmap_alloc_range(&hmem->bitmap, nchunk, 1);
 		if (buf->base == -1) {
 			free_huge_mem(hmem);
-			/* TBD: remove after proven stability */
-			fprintf(stderr, "BUG: huge allocation\n");
 			return -1;
 		}
 
@@ -473,7 +471,7 @@ int mlx5_free_actual_buf(struct mlx5_context *ctx, struct mlx5_buf *buf)
 		break;
 
 	default:
-		fprintf(stderr, "Bad allocation type\n");
+		mlx5_err(ctx->dbg_fp, "Bad allocation type\n");
 	}
 
 	return err;
@@ -557,7 +555,8 @@ void mlx5_get_alloc_type(struct mlx5_context *context,
 	}
 }
 
-static void mlx5_alloc_get_env_info(int *max_block_log,
+static void mlx5_alloc_get_env_info(struct mlx5_context *mctx,
+				    int *max_block_log,
 				    int *min_block_log,
 				    const char *component)
 
@@ -578,8 +577,8 @@ static void mlx5_alloc_get_env_info(int *max_block_log,
 		    value >= MLX5_MIN_LOG2_CONTIG_BLOCK_SIZE)
 			*max_block_log = value;
 		else
-			fprintf(stderr, "Invalid value %d for %s\n",
-				value, name);
+			mlx5_err(mctx->dbg_fp, "Invalid value %d for %s\n",
+				 value, name);
 	}
 	sprintf(name, "%s_MIN_LOG2_CONTIG_BSIZE", component);
 	env = getenv(name);
@@ -589,8 +588,8 @@ static void mlx5_alloc_get_env_info(int *max_block_log,
 		    value  <=  *max_block_log)
 			*min_block_log = value;
 		else
-			fprintf(stderr, "Invalid value %d for %s\n",
-				value, name);
+			mlx5_err(mctx->dbg_fp, "Invalid value %d for %s\n",
+				 value, name);
 	}
 }
 
@@ -606,7 +605,7 @@ int mlx5_alloc_buf_contig(struct mlx5_context *mctx,
 	struct ibv_context *context = &mctx->ibv_ctx.context;
 	off_t offset;
 
-	mlx5_alloc_get_env_info(&max_block_log,
+	mlx5_alloc_get_env_info(mctx, &max_block_log,
 				&min_block_log,
 				component);
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -325,7 +325,8 @@ man cpuset
   The first "1" is for bit 64, the second for bit 32, the third for bit 16, the fourth for bit 8, the fifth for
   bit 4, and the "7" is for bits 2, 1, and 0.
 */
-static void mlx5_local_cpu_set(struct ibv_device *ibdev, cpu_set_t *cpu_set)
+static void mlx5_local_cpu_set(struct ibv_device *ibdev, struct mlx5_context *mctx,
+			       cpu_set_t *cpu_set)
 {
 	char *p, buf[1024] = {};
 	char *env_value;
@@ -344,11 +345,11 @@ static void mlx5_local_cpu_set(struct ibv_device *ibdev, cpu_set_t *cpu_set)
 
 		fp = fopen(fname, "r");
 		if (!fp) {
-			fprintf(stderr, PFX "Warning: can not get local cpu set: failed to open %s\n", fname);
+			mlx5_err(mctx->dbg_fp, PFX "Warning: can not get local cpu set: failed to open %s\n", fname);
 			return;
 		}
 		if (!fgets(buf, sizeof(buf), fp)) {
-			fprintf(stderr, PFX "Warning: can not get local cpu set: failed to read cpu mask\n");
+			mlx5_err(mctx->dbg_fp, PFX "Warning: can not get local cpu set: failed to read cpu mask\n");
 			fclose(fp);
 			return;
 		}
@@ -383,7 +384,7 @@ static void mlx5_local_cpu_set(struct ibv_device *ibdev, cpu_set_t *cpu_set)
 	} while (i < CPU_SETSIZE);
 }
 
-static int mlx5_enable_sandy_bridge_fix(struct ibv_device *ibdev)
+static int mlx5_enable_sandy_bridge_fix(struct ibv_device *ibdev, struct mlx5_context *mctx)
 {
 	cpu_set_t my_cpus, dev_local_cpus, result_set;
 	int stall_enable;
@@ -408,14 +409,14 @@ static int mlx5_enable_sandy_bridge_fix(struct ibv_device *ibdev)
 	ret = sched_getaffinity(0, sizeof(my_cpus), &my_cpus);
 	if (ret == -1) {
 		if (errno == EINVAL)
-			fprintf(stderr, PFX "Warning: my cpu set is too small\n");
+			mlx5_err(mctx->dbg_fp, PFX "Warning: my cpu set is too small\n");
 		else
-			fprintf(stderr, PFX "Warning: failed to get my cpu set\n");
+			mlx5_err(mctx->dbg_fp, PFX "Warning: failed to get my cpu set\n");
 		goto out;
 	}
 
 	/* get device local cpu set */
-	mlx5_local_cpu_set(ibdev, &dev_local_cpus);
+	mlx5_local_cpu_set(ibdev, mctx, &dev_local_cpus);
 
 	/* check if my cpu set is in dev cpu */
 	CPU_OR(&result_set, &my_cpus, &dev_local_cpus);
@@ -435,7 +436,7 @@ static void mlx5_read_env(struct ibv_device *ibdev, struct mlx5_context *ctx)
 		ctx->stall_enable = (strcmp(env_value, "0")) ? 1 : 0;
 	else
 		/* autodetect if we need to do cq polling */
-		ctx->stall_enable = mlx5_enable_sandy_bridge_fix(ibdev);
+		ctx->stall_enable = mlx5_enable_sandy_bridge_fix(ibdev, ctx);
 
 	env_value = getenv("MLX5_STALL_NUM_LOOP");
 	if (env_value)
@@ -492,17 +493,22 @@ static int get_total_uuars(int page_size)
 static void open_debug_file(struct mlx5_context *ctx)
 {
 	char *env;
+	FILE *default_dbg_fp = NULL;
+
+#ifdef MLX5_DEBUG
+	default_dbg_fp = stderr;
+#endif
 
 	env = getenv("MLX5_DEBUG_FILE");
 	if (!env) {
-		ctx->dbg_fp = stderr;
+		ctx->dbg_fp = default_dbg_fp;
 		return;
 	}
 
 	ctx->dbg_fp = fopen(env, "aw+");
 	if (!ctx->dbg_fp) {
-		fprintf(stderr, "Failed opening debug file %s, using stderr\n", env);
-		ctx->dbg_fp = stderr;
+		ctx->dbg_fp = default_dbg_fp;
+		mlx5_err(ctx->dbg_fp, "Failed opening debug file %s\n", env);
 		return;
 	}
 }
@@ -656,9 +662,9 @@ static int mlx5_map_internal_clock(struct mlx5_device *mdev,
 			      mdev->page_size * offset);
 
 	if (hca_clock_page == MAP_FAILED) {
-		fprintf(stderr, PFX
-			"Warning: Timestamp available,\n"
-			"but failed to mmap() hca core clock page.\n");
+		mlx5_err(context->dbg_fp, PFX
+			 "Warning: Timestamp available,\n"
+			 "but failed to mmap() hca core clock page.\n");
 		return -1;
 	}
 

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -35,6 +35,7 @@
 
 #include <stddef.h>
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdatomic.h>
 #include <util/compiler.h>
 
@@ -109,6 +110,18 @@ static inline void mlx5_dbg(FILE *fp, uint32_t mask, const char *fmt, ...)
 {
 }
 #endif
+
+__attribute__((format(printf, 2, 3)))
+static inline void mlx5_err(FILE *fp, const char *fmt, ...)
+{
+	va_list args;
+
+	if (!fp)
+		return;
+	va_start(args, fmt);
+	vfprintf(fp, fmt, args);
+	va_end(args);
+}
 
 enum {
 	MLX5_STAT_RATE_OFFSET		= 5
@@ -931,7 +944,7 @@ int mlx5_arm_cq(struct ibv_cq *cq, int solicited);
 void mlx5_cq_event(struct ibv_cq *cq);
 void __mlx5_cq_clean(struct mlx5_cq *cq, uint32_t qpn, struct mlx5_srq *srq);
 void mlx5_cq_clean(struct mlx5_cq *cq, uint32_t qpn, struct mlx5_srq *srq);
-void mlx5_cq_resize_copy_cqes(struct mlx5_cq *cq);
+void mlx5_cq_resize_copy_cqes(struct mlx5_context *mctx, struct mlx5_cq *cq);
 
 struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 				 struct ibv_srq_init_attr *attr);
@@ -1080,7 +1093,7 @@ static inline int mlx5_spin_lock(struct mlx5_spinlock *lock)
 		return pthread_spin_lock(&lock->lock);
 
 	if (unlikely(lock->in_use)) {
-		fprintf(stderr, "*** ERROR: multithreading vilation ***\n"
+		fprintf(stderr, "*** ERROR: multithreading violation ***\n"
 			"You are running a multithreaded application but\n"
 			"you set MLX5_SINGLE_THREADED=1. Please unset it.\n");
 		abort();

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -124,7 +124,7 @@ int mlx5_copy_to_send_wqe(struct mlx5_qp *qp, int idx, void *buf, int size)
 	idx &= (qp->sq.wqe_cnt - 1);
 	ctrl = mlx5_get_send_wqe(qp, idx);
 	if (qp->ibv_qp->qp_type != IBV_QPT_RC) {
-		fprintf(stderr, "scatter to CQE is supported only for RC QPs\n");
+		mlx5_err(ctx->dbg_fp, "scatter to CQE is supported only for RC QPs\n");
 		return IBV_WC_GENERAL_ERR;
 	}
 	p = ctrl + 1;
@@ -141,7 +141,7 @@ int mlx5_copy_to_send_wqe(struct mlx5_qp *qp, int idx, void *buf, int size)
 		break;
 
 	default:
-		fprintf(stderr, "scatter to CQE for opcode %d\n",
+		mlx5_err(ctx->dbg_fp, "scatter to CQE for opcode %d\n",
 			be32toh(ctrl->opmod_idx_opcode) & 0xff);
 		return IBV_WC_REM_INV_REQ_ERR;
 	}
@@ -372,13 +372,12 @@ static uint8_t wq_sig(struct mlx5_wqe_ctrl_seg *ctrl)
 }
 
 #ifdef MLX5_DEBUG
-static void dump_wqe(FILE *fp, int idx, int size_16, struct mlx5_qp *qp)
+static void dump_wqe(struct mlx5_context *mctx, int idx, int size_16, struct mlx5_qp *qp)
 {
 	uint32_t *uninitialized_var(p);
 	int i, j;
 	int tidx = idx;
-
-	fprintf(fp, "dump wqe at %p\n", mlx5_get_send_wqe(qp, tidx));
+	mlx5_err(mctx->dbg_fp, "dump wqe at %p\n", mlx5_get_send_wqe(qp, tidx));
 	for (i = 0, j = 0; i < size_16 * 4; i += 4, j += 4) {
 		if ((i & 0xf) == 0) {
 			void *buf = mlx5_get_send_wqe(qp, tidx);
@@ -386,8 +385,8 @@ static void dump_wqe(FILE *fp, int idx, int size_16, struct mlx5_qp *qp)
 			p = buf;
 			j = 0;
 		}
-		fprintf(fp, "%08x %08x %08x %08x\n", be32toh(p[j]), be32toh(p[j + 1]),
-			be32toh(p[j + 2]), be32toh(p[j + 3]));
+		mlx5_err(mctx->dbg_fp, "%08x %08x %08x %08x\n", be32toh(p[j]), be32toh(p[j + 1]),
+			 be32toh(p[j + 2]), be32toh(p[j + 3]));
 	}
 }
 #endif /* MLX5_DEBUG */
@@ -1134,7 +1133,7 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 
 #ifdef MLX5_DEBUG
 		if (mlx5_debug_mask & MLX5_DBG_QP_SEND)
-			dump_wqe(to_mctx(ibqp->context)->dbg_fp, idx, size, qp);
+			dump_wqe(to_mctx(ibqp->context), idx, size, qp);
 #endif
 	}
 
@@ -1279,9 +1278,8 @@ static inline void _common_wqe_finilize(struct mlx5_qp *mqp)
 #ifdef MLX5_DEBUG
 	if (mlx5_debug_mask & MLX5_DBG_QP_SEND) {
 		int idx = mqp->sq.cur_post & (mqp->sq.wqe_cnt - 1);
-		FILE *fp = to_mctx(mqp->ibv_qp->context)->dbg_fp;
 
-		dump_wqe(fp, idx, mqp->cur_size, mqp);
+		dump_wqe(to_mctx(mqp->ibv_qp->context), idx, mqp->cur_size, mqp);
 	}
 #endif
 
@@ -2880,7 +2878,7 @@ int mlx5_post_srq_ops(struct ibv_srq *ibsrq, struct ibv_ops_wr *wr,
 
 #ifdef MLX5_DEBUG
 		if (mlx5_debug_mask & MLX5_DBG_QP_SEND)
-			dump_wqe(fp, idx, size, qp);
+			dump_wqe(ctx, idx, size, qp);
 #endif
 	}
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1243,7 +1243,7 @@ int mlx5_resize_cq(struct ibv_cq *ibcq, int cqe)
 	if (err)
 		goto out_buf;
 
-	mlx5_cq_resize_copy_cqes(cq);
+	mlx5_cq_resize_copy_cqes(mctx, cq);
 	mlx5_free_cq_buf(mctx, cq->active_buf);
 	cq->active_buf = cq->resize_buf;
 	cq->verbs_cq.cq.cqe = cqe - 1;
@@ -1293,20 +1293,20 @@ struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 	ctx = to_mctx(pd->context);
 	srq = calloc(1, sizeof *srq);
 	if (!srq) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		return NULL;
 	}
 	ibsrq = &srq->vsrq.srq;
 
 	memset(&cmd, 0, sizeof cmd);
 	if (mlx5_spinlock_init_pd(&srq->lock, pd)) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err;
 	}
 
 	if (attr->attr.max_wr > ctx->max_srq_recv_wr) {
-		fprintf(stderr, "%s-%d:max_wr %d, max_srq_recv_wr %d\n", __func__, __LINE__,
-			attr->attr.max_wr, ctx->max_srq_recv_wr);
+		mlx5_err(ctx->dbg_fp, "%s-%d:max_wr %d, max_srq_recv_wr %d\n", __func__, __LINE__,
+			 attr->attr.max_wr, ctx->max_srq_recv_wr);
 		errno = EINVAL;
 		goto err;
 	}
@@ -1318,7 +1318,7 @@ struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 	 */
 	max_sge = ctx->max_rq_desc_sz / sizeof(struct mlx5_wqe_data_seg);
 	if (attr->attr.max_sge > max_sge) {
-		fprintf(stderr, "%s-%d:max_wr %d, max_srq_recv_wr %d\n", __func__, __LINE__,
+		mlx5_err(ctx->dbg_fp, "%s-%d:max_wr %d, max_srq_recv_wr %d\n", __func__, __LINE__,
 			attr->attr.max_wr, ctx->max_srq_recv_wr);
 		errno = EINVAL;
 		goto err;
@@ -1328,13 +1328,13 @@ struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 	srq->counter = 0;
 
 	if (mlx5_alloc_srq_buf(pd->context, srq, attr->attr.max_wr, pd)) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err;
 	}
 
 	srq->db = mlx5_alloc_dbrec(to_mctx(pd->context), pd, &srq->custom_db);
 	if (!srq->db) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err_free;
 	}
 
@@ -3249,7 +3249,6 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 	int max_sge;
 	struct ibv_srq *ibsrq;
 	int uidx;
-	FILE *fp = ctx->dbg_fp;
 
 	if (!(attr->comp_mask & IBV_SRQ_INIT_ATTR_TYPE) ||
 	    (attr->srq_type == IBV_SRQT_BASIC))
@@ -3279,14 +3278,14 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 	memset(&resp, 0, sizeof(resp));
 
 	if (mlx5_spinlock_init_pd(&msrq->lock, attr->pd)) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err;
 	}
 
 	if (attr->attr.max_wr > ctx->max_srq_recv_wr) {
-		fprintf(stderr, "%s-%d:max_wr %d, max_srq_recv_wr %d\n",
-			__func__, __LINE__, attr->attr.max_wr,
-			ctx->max_srq_recv_wr);
+		mlx5_err(ctx->dbg_fp, "%s-%d:max_wr %d, max_srq_recv_wr %d\n",
+			 __func__, __LINE__, attr->attr.max_wr,
+			 ctx->max_srq_recv_wr);
 		errno = EINVAL;
 		goto err;
 	}
@@ -3298,9 +3297,9 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 	 */
 	max_sge = ctx->max_recv_wr / sizeof(struct mlx5_wqe_data_seg);
 	if (attr->attr.max_sge > max_sge) {
-		fprintf(stderr, "%s-%d:max_wr %d, max_srq_recv_wr %d\n",
-			__func__, __LINE__, attr->attr.max_wr,
-			ctx->max_srq_recv_wr);
+		mlx5_err(ctx->dbg_fp, "%s-%d:max_wr %d, max_srq_recv_wr %d\n",
+			 __func__, __LINE__, attr->attr.max_wr,
+			 ctx->max_srq_recv_wr);
 		errno = EINVAL;
 		goto err;
 	}
@@ -3309,13 +3308,13 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 	msrq->counter = 0;
 
 	if (mlx5_alloc_srq_buf(context, msrq, attr->attr.max_wr, attr->pd)) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err;
 	}
 
 	msrq->db = mlx5_alloc_dbrec(ctx, attr->pd, &msrq->custom_db);
 	if (!msrq->db) {
-		fprintf(stderr, "%s-%d:\n", __func__, __LINE__);
+		mlx5_err(ctx->dbg_fp, "%s-%d:\n", __func__, __LINE__);
 		goto err_free;
 	}
 
@@ -3332,7 +3331,7 @@ struct ibv_srq *mlx5_create_srq_ex(struct ibv_context *context,
 	if (ctx->cqe_version) {
 		uidx = mlx5_store_uidx(ctx, msrq);
 		if (uidx < 0) {
-			mlx5_dbg(fp, MLX5_DBG_QP, "Couldn't find free user index\n");
+			mlx5_dbg(ctx->dbg_fp, MLX5_DBG_QP, "Couldn't find free user index\n");
 			goto err_free_db;
 		}
 		cmd.uidx = uidx;


### PR DESCRIPTION
Replace the legacy fprintfs with mlx5_err() wrapper to better control output according to debug mode.