### PR TITLE
efa: Add missing man pages to CMakeLists.txt

### DIFF
--- a/providers/efa/man/CMakeLists.txt
+++ b/providers/efa/man/CMakeLists.txt
@@ -1,4 +1,7 @@
 rdma_man_pages(
-  efadv_create_driver_qp.3.md
   efadv.7.md
+  efadv_create_driver_qp.3.md
+  efadv_create_qp_ex.3.md
+  efadv_query_ah.3.md
+  efadv_query_device.3.md
 )


### PR DESCRIPTION
Include all the provider's man pages in CMakeLists.txt.

Signed-off-by: Gal Pressman <galpress@amazon.com>