### PR TITLE
mlx5: Improve the entropy support in few areas

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -114,6 +114,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_action_create_push_vlan@MLX5_1.17 33
  mlx5dv_dr_action_modify_aso@MLX5_1.17 33
  mlx5dv_modify_qp_sched_elem@MLX5_1.17 33
+ mlx5dv_modify_qp_udp_sport@MLX5_1.17 33
  mlx5dv_sched_leaf_create@MLX5_1.17 33
  mlx5dv_sched_leaf_destroy@MLX5_1.17 33
  mlx5dv_sched_leaf_modify@MLX5_1.17 33

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -160,6 +160,7 @@ MLX5_1.17 {
 		mlx5dv_dr_action_create_push_vlan;
 		mlx5dv_dr_action_modify_aso;
 		mlx5dv_modify_qp_sched_elem;
+		mlx5dv_modify_qp_udp_sport;
 		mlx5dv_sched_leaf_create;
 		mlx5dv_sched_leaf_destroy;
 		mlx5dv_sched_leaf_modify;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -25,6 +25,7 @@ rdma_man_pages(
   mlx5dv_is_supported.3.md
   mlx5dv_modify_qp_lag_port.3.md
   mlx5dv_modify_qp_sched_elem.3.md
+  mlx5dv_modify_qp_udp_sport.3.md
   mlx5dv_open_device.3.md
   mlx5dv_pp_alloc.3.md
   mlx5dv_query_device.3

--- a/providers/mlx5/man/mlx5dv_modify_qp_udp_sport.3.md
+++ b/providers/mlx5/man/mlx5dv_modify_qp_udp_sport.3.md
@@ -1,0 +1,43 @@
+---
+layout: page
+title: mlx5dv_modify_qp_udp_sport
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_modify_qp_udp_sport - Modify the UDP source port of a given QP
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport)
+```
+
+# DESCRIPTION
+
+The UDP source port is used to create entropy for network routers (ECMP),
+load balancers and 802.3ad link aggregation switching that are not aware of
+RoCE IB headers.
+
+This API enables modifying the configured UDP source port of a given RC/UC QP
+when QP is in RTS state.
+
+# ARGUMENTS
+
+*qp*
+:	The ibv_qp object to issue the action on.
+
+*udp_sport*
+:	The UDP source port to set for the QP.
+
+# RETURN VALUE
+
+Returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+
+# AUTHOR
+
+Maor Gottlieb <maorg@nvidia.com>

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1132,6 +1132,36 @@ int mlx5dv_modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num)
 	return ret;
 }
 
+int mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport)
+{
+	uint32_t in[DEVX_ST_SZ_DW(rts2rts_qp_in)] = {};
+	uint32_t out[DEVX_ST_SZ_DW(rts2rts_qp_out)] = {};
+	struct mlx5_context *mctx = to_mctx(qp->context);
+
+	if (!is_mlx5_dev(qp->context->device))
+		return EOPNOTSUPP;
+
+	switch (qp->qp_type) {
+	case IBV_QPT_RC:
+	case IBV_QPT_UC:
+		if (qp->state != IBV_QPS_RTS ||
+		    !mctx->entropy_caps.rts2rts_qp_udp_sport)
+			return EOPNOTSUPP;
+		break;
+	default:
+		return EOPNOTSUPP;
+	}
+	DEVX_SET(rts2rts_qp_in, in, opcode, MLX5_CMD_OP_RTS2RTS_QP);
+	DEVX_SET(rts2rts_qp_in, in, qpn, qp->qp_num);
+	DEVX_SET64(rts2rts_qp_in, in, opt_param_mask_95_32,
+		   MLX5_QPC_OPT_MASK_32_UDP_SPORT);
+	DEVX_SET(rts2rts_qp_in, in, qpc.primary_address_path.udp_sport,
+		 udp_sport);
+
+	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out,
+				     sizeof(out));
+}
+
 static bool sched_supported(struct ibv_context *ctx)
 {
 	struct mlx5_qos_caps *qc = &to_mctx(ctx)->qos_caps;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -807,8 +807,9 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 	}
 
 	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS) {
-		if (mctx->lag_caps.num_lag_ports) {
-			attrs_out->num_lag_ports = mctx->lag_caps.num_lag_ports;
+		if (mctx->entropy_caps.num_lag_ports) {
+			attrs_out->num_lag_ports =
+				mctx->entropy_caps.num_lag_ports;
 			comp_mask_out |= MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS;
 		}
 	}
@@ -1017,7 +1018,7 @@ static bool lag_operation_supported(struct ibv_qp *qp)
 	struct mlx5_qp *mqp = to_mqp(qp);
 
 	if (!is_mlx5_dev(qp->context->device) ||
-	    (mctx->lag_caps.num_lag_ports <= 1))
+	    (mctx->entropy_caps.num_lag_ports <= 1))
 		return false;
 
 	if ((qp->qp_type == IBV_QPT_RC) ||
@@ -1053,7 +1054,7 @@ int mlx5dv_query_qp_lag_port(struct ibv_qp *qp, uint8_t *port_num,
 	if (ret)
 		return ret;
 
-	if (!lag_state && !mctx->lag_caps.lag_tx_port_affinity)
+	if (!lag_state && !mctx->entropy_caps.lag_tx_port_affinity)
 		return EOPNOTSUPP;
 
 	switch (qp->qp_type) {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -253,9 +253,10 @@ enum mlx5_ctx_flags {
 	MLX5_CTX_FLAGS_ECE_SUPPORTED = 1 << 2,
 };
 
-struct mlx5_lag_caps {
+struct mlx5_entropy_caps {
 	uint8_t num_lag_ports;
-	uint8_t lag_tx_port_affinity;
+	uint8_t lag_tx_port_affinity:1;
+	uint8_t rts2rts_qp_udp_sport:1;
 };
 
 struct mlx5_qos_caps {
@@ -338,7 +339,7 @@ struct mlx5_context {
 	struct mlx5dv_striding_rq_caps	striding_rq_caps;
 	uint32_t			tunnel_offloads_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
-	struct mlx5_lag_caps		lag_caps;
+	struct mlx5_entropy_caps	entropy_caps;
 	struct mlx5_qos_caps		qos_caps;
 	uint8_t				qpc_extension_cap:1;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -257,6 +257,7 @@ struct mlx5_entropy_caps {
 	uint8_t num_lag_ports;
 	uint8_t lag_tx_port_affinity:1;
 	uint8_t rts2rts_qp_udp_sport:1;
+	uint8_t rts2rts_lag_tx_port_affinity:1;
 };
 
 struct mlx5_qos_caps {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -656,7 +656,8 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         log_max_ra_req_qp[0x6];
 	u8         reserved_at_150[0x1];
 	u8         rts2rts_qp_udp_sport[0x1];
-	u8         reserved_at_152[0x8];
+	u8         rts2rts_lag_tx_port_affinity[0x1];
+	u8         reserved_at_153[0x7];
 	u8         log_max_ra_res_qp[0x6];
 
 	u8         end_pad[0x1];
@@ -2825,6 +2826,10 @@ enum mlx5_qpc_opt_mask_32 {
 	MLX5_QPC_OPT_MASK_32_UDP_SPORT = 1 << 2,
 };
 
+enum mlx5_qpc_opt_mask {
+	MLX5_QPC_OPT_MASK_RTS2RTS_LAG_TX_PORT_AFFINITY = 1 << 15,
+};
+
 struct mlx5_ifc_init2init_qp_out_bits {
 	u8         status[0x8];
 	u8         reserved_at_8[0x18];
@@ -2966,7 +2971,11 @@ struct mlx5_ifc_rts2rts_qp_in_bits {
 	u8         reserved_at_41[0x7];
 	u8         qpn[0x18];
 
-	u8         reserved_at_60[0x60];
+	u8         reserved_at_60[0x20];
+
+	u8         opt_param_mask[0x20];
+
+	u8         reserved_at_a0[0x20];
 
 	struct mlx5_ifc_qpc_bits qpc;
 
@@ -2975,7 +2984,6 @@ struct mlx5_ifc_rts2rts_qp_in_bits {
 	u8         opt_param_mask_95_32[0x40];
 
 	struct mlx5_ifc_qpc_ext_bits qpc_data_ext;
-
 };
 
 struct mlx5_ifc_query_qp_out_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -2822,6 +2822,7 @@ struct mlx5_ifc_create_qp_in_bits {
 
 enum mlx5_qpc_opt_mask_32 {
 	MLX5_QPC_OPT_MASK_32_QOS_QUEUE_GROUP_ID = 1 << 1,
+	MLX5_QPC_OPT_MASK_32_UDP_SPORT = 1 << 2,
 };
 
 struct mlx5_ifc_init2init_qp_out_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -654,7 +654,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 
 	u8         reserved_at_140[0xa];
 	u8         log_max_ra_req_qp[0x6];
-	u8         reserved_at_150[0xa];
+	u8         reserved_at_150[0x1];
+	u8         rts2rts_qp_udp_sport[0x1];
+	u8         reserved_at_152[0x8];
 	u8         log_max_ra_res_qp[0x6];
 
 	u8         end_pad[0x1];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1618,6 +1618,8 @@ int mlx5dv_query_qp_lag_port(struct ibv_qp *qp,
 
 int mlx5dv_modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num);
 
+int mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport);
+
 enum mlx5dv_sched_elem_attr_flags {
 	MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE	= 1 << 0,
 	MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW	= 1 << 1,

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3456,6 +3456,10 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 		DEVX_GET(query_hca_cap_out, out,
 			 capability.cmd_hca_cap.rts2rts_qp_udp_sport);
 
+	mctx->entropy_caps.rts2rts_lag_tx_port_affinity =
+		DEVX_GET(query_hca_cap_out, out,
+			 capability.cmd_hca_cap.rts2rts_lag_tx_port_affinity);
+
 	mctx->qos_caps.qos =
 		DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.qos);
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3444,13 +3444,17 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 	if (ret)
 		return;
 
-	mctx->lag_caps.num_lag_ports =
+	mctx->entropy_caps.num_lag_ports =
 		DEVX_GET(query_hca_cap_out, out,
 			 capability.cmd_hca_cap.num_lag_ports);
 
-	mctx->lag_caps.lag_tx_port_affinity =
+	mctx->entropy_caps.lag_tx_port_affinity =
 		DEVX_GET(query_hca_cap_out, out,
 			 capability.cmd_hca_cap.lag_tx_port_affinity);
+
+	mctx->entropy_caps.rts2rts_qp_udp_sport =
+		DEVX_GET(query_hca_cap_out, out,
+			 capability.cmd_hca_cap.rts2rts_qp_udp_sport);
 
 	mctx->qos_caps.qos =
 		DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.qos);

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -101,6 +101,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     int mlx5dv_query_qp_lag_port(v.ibv_qp *qp, uint8_t *port_num,
                                  uint8_t *active_port_num)
     int mlx5dv_modify_qp_lag_port(v.ibv_qp *qp, uint8_t port_num)
+    int mlx5dv_modify_qp_udp_sport(v.ibv_qp *qp, uint16_t udp_sport)
     v.ibv_cq_ex *mlx5dv_create_cq(v.ibv_context *context,
                                   v.ibv_cq_init_attr_ex *cq_attr,
                                   mlx5dv_cq_init_attr *mlx5_cq_attr)

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
 
-from libc.stdint cimport uintptr_t, uint8_t
+from libc.stdint cimport uintptr_t, uint8_t, uint16_t
 import logging
 
 from pyverbs.pyverbs_error import PyverbsUserError, PyverbsRDMAError
@@ -409,6 +409,18 @@ cdef class Mlx5QP(QPEx):
         rc = dv.mlx5dv_modify_qp_sched_elem(qp.qp, req_se, resp_se)
         if rc != 0:
             raise PyverbsRDMAError(f'Failed to modify QP #{qp.qp.qp_num} sched element', rc)
+
+    @staticmethod
+    def modify_udp_sport(QP qp, uint16_t udp_sport):
+        """
+        Modifies the UDP source port of a given QP.
+        :param qp: A QP in RTS state to modify its UDP sport.
+        :param udp_sport: The desired UDP sport to be used by the QP.
+        """
+        rc = dv.mlx5dv_modify_qp_udp_sport(qp.qp, udp_sport)
+        if rc != 0:
+            raise PyverbsRDMAError(f'Failed to modify UDP source port of QP '
+                                   f'#{qp.qp.qp_num}', rc)
 
 
 cdef class Mlx5DVCQInitAttr(PyverbsObject):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ rdma_python_test(tests
   test_mlx5_pp.py
   test_mlx5_sched.py
   test_mlx5_uar.py
+  test_mlx5_udp_sport.py
   test_mlx5_var.py
   test_mr.py
   test_odp.py

--- a/tests/test_mlx5_udp_sport.py
+++ b/tests/test_mlx5_udp_sport.py
@@ -1,0 +1,49 @@
+import unittest
+import errno
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from tests.base import RCResources, RDMATestCase
+from pyverbs.providers.mlx5.mlx5dv import Mlx5QP
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class UdpSportTestCase(RDMATestCase):
+    def __init__(self, methodName='runTest', dev_name=None, ib_port=None,
+                 gid_index=None, pkey_index=None, gid_type=e.IBV_GID_TYPE_SYSFS_ROCE_V2):
+        # Modify UDP source port is not supported on RoCEv1
+        super().__init__(methodName, dev_name, ib_port, gid_index, pkey_index, gid_type)
+
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Initialize tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dictionary of args that specify the resource
+                             specific attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+
+    def test_rc_modify_udp_sport(self):
+        """
+        Create RC resources and change the server QP's UDP source port to an
+        arbitrary legal value (55555). Then run SEND traffic.
+        :return: None
+        """
+        self.create_players(RCResources)
+        try:
+            Mlx5QP.modify_udp_sport(self.server.qp, udp_sport=55555)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Modifying a QP UDP sport is not supported')
+            raise ex
+        u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)


### PR DESCRIPTION
This series Improves the entropy support in few areas as of below.

It enables modifying the configured UDP source port of a given RC/UC QP when QP is in RTS state over DV & DEVX.
In addition, it extends mlx5dv_modify_qp_lag_port() to support extra QP types based on device capabilities.

A matching pyverbs stuff was added to demonstrate the usage. 