### PR TITLE
tests: Port command line option

### DIFF
--- a/tests/args_parser.py
+++ b/tests/args_parser.py
@@ -16,6 +16,9 @@ class ArgsParser(object):
         parser = argparse.ArgumentParser()
         parser.add_argument('--dev',
                             help='RDMA device to run the tests on')
+        parser.add_argument('--port',
+                            help='Use port <port> of RDMA device', type=int,
+                            default=1)
         parser.add_argument('-v', '--verbose', dest='verbosity',
                             action='store_const',
                             const=2, help='Verbose output')

--- a/tests/base.py
+++ b/tests/base.py
@@ -68,6 +68,7 @@ class PyverbsAPITestCase(unittest.TestCase):
         Opens the devices and queries them
         """
         self.devices = []
+        self.ib_port = self.config['port']
 
         dev_name = self.config['dev']
         if dev_name:
@@ -118,7 +119,7 @@ class RDMATestCase(unittest.TestCase):
         self.config = parser.get_config()
         dev = self.config['dev']
         self.dev_name = dev_name if dev_name else dev
-        self.ib_port = ib_port
+        self.ib_port = ib_port if ib_port else self.config['port']
         self.gid_index = gid_index
         self.pkey_index = pkey_index
         self.gid_type = gid_type if gid_index is None else None
@@ -250,9 +251,7 @@ class RDMATestCase(unittest.TestCase):
                 self.args.append([dev, port, idx, ip_addr])
 
     def _add_gids_per_device(self, ctx, dev):
-        port_count = ctx.query_device().phys_port_cnt
-        for port in range(port_count):
-            self._add_gids_per_port(ctx, dev, port+1)
+        self._add_gids_per_port(ctx, dev, self.ib_port)
 
     def _select_config(self):
         args_with_inet_ip = []

--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -5,8 +5,9 @@ import unittest
 import errno
 
 from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
-from pyverbs.addr import GlobalRoute, AHAttr, AH
 from tests.base import PyverbsAPITestCase
+from pyverbs.addr import AHAttr, AH
+import pyverbs.device as d
 import pyverbs.enums as e
 from pyverbs.pd import PD
 import tests.utils as u
@@ -16,77 +17,69 @@ class AHTest(PyverbsAPITestCase):
     """
     Test various functionalities of the AH class.
     """
+    def verify_link_layer_ether(self, ctx):
+        """
+        Aux function to verify link layer
+        """
+        link_layer = ctx.query_port(self.ib_port).link_layer
+        if link_layer != e.IBV_LINK_LAYER_ETHERNET:
+            raise unittest.SkipTest(f'Link layer of port={self.ib_port} is {d.translate_link_layer(link_layer)} , skip RoCE test')
+
+    def verify_state(self, ctx):
+        """
+        Aux function to verify port state
+        """
+        state = ctx.query_port(self.ib_port).state
+        if state != e.IBV_PORT_ACTIVE and state != e.IBV_PORT_INIT:
+            raise unittest.SkipTest(f'Port {self.ib_port} is not up, can not create AH')
+
     def test_create_ah(self):
         """
         Test ibv_create_ah.
         """
-        done = 0
-        for ctx, attr, attr_ex in self.devices:
+        for ctx, _, _ in self.devices:
+            self.verify_state(ctx)
+            gr = u.get_global_route(ctx, port_num=self.ib_port)
+            ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
             pd = PD(ctx)
-            for port_num in range(1, 1 + attr.phys_port_cnt):
-                state = ctx.query_port(port_num).state
-                if state != e.IBV_PORT_ACTIVE and state != e.IBV_PORT_INIT:
-                    continue
-                gr = u.get_global_route(ctx, port_num=port_num)
-                ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
-                try:
-                    with AH(pd, attr=ah_attr):
-                        done += 1
-                except PyverbsRDMAError as ex:
-                    if ex.error_code == errno.EOPNOTSUPP:
-                        raise unittest.SkipTest('Create AH is not supported')
-                    raise ex
-        if done == 0:
-            raise unittest.SkipTest('No port is up, can\'t create AH')
-    # TODO: Test ibv_create_ah_from_wc once we have traffic
+            try:
+                AH(pd, attr=ah_attr)
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Create AH is not supported')
+                raise ex
 
     def test_create_ah_roce(self):
         """
         Verify that AH can't be created without GRH in RoCE
         """
-        done = 0
-        for ctx, attr, attr_ex in self.devices:
+        for ctx, _, _ in self.devices:
+            self.verify_link_layer_ether(ctx)
+            self.verify_state(ctx)
             pd = PD(ctx)
-            for port_num in range(1, 1 + attr.phys_port_cnt):
-                port_attr = ctx.query_port(port_num)
-                if port_attr.state != e.IBV_PORT_ACTIVE and \
-                   port_attr.state != e.IBV_PORT_INIT:
-                    continue
-                if port_attr.link_layer != e.IBV_LINK_LAYER_ETHERNET:
-                    raise unittest.SkipTest('RoCE tests are only supported on Ethernet link layer')
-                ah_attr = AHAttr(is_global=0, port_num=port_num)
-                try:
-                    ah = AH(pd, attr=ah_attr)
-                except PyverbsRDMAError as ex:
-                    if ex.error_code == errno.EOPNOTSUPP:
-                        raise unittest.SkipTest('Create AH is not supported')
-                    assert 'Failed to create AH' in str(ex)
-                    done +=1
-                else:
-                    raise PyverbsError('Created a non-global AH on RoCE')
-        if done == 0:
-            raise unittest.SkipTest('No port is up, can\'t create AH')
+            ah_attr = AHAttr(is_global=0, port_num=self.ib_port)
+            try:
+                AH(pd, attr=ah_attr)
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Create AH is not supported')
+                assert 'Failed to create AH' in str(ex)
+            else:
+                raise PyverbsError(f'Successfully created a non-global AH on RoCE port={self.ib_port}')
 
     def test_destroy_ah(self):
         """
         Test ibv_destroy_ah.
         """
-        done = 0
-        for ctx, attr, attr_ex in self.devices:
+        for ctx, _, _ in self.devices:
+            self.verify_state(ctx)
+            gr = u.get_global_route(ctx, port_num=self.ib_port)
+            ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
             pd = PD(ctx)
-            for port_num in range(1, 1 + attr.phys_port_cnt):
-                state = ctx.query_port(port_num).state
-                if state != e.IBV_PORT_ACTIVE and state != e.IBV_PORT_INIT:
-                    continue
-                gr = u.get_global_route(ctx)
-                ah_attr = AHAttr(gr=gr, is_global=1, port_num=port_num)
-                try:
-                    with AH(pd, attr=ah_attr) as ah:
-                        ah.close()
-                        done += 1
-                except PyverbsRDMAError as ex:
-                    if ex.error_code == errno.EOPNOTSUPP:
-                        raise unittest.SkipTest('Create AH is not supported')
-                    raise ex
-        if done == 0:
-            raise unittest.SkipTest('No port is up, can\'t create AH')
+            try:
+                with AH(pd, attr=ah_attr) as ah:
+                    ah.close()
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Create AH is not supported')
+                raise ex

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -50,8 +50,8 @@ class EfaAHTest(PyverbsAPITestCase):
         for ctx, attr, attr_ex in self.devices:
             pd = PD(ctx)
             try:
-                gr = u.get_global_route(ctx, port_num=1)
-                ah_attr = AHAttr(gr=gr, is_global=1, port_num=1)
+                gr = u.get_global_route(ctx, port_num=self.ib_port)
+                ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
                 ah = efa.EfaAH(pd, attr=ah_attr)
                 query_ah_attr = ah.query_efa_ah()
                 if self.config['verbosity']:


### PR DESCRIPTION
This PR adds the '--port' command line option that will be used to run the pyverbs on a specific device port, This is needed when there are multiple ports supported by one device, so the tests will run on the specified device port instead of on all of them.