### PR TITLE
EFA host information userspace version

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -27,7 +27,8 @@ enum {
 
 struct efa_ibv_alloc_ucontext_cmd {
 	__u32 comp_mask;
-	__u8 reserved_20[4];
+	__u8 userspace_ver[32];
+	__u8 reserved_120[4];
 };
 
 enum efa_ibv_user_cmds_supp_udata {

--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -181,4 +181,25 @@ struct rxe_modify_srq_cmd {
 	__aligned_u64 mmap_info_addr;
 };
 
+/* This data structure is stored at the base of work and
+ * completion queues shared between user space and kernel space.
+ * It contains the producer and consumer indices. Is also
+ * contains a copy of the queue size parameters for user space
+ * to use but the kernel must use the parameters in the
+ * rxe_queue struct. For performance reasons arrange to have
+ * producer and consumer indices in separate cache lines
+ * the kernel should always mask the indices to avoid accessing
+ * memory outside of the data area
+ */
+struct rxe_queue_buf {
+	__u32			log2_elem_size;
+	__u32			index_mask;
+	__u32			pad_1[30];
+	__u32			producer_index;
+	__u32			pad_2[31];
+	__u32			consumer_index;
+	__u32			pad_3[31];
+	__u8			data[];
+};
+
 #endif /* RDMA_USER_RXE_H */

--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -57,6 +57,8 @@ static struct verbs_context *efa_alloc_context(struct ibv_device *vdev,
 
 	cmd.comp_mask |= EFA_ALLOC_UCONTEXT_CMD_COMP_TX_BATCH;
 	cmd.comp_mask |= EFA_ALLOC_UCONTEXT_CMD_COMP_MIN_SQ_WR;
+	strncpy((char *)cmd.userspace_ver, PACKAGE_VERSION,
+		sizeof(cmd.userspace_ver));
 
 	ctx = verbs_init_and_alloc_context(vdev, cmd_fd, ctx, ibvctx,
 					   RDMA_DRIVER_EFA);


### PR DESCRIPTION
This small series reports the userspace rdma-core version to the EFA driver which passes it to the device through the host information feature,  used for debugging and troubleshooting purposes.

Kernel submission:
https://lore.kernel.org/linux-rdma/20210105104326.67895-1-galpress@amazon.com/