### PR TITLE
libhns: Add support of UD for HIP09

### DIFF
--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -13,7 +13,6 @@
 	({ *(ptr) |= ((value) << type##_SHIFT) & type##_MASK; })
 
 #define BIT(nr) (1UL << (nr))
-#define GENMASK(h, l) (((1U << ((h) - (l) + 1)) - 1) << (l))
 
 #define EFA_IO_TX_DESC_NUM_BUFS              2
 #define EFA_IO_TX_DESC_NUM_RDMA_BUFS         1

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -84,6 +84,8 @@ static const struct verbs_context_ops hns_common_ops = {
 	.query_srq = hns_roce_u_query_srq,
 	.destroy_srq = hns_roce_u_destroy_srq,
 	.free_context = hns_roce_free_context,
+	.create_ah = hns_roce_u_create_ah,
+	.destroy_ah = hns_roce_u_destroy_ah,
 };
 
 static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -116,6 +116,25 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	for (i = 0; i < HNS_ROCE_QP_TABLE_SIZE; ++i)
 		context->qp_table[i].refcnt = 0;
 
+	if (!resp.cqe_size)
+		context->cqe_size = HNS_ROCE_CQE_SIZE;
+	else if (resp.cqe_size <= HNS_ROCE_V3_CQE_SIZE)
+		context->cqe_size = resp.cqe_size;
+	else
+		context->cqe_size = HNS_ROCE_V3_CQE_SIZE;
+
+	if (hns_roce_u_query_device(&context->ibv_ctx.context, NULL,
+				    container_of(&dev_attrs,
+						 struct ibv_device_attr_ex,
+						 orig_attr),
+				    sizeof(dev_attrs)))
+		goto err_free;
+
+	hr_dev->hw_version = dev_attrs.hw_ver;
+	context->max_qp_wr = dev_attrs.max_qp_wr;
+	context->max_sge = dev_attrs.max_sge;
+	context->max_cqe = dev_attrs.max_cqe;
+
 	context->uar = mmap(NULL, hr_dev->page_size, PROT_READ | PROT_WRITE,
 			    MAP_SHARED, cmd_fd, offset);
 	if (context->uar == MAP_FAILED)
@@ -135,37 +154,12 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 			goto db_free;
 	}
 
-	if (!resp.cqe_size)
-		context->cqe_size = HNS_ROCE_CQE_SIZE;
-	else if (resp.cqe_size <= HNS_ROCE_V3_CQE_SIZE)
-		context->cqe_size = resp.cqe_size;
-	else
-		context->cqe_size = HNS_ROCE_V3_CQE_SIZE;
-
 	pthread_spin_init(&context->uar_lock, PTHREAD_PROCESS_PRIVATE);
 
 	verbs_set_ops(&context->ibv_ctx, &hns_common_ops);
 	verbs_set_ops(&context->ibv_ctx, &hr_dev->u_hw->hw_ops);
 
-	if (hns_roce_u_query_device(&context->ibv_ctx.context, NULL,
-				    container_of(&dev_attrs,
-						 struct ibv_device_attr_ex,
-						 orig_attr),
-				    sizeof(dev_attrs)))
-		goto tptr_free;
-
-	context->max_qp_wr = dev_attrs.max_qp_wr;
-	context->max_sge = dev_attrs.max_sge;
-	context->max_cqe = dev_attrs.max_cqe;
-
 	return &context->ibv_ctx;
-
-tptr_free:
-	if (hr_dev->hw_version == HNS_ROCE_HW_VER1) {
-		if (munmap(context->cq_tptr_base, HNS_ROCE_CQ_DB_BUF_SIZE))
-			fprintf(stderr, PFX "Warning: Munmap tptr failed.\n");
-		context->cq_tptr_base = NULL;
-	}
 
 db_free:
 	munmap(context->uar, hr_dev->page_size);

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -44,11 +44,13 @@
 #include <ccan/array_size.h>
 #include <ccan/bitmap.h>
 #include <ccan/container_of.h>
+#include <linux/if_ether.h>
 #include "hns_roce_u_abi.h"
 
 #define HNS_ROCE_HW_VER1		('h' << 24 | 'i' << 16 | '0' << 8 | '6')
 
 #define HNS_ROCE_HW_VER2		('h' << 24 | 'i' << 16 | '0' << 8 | '8')
+#define HNS_ROCE_HW_VER3		0x130
 
 #define PFX				"hns: "
 
@@ -269,6 +271,23 @@ struct hns_roce_qp {
 	unsigned long			flags;
 };
 
+struct hns_roce_av {
+	uint8_t port;
+	uint8_t gid_index;
+	uint8_t hop_limit;
+	uint32_t flowlabel;
+	uint16_t udp_sport;
+	uint8_t sl;
+	uint8_t tclass;
+	uint8_t dgid[HNS_ROCE_GID_SIZE];
+	uint8_t mac[ETH_ALEN];
+};
+
+struct hns_roce_ah {
+	struct ibv_ah ibv_ah;
+	struct hns_roce_av av;
+};
+
 struct hns_roce_u_hw {
 	uint32_t hw_version;
 	struct verbs_context_ops hw_ops;
@@ -316,6 +335,11 @@ static inline struct  hns_roce_qp *to_hr_qp(struct ibv_qp *ibv_qp)
 	return container_of(ibv_qp, struct hns_roce_qp, ibv_qp);
 }
 
+static inline struct hns_roce_ah *to_hr_ah(struct ibv_ah *ibv_ah)
+{
+	return container_of(ibv_ah, struct hns_roce_ah, ibv_ah);
+}
+
 int hns_roce_u_query_device(struct ibv_context *context,
 			    const struct ibv_query_device_ex_input *input,
 			    struct ibv_device_attr_ex *attr, size_t attr_size);
@@ -355,6 +379,10 @@ struct ibv_qp *hns_roce_u_create_qp(struct ibv_pd *pd,
 
 int hns_roce_u_query_qp(struct ibv_qp *ibqp, struct ibv_qp_attr *attr,
 			int attr_mask, struct ibv_qp_init_attr *init_attr);
+
+struct ibv_ah *hns_roce_u_create_ah(struct ibv_pd *pd,
+				    struct ibv_ah_attr *attr);
+int hns_roce_u_destroy_ah(struct ibv_ah *ah);
 
 int hns_roce_alloc_buf(struct hns_roce_buf *buf, unsigned int size,
 		       int page_size);

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -265,6 +265,7 @@ struct hns_roce_qp {
 	unsigned int			next_sge;
 	int				port_num;
 	int				sl;
+	unsigned int			qkey;
 	enum ibv_mtu			path_mtu;
 
 	struct hns_roce_rinl_buf	rq_rinl_buf;

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -766,6 +766,116 @@ static __le32 get_immtdata(enum ibv_wr_opcode opcode, const struct ibv_send_wr *
 	}
 }
 
+static int check_ud_opcode(struct hns_roce_ud_sq_wqe *ud_sq_wqe,
+			   const struct ibv_send_wr *wr)
+{
+	uint32_t ib_op = wr->opcode;
+
+	if (ib_op != IBV_WR_SEND && ib_op != IBV_WR_SEND_WITH_IMM)
+		return EINVAL;
+
+	ud_sq_wqe->immtdata = get_immtdata(ib_op, wr);
+
+	roce_set_field(ud_sq_wqe->rsv_opcode, UD_SQ_WQE_OPCODE_M,
+		       UD_SQ_WQE_OPCODE_S, to_hr_opcode(ib_op));
+
+	return 0;
+}
+
+static int fill_ud_av(struct hns_roce_ud_sq_wqe *ud_sq_wqe,
+		      struct hns_roce_ah *ah)
+{
+	if (unlikely(ah->av.sl > MAX_SERVICE_LEVEL))
+		return EINVAL;
+
+	roce_set_field(ud_sq_wqe->lbi_flow_label, UD_SQ_WQE_SL_M,
+		       UD_SQ_WQE_SL_S, ah->av.sl);
+
+	roce_set_field(ud_sq_wqe->sge_num_pd, UD_SQ_WQE_PD_M,
+		       UD_SQ_WQE_PD_S, to_hr_pd(ah->ibv_ah.pd)->pdn);
+
+	roce_set_field(ud_sq_wqe->tclass_vlan, UD_SQ_WQE_TCLASS_M,
+		       UD_SQ_WQE_TCLASS_S, ah->av.tclass);
+
+	roce_set_field(ud_sq_wqe->tclass_vlan, UD_SQ_WQE_HOPLIMIT_M,
+		       UD_SQ_WQE_HOPLIMIT_S, ah->av.hop_limit);
+
+	roce_set_field(ud_sq_wqe->lbi_flow_label, UD_SQ_WQE_FLOW_LABEL_M,
+		       UD_SQ_WQE_FLOW_LABEL_S, ah->av.flowlabel);
+
+	roce_set_field(ud_sq_wqe->udpspn_rsv, UD_SQ_WQE_UDP_SPN_M,
+		       UD_SQ_WQE_UDP_SPN_S, ah->av.udp_sport);
+
+	memcpy(ud_sq_wqe->dmac, ah->av.mac, ETH_ALEN);
+	ud_sq_wqe->sgid_index = ah->av.gid_index;
+	memcpy(ud_sq_wqe->dgid, ah->av.dgid, HNS_ROCE_GID_SIZE);
+
+	return 0;
+}
+
+static void fill_ud_data_seg(struct hns_roce_ud_sq_wqe *ud_sq_wqe,
+			     struct hns_roce_qp *qp, struct ibv_send_wr *wr,
+			     struct hns_roce_sge_info *sge_info)
+{
+	roce_set_field(ud_sq_wqe->rsv_msg_start_sge_idx,
+		       UD_SQ_WQE_MSG_START_SGE_IDX_M,
+		       UD_SQ_WQE_MSG_START_SGE_IDX_S,
+		       sge_info->start_idx & (qp->ex_sge.sge_cnt - 1));
+
+	set_sge((struct hns_roce_v2_wqe_data_seg *)ud_sq_wqe, qp, wr, sge_info);
+
+	ud_sq_wqe->msg_len = htole32(sge_info->total_len);
+
+	roce_set_field(ud_sq_wqe->sge_num_pd, UD_SQ_WQE_SGE_NUM_M,
+		       UD_SQ_WQE_SGE_NUM_S, sge_info->valid_num);
+}
+
+static int set_ud_wqe(void *wqe, struct hns_roce_qp *qp,
+		      struct ibv_send_wr *wr, int nreq,
+		      struct hns_roce_sge_info *sge_info)
+{
+	struct hns_roce_ah *ah = to_hr_ah(wr->wr.ud.ah);
+	struct hns_roce_ud_sq_wqe *ud_sq_wqe = wqe;
+	int ret = 0;
+
+	memset(ud_sq_wqe, 0, sizeof(*ud_sq_wqe));
+
+	roce_set_bit(ud_sq_wqe->rsv_opcode, UD_SQ_WQE_CQE_S,
+		     !!(wr->send_flags & IBV_SEND_SIGNALED));
+	roce_set_bit(ud_sq_wqe->rsv_opcode, UD_SQ_WQE_SE_S,
+		     !!(wr->send_flags & IBV_SEND_SOLICITED));
+
+	ret = check_ud_opcode(ud_sq_wqe, wr);
+	if (ret)
+		return ret;
+
+	ud_sq_wqe->qkey = htole32(wr->wr.ud.remote_qkey & 0x80000000 ?
+				  qp->qkey : wr->wr.ud.remote_qkey);
+
+	roce_set_field(ud_sq_wqe->rsv_dqpn, UD_SQ_WQE_DQPN_M,
+		       UD_SQ_WQE_DQPN_S, wr->wr.ud.remote_qpn);
+
+	ret = fill_ud_av(ud_sq_wqe, ah);
+	if (ret)
+		return ret;
+
+	fill_ud_data_seg(ud_sq_wqe, qp, wr, sge_info);
+
+	/*
+	 * The pipeline can sequentially post all valid WQEs in wq buf,
+	 * including those new WQEs waiting for doorbell to update the PI again.
+	 * Therefore, the valid bit of WQE MUST be updated after all of fields
+	 * and extSGEs have been written into DDR instead of cache.
+	 */
+	if (qp->flags & HNS_ROCE_QP_CAP_OWNER_DB)
+		udma_to_device_barrier();
+
+	roce_set_bit(ud_sq_wqe->rsv_opcode, UD_SQ_WQE_OWNER_S,
+		     ~(((qp->sq.head + nreq) >> qp->sq.shift) & 0x1));
+
+	return ret;
+}
+
 static int set_rc_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 		      struct hns_roce_rc_sq_wqe *rc_sq_wqe,
 		      struct hns_roce_sge_info *sge_info)
@@ -989,15 +1099,15 @@ int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 		switch (ibvqp->qp_type) {
 		case IBV_QPT_RC:
 			ret = set_rc_wqe(wqe, qp, wr, nreq, &sge_info);
-			if (ret) {
-				*bad_wr = wr;
-				goto out;
-			}
 			break;
-		case IBV_QPT_UC:
 		case IBV_QPT_UD:
+			ret = set_ud_wqe(wqe, qp, wr, nreq, &sge_info);
+			break;
 		default:
 			ret = EINVAL;
+		}
+
+		if (ret) {
 			*bad_wr = wr;
 			goto out;
 		}
@@ -1193,6 +1303,9 @@ static void record_qp_attr(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 
 	if (attr_mask & IBV_QP_AV)
 		hr_qp->sl = attr->ah_attr.sl;
+
+	if (attr_mask & IBV_QP_QKEY)
+		hr_qp->qkey = attr->qkey;
 
 	if (qp->qp_type == IBV_QPT_UD)
 		hr_qp->path_mtu = IBV_MTU_4096;

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -290,4 +290,77 @@ int hns_roce_u_v2_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 #define EXTEND_ATOMIC_U_BYTE_32 0x20
 #define EXTEND_ATOMIC_U_BYTE_64 0x40
 
+struct hns_roce_ud_sq_wqe {
+	__le32 rsv_opcode;
+	__le32 msg_len;
+	__le32 immtdata;
+	__le32 sge_num_pd;
+	__le32 rsv_msg_start_sge_idx;
+	__le32 udpspn_rsv;
+	__le32 qkey;
+	__le32 rsv_dqpn;
+	__le32 tclass_vlan;
+	__le32 lbi_flow_label;
+	uint8_t dmac[ETH_ALEN];
+	uint8_t sgid_index;
+	uint8_t smac_index;
+	uint8_t dgid[HNS_ROCE_GID_SIZE];
+};
+
+#define UD_SQ_WQE_OPCODE_S 0
+#define UD_SQ_WQE_OPCODE_M GENMASK(4, 0)
+
+#define UD_SQ_WQE_DB_SL_L_S 5
+#define UD_SQ_WQE_DB_SL_L_M GENMASK(6, 5)
+
+#define UD_SQ_WQE_DB_SL_H_S 13
+#define UD_SQ_WQE_DB_SL_H_M GENMASK(14, 13)
+
+#define UD_SQ_WQE_INDEX_S 15
+#define UD_SQ_WQE_INDEX_M GENMASK(30, 15)
+
+#define UD_SQ_WQE_OWNER_S 7
+
+#define UD_SQ_WQE_CQE_S 8
+
+#define UD_SQ_WQE_SE_S 11
+
+#define UD_SQ_WQE_FLAG_S 31
+
+#define UD_SQ_WQE_PD_S 0
+#define UD_SQ_WQE_PD_M GENMASK(23, 0)
+
+#define UD_SQ_WQE_SGE_NUM_S 24
+#define UD_SQ_WQE_SGE_NUM_M GENMASK(31, 24)
+
+#define UD_SQ_WQE_MSG_START_SGE_IDX_S 0
+#define UD_SQ_WQE_MSG_START_SGE_IDX_M GENMASK(23, 0)
+
+#define UD_SQ_WQE_UDP_SPN_S 16
+#define UD_SQ_WQE_UDP_SPN_M GENMASK(31, 16)
+
+#define UD_SQ_WQE_DQPN_S 0
+#define UD_SQ_WQE_DQPN_M GENMASK(23, 0)
+
+#define UD_SQ_WQE_VLAN_S 0
+#define UD_SQ_WQE_VLAN_M GENMASK(15, 0)
+
+#define UD_SQ_WQE_HOPLIMIT_S 16
+#define UD_SQ_WQE_HOPLIMIT_M GENMASK(23, 16)
+
+#define UD_SQ_WQE_TCLASS_S 24
+#define UD_SQ_WQE_TCLASS_M GENMASK(31, 24)
+
+#define UD_SQ_WQE_FLOW_LABEL_S 0
+#define UD_SQ_WQE_FLOW_LABEL_M GENMASK(19, 0)
+
+#define UD_SQ_WQE_SL_S 20
+#define UD_SQ_WQE_SL_M GENMASK(23, 20)
+
+#define UD_SQ_WQE_VLAN_EN_S 30
+
+#define UD_SQ_WQE_LBI_S 31
+
+#define MAX_SERVICE_LEVEL 0x7
+
 #endif /* _HNS_ROCE_U_HW_V2_H */

--- a/providers/mlx5/bitmap.h
+++ b/providers/mlx5/bitmap.h
@@ -42,6 +42,7 @@
 #include <sys/shm.h>
 #include <sys/mman.h>
 #include <linux/errno.h>
+#include <util/util.h>
 #include "mlx5.h"
 
 /* Only ia64 requires this */
@@ -53,7 +54,6 @@
 #define MLX5_SHMAT_FLAGS 0
 #endif
 
-#define BITS_PER_LONG		(8 * sizeof(long))
 #define BITS_TO_LONGS(nr)	DIV_ROUND_UP(nr, BITS_PER_LONG)
 
 #ifndef HPAGE_SIZE

--- a/util/util.h
+++ b/util/util.h
@@ -26,6 +26,11 @@ static inline bool __good_snprintf(size_t len, int rc)
 #define offsetofend(_type, _member)                                            \
 	(offsetof(_type, _member) + sizeof(((_type *)0)->_member))
 
+#define BITS_PER_LONG	(8 * sizeof(long))
+
+#define GENMASK(h, l) \
+	(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+
 static inline unsigned long align(unsigned long val, unsigned long align)
 {
 	return (val + align - 1) & ~(align - 1);


### PR DESCRIPTION
Add service type of Unreliable Datagram support for HIP09 by achieving Address Handle related interfaces and adding a branch in hns_roce_post_send().