### PR TITLE
tests: Add mlx5 ODP DC test

### DIFF
--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -84,13 +84,13 @@ cdef class Mlx5Context(Context):
                 dve.MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS |\
                 dve.MLX5DV_CONTEXT_MASK_DYN_BFREGS |\
                 dve.MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE |\
+                dve.MLX5DV_CONTEXT_MASK_DC_ODP_CAPS |\
                 dve.MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS
         else:
             dv_attr.comp_mask = comp_mask
         rc = dv.mlx5dv_query_device(self.context, &dv_attr.dv)
         if rc != 0:
-            raise PyverbsRDMAErrno('Failed to query mlx5 device {name}, got {rc}'.
-                                   format(name=self.name, rc=rc))
+            raise PyverbsRDMAError(f'Failed to query mlx5 device {self.name}.', rc)
         return dv_attr
 
     def __dealloc__(self):

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -16,6 +16,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_MASK_DYN_BFREGS          = 1 << 4
         MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE   = 1 << 5
         MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS   = 1 << 6
+        MLX5DV_CONTEXT_MASK_DC_ODP_CAPS         = 1 << 7
         MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9
 
     cpdef enum mlx5dv_context_flags:

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -1,10 +1,24 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2020 NVIDIA Corporation . All rights reserved. See COPYING file
 
+import unittest
+import errno
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
 from tests.mlx5_base import Mlx5DcResources
 from tests.base import RDMATestCase
 import pyverbs.enums as e
 import tests.utils as u
+
+
+class OdpDc(Mlx5DcResources):
+    def create_mr(self):
+        try:
+            self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Reg ODP MR is not supported')
+            raise ex
 
 
 class DCTest(RDMATestCase):
@@ -14,6 +28,12 @@ class DCTest(RDMATestCase):
         self.server = None
         self.client = None
         self.traffic_args = None
+
+    def tearDown(self):
+        if self.server:
+            self.server.ctx.close()
+        if self.client:
+            self.client.ctx.close()
 
     def sync_remote_attr(self):
         """
@@ -52,5 +72,22 @@ class DCTest(RDMATestCase):
     def test_dc_send(self):
         self.create_players(Mlx5DcResources, qp_count=2,
                             send_ops_flags=e.IBV_QP_EX_WITH_SEND)
+        u.traffic(**self.traffic_args, new_send=True,
+                  send_op=e.IBV_QP_EX_WITH_SEND)
+
+    def check_odp_dc_support(self):
+        """
+        Check if the device supports ODP with DC.
+        :raises SkipTest: In case ODP is not supported with DC
+        """
+        dc_odp_caps = self.server.ctx.query_mlx5_device().dc_odp_caps
+        required_odp_caps = e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV
+        if required_odp_caps & dc_odp_caps != required_odp_caps:
+            raise unittest.SkipTest('ODP is not supported using DC')
+
+    def test_odp_dc_traffic(self):
+        send_ops_flag = e.IBV_QP_EX_WITH_SEND
+        self.create_players(OdpDc, qp_count=2, send_ops_flags=send_ops_flag)
+        self.check_odp_dc_support()
         u.traffic(**self.traffic_args, new_send=True,
                   send_op=e.IBV_QP_EX_WITH_SEND)


### PR DESCRIPTION
This series adds the ability to query DC ODP caps and adds an mlx5 test that runs DC traffic with ODP.