### PR TITLE
srp_daemon: Fix systemd dependency

### DIFF
--- a/srp_daemon/srp_daemon.service.in
+++ b/srp_daemon/srp_daemon.service.in
@@ -16,4 +16,4 @@ ProtectKernelModules=yes
 RestrictRealtime=yes
 
 [Install]
-WantedBy=remote-fs-pre.target
+WantedBy=multi-user.target


### PR DESCRIPTION
remote-fs-pre.target is a passive target that is not loaded without someone
actively requiring it. Even is remote-fs.target is active.
This means that srp_daemon will not get started at boot
unless another service explicitely requires remote-fs-pre.target.

This solves the issue by having the srp_daemon service itself actively
asking for remote-fs-pre.target to be loaded.

Fixes: 08f689176497 (Revise systemd dependencies for all units)
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>