### PR TITLE
libqedr: Fix reported error code from create_cq

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -234,7 +234,8 @@ struct ibv_cq *qelr_create_cq(struct ibv_context *context, int cqe,
 	if (!cqe || cqe > cxt->max_cqes) {
 		DP_ERR(cxt->dbg_fp,
 		       "create cq: failed. attempted to allocate %d cqes but valid range is 1...%d\n",
-		       cqe, cqe > cxt->max_cqes);
+		       cqe, cxt->max_cqes);
+		errno = EINVAL;
 		return NULL;
 	}
 


### PR DESCRIPTION
Report EINVAL when trying to call qelr_create_cq() with number of CQEs
bigger than the supported max_cqes, also fix the printed range.

Fixes: c0965e4fe6fe ("libqedr (qelr) verbs")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>