### PR TITLE
mlx5: Expose DV APIs to control the transmit scheduler

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -113,6 +113,12 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_pop_vlan@MLX5_1.17 33
  mlx5dv_dr_action_create_push_vlan@MLX5_1.17 33
  mlx5dv_dr_action_modify_aso@MLX5_1.17 33
+ mlx5dv_sched_leaf_create@MLX5_1.17 33
+ mlx5dv_sched_leaf_destroy@MLX5_1.17 33
+ mlx5dv_sched_leaf_modify@MLX5_1.17 33
+ mlx5dv_sched_node_create@MLX5_1.17 33
+ mlx5dv_sched_node_destroy@MLX5_1.17 33
+ mlx5dv_sched_node_modify@MLX5_1.17 33
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -113,6 +113,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_pop_vlan@MLX5_1.17 33
  mlx5dv_dr_action_create_push_vlan@MLX5_1.17 33
  mlx5dv_dr_action_modify_aso@MLX5_1.17 33
+ mlx5dv_modify_qp_sched_elem@MLX5_1.17 33
  mlx5dv_sched_leaf_create@MLX5_1.17 33
  mlx5dv_sched_leaf_destroy@MLX5_1.17 33
  mlx5dv_sched_leaf_modify@MLX5_1.17 33

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -159,4 +159,10 @@ MLX5_1.17 {
 		mlx5dv_dr_action_create_pop_vlan;
 		mlx5dv_dr_action_create_push_vlan;
 		mlx5dv_dr_action_modify_aso;
+		mlx5dv_sched_leaf_create;
+		mlx5dv_sched_leaf_destroy;
+		mlx5dv_sched_leaf_modify;
+		mlx5dv_sched_node_create;
+		mlx5dv_sched_node_destroy;
+		mlx5dv_sched_node_modify;
 } MLX5_1.16;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -159,6 +159,7 @@ MLX5_1.17 {
 		mlx5dv_dr_action_create_pop_vlan;
 		mlx5dv_dr_action_create_push_vlan;
 		mlx5dv_dr_action_modify_aso;
+		mlx5dv_modify_qp_sched_elem;
 		mlx5dv_sched_leaf_create;
 		mlx5dv_sched_leaf_destroy;
 		mlx5dv_sched_leaf_modify;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -28,6 +28,7 @@ rdma_man_pages(
   mlx5dv_pp_alloc.3.md
   mlx5dv_query_device.3
   mlx5dv_query_qp_lag_port.3.md
+  mlx5dv_sched_node_create.3.md
   mlx5dv_ts_to_ns.3
   mlx5dv_wr_post.3.md
   mlx5dv.7
@@ -89,6 +90,11 @@ rdma_alias_man_pages(
  mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
  mlx5dv_dump.3 mlx5dv_dump_dr_table.3
  mlx5dv_pp_alloc.3 mlx5dv_pp_free.3
+ mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_create.3
+ mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_destroy.3
+ mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_modify.3
+ mlx5dv_sched_node_create.3 mlx5dv_sched_node_destroy.3
+ mlx5dv_sched_node_create.3 mlx5dv_sched_node_modify.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_interleaved.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -24,6 +24,7 @@ rdma_man_pages(
   mlx5dv_init_obj.3
   mlx5dv_is_supported.3.md
   mlx5dv_modify_qp_lag_port.3.md
+  mlx5dv_modify_qp_sched_elem.3.md
   mlx5dv_open_device.3.md
   mlx5dv_pp_alloc.3.md
   mlx5dv_query_device.3

--- a/providers/mlx5/man/mlx5dv_modify_qp_sched_elem.3.md
+++ b/providers/mlx5/man/mlx5dv_modify_qp_sched_elem.3.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: mlx5dv_modify_qp_sched_elem
+section: 3
+tagline: Verbs
+date: 2020-9-22
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_modify_qp_sched_elem - Connect a QP with a requestor and/or a responder scheduling element
+
+# SYNOPSIS
+
+```c
+int mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
+				struct mlx5dv_sched_leaf *requestor,
+				struct mlx5dv_sched_leaf *responder);
+
+```
+
+# DESCRIPTION
+
+The QP scheduling element (SE) allows the association of a QP to a SE tree. The SE is described in *mlx5dv_sched_node_create(3)* man page.
+
+By default, all QPs are not associated to SE. The default setting is ensuring fair bandwidth allocation with no maximum bandwidth limiting.
+
+A QP can be associate to a requestor and/or a responder SE following the IB spec definition.
+
+# RETURN VALUE
+
+upon success 0 is returned or the value of errno on a failure.
+
+# SEE ALSO
+
+**mlx5dv_sched_node_create**(3)
+
+# AUTHOR
+
+Mark Zhang <markzhang@nvidia.com>
+Ariel Almog <ariela@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_sched_node_create.3.md
+++ b/providers/mlx5/man/mlx5dv_sched_node_create.3.md
@@ -1,0 +1,171 @@
+---
+layout: page
+title: mlx5dv_sched_node[/leaf]_create / modify / destroy
+section: 3
+tagline: Verbs
+date: 2020-9-3
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_sched_node_create - Creates a scheduling node element
+
+mlx5dv_sched_leaf_create - Creates a scheduling leaf element
+
+mlx5dv_sched_node_modify - Modifies a node scheduling element
+
+mlx5dv_sched_leaf_modify - Modifies a leaf scheduling element
+
+mlx5dv_sched_node_destroy - Destroys a node scheduling element
+
+mlx5dv_sched_leaf_destroy - Destroys a leaf scheduling element
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_sched_node *mlx5dv_sched_node_create(struct ibv_context *context,
+						   struct mlx5dv_sched_attr *sched_attr);
+
+struct mlx5dv_sched_leaf *mlx5dv_sched_leaf_create(struct ibv_context *context,
+						   struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_node_modify(struct mlx5dv_sched_node *node,
+			     struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_leaf_modify(struct mlx5dv_sched_leaf *leaf,
+			     struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_node_destroy(struct mlx5dv_sched_node *node);
+
+int mlx5dv_sched_leaf_destroy(struct mlx5dv_sched_leaf *leaf);
+
+```
+
+
+# DESCRIPTION
+
+The transmit scheduling element (SE) is scheduling the transmission for of all nodes connected it.
+By configuring the SE, QoS policies may be enforced between the competing entities (e.g. SQ, QP).
+
+In each scheduling cycle, the SE schedules all ready-to-transmit entities. The SE assures that weight for each entity is met.
+If entity has reached its maximum allowed bandwidth within the scheduling cycle, it won’t be scheduled till end of the scheduling cycle.
+The unused transmission bandwidth will be distributed among the remaining entities assuring the weight setting.
+
+The SEs are connected in a tree structure. The entity is connected to a leaf. One or more leaves can be connected to a SE node.
+One or more SE nodes can be connected to a SE node, until reaching the SE root.
+For each input on each node, user can assign the maximum bandwidth and the scheduling weight.
+
+The SE APIs (mlx5dv_sched_*) allows access by verbs application to set the hierarchical SE tree to the device.
+The ibv_qp shall be connected to a leaf.
+
+# ARGUMENTS
+
+Please see *ibv_create_qp_ex(3)* man page for *context*.
+
+## mlx5dv_sched_attr
+
+```c
+
+struct mlx5dv_sched_attr {
+	struct mlx5dv_sched_node *parent;
+	uint32_t flags;
+	uint32_t bw_share;
+	uint32_t max_avg_bw;
+	uint64_t comp_mask;
+};
+```
+
+*parent*
+:	A node handler to the parent scheduling element which this scheduling element will be connected to. The root scheduling element doesn't have a parent.
+
+*flags*
+:	Specifying what attributes in the structure are valid:
+
+	MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE for *bw_share*
+
+	MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW for *max_avg_bw*
+
+*bw_share*
+:	The relative bandwidth share allocated for this element. This field has no units.
+        The bandwidth is shared between all elements connected to the same parent element, relatively to their bw_share.
+        Value of 0, indicates a device default Weight. This field must be 0 for the root TSAR.
+
+*max_avg_bw*
+:	The maximal transmission rate allowed for the element, averaged over time. Value is given in units of 1 Mbit/sec. Value 0x0 indicates the rate is unlimited.
+        This field must be 0 for the root TSAR.
+
+*comp_mask*
+:	Reserved for future extension, must be 0 now.
+
+*node/leaf*
+:      For modify, destroy: the scheduling element to work on.
+
+*sched_attr*
+:      For create, modify: the attribute of the scheduling element to work on.
+
+# NOTES
+
+For example if an application wants to create 2 QoS QP groups:
+```c
+g1: 70% bandwidth share of this application
+g2: 30% bandwidth share of this application, with maximum average bandwidth limited to 4Gbps
+```
+
+Pseudo code:
+
+```c
+
+struct mlx5dv_sched_node *root;
+struct mlx5dv_sched_leaf *leaf_g1, *leaf_g2;
+struct mlx5dv_sched_attr;
+struct ibv_qp *qp1, qp2;
+
+/* Create root node */
+attr.comp_mask = 0;
+attr.parent = NULL;
+attr.flags = 0;
+root = mlx5dv_sched_node_create(context, attr);
+
+/* Create group1 */
+attr.comp_mask = 0;
+attr.parent = root;
+attr.bw_share = 7;
+attr.flags = MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE;
+leaf_g1 = mlx5dv_sched_leaf_create(context, attr);
+
+/* Create group2 */
+attr.comp_mask = 0;
+attr.parent = root;
+attr.bw_share = 3;
+attr.max_avg_bw = 4096;
+attr.flags = MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE | MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW;
+leaf_g2 = mlx5dv_sched_leaf_create(context, attr);
+
+foreach (qp1 in group1)
+	mlx5dv_modify_qp_sched_elem(qp1, leaf_g1, NULL);
+
+foreach (qp2 in group2)
+	mlx5dv_modify_qp_sched_elem(qp2, leaf_g2, NULL);
+
+```
+
+# RETURN VALUE
+
+Upon success *mlx5dv_sched_node[/leaf]_create()* will return a new *struct mlx5dv_sched_node[/leaf]*, on error NULL will be returned and errno will be set.
+
+Upon success modify and destroy, 0 is returned or the value of errno on a failure.
+
+# SEE ALSO
+
+**ibv_create_qp_ex**(3), **mlx5dv_modify_qp_sched_elem**(3)
+
+# AUTHOR
+
+Mark Zhang <markzhang@nvidia.com>
+
+Ariel Almog <ariela@nvidia.com>
+

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -258,6 +258,18 @@ struct mlx5_lag_caps {
 	uint8_t lag_tx_port_affinity;
 };
 
+struct mlx5_qos_caps {
+	uint8_t qos:1;
+
+	uint8_t nic_sq_scheduling:1;
+	uint8_t nic_bw_share:1;
+	uint8_t nic_rate_limit:1;
+	uint8_t nic_qp_scheduling:1;
+
+	uint32_t nic_element_type;
+	uint32_t nic_tsar_type;
+};
+
 struct mlx5_context {
 	struct verbs_context		ibv_ctx;
 	int				max_num_qps;
@@ -327,6 +339,7 @@ struct mlx5_context {
 	uint32_t			tunnel_offloads_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	struct mlx5_lag_caps		lag_caps;
+	struct mlx5_qos_caps		qos_caps;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
 	uint32_t			max_num_legacy_dyn_uar_sys_page;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -340,6 +340,7 @@ struct mlx5_context {
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	struct mlx5_lag_caps		lag_caps;
 	struct mlx5_qos_caps		qos_caps;
+	uint8_t				qpc_extension_cap:1;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
 	uint32_t			max_num_legacy_dyn_uar_sys_page;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -749,6 +749,16 @@ struct mlx5_flow_action_attr_aux {
 	uint32_t offset;
 };
 
+struct mlx5dv_sched_node {
+	struct mlx5dv_sched_node *parent;
+	struct mlx5dv_devx_obj *obj;
+};
+
+struct mlx5dv_sched_leaf {
+	struct mlx5dv_sched_node *parent;
+	struct mlx5dv_devx_obj *obj;
+};
+
 struct ibv_flow *
 __mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		     struct mlx5dv_flow_match_parameters *match_value,

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1091,6 +1091,25 @@ struct mlx5_ifc_odp_cap_bits {
 	u8         reserved_at_120[0x6e0];
 };
 
+struct mlx5_ifc_qos_cap_bits {
+	u8         reserved_at_0[0x8];
+	u8         nic_sq_scheduling[0x1];
+	u8         nic_bw_share[0x1];
+	u8         nic_rate_limit[0x1];
+	u8         reserved_at_b[0x15];
+
+	u8         reserved_at_20[0x1];
+	u8         nic_qp_scheduling[0x1];
+	u8         reserved_at_22[0x1e];
+
+	u8         reserved_at_40[0xc0];
+
+	u8         nic_element_type[0x10];
+	u8         nic_tsar_type[0x10];
+
+	u8         reserved_at_120[0x6e0];
+};
+
 union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_atomic_caps_bits atomic_caps;
 	struct mlx5_ifc_cmd_hca_cap_bits cmd_hca_cap;
@@ -1099,6 +1118,7 @@ union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_device_mem_cap_bits device_mem_cap;
 	struct mlx5_ifc_odp_cap_bits odp_cap;
 	struct mlx5_ifc_roce_cap_bits roce_caps;
+	struct mlx5_ifc_qos_cap_bits qos_caps;
 	u8         reserved_at_0[0x8000];
 };
 
@@ -1137,6 +1157,7 @@ enum {
 	MLX5_SET_HCA_CAP_OP_MOD_ROCE                  = 0x4 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_NIC_FLOW_TABLE        = 0x7 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_ESW_FLOW_TABLE        = 0x8 << 1,
+	MLX5_SET_HCA_CAP_OP_MOD_QOS                   = 0xc << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY         = 0xf << 1,
 };
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1091,6 +1091,15 @@ struct mlx5_ifc_odp_cap_bits {
 	u8         reserved_at_120[0x6e0];
 };
 
+enum {
+	ELEMENT_TYPE_CAP_MASK_TASR = 1 << 0,
+	ELEMENT_TYPE_CAP_MASK_QUEUE_GROUP = 1 << 4,
+};
+
+enum {
+	TSAR_TYPE_CAP_MASK_DWRR = 1 << 0,
+};
+
 struct mlx5_ifc_qos_cap_bits {
 	u8         reserved_at_0[0x8];
 	u8         nic_sq_scheduling[0x1];
@@ -2394,6 +2403,7 @@ enum {
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
 	MLX5_OBJ_TYPE_ASO_FLOW_METER = 0x0024,
 	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
+	MLX5_OBJ_TYPE_SCHEDULING_ELEMENT = 0x0026,
 };
 
 struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
@@ -3230,5 +3240,73 @@ enum {
 enum {
 	MLX5_ASO_FIRST_HIT_NUM_PER_OBJ = 512,
 	MLX5_ASO_FLOW_METER_NUM_PER_OBJ = 2,
+};
+
+enum mlx5_sched_hierarchy_type {
+	MLX5_SCHED_HIERARCHY_NIC = 3,
+};
+
+enum mlx5_sched_elem_type {
+	MLX5_SCHED_ELEM_TYPE_TSAR		= 0x0,
+	MLX5_SCHED_ELEM_TYPE_VPORT		= 0x1,
+	MLX5_SCHED_ELEM_TYPE_VPORT_TC		= 0x2,
+	MLX5_SCHED_ELEM_TYPE_PARA_VPORT_TC	= 0x3,
+	MLX5_SCHED_ELEM_TYPE_QUEUE_GROUP	= 0x4,
+};
+
+enum mlx5_sched_tsar_type {
+	MLX5_SCHED_TSAR_TYPE_DWRR		= 0x0,
+	MLX5_SCHED_TSAR_TYPE_ROUND_ROBIN	= 0x1,
+	MLX5_SCHED_TSAR_TYPE_ETS		= 0x2,
+};
+
+struct mlx5_ifc_sched_elem_attr_tsar_bits {
+	u8	reserved_at_0[0x8];
+	u8	tsar_type[0x8];
+	u8	reserved_at_10[0x10];
+};
+
+union mlx5_ifc_sched_elem_attr_bits {
+	struct mlx5_ifc_sched_elem_attr_tsar_bits tsar;
+};
+
+struct  mlx5_ifc_sched_context_bits {
+	u8	element_type[0x8];
+	u8	reserved_at_8[0x18];
+
+	union	mlx5_ifc_sched_elem_attr_bits sched_elem_attr;
+
+	u8	parent_element_id[0x20];
+
+	u8	reserved_at_60[0x40];
+
+	u8	bw_share[0x20];
+
+	u8	max_average_bw[0x20];
+
+	u8	reserved_at_e0[0x120];
+};
+
+struct mlx5_ifc_sched_elem_bits {
+	u8	modify_field_select[0x40];
+
+	u8	scheduling_hierarchy[0x8];
+	u8	reserved_at_48[0x18];
+
+	u8	reserved_at_60[0xa0];
+
+	struct	mlx5_ifc_sched_context_bits sched_context;
+
+	u8	reserved_at_300[0x100];
+};
+
+struct mlx5_ifc_create_sched_elem_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits	hdr;
+	struct mlx5_ifc_sched_elem_bits			sched_elem;
+};
+
+struct mlx5_ifc_create_modify_elem_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits	hdr;
+	struct mlx5_ifc_sched_elem_bits			sched_elem;
 };
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -54,6 +54,7 @@ enum {
 	MLX5_CMD_OP_QUERY_ROCE_ADDRESS = 0x760,
 	MLX5_CMD_OP_QUERY_LAG = 0x842,
 	MLX5_CMD_OP_CREATE_TIR = 0x900,
+	MLX5_CMD_OP_MODIFY_SQ = 0x905,
 	MLX5_CMD_OP_MODIFY_TIS = 0x913,
 	MLX5_CMD_OP_QUERY_TIS = 0x915,
 	MLX5_CMD_OP_CREATE_FLOW_TABLE = 0x930,
@@ -3389,4 +3390,55 @@ struct mlx5_ifc_create_modify_elem_in_bits {
 	struct mlx5_ifc_general_obj_in_cmd_hdr_bits	hdr;
 	struct mlx5_ifc_sched_elem_bits			sched_elem;
 };
+
+enum {
+	MLX5_SQC_STATE_RDY  = 0x1,
+};
+
+struct mlx5_ifc_sqc_bits {
+	u8	reserved_at_0[0x8];
+	u8	state[0x4];
+	u8	reserved_at_c[0x14];
+
+	u8	reserved_at_20[0xe0];
+
+	u8	reserved_at_100[0x10];
+	u8	qos_queue_group_id[0x10];
+
+	u8	reserved_at_120[0x660];
+};
+
+enum {
+	MLX5_MODIFY_SQ_BITMASK_QOS_QUEUE_GROUP_ID	= 1 << 2,
+};
+
+struct mlx5_ifc_modify_sq_out_bits {
+	u8	status[0x8];
+	u8	reserved_at_8[0x18];
+
+	u8	syndrome[0x20];
+
+	u8	reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_modify_sq_in_bits {
+	u8	opcode[0x10];
+	u8	uid[0x10];
+
+	u8	reserved_at_20[0x10];
+	u8	op_mod[0x10];
+
+	u8	sq_state[0x4];
+	u8	reserved_at_44[0x4];
+	u8	sqn[0x18];
+
+	u8	reserved_at_60[0x20];
+
+	u8	modify_bitmask[0x40];
+
+	u8	reserved_at_c0[0x40];
+
+	struct mlx5_ifc_sqc_bits sq_context;
+};
+
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -48,6 +48,7 @@ enum {
 	MLX5_CMD_OP_RTR2RTS_QP = 0x504,
 	MLX5_CMD_OP_RTS2RTS_QP = 0x505,
 	MLX5_CMD_OP_QUERY_QP = 0x50b,
+	MLX5_CMD_OP_INIT2INIT_QP = 0x50e,
 	MLX5_CMD_OP_QUERY_ESW_VPORT_CONTEXT = 0x752,
 	MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT = 0x754,
 	MLX5_CMD_OP_QUERY_ROCE_ADDRESS = 0x760,
@@ -643,7 +644,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         null_mkey[0x1];
 	u8         log_max_klm_list_size[0x6];
 
-	u8         reserved_at_120[0xa];
+	u8         reserved_at_120[0x2];
+	u8         qpc_extension[0x1];
+	u8         reserved_at_123[0x7];
 	u8         log_max_ra_req_dc[0x6];
 	u8         reserved_at_130[0xa];
 	u8         log_max_ra_res_dc[0x6];
@@ -2755,6 +2758,16 @@ struct mlx5_ifc_qpc_bits {
 	u8         dbr_umem_id[0x20];
 };
 
+struct mlx5_ifc_qpc_ext_bits {
+	u8         reserved_at_0[0x20];
+
+	u8         qos_queue_group_id_requester[0x20];
+
+	u8         qos_queue_group_id_responder[0x20];
+
+	u8         reserved_at_60[0x7a0];
+};
+
 struct mlx5_ifc_create_tir_out_bits {
 	u8         status[0x8];
 	u8         icm_address_63_40[0x18];
@@ -2802,6 +2815,41 @@ struct mlx5_ifc_create_qp_in_bits {
 	u8         reserved_at_861[0x1f];
 
 	u8         pas[0][0x40];
+};
+
+enum mlx5_qpc_opt_mask_32 {
+	MLX5_QPC_OPT_MASK_32_QOS_QUEUE_GROUP_ID = 1 << 1,
+};
+
+struct mlx5_ifc_init2init_qp_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_init2init_qp_in_bits {
+	u8         opcode[0x10];
+	u8         uid[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         qpc_ext[0x1];
+	u8         reserved_at_41[0x7];
+	u8         qpn[0x18];
+
+	u8         reserved_at_60[0x60];
+
+	struct mlx5_ifc_qpc_bits qpc;
+
+	u8         reserved_at_800[0x40];
+
+	u8         opt_param_mask_95_32[0x40];
+
+	struct mlx5_ifc_qpc_ext_bits qpc_data_ext;
 };
 
 struct mlx5_ifc_init2rtr_qp_out_bits {
@@ -2892,6 +2940,38 @@ struct mlx5_ifc_rst2init_qp_in_bits {
 	struct mlx5_ifc_qpc_bits qpc;
 
 	u8         reserved_at_800[0x80];
+};
+
+struct mlx5_ifc_rts2rts_qp_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_rts2rts_qp_in_bits {
+	u8         opcode[0x10];
+	u8         uid[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         qpc_ext[0x1];
+	u8         reserved_at_41[0x7];
+	u8         qpn[0x18];
+
+	u8         reserved_at_60[0x60];
+
+	struct mlx5_ifc_qpc_bits qpc;
+
+	u8         reserved_at_800[0x40];
+
+	u8         opt_param_mask_95_32[0x40];
+
+	struct mlx5_ifc_qpc_ext_bits qpc_data_ext;
+
 };
 
 struct mlx5_ifc_query_qp_out_bits {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1618,6 +1618,39 @@ int mlx5dv_query_qp_lag_port(struct ibv_qp *qp,
 
 int mlx5dv_modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num);
 
+enum mlx5dv_sched_elem_attr_flags {
+	MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE	= 1 << 0,
+	MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW	= 1 << 1,
+};
+
+struct mlx5dv_sched_attr {
+	struct mlx5dv_sched_node *parent;
+	uint32_t flags;		/* Use mlx5dv_sched_elem_attr_flags */
+	uint32_t bw_share;
+	uint32_t max_avg_bw;
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_sched_node;
+struct mlx5dv_sched_leaf;
+
+struct mlx5dv_sched_node *
+mlx5dv_sched_node_create(struct ibv_context *context,
+			 const struct mlx5dv_sched_attr *sched_attr);
+struct mlx5dv_sched_leaf *
+mlx5dv_sched_leaf_create(struct ibv_context *context,
+			 const struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_node_modify(struct mlx5dv_sched_node *node,
+			     const struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_leaf_modify(struct mlx5dv_sched_leaf *leaf,
+			     const struct mlx5dv_sched_attr *sched_attr);
+
+int mlx5dv_sched_node_destroy(struct mlx5dv_sched_node *node);
+
+int mlx5dv_sched_leaf_destroy(struct mlx5dv_sched_leaf *leaf);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1651,6 +1651,10 @@ int mlx5dv_sched_node_destroy(struct mlx5dv_sched_node *node);
 
 int mlx5dv_sched_leaf_destroy(struct mlx5dv_sched_leaf *leaf);
 
+int mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
+				const struct mlx5dv_sched_leaf *requestor,
+				const struct mlx5dv_sched_leaf *responder);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3454,6 +3454,10 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 
 	mctx->qos_caps.qos =
 		DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.qos);
+
+	mctx->qpc_extension_cap =
+		DEVX_GET(query_hca_cap_out, out,
+			 capability.cmd_hca_cap.qpc_extension);
 }
 
 static void get_qos_caps(struct mlx5_context *mctx)

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -21,6 +21,8 @@ cdef class Context(PyverbsCM):
     cdef object vars
     cdef object uars
     cdef object pps
+    cdef object sched_nodes
+    cdef object sched_leafs
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -115,6 +115,8 @@ cdef class Context(PyverbsCM):
         self.vars = weakref.WeakSet()
         self.uars = weakref.WeakSet()
         self.pps = weakref.WeakSet()
+        self.sched_nodes = weakref.WeakSet()
+        self.sched_leafs = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -167,7 +169,8 @@ cdef class Context(PyverbsCM):
         if self.context != NULL:
             self.logger.debug('Closing Context')
             close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
-                            self.xrcds, self.vars])
+                            self.xrcds, self.vars, self.sched_leafs,
+                            self.sched_nodes])
             rc = v.ibv_close_device(self.context)
             if rc != 0:
                 raise PyverbsRDMAErrno(f'Failed to close device {self.name}')

--- a/pyverbs/providers/mlx5/CMakeLists.txt
+++ b/pyverbs/providers/mlx5/CMakeLists.txt
@@ -4,4 +4,5 @@
 rdma_cython_module(pyverbs/providers/mlx5 mlx5
   mlx5dv.pyx
   mlx5_enums.pyx
+  mlx5dv_sched.pyx
 )

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -79,6 +79,17 @@ cdef extern from 'infiniband/mlx5dv.h':
     cdef struct mlx5dv_qp_ex:
         uint64_t comp_mask
 
+    cdef struct mlx5dv_sched_node
+
+    cdef struct mlx5dv_sched_leaf
+
+    cdef struct mlx5dv_sched_attr:
+        mlx5dv_sched_node *parent;
+        uint32_t flags;
+        uint32_t bw_share;
+        uint32_t max_avg_bw;
+        uint64_t comp_mask;
+
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)
@@ -105,3 +116,15 @@ cdef extern from 'infiniband/mlx5dv.h':
     void mlx5dv_wr_set_dc_addr(mlx5dv_qp_ex *mqp, v.ibv_ah *ah,
                                uint32_t remote_dctn, uint64_t remote_dc_key)
     mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(v.ibv_qp_ex *qp_ex)
+    mlx5dv_sched_node *mlx5dv_sched_node_create(v.ibv_context *context,
+                                                mlx5dv_sched_attr *sched_attr)
+    mlx5dv_sched_leaf *mlx5dv_sched_leaf_create(v.ibv_context *context,
+                                                mlx5dv_sched_attr *sched_attr)
+    int mlx5dv_sched_node_modify(mlx5dv_sched_node *node,
+                                 mlx5dv_sched_attr *sched_attr)
+    int mlx5dv_sched_leaf_modify(mlx5dv_sched_leaf *leaf,
+                                 mlx5dv_sched_attr *sched_attr)
+    int mlx5dv_sched_node_destroy(mlx5dv_sched_node *node)
+    int mlx5dv_sched_leaf_destroy(mlx5dv_sched_leaf *leaf)
+    int mlx5dv_modify_qp_sched_elem(v.ibv_qp *qp, mlx5dv_sched_leaf *requestor,
+                                    mlx5dv_sched_leaf *responder)

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -36,6 +36,10 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CQE_RES_FORMAT_CSUM          = 1 << 1
         MLX5DV_CQE_RES_FORMAT_CSUM_STRIDX   = 1 << 2
 
+    cpdef enum mlx5dv_sched_elem_attr_flags:
+        MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE    = 1 << 0
+        MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW  = 1 << 1
+
     cpdef enum mlx5dv_tunnel_offloads:
         MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_VXLAN            = 1 << 0
         MLX5DV_RAW_PACKET_CAP_TUNNELED_OFFLOAD_GRE              = 1 << 1

--- a/pyverbs/providers/mlx5/mlx5dv_sched.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_sched.pxd
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia, Inc. All rights reserved. See COPYING file
+
+#cython: language_level=3
+
+cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.base cimport PyverbsObject
+
+
+cdef class Mlx5dvSchedAttr(PyverbsObject):
+    cdef dv.mlx5dv_sched_attr sched_attr
+    cdef object parent_sched_node
+
+cdef class Mlx5dvSchedNode(PyverbsObject):
+    cdef dv.mlx5dv_sched_node *sched_node
+    cdef object context
+    cdef object sched_attr
+    cpdef close(self)
+
+cdef class Mlx5dvSchedLeaf(PyverbsObject):
+    cdef dv.mlx5dv_sched_leaf *sched_leaf
+    cdef object context
+    cdef object sched_attr
+    cpdef close(self)

--- a/pyverbs/providers/mlx5/mlx5dv_sched.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_sched.pyx
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia, Inc. All rights reserved. See COPYING file
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.device cimport Context
+
+
+cdef class Mlx5dvSchedAttr(PyverbsObject):
+    def __init__(self, Mlx5dvSchedNode parent_sched_node=None, bw_share=0,
+                 max_avg_bw=0, flags=0, comp_mask=0):
+        """
+        Create a Schedule attr.
+        :param parent_sched_node: The parent Mlx5dvSchedNode. None if this Attr
+                                  is for the root node.
+        :param flags: Bitmask specifying what attributes in the structure
+                      are valid.
+        :param bw_share: The relative bandwidth share allocated for this
+                         element.
+        :param max_avg_bw: The maximal transmission rate allowed for the element,
+                           averaged over time.
+        :param comp_mask: Reserved for future extension.
+        """
+        self.parent_sched_node = parent_sched_node
+        parent_node = parent_sched_node.sched_node if parent_sched_node \
+            else NULL
+        self.sched_attr.parent = parent_node
+        self.sched_attr.flags = flags
+        self.sched_attr.bw_share = bw_share
+        self.sched_attr.max_avg_bw = max_avg_bw
+        self.sched_attr.comp_mask = comp_mask
+
+    @property
+    def bw_share(self):
+        return self.sched_attr.bw_share
+
+    @property
+    def max_avg_bw(self):
+        return self.sched_attr.max_avg_bw
+
+    @property
+    def flags(self):
+        return self.sched_attr.flags
+
+    @property
+    def comp_mask(self):
+        return self.sched_attr.comp_mask
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return 'Mlx5dvSchedAttr:\n' +\
+               print_format.format('BW share', self.bw_share) +\
+               print_format.format('Max avgerage BW', self.max_avg_bw) +\
+               print_format.format('Flags', self.flags) +\
+               print_format.format('Comp mask', self.comp_mask)
+
+
+cdef class Mlx5dvSchedNode(PyverbsObject):
+    def __init__(self, Context context not None, Mlx5dvSchedAttr sched_attr):
+        """
+        Create a Schedule node.
+        :param context: Context to create the schedule resources on.
+        :param sched_attr: Mlx5dvSchedAttr, containing the sched attributes.
+        """
+        self.sched_attr = sched_attr
+        self.sched_node = dv.mlx5dv_sched_node_create(context.context,
+                                                      &sched_attr.sched_attr)
+        if self.sched_node == NULL:
+            raise PyverbsRDMAErrno('Failed to create sched node')
+        self.context = context
+        context.sched_nodes.add(self)
+
+    def modify(self, Mlx5dvSchedAttr sched_attr):
+        rc = dv.mlx5dv_sched_node_modify(self.sched_node,
+                                         &sched_attr.sched_attr)
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return 'Mlx5dvSchedNode:\n' +\
+               print_format.format('sched attr', str(self.sched_attr))
+
+    @property
+    def sched_attr(self):
+        return self.sched_attr
+
+    @property
+    def bw_share(self):
+        return self.sched_attr.bw_share
+
+    @property
+    def max_avg_bw(self):
+        return self.sched_attr.max_avg_bw
+
+    @property
+    def flags(self):
+        return self.sched_attr.flags
+
+    @property
+    def comp_mask(self):
+        return self.sched_attr.comp_mask
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.sched_node != NULL:
+            rc = dv.mlx5dv_sched_node_destroy(self.sched_node)
+            if rc != 0:
+                raise PyverbsRDMAError('Failed to destroy a sched node', rc)
+            self.sched_node = NULL
+            self.context = None
+
+
+cdef class Mlx5dvSchedLeaf(PyverbsObject):
+    def __init__(self, Context context not None, Mlx5dvSchedAttr sched_attr):
+        """
+        Create a Schedule leaf.
+        :param context: Context to create the schedule resources on.
+        :param sched_attr: Mlx5dvSchedAttr, containing the sched attributes.
+        """
+        self.sched_attr = sched_attr
+        self.sched_leaf = dv.mlx5dv_sched_leaf_create(context.context,
+                                                      &sched_attr.sched_attr)
+        if self.sched_leaf == NULL:
+            raise PyverbsRDMAErrno('Failed to create sched leaf')
+        self.context = context
+        context.sched_leafs.add(self)
+
+    def modify(self, Mlx5dvSchedAttr sched_attr):
+        rc = dv.mlx5dv_sched_leaf_modify(self.sched_leaf,
+                                         &sched_attr.sched_attr)
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return 'Mlx5dvSchedLeaf:\n' +\
+               print_format.format('sched attr', str(self.sched_attr))
+
+    @property
+    def sched_attr(self):
+        return self.sched_attr
+
+    @property
+    def bw_share(self):
+        return self.sched_attr.bw_share
+
+    @property
+    def max_avg_bw(self):
+        return self.sched_attr.max_avg_bw
+
+    @property
+    def flags(self):
+        return self.sched_attr.flags
+
+    @property
+    def comp_mask(self):
+        return self.sched_attr.comp_mask
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.sched_leaf != NULL:
+            rc = dv.mlx5dv_sched_leaf_destroy(self.sched_leaf)
+            if rc != 0:
+                raise PyverbsRDMAError('Failed to destroy a sched leaf', rc)
+            self.sched_leaf = NULL
+            self.context = None

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ rdma_python_test(tests
   test_mlx5_dc.py
   test_mlx5_lag_affinity.py
   test_mlx5_pp.py
+  test_mlx5_sched.py
   test_mlx5_uar.py
   test_mlx5_var.py
   test_mr.py

--- a/tests/test_mlx5_sched.py
+++ b/tests/test_mlx5_sched.py
@@ -1,0 +1,105 @@
+import unittest
+import errno
+
+from pyverbs.providers.mlx5.mlx5dv_sched import Mlx5dvSchedAttr, \
+    Mlx5dvSchedNode, Mlx5dvSchedLeaf
+from tests.base import RDMATestCase, RCResources, PyverbsAPITestCase
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.providers.mlx5.mlx5dv import Mlx5QP
+import pyverbs.providers.mlx5.mlx5_enums as dve
+import tests.utils as u
+
+
+class Mlx5SchedTest(PyverbsAPITestCase):
+    def test_create_sched_tree(self):
+        """
+        Create schedule elements tree. Test the schedule elements API, this
+        includes creating schedule nodes with different flags and connecting
+        them with schedule leaves. In addition, modify some nodes with
+        different BW share and max BW.
+        """
+        ctx, _, _ = self.devices[0]
+        try:
+            root_node = Mlx5dvSchedNode(ctx, Mlx5dvSchedAttr())
+            # Create a node with only max_avg_bw argument.
+            max_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=10,
+                                             flags=dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW)
+            max_bw_node = Mlx5dvSchedNode(ctx, max_sched_attr)
+
+            # Create a node with only bw_share argument.
+            weighed_sched_attr = Mlx5dvSchedAttr(root_node, bw_share=10,
+                                                 flags=dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE)
+            max_bw_node = Mlx5dvSchedNode(ctx, weighed_sched_attr)
+
+            # Create a node with max_avg_bw and bw_share arguments.
+            mixed_flags = dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW | \
+                dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE
+            mixed_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=10, bw_share=2,
+                                               flags=mixed_flags)
+            mixed_bw_node = Mlx5dvSchedNode(ctx, mixed_sched_attr)
+
+            # Modify a node.
+            modify_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=4, bw_share=1,
+                                                flags=mixed_flags)
+            mixed_bw_node.modify(modify_sched_attr)
+
+            # Attach sched leaf to mixed_bw_node
+            max_sched_attr = Mlx5dvSchedAttr(mixed_bw_node)
+            sched_leaf = Mlx5dvSchedLeaf(ctx, max_sched_attr)
+
+            # Modify a leaf.
+            modify_sched_attr = Mlx5dvSchedAttr(mixed_bw_node, max_avg_bw=3, bw_share=3,
+                                                flags=mixed_flags)
+            sched_leaf.modify(modify_sched_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create schedule elements is not supported')
+            raise ex
+
+
+class Mlx5SchedTrafficTest(RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+        self.traffic_args = None
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init schedule elements traffic tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+                             attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
+
+    def test_sched_per_qp_traffic(self):
+        """
+        Tests attaching a QP to a sched leaf. The test creates a sched tree
+        consisting of a root node and a leaf with max BW and share BW, modifies
+        two RC QPs to be attached to the sched leaf and then run traffic using
+        those QPs.
+        """
+        self.create_players(RCResources)
+        try:
+            root_node = Mlx5dvSchedNode(self.server.ctx, Mlx5dvSchedAttr())
+            mixed_flags = dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW | \
+                dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE
+            mixed_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=10,
+                                               bw_share=2, flags=mixed_flags)
+            leaf = Mlx5dvSchedLeaf(self.server.ctx, mixed_sched_attr)
+            Mlx5QP.modify_qp_sched_elem(self.server.qp, req_sched_leaf=leaf,
+                                        resp_sched_leaf=leaf)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Creation or usage of schedule elements is not supported')
+            raise ex
+        u.traffic(**self.traffic_args)


### PR DESCRIPTION
Expose DV APIs to control the transmit scheduler, this allows enforcing QoS policies.
The internal implementation was done over DEVX, detailed man pages to describe the usage are part of the series.

Note:
The first 9 patches in the series were taken from https://github.com/linux-rdma/rdma-core/pull/890 as the series touches the same area of the context capabilities.