### PR TITLE
cxgb4: Fix reported error code from create_cq

### DIFF
--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -175,6 +175,11 @@ struct ibv_cq *c4iw_create_cq(struct ibv_context *context, int cqe,
 	struct c4iw_dev *dev = to_c4iw_dev(context->device);
 	int ret;
 
+	if (!cqe || cqe > T4_MAX_CQ_DEPTH) {
+		errno = EINVAL;
+		return NULL;
+	}
+
 	chp = calloc(1, sizeof *chp);
 	if (!chp) {
 		return NULL;


### PR DESCRIPTION
Report EINVAL when trying to call c4iw_create_cq() with number of CQEs
out of the supported range.

Fixes: d6e6ae69be5e ("Add libcxgb4 files.")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>