### PR TITLE
verbs: Update the type of some variables in documents

### DIFF
--- a/libibverbs/man/ibv_bind_mw.3
+++ b/libibverbs/man/ibv_bind_mw.3
@@ -28,7 +28,7 @@ is an ibv_mw_bind struct, as defined in <infiniband/verbs.h>.
 struct ibv_mw_bind {
 .in +8
 uint64_t                     wr_id;           /* User defined WR ID */
-int                          send_flags;      /* Use ibv_send_flags */
+unsigned int                 send_flags;      /* Use ibv_send_flags */
 struct ibv_mw_bind_info      bind_info;       /* MW bind information */
 .in -8
 }
@@ -40,7 +40,7 @@ struct ibv_mw_bind_info {
 struct ibv_mr                *mr;             /* The MR to bind the MW to */
 uint64_t                     addr;            /* The address the MW should start at */
 uint64_t                     length;          /* The length (in bytes) the MW should span */
-int                          mw_access_flags; /* Access flags to the MW. Use ibv_access_flags */
+unsigned int                 mw_access_flags; /* Access flags to the MW. Use ibv_access_flags */
 .in -8
 };
 .fi

--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -122,7 +122,7 @@ Below members and functions are used in order to poll the current completion. Th
 .BI "uint32_t ibv_wc_read_src_qp(struct ibv_cq_ex " "*cq"); \c
  Get the source QP number field from the current completion.
 
-.BI "int ibv_wc_read_wc_flags(struct ibv_cq_ex " "*cq"); \c
+.BI "unsigned int ibv_wc_read_wc_flags(struct ibv_cq_ex " "*cq"); \c
  Get the QP flags field from the current completion.
 
 .BI "uint16_t ibv_wc_read_pkey_index(struct ibv_cq_ex " "*cq"); \c

--- a/libibverbs/man/ibv_modify_qp.3
+++ b/libibverbs/man/ibv_modify_qp.3
@@ -32,7 +32,7 @@ uint32_t                qkey;                   /* Q_Key for the QP (valid only 
 uint32_t                rq_psn;                 /* PSN for receive queue (valid only for RC/UC QPs) */
 uint32_t                sq_psn;                 /* PSN for send queue */
 uint32_t                dest_qp_num;            /* Destination QP number (valid only for RC/UC QPs) */
-int                     qp_access_flags;        /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
+unsigned int            qp_access_flags;        /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
 struct ibv_qp_cap       cap;                    /* QP capabilities (valid if HCA supports QP resizing) */
 struct ibv_ah_attr      ah_attr;                /* Primary path address vector (valid only for RC/UC QPs) */
 struct ibv_ah_attr      alt_ah_attr;            /* Alternate path address vector (valid only for RC/UC QPs) */

--- a/libibverbs/man/ibv_poll_cq.3
+++ b/libibverbs/man/ibv_poll_cq.3
@@ -39,7 +39,7 @@ uint32_t                invalidated_rkey; /* Local RKey that was invalidated */
 };
 uint32_t                qp_num;         /* Local QP number of completed WR */
 uint32_t                src_qp;         /* Source QP number (remote QP number) of completed WR (valid only for UD QPs) */
-int                     wc_flags;       /* Flags of the completed WR */
+unsigned int            wc_flags;       /* Flags of the completed WR */
 uint16_t                pkey_index;     /* P_Key index (valid only for GSI QPs) */
 uint16_t                slid;           /* Source LID */
 uint8_t                 sl;             /* Service Level */

--- a/libibverbs/man/ibv_post_send.3
+++ b/libibverbs/man/ibv_post_send.3
@@ -34,7 +34,7 @@ struct ibv_send_wr     *next;                   /* Pointer to next WR in list, N
 struct ibv_sge         *sg_list;                /* Pointer to the s/g array */
 int                     num_sge;                /* Size of the s/g array */
 enum ibv_wr_opcode      opcode;                 /* Operation type */
-int                     send_flags;             /* Flags of the WR properties */
+unsigned int            send_flags;             /* Flags of the WR properties */
 union {
 .in +8
 __be32                  imm_data;               /* Immediate data (in network byte order) */
@@ -103,7 +103,7 @@ struct ibv_mw_bind_info {
 struct ibv_mr            *mr;             /* The Memory region (MR) to bind the MW to */
 uint64_t                 addr;           /* The address the MW should start at */
 uint64_t                 length;          /* The length (in bytes) the MW should span */
-int                      mw_access_flags; /* Access flags to the MW. Use ibv_access_flags */
+unsigned int             mw_access_flags; /* Access flags to the MW. Use ibv_access_flags */
 .in -8
 };
 .fi

--- a/libibverbs/man/ibv_query_qp.3
+++ b/libibverbs/man/ibv_query_qp.3
@@ -37,7 +37,7 @@ uint32_t                qkey;                /* Q_Key of the QP (valid only for 
 uint32_t                rq_psn;              /* PSN for receive queue (valid only for RC/UC QPs) */
 uint32_t                sq_psn;              /* PSN for send queue */
 uint32_t                dest_qp_num;         /* Destination QP number (valid only for RC/UC QPs) */
-int                     qp_access_flags;     /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
+unsigned int            qp_access_flags;     /* Mask of enabled remote access operations (valid only for RC/UC QPs) */
 struct ibv_qp_cap       cap;                 /* QP capabilities */
 struct ibv_ah_attr      ah_attr;             /* Primary path address vector (valid only for RC/UC QPs) */
 struct ibv_ah_attr      alt_ah_attr;         /* Alternate path address vector (valid only for RC/UC QPs) */


### PR DESCRIPTION
The type of some variables has been changed from int to
unsigned int thus update the corresponding documents.

Fixes: 8fe7f12f1723 ("verbs: Bitwise flag values should be unsigned")
Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>