### PR TITLE
ibdiag: Initial NDR support

### DIFF
--- a/libibmad/dump.c
+++ b/libibmad/dump.c
@@ -335,6 +335,9 @@ void mad_dump_linkspeedext(char *buf, int bufsz, void *val, int valsz)
 	case 4:
 		snprintf(buf, bufsz, "53.125 Gbps");
 		break;
+	case 8:
+		snprintf(buf, bufsz, "106.25 Gbps");
+		break;
 	default:
 		snprintf(buf, bufsz, "undefined (%d)", speed);
 		break;
@@ -356,6 +359,8 @@ static void dump_linkspeedext(char *buf, int bufsz, int speed)
 		n += snprintf(buf + n, bufsz - n, "25.78125 Gbps or ");
 	if (n < bufsz && speed & 0x4)
 		n += snprintf(buf + n, bufsz - n, "53.125 Gbps or ");
+	if (n < bufsz && speed & 0x8)
+		n += snprintf(buf + n, bufsz - n, "106.25 Gbps or ");
 
 	if (n >= bufsz) {
 		if (bufsz > 3)
@@ -363,7 +368,7 @@ static void dump_linkspeedext(char *buf, int bufsz, int speed)
 		return;
 	}
 
-	if (speed >> 3) {
+	if (speed >> 4) {
 		n += snprintf(buf + n, bufsz - n, "undefined (%d)", speed);
 		return;
 	} else if (bufsz > 3)
@@ -636,6 +641,16 @@ void mad_dump_portcapmask2(char *buf, int bufsz, void *val, int valsz)
 		s += sprintf(s, "\t\t\t\tIsLinkWidth2xSupported\n");
 	if (mask & (1 << 5))
 		s += sprintf(s, "\t\t\t\tIsLinkSpeedHDRSupported\n");
+	if (mask & (1 << 6))
+		s += sprintf(s, "\t\t\t\tIsMKeyProtectBitsExtSupported\n");
+	if (mask & (1 << 7))
+		s += sprintf(s, "\t\t\t\tIsEnhancedTrap128Supported\n");
+	if (mask & (1 << 8))
+		s += sprintf(s, "\t\t\t\tIsPartitionTopSupported\n");
+	if (mask & (1 << 9))
+		s += sprintf(s, "\t\t\t\tIsEnhancedQoSArbiterSupported\n");
+	if (mask & (1 << 10))
+		s += sprintf(s, "\t\t\t\tIsLinkSpeedNDRSupported\n");
 
 	if (s != buf)
 		*(--s) = 0;
@@ -1179,16 +1194,25 @@ void mad_dump_classportinfo(char *buf, int bufsz, void *val, int valsz)
 
 void mad_dump_portinfo_ext(char *buf, int bufsz, void *val, int valsz)
 {
-	int cnt;
+	int cnt, n;
 
 	cnt = _dump_fields(buf, bufsz, val, IB_PORT_EXT_FIRST_F,
 			   IB_PORT_EXT_LAST_F);
 	if (cnt < 0)
 		return;
 
+	n = _dump_fields(buf + cnt, bufsz - cnt, val,
+			 IB_PORT_EXT_HDR_FEC_MODE_SUPPORTED_F,
+			 IB_PORT_EXT_HDR_FEC_MODE_LAST_F);
+
+	if (n < 0)
+		return;
+
+	cnt += n;
+
 	_dump_fields(buf + cnt, bufsz - cnt, val,
-		     IB_PORT_EXT_HDR_FEC_MODE_SUPPORTED_F,
-		     IB_PORT_EXT_HDR_FEC_MODE_LAST_F);
+		     IB_PORT_EXT_NDR_FEC_MODE_SUPPORTED_F,
+		     IB_PORT_EXT_NDR_FEC_MODE_LAST_F);
 }
 
 void xdump(FILE * file, const char *msg, void *p, int size)

--- a/libibmad/fields.c
+++ b/libibmad/fields.c
@@ -1006,11 +1006,18 @@ static const ib_field_t ib_mad_f[] = {
 	{160, 16, "QP1Dropped", mad_dump_uint},
 
 	/*
-	 * More PortInfoExtended fields
+	 * More PortInfoExtended fields (HDR)
 	 */
 	{112, 16, "HDRFECModeSupported", mad_dump_hex},
 	{128, 16, "HDRFECModeEnabled", mad_dump_hex},
 	{},			/* IB_PORT_EXT_HDR_FEC_MODE_LAST_F */
+
+	/*
+	 * More PortInfoExtended fields (NDR)
+	 */
+	{144, 16, "NDRFECModeSupported", mad_dump_hex},
+	{160, 16, "NDRFECModeEnabled", mad_dump_hex},
+	{},			/* IB_PORT_EXT_NDR_FEC_MODE_LAST_F */
 
 	{}			/* IB_FIELD_LAST_ */
 };

--- a/libibmad/mad.h
+++ b/libibmad/mad.h
@@ -76,7 +76,7 @@ extern "C" {
 #define IB_BM_BKEY_AND_DATA_SZ	(IB_MAD_SIZE - IB_BM_BKEY_OFFS)
 #define IB_CC_DATA_OFFS         64
 #define IB_CC_DATA_SZ           (IB_MAD_SIZE - IB_CC_DATA_OFFS)
-#define IB_CC_LOG_DATA_OFFS     32 
+#define IB_CC_LOG_DATA_OFFS     32
 #define IB_CC_LOG_DATA_SZ       (IB_MAD_SIZE - IB_CC_LOG_DATA_OFFS)
 
 enum MAD_CLASSES {
@@ -1319,11 +1319,18 @@ enum MAD_FIELDS {
 	IB_PC_QP1_DROP_F,
 
 	/*
-	 * More PortInfoExtended fields
+	 * More PortInfoExtended fields (HDR)
 	 */
 	IB_PORT_EXT_HDR_FEC_MODE_SUPPORTED_F,
 	IB_PORT_EXT_HDR_FEC_MODE_ENABLED_F,
 	IB_PORT_EXT_HDR_FEC_MODE_LAST_F,
+
+	/*
+	 * More PortInfoExtended fields (NDR)
+	 */
+	IB_PORT_EXT_NDR_FEC_MODE_SUPPORTED_F,
+	IB_PORT_EXT_NDR_FEC_MODE_ENABLED_F,
+	IB_PORT_EXT_NDR_FEC_MODE_LAST_F,
 
 	IB_FIELD_LAST_		/* must be last */
 };


### PR DESCRIPTION
Added support new speed 106.25
Added support for NDRFECModeSupported & NDRFECModeEnabled
Added support for IsLinkSpeedNDRSupported (PortInfo.CapabilityMask2)
Added support for other lost flags of PortInfo.CapabilityMask2
	6: IsMKeyProtectBitsExtSupported
	7: IsEnhancedTrap128Supported
	8: IsPartitionTopSupported
	9: IsEnhancedQoSArbiterSupported

Signed-off-by: Haim Boozaglo <haimbo@nvidia.com>