### PR TITLE
tests: Add rereg MR tests

### DIFF
--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -507,6 +507,8 @@ cdef extern from 'infiniband/verbs.h':
     ibv_pd *ibv_alloc_pd(ibv_context *context)
     int ibv_dealloc_pd(ibv_pd *pd)
     ibv_mr *ibv_reg_mr(ibv_pd *pd, void *addr, size_t length, int access)
+    int ibv_rereg_mr(ibv_mr *mr, int flags, ibv_pd *pd, void *addr,
+                     size_t length, int access)
     int ibv_dereg_mr(ibv_mr *mr)
     int ibv_advise_mr(ibv_pd *pd, uint32_t advice, uint32_t flags,
                       ibv_sge *sg_list, uint32_t num_sge)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -115,6 +115,18 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_ACCESS_HUGETLB
         IBV_ACCESS_RELAXED_ORDERING
 
+    cpdef enum ibv_rereg_mr_flags:
+        IBV_REREG_MR_CHANGE_TRANSLATION
+        IBV_REREG_MR_CHANGE_PD
+        IBV_REREG_MR_CHANGE_ACCESS
+
+    cpdef enum ibv_rereg_mr_err_code:
+        IBV_REREG_MR_ERR_INPUT
+        IBV_REREG_MR_ERR_DONT_FORK_NEW
+        IBV_REREG_MR_ERR_DO_FORK_OLD
+        IBV_REREG_MR_ERR_CMD
+        IBV_REREG_MR_ERR_CMD_AND_DO_FORK_NEW
+
     cpdef enum ibv_wr_opcode:
         IBV_WR_RDMA_WRITE
         IBV_WR_RDMA_WRITE_WITH_IMM

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -13,6 +13,7 @@ cdef class PD(PyverbsCM):
     cdef v.ibv_pd *pd
     cdef Context ctx
     cdef add_ref(self, obj)
+    cdef remove_ref(self, obj)
     cdef object srqs
     cdef object mrs
     cdef object mws

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -128,6 +128,12 @@ cdef class PD(PyverbsCM):
         else:
             raise PyverbsError('Unrecognized object type')
 
+    cdef remove_ref(self, obj):
+        if isinstance(obj, MR):
+            self.mrs.remove(obj)
+        else:
+            raise PyverbsError('Unrecognized object type')
+
     @property
     def handle(self):
         return self.pd.handle

--- a/pyverbs/utils.py
+++ b/pyverbs/utils.py
@@ -4,6 +4,7 @@
 import struct
 
 from pyverbs.pyverbs_error import PyverbsUserError
+import pyverbs.enums as e
 
 be64toh = lambda num: struct.unpack('Q', struct.pack('!Q', num))[0]
 
@@ -79,3 +80,16 @@ def mig_state_to_str(mig):
         return mig_states[mig]
     except KeyError:
         return 'Unknown ({m})'.format(m=mig)
+
+def rereg_error_to_str(error):
+    error_map = {e.IBV_REREG_MR_ERR_INPUT: 'IBV_REREG_MR_ERR_INPUT',
+                 e.IBV_REREG_MR_ERR_DONT_FORK_NEW: \
+                     'IBV_REREG_MR_ERR_DONT_FORK_NEW',
+                 e.IBV_REREG_MR_ERR_DO_FORK_OLD: 'IBV_REREG_MR_ERR_DO_FORK_OLD',
+                 e.IBV_REREG_MR_ERR_CMD: 'IBV_REREG_MR_ERR_CMD',
+                 e.IBV_REREG_MR_ERR_CMD_AND_DO_FORK_NEW: \
+                     'IBV_REREG_MR_ERR_CMD_AND_DO_FORK_NEW'}
+    try:
+        return error_map[error]
+    except KeyError:
+        return f'Unknown error ({error})'

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -10,7 +10,8 @@ import errno
 from tests.base import PyverbsAPITestCase, RCResources, RDMATestCase
 from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
 from pyverbs.mr import MR, MW, DMMR, MWBindInfo, MWBind
-from pyverbs.qp import QPAttr
+from pyverbs.qp import QPCap, QPInitAttr, QPAttr, QP
+from pyverbs.mem_alloc import posix_memalign, free
 from pyverbs.wr import SendWR
 import pyverbs.device as d
 from pyverbs.pd import PD
@@ -18,10 +19,152 @@ import pyverbs.enums as e
 import tests.utils as u
 
 
