### PR TITLE
tests: Retrieve tests that generates mlx5 CQE errors

### DIFF
--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -303,11 +303,41 @@ class MWTest(RDMATestCase):
         u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
                        self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
 
+    def test_invalidate_mw_type1(self):
+        self.test_mw_type1()
+        self.invalidate_mw_type1()
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote access error'):
+            u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
+                           self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
+
     def test_mw_type2(self):
         self.create_players(MWRC, mw_type=e.IBV_MW_TYPE_2)
         self.bind_mw_type_2()
         u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
                        self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_mw_type2_invalidate_local(self):
+        self.test_mw_type2()
+        self.invalidate_mw_type2_local()
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote access error'):
+            u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
+                           self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_mw_type2_invalidate_remote(self):
+        self.test_mw_type2()
+        self.invalidate_mw_type2_remote()
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote access error'):
+            u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
+                           self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_mw_type2_invalidate_dealloc(self):
+        self.test_mw_type2()
+        # Dealloc the MW by closing the pyverbs objects.
+        self.server.mw.close()
+        self.client.mw.close()
+        with self.assertRaisesRegex(PyverbsRDMAError, 'Remote access error'):
+            u.rdma_traffic(self.client, self.server, self.iters, self.gid_index,
+                           self.ib_port, send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_reg_mw_wrong_type(self):
         """

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -260,3 +260,46 @@ class QpExTestCase(RDMATestCase):
         server.mr.write('s' * 8, 8)
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
                        new_send=True, send_op=e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
+
+    def test_qp_ex_rc_bind_mw(self):
+        """
+        Verify bind memory window operation using the new post_send API.
+        Instead of checking through regular pingpong style traffic, we'll
+        do as follows:
+        - Register an MR with remote write access
+        - Bind a MW without remote write permission to the MR
+        - Verify that remote write fails
+        Since it's a unique flow, it's an integral part of that test rather
+        than a utility method.
+        """
+        client, server = self.create_players('rc_bind_mw')
+        client_sge = u.get_send_elements(client, False)[1]
+        # Create a MW and bind it
+        server.qp.wr_start()
+        server.qp.wr_id = 0x123
+        server.qp.wr_flags = e.IBV_SEND_SIGNALED
+        bind_info = MWBindInfo(server.mr, server.mr.buf, server.mr.length,
+                               e.IBV_ACCESS_LOCAL_WRITE)
+        try:
+            mw = MW(server.pd, mw_type=e.IBV_MW_TYPE_2)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Memory Window allocation is not supported')
+            raise ex
+        new_key = inc_rkey(server.mr.rkey)
+        server.qp.wr_bind_mw(mw, new_key, bind_info)
+        server.qp.wr_complete()
+        u.poll_cq(server.cq)
+        # Verify that remote write fails
+        client.qp.wr_start()
+        client.qp.wr_id = 0x124
+        client.qp.wr_flags = e.IBV_SEND_SIGNALED
+        client.qp.wr_rdma_write(new_key, server.mr.buf)
+        client.qp.wr_set_sge(client_sge)
+        client.qp.wr_complete()
+        try:
+            u.poll_cq(client.cq)
+        except PyverbsRDMAError as ex:
+            if ex.error_code != e.IBV_WC_REM_ACCESS_ERR:
+                raise ex
+


### PR DESCRIPTION
The library was changed and now mlx5 doesn't print to stdout by
default, so those tests that were deleted can be retrieved back.
This reverts commit a48b9b172d8018c83f960f08d0e4bcce0e29fc2d.