### PR TITLE
verbs: Let kernel knows whether TS is required for a given CQ

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ set(PACKAGE_VERSION "34.0")
 # When this is changed the values in these files need changing too:
 #   debian/control
 #   debian/libibverbs1.symbols
-set(IBVERBS_PABI_VERSION "33")
+set(IBVERBS_PABI_VERSION "34")
 set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 #-------------------------

--- a/debian/control
+++ b/debian/control
@@ -152,7 +152,7 @@ Section: libs
 Pre-Depends: ${misc:Pre-Depends}
 Depends: adduser, ${misc:Depends}, ${shlibs:Depends}
 Recommends: ibverbs-providers
-Breaks: ibverbs-providers (<< 33~)
+Breaks: ibverbs-providers (<< 34~)
 Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  libibverbs is a library that allows userspace processes to use RDMA
  "verbs" as described in the InfiniBand Architecture Specification and

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -9,7 +9,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.9@IBVERBS_1.9 30
  IBVERBS_1.10@IBVERBS_1.10 31
  IBVERBS_1.11@IBVERBS_1.11 32
- (symver)IBVERBS_PRIVATE_33 33
+ (symver)IBVERBS_PRIVATE_34 34
  _ibv_query_gid_ex@IBVERBS_1.11 32
  _ibv_query_gid_table@IBVERBS_1.11 32
  ibv_ack_async_event@IBVERBS_1.0 1.1.6

--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -36,7 +36,8 @@
 static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_comp_channel *channel, int comp_vector,
 			      uint32_t flags, struct ibv_cq *cq,
-			      struct ibv_command_buffer *link)
+			      struct ibv_command_buffer *link,
+			      uint32_t cmd_flags)
 {
 	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE, 8, link);
 	struct verbs_ex_private *priv = get_priv(context);
@@ -63,7 +64,9 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 		attr_optional(async_fd_attr);
 
 	if (flags) {
-		fallback_require_ex(cmdb);
+		if ((flags & ~IB_UVERBS_CQ_FLAGS_TIMESTAMP_COMPLETION) ||
+		    (!(cmd_flags & CREATE_CQ_CMD_FLAGS_TS_IGNORED_EX)))
+			fallback_require_ex(cmdb);
 		fill_attr_in_uint32(cmdb, UVERBS_ATTR_CREATE_CQ_FLAGS, flags);
 	}
 
@@ -135,16 +138,17 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 				  resp_size);
 
 	return ibv_icmd_create_cq(context, cqe, channel, comp_vector, 0, cq,
-				  cmdb);
+				  cmdb, 0);
 }
 
 int ibv_cmd_create_cq_ex(struct ibv_context *context,
-			 struct ibv_cq_init_attr_ex *cq_attr,
+			 const struct ibv_cq_init_attr_ex *cq_attr,
 			 struct verbs_cq *cq,
 			 struct ibv_create_cq_ex *cmd,
 			 size_t cmd_size,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
-			 size_t resp_size)
+			 size_t resp_size,
+			 uint32_t cmd_flags)
 {
 	DECLARE_CMD_BUFFER_COMPAT(cmdb, UVERBS_OBJECT_CQ,
 				  UVERBS_METHOD_CQ_CREATE, cmd, cmd_size, resp,
@@ -154,7 +158,8 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 	if (!check_comp_mask(cq_attr->comp_mask, IBV_CQ_INIT_ATTR_MASK_FLAGS))
 		return EOPNOTSUPP;
 
-	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP)
+	if (cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP ||
+	    cq_attr->wc_flags & IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK)
 		flags |= IB_UVERBS_CQ_FLAGS_TIMESTAMP_COMPLETION;
 
 	if (cq_attr->flags & IBV_CREATE_CQ_ATTR_IGNORE_OVERRUN)
@@ -162,7 +167,7 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 
 	return ibv_icmd_create_cq(context, cq_attr->cqe, cq_attr->channel,
 				  cq_attr->comp_vector, flags,
-				  &cq->cq, cmdb);
+				  &cq->cq, cmdb, cmd_flags);
 }
 
 int ibv_cmd_destroy_cq(struct ibv_cq *cq)

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -53,6 +53,10 @@ enum verbs_xrcd_mask {
 	VERBS_XRCD_RESERVED	= 1 << 1
 };
 
+enum create_cq_cmd_flags {
+	CREATE_CQ_CMD_FLAGS_TS_IGNORED_EX = 1 << 0,
+};
+
 struct verbs_xrcd {
 	struct ibv_xrcd		xrcd;
 	uint32_t		comp_mask;
@@ -500,12 +504,13 @@ int ibv_cmd_create_cq(struct ibv_context *context, int cqe,
 		      struct ibv_create_cq *cmd, size_t cmd_size,
 		      struct ib_uverbs_create_cq_resp *resp, size_t resp_size);
 int ibv_cmd_create_cq_ex(struct ibv_context *context,
-			 struct ibv_cq_init_attr_ex *cq_attr,
+			 const struct ibv_cq_init_attr_ex *cq_attr,
 			 struct verbs_cq *cq,
 			 struct ibv_create_cq_ex *cmd,
 			 size_t cmd_size,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
-			 size_t resp_size);
+			 size_t resp_size,
+			 uint32_t cmd_flags);
 int ibv_cmd_poll_cq(struct ibv_cq *cq, int ne, struct ibv_wc *wc);
 int ibv_cmd_req_notify_cq(struct ibv_cq *cq, int solicited_only);
 int ibv_cmd_resize_cq(struct ibv_cq *cq, int cqe,

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -666,7 +666,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
 	attr->cqe = roundup_pow_of_two(attr->cqe);
 	err = ibv_cmd_create_cq_ex(ibvctx, attr, &cq->verbs_cq,
 				   &cmd.ibv_cmd, sizeof(cmd),
-				   &resp.ibv_resp, sizeof(resp));
+				   &resp.ibv_resp, sizeof(resp), 0);
 	if (err) {
 		errno = err;
 		goto err_free_cq;

--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -463,7 +463,8 @@ static int mlx4_cmd_create_cq_ex(struct ibv_context *context,
 				   &cq->verbs_cq, &cmd.ibv_cmd,
 				   sizeof(cmd),
 				   &resp.ibv_resp,
-				   sizeof(resp));
+				   sizeof(resp),
+				   0);
 	if (!ret)
 		cq->cqn = resp.cqn;
 

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -357,7 +357,7 @@ static struct ibv_cq_ex *rxe_create_cq_ex(struct ibv_context *context,
 
 	ret = ibv_cmd_create_cq_ex(context, attr, &cq->vcq,
 				   NULL, 0,
-				   &resp.ibv_resp, sizeof(resp));
+				   &resp.ibv_resp, sizeof(resp), 0);
 	if (ret)
 		goto err_free;
 


### PR DESCRIPTION
Let kernel knows whether TS is required for a given CQ, this is done by choosing the
ibv_cmd_create_cq_ex() path from mlx5 in the general case.

In addition, a driver can mark whether to not fallback to the 'write EX' mode in case 'ioctl' create CQ is not supported, this is required only for mlx5.