### PR TITLE
bnxt_re: Fix reported error code from create_cq

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -178,8 +178,10 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
 
-	if (ncqe > dev->max_cq_depth)
+	if (!ncqe || ncqe > dev->max_cq_depth) {
+		errno = EINVAL;
 		return NULL;
+	}
 
 	cq = calloc(1, sizeof(*cq));
 	if (!cq)


### PR DESCRIPTION
Report EINVAL when trying to call bnxt_re_create_cq() with number of CQEs
out of the supported range.

Fixes: fa8dce26b88c ("libbnxt_re: Add support for CQ and QP management")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>