### PR TITLE
pyverbs: Add a new active speed translation

### DIFF
--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -1078,7 +1078,8 @@ def width_to_str(width):
 
 def speed_to_str(speed):
     l = {0: '0.0 Gbps', 1: '2.5 Gbps', 2: '5.0 Gbps', 4: '5.0 Gbps',
-         8: '10.0 Gbps', 16: '14.0 Gbps', 32: '25.0 Gbps', 64: '50.0 Gbps'}
+         8: '10.0 Gbps', 16: '14.0 Gbps', 32: '25.0 Gbps', 64: '50.0 Gbps',
+         128: '100.0 Gbps'}
     try:
         return '{s} ({n})'.format(s=l[speed], n=speed)
     except KeyError:


### PR DESCRIPTION
Prepare support for a new IB speed rate (NDR).
A translation was added to the active speed attribute.