### PR TITLE
docs: fix simple typo, untill -> until

### DIFF
--- a/ccan/list.h
+++ b/ccan/list.h
@@ -721,7 +721,7 @@ static inline void list_prepend_list_(struct list_head *to,
  * properly filled `struct node_list' which in turn contains pointers to
  * memory chunks and it's turtles all the way down. Whith all that in mind
  * remember that given the wrong pointer/offset couple this macro will
- * happilly churn all you memory untill SEGFAULT stops it, in other words
+ * happilly churn all you memory until SEGFAULT stops it, in other words
  * caveat emptor.
  *
  * It is worth mentioning that one of legitimate use-cases for that wrapper


### PR DESCRIPTION
There is a small typo in ccan/list.h.

Should read `until` rather than `untill`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md