### PR TITLE
efa: EFA_GET/SET() fixes

### DIFF
--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -16,6 +16,12 @@
 #include "efa-abi.h"
 #include "efa_io_defs.h"
 
+#define EFA_GET(ptr, type) \
+	((*(ptr) & type##_MASK) >> type##_SHIFT)
+
+#define EFA_SET(ptr, type, value) \
+	({ *(ptr) |= ((value) << type##_SHIFT) & type##_MASK; })
+
 struct efa_context {
 	struct verbs_context ibvctx;
 	uint32_t cmds_supp_udata_mask;

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -16,11 +16,14 @@
 #include "efa-abi.h"
 #include "efa_io_defs.h"
 
-#define EFA_GET(ptr, type) \
-	((*(ptr) & type##_MASK) >> type##_SHIFT)
+#define EFA_GET(ptr, mask) FIELD_GET(mask##_MASK, *(ptr))
 
-#define EFA_SET(ptr, type, value) \
-	({ *(ptr) |= ((value) << type##_SHIFT) & type##_MASK; })
+#define EFA_SET(ptr, mask, value)                                              \
+	({                                                                     \
+		typeof(ptr) _ptr = ptr;                                        \
+		*_ptr = (*_ptr & ~(mask##_MASK)) |                             \
+			FIELD_PREP(mask##_MASK, value);                        \
+	})
 
 struct efa_context {
 	struct verbs_context ibvctx;

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2018-2019 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef _EFA_IO_H_
@@ -11,8 +11,6 @@
 
 #define EFA_SET(ptr, type, value) \
 	({ *(ptr) |= ((value) << type##_SHIFT) & type##_MASK; })
-
-#define BIT(nr) (1UL << (nr))
 
 #define EFA_IO_TX_DESC_NUM_BUFS              2
 #define EFA_IO_TX_DESC_NUM_RDMA_BUFS         1

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -6,12 +6,6 @@
 #ifndef _EFA_IO_H_
 #define _EFA_IO_H_
 
-#define EFA_GET(ptr, type) \
-	((*(ptr) & type##_MASK) >> type##_SHIFT)
-
-#define EFA_SET(ptr, type, value) \
-	({ *(ptr) |= ((value) << type##_SHIFT) & type##_MASK; })
-
 #define EFA_IO_TX_DESC_NUM_BUFS              2
 #define EFA_IO_TX_DESC_NUM_RDMA_BUFS         1
 #define EFA_IO_TX_DESC_INLINE_MAX_SIZE       32

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -281,45 +281,28 @@ struct efa_io_rx_cdesc_wide {
 };
 
 /* tx_meta_desc */
-#define EFA_IO_TX_META_DESC_OP_TYPE_SHIFT                   0
 #define EFA_IO_TX_META_DESC_OP_TYPE_MASK                    GENMASK(3, 0)
-#define EFA_IO_TX_META_DESC_HAS_IMM_SHIFT                   4
 #define EFA_IO_TX_META_DESC_HAS_IMM_MASK                    BIT(4)
-#define EFA_IO_TX_META_DESC_INLINE_MSG_SHIFT                5
 #define EFA_IO_TX_META_DESC_INLINE_MSG_MASK                 BIT(5)
-#define EFA_IO_TX_META_DESC_META_EXTENSION_SHIFT            6
 #define EFA_IO_TX_META_DESC_META_EXTENSION_MASK             BIT(6)
-#define EFA_IO_TX_META_DESC_META_DESC_SHIFT                 7
 #define EFA_IO_TX_META_DESC_META_DESC_MASK                  BIT(7)
-#define EFA_IO_TX_META_DESC_PHASE_SHIFT                     0
 #define EFA_IO_TX_META_DESC_PHASE_MASK                      BIT(0)
-#define EFA_IO_TX_META_DESC_FIRST_SHIFT                     2
 #define EFA_IO_TX_META_DESC_FIRST_MASK                      BIT(2)
-#define EFA_IO_TX_META_DESC_LAST_SHIFT                      3
 #define EFA_IO_TX_META_DESC_LAST_MASK                       BIT(3)
-#define EFA_IO_TX_META_DESC_COMP_REQ_SHIFT                  4
 #define EFA_IO_TX_META_DESC_COMP_REQ_MASK                   BIT(4)
 
 /* tx_buf_desc */
-#define EFA_IO_TX_BUF_DESC_LKEY_SHIFT                       0
 #define EFA_IO_TX_BUF_DESC_LKEY_MASK                        GENMASK(23, 0)
 
 /* rx_desc */
-#define EFA_IO_RX_DESC_LKEY_SHIFT                           0
 #define EFA_IO_RX_DESC_LKEY_MASK                            GENMASK(23, 0)
-#define EFA_IO_RX_DESC_FIRST_SHIFT                          30
 #define EFA_IO_RX_DESC_FIRST_MASK                           BIT(30)
-#define EFA_IO_RX_DESC_LAST_SHIFT                           31
 #define EFA_IO_RX_DESC_LAST_MASK                            BIT(31)
 
 /* cdesc_common */
-#define EFA_IO_CDESC_COMMON_PHASE_SHIFT                     0
 #define EFA_IO_CDESC_COMMON_PHASE_MASK                      BIT(0)
-#define EFA_IO_CDESC_COMMON_Q_TYPE_SHIFT                    1
 #define EFA_IO_CDESC_COMMON_Q_TYPE_MASK                     GENMASK(2, 1)
-#define EFA_IO_CDESC_COMMON_HAS_IMM_SHIFT                   3
 #define EFA_IO_CDESC_COMMON_HAS_IMM_MASK                    BIT(3)
-#define EFA_IO_CDESC_COMMON_WIDE_COMPLETION_SHIFT           4
 #define EFA_IO_CDESC_COMMON_WIDE_COMPLETION_MASK            BIT(4)
 
 #endif /* _EFA_IO_H_ */

--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1541,8 +1541,6 @@ static inline void mlx5_cq_read_wc_tm_info(struct ibv_cq_ex *ibcq,
 	tm_info->priv = be32toh(cq->cqe64->tmh.app_ctx);
 }
 
-#define BIT(i) (1UL << (i))
-
 #define SINGLE_THREADED BIT(0)
 #define STALL BIT(1)
 #define V1 BIT(2)

--- a/util/util.h
+++ b/util/util.h
@@ -31,6 +31,8 @@ static inline bool __good_snprintf(size_t len, int rc)
 #define GENMASK(h, l) \
 	(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
 
+#define BIT(nr) (1UL << (nr))
+
 static inline unsigned long align(unsigned long val, unsigned long align)
 {
 	return (val + align - 1) & ~(align - 1);

--- a/util/util.h
+++ b/util/util.h
@@ -33,6 +33,34 @@ static inline bool __good_snprintf(size_t len, int rc)
 
 #define BIT(nr) (1UL << (nr))
 
+#define __bf_shf(x) (__builtin_ffsll(x) - 1)
+
+/**
+ * FIELD_PREP() - prepare a bitfield element
+ * @_mask: shifted mask defining the field's length and position
+ * @_val:  value to put in the field
+ *
+ * FIELD_PREP() masks and shifts up the value.  The result should
+ * be combined with other fields of the bitfield using logical OR.
+ */
+#define FIELD_PREP(_mask, _val)                                                \
+	({                                                                     \
+		((typeof(_mask))(_val) << __bf_shf(_mask)) & (_mask);          \
+	})
+
+/**
+ * FIELD_GET() - extract a bitfield element
+ * @_mask: shifted mask defining the field's length and position
+ * @_reg:  value of entire bitfield
+ *
+ * FIELD_GET() extracts the field specified by @_mask from the
+ * bitfield passed in as @_reg by masking and shifting it down.
+ */
+#define FIELD_GET(_mask, _reg)                                                 \
+	({                                                                     \
+		(typeof(_mask))(((_reg) & (_mask)) >> __bf_shf(_mask));        \
+	})
+
 static inline unsigned long align(unsigned long val, unsigned long align)
 {
 	return (val + align - 1) & ~(align - 1);


### PR DESCRIPTION
This commit matches the EFA_GET/SET() macros with their kernel
counterparts.
This change clears the mask before assigning the new value, and makes
use of FIELD_GET/PREP() which makes the various *_SHIFT definitions
redundant.

Signed-off-by: Gal Pressman <galpress@amazon.com>