### PR TITLE
verbs: Replace SQ with RQ in max_recv_sge's documents

### DIFF
--- a/libibverbs/man/ibv_create_qp.3
+++ b/libibverbs/man/ibv_create_qp.3
@@ -40,7 +40,7 @@ struct ibv_qp_cap {
 uint32_t                max_send_wr;    /* Requested max number of outstanding WRs in the SQ */
 uint32_t                max_recv_wr;    /* Requested max number of outstanding WRs in the RQ */
 uint32_t                max_send_sge;   /* Requested max number of scatter/gather (s/g) elements in a WR in the SQ */
-uint32_t                max_recv_sge;   /* Requested max number of s/g elements in a WR in the SQ */
+uint32_t                max_recv_sge;   /* Requested max number of s/g elements in a WR in the RQ */
 uint32_t                max_inline_data;/* Requested max number of data (bytes) that can be posted inline to the SQ, otherwise 0 */
 .in -8
 };

--- a/libibverbs/man/ibv_create_qp_ex.3
+++ b/libibverbs/man/ibv_create_qp_ex.3
@@ -49,7 +49,7 @@ struct ibv_qp_cap {
 uint32_t                max_send_wr;    /* Requested max number of outstanding WRs in the SQ */
 uint32_t                max_recv_wr;    /* Requested max number of outstanding WRs in the RQ */
 uint32_t                max_send_sge;   /* Requested max number of scatter/gather (s/g) elements in a WR in the SQ */
-uint32_t                max_recv_sge;   /* Requested max number of s/g elements in a WR in the SQ */
+uint32_t                max_recv_sge;   /* Requested max number of s/g elements in a WR in the RQ */
 uint32_t                max_inline_data;/* Requested max number of data (bytes) that can be posted inline to the SQ, otherwise 0 */
 .in -8
 };


### PR DESCRIPTION
Fix copy/paste mistake.

Fixes: 9845a77c8812 ("Add remaining libibverbs manpages")
Fixes: 058c67977dad ("XRC man pages")
Signed-off-by: Xiao Yang <yangx.jy@cn.fujitsu.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>