### PR TITLE
ibacm: acm.c load plugin while it is soft link

### DIFF
--- a/ibacm/src/acm.c
+++ b/ibacm/src/acm.c
@@ -2879,7 +2879,7 @@ static int acm_open_providers(void)
 			acm_log(0, "Error - could not stat: %s\n", file_name);
 			continue;
 		}
-		if (!S_ISREG(buf.st_mode))
+		if (!(S_ISREG(buf.st_mode) || S_ISLNK(buf.st_mode)))
 			continue;
 
 		acm_log(2, "Loading provider %s...\n", file_name);


### PR DESCRIPTION
Because of commit ad5d934d688911149d795aee1d3b9fa06bf171a9,
the provider libdsap.so.1.0.0 was not opened/used for address resolution
for OPA device.

As discussed in this closed PR:
https://github.com/linux-rdma/rdma-core/pull/848

I create a soft link for libdsap.so => libdsap.so.1.0.0 . The soft link
was ignored becuase it is a not regular file.

Signed-off-by: Honggang Li <honli@redhat.com>