+class MRRes(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index,
+                 mr_access=e.IBV_ACCESS_LOCAL_WRITE):
+        """
+        Initialize MR resources based on RC resources that include RC QP.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param mr_access: The MR access
+        """
+        self.mr_access = mr_access
+        super().__init__(dev_name=dev_name, ib_port=ib_port, gid_index=gid_index)
+
+    def create_mr(self):
+        try:
+            self.mr = MR(self.pd, self.msg_size, self.mr_access)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Reg MR with access ({self.mr_access}) is not supported')
+            raise ex
+
+    def create_qp_attr(self):
+        qp_attr = QPAttr(port_num=self.ib_port)
+        qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
+        qp_attr.qp_access_flags = qp_access
+        return qp_attr
+
+    def rereg_mr(self, flags, pd=None, addr=0, length=0, access=0):
+        try:
+            self.mr.rereg(flags, pd, addr, length, access)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Rereg MR is not supported ({str(ex)})')
+            raise ex
+
+
 class MRTest(RDMATestCase):
     """
     Test various functionalities of the MR class.
     """
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+        self.server_qp_attr = None
+        self.client_qp_attr = None
+        self.traffic_args = None
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init MR tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.sync_remote_attr()
+        self.server_qp_attr, _ = self.server.qp.query(0x1ffffff)
+        self.client_qp_attr, _ = self.client.qp.query(0x1ffffff)
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
+
+    def sync_remote_attr(self):
+        """
+        Exchange the MR remote attributes between the server and the client.
+        """
+        self.server.rkey = self.client.mr.rkey
+        self.server.remote_addr = self.client.mr.buf
+        self.client.rkey = self.server.mr.rkey
+        self.client.remote_addr = self.server.mr.buf
+
+    def restate_qps(self):
+        """
+        Restate the resources QPs from ERR back to RTS state.
+        """
+        self.server.qp.modify(QPAttr(qp_state=e.IBV_QPS_RESET), e.IBV_QP_STATE)
+        self.server.qp.to_rts(self.server_qp_attr)
+        self.client.qp.modify(QPAttr(qp_state=e.IBV_QPS_RESET), e.IBV_QP_STATE)
+        self.client.qp.to_rts(self.client_qp_attr)
+
+    def test_mr_rereg_access(self):
+        self.create_players(MRRes)
+        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_ACCESS, access=access)
+        self.client.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_ACCESS, access=access)
+        u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_mr_rereg_access_bad_flow(self):
+        """
+        Test that cover rereg MR's access with this flow:
+        Run remote traffic on MR with compatible access, then rereg the MR
+        without remote access and verify that traffic fails with the relevant
+        error.
+        """
+        remote_access = e.IBV_ACCESS_LOCAL_WRITE |e.IBV_ACCESS_REMOTE_WRITE
+        self.create_players(MRRes, mr_access=remote_access)
+        u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)
+        access = e.IBV_ACCESS_LOCAL_WRITE
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_ACCESS, access=access)
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote access error'):
+            u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_mr_rereg_pd(self):
+        """
+        Test that cover rereg MR's PD with this flow:
+        Use MR with QP that was created with the same PD. Then rereg the MR's PD
+        and use the MR with the same QP, expect the traffic to fail with "remote
+        operation error". Restate the QP from ERR state, rereg the MR back
+        to its previous PD and use it again with the QP, verify that it now
+        succeeds.
+        """
+        self.create_players(MRRes)
+        u.traffic(**self.traffic_args)
+        server_new_pd = PD(self.server.ctx)
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_PD, pd=server_new_pd)
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote operation error'):
+            u.traffic(**self.traffic_args)
+        self.restate_qps()
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_PD, pd=self.server.pd)
+        u.traffic(**self.traffic_args)
+        # Rereg the MR again with the new PD to cover
+        # destroying a PD with a re-registered MR.
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_PD, pd=server_new_pd)
+
+    def test_mr_rereg_addr(self):
+        self.create_players(MRRes)
+        s_recv_wr = u.get_recv_wr(self.server)
+        self.server.qp.post_recv(s_recv_wr)
+        server_addr = posix_memalign(self.server.msg_size)
+        self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_TRANSLATION,
+                             addr=server_addr,
+                             length=self.server.msg_size)
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote operation error'):
+            # The server QP receive queue has WR with the old MR address,
+            # therefore traffic should fail.
+            u.traffic(**self.traffic_args)
+        self.restate_qps()
+        u.traffic(**self.traffic_args)
+        free(server_addr)
+
     def test_reg_mr_bad_flags(self):
         """
         Verify that illegal flags combination fails as expected


### PR DESCRIPTION
This series adds ibv_rereg_mr support to Pyverbs and adds multiple rereg MR tests.
It also includes the following changes:
- Removal of multiple MR tests that were basic sanity checks as they are already covered by other tests.
- Some MR tests were modified to run only over one device instead of running in a loop over all the rdma devices that exist.