### PR TITLE
librdmacm: Don't overwrite errno returned from libibverbs

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -635,7 +635,7 @@ static int ucma_get_device(struct cma_id_private *id_priv, __be64 guid,
 	if (!cma_dev->pd)
 		cma_dev->pd = ibv_alloc_pd(cma_dev->verbs);
 	if (!cma_dev->pd) {
-		ret = ERR(ENOMEM);
+		ret = -1;
 		goto out;
 	}
 
@@ -1490,7 +1490,7 @@ static int ucma_create_cqs(struct rdma_cm_id *id, uint32_t send_size, uint32_t r
 	return 0;
 err:
 	ucma_destroy_cqs(id);
-	return ERR(ENOMEM);
+	return -1;
 }
 
 int rdma_create_srq_ex(struct rdma_cm_id *id, struct ibv_srq_init_attr_ex *attr)
@@ -1662,7 +1662,7 @@ int rdma_create_qp_ex(struct rdma_cm_id *id,
 		attr->srq = id->srq;
 	qp = ibv_create_qp_ex(id->verbs, attr);
 	if (!qp) {
-		ret = ERR(ENOMEM);
+		ret = -1;
 		goto err1;
 	}
 


### PR DESCRIPTION
Some functions reports fixed ENOMEM when getting any failure, so
it's hard for user to know which actual error happens on them.

Fixes: 663098bfc3ac ("Rename librdmacm")
Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>