### PR TITLE
mlx5: Expose DV APIs to allocate/deallocate reserved QPNs

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -25,6 +25,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.15@MLX5_1.15 31
  MLX5_1.16@MLX5_1.16 32
  MLX5_1.17@MLX5_1.17 33
+ MLX5_1.18@MLX5_1.18 34
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -121,6 +122,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_sched_node_create@MLX5_1.17 33
  mlx5dv_sched_node_destroy@MLX5_1.17 33
  mlx5dv_sched_node_modify@MLX5_1.17 33
+ mlx5dv_reserved_qpn_alloc@MLX5_1.18 34
+ mlx5dv_reserved_qpn_dealloc@MLX5_1.18 34
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.17.${PACKAGE_VERSION}
+  1 1.18.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -168,3 +168,9 @@ MLX5_1.17 {
 		mlx5dv_sched_node_destroy;
 		mlx5dv_sched_node_modify;
 } MLX5_1.16;
+
+MLX5_1.18 {
+	global:
+		mlx5dv_reserved_qpn_alloc;
+		mlx5dv_reserved_qpn_dealloc;
+} MLX5_1.17;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -30,6 +30,7 @@ rdma_man_pages(
   mlx5dv_pp_alloc.3.md
   mlx5dv_query_device.3
   mlx5dv_query_qp_lag_port.3.md
+  mlx5dv_reserved_qpn_alloc.3.md
   mlx5dv_sched_node_create.3.md
   mlx5dv_ts_to_ns.3
   mlx5dv_wr_post.3.md
@@ -92,6 +93,7 @@ rdma_alias_man_pages(
  mlx5dv_dump.3 mlx5dv_dump_dr_rule.3
  mlx5dv_dump.3 mlx5dv_dump_dr_table.3
  mlx5dv_pp_alloc.3 mlx5dv_pp_free.3
+ mlx5dv_reserved_qpn_alloc.3 mlx5dv_reserved_qpn_dealloc.3
  mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_create.3
  mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_destroy.3
  mlx5dv_sched_node_create.3 mlx5dv_sched_leaf_modify.3

--- a/providers/mlx5/man/mlx5dv_reserved_qpn_alloc.3.md
+++ b/providers/mlx5/man/mlx5dv_reserved_qpn_alloc.3.md
@@ -1,0 +1,54 @@
+---
+layout: page
+title: mlx5dv_reserved_qpn_alloc / dealloc
+section: 3
+tagline: Verbs
+date: 2020-12-29
+header: "mlx5 Programmer's Manual"
+footer: mlx5
+---
+
+# NAME
+
+mlx5dv_reserved_qpn_alloc - Allocate a reserved QP number from device
+
+mlx5dv_reserved_qpn_dealloc - Release the reserved QP number
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_reserved_qpn_alloc(struct ibv_context *ctx, uint32_t *qpn);
+
+int mlx5dv_reserved_qpn_dealloc(struct ibv_context *ctx, uint32_t qpn);
+```
+
+# DESCRIPTION
+
+When work with RDMA_CM RDMA_TCP_PS + external QP support, a client node needs GUID level unique QP numbers to comply with the CM's timewait logic.
+
+If a real unique QP is not allocated, a device global QPN value is required and can be allocated via this interface.
+
+The mlx5 DCI QP is such an example, which could connect to the remote DCT's multiple times as long as the application provides unique QPN for each new RDMA_CM connection.
+
+These 2 APIs provide the allocation/deallocation of a unique QP number from/to device. This qpn can be used with
+DC QPN in RDMA_CM connection establishment, which will comply with the CM timewait kernel logic.
+
+# ARGUMENTS
+
+*ctx*
+:	The device context to issue the action on.
+
+*qpn*
+:	The allocated QP number (for alloc API), or the QP number to be deallocated (for dealloc API).
+
+# RETURN VALUE
+
+0 on success; EOPNOTSUPP if not supported, or other errno value on other failures.
+
+# AUTHOR
+
+Mark Zhang <markzhang@nvidia.com>
+
+Alex Rosenbaum <alexr@nvidia.com>

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1557,6 +1557,160 @@ int mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
 	}
 }
 
+static struct reserved_qpn_blk *reserved_qpn_blk_alloc(struct mlx5_context *mctx)
+{
+	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
+	uint32_t in[DEVX_ST_SZ_DW(create_reserved_qpn_in)] = {};
+	struct reserved_qpn_blk *blk;
+	void *attr;
+
+	blk = calloc(1, sizeof(*blk));
+	if (!blk) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	blk->bmp = bitmap_alloc0(1 << mctx->hca_cap_2_caps.log_reserved_qpns_per_obj);
+	if (!blk->bmp) {
+		errno = ENOMEM;
+		goto bmp_alloc_fail;
+	}
+
+	attr = DEVX_ADDR_OF(create_reserved_qpn_in, in, hdr);
+	DEVX_SET(general_obj_in_cmd_hdr,
+		 attr, opcode, MLX5_CMD_OP_CREATE_GENERAL_OBJECT);
+	DEVX_SET(general_obj_in_cmd_hdr,
+		 attr, obj_type, MLX5_OBJ_TYPE_RESERVED_QPN);
+	DEVX_SET(general_obj_in_cmd_hdr,
+		 attr, log_obj_range, mctx->hca_cap_2_caps.log_reserved_qpns_per_obj);
+
+	blk->obj = mlx5dv_devx_obj_create(&mctx->ibv_ctx.context,
+					  in, sizeof(in), out, sizeof(out));
+	if (!blk->obj)
+		goto obj_alloc_fail;
+
+	blk->first_qpn = blk->obj->object_id;
+	blk->next_avail_slot = 0;
+
+	return blk;
+
+obj_alloc_fail:
+	free(blk->bmp);
+
+bmp_alloc_fail:
+	free(blk);
+	return NULL;
+}
+
+static void reserved_qpn_blk_dealloc(struct reserved_qpn_blk *blk)
+{
+	if (mlx5dv_devx_obj_destroy(blk->obj))
+		assert(false);
+
+	free(blk->bmp);
+	free(blk);
+}
+
+static void reserved_qpn_blks_free(struct mlx5_context *mctx)
+{
+	struct reserved_qpn_blk *blk, *tmp;
+
+	pthread_mutex_lock(&mctx->reserved_qpns.mutex);
+
+	list_for_each_safe(&mctx->reserved_qpns.blk_list,
+			   blk, tmp, entry) {
+		list_del(&blk->entry);
+		reserved_qpn_blk_dealloc(blk);
+	}
+
+	pthread_mutex_unlock(&mctx->reserved_qpns.mutex);
+}
+
+/**
+ * Allocate a reserved QPN either from the last FW object allocated,
+ * or by allocating a new one. When find a free QPN in an object, it
+ * always starts from last allocation position, to make sure the QPN
+ * always move forward to prevent stale QPN.
+ */
+int mlx5dv_reserved_qpn_alloc(struct ibv_context *ctx, uint32_t *qpn)
+{
+	struct mlx5_context *mctx = to_mctx(ctx);
+	struct reserved_qpn_blk *blk;
+	uint32_t qpns_per_obj;
+	int ret = 0;
+
+	if (!is_mlx5_dev(ctx->device) ||
+	    !(mctx->general_obj_types_caps & (1ULL << MLX5_OBJ_TYPE_RESERVED_QPN)))
+		return EOPNOTSUPP;
+
+	qpns_per_obj = 1 << mctx->hca_cap_2_caps.log_reserved_qpns_per_obj;
+
+	pthread_mutex_lock(&mctx->reserved_qpns.mutex);
+
+	blk = list_tail(&mctx->reserved_qpns.blk_list,
+			struct reserved_qpn_blk, entry);
+	if (!blk ||
+	    (blk->next_avail_slot >= qpns_per_obj)) {
+		blk = reserved_qpn_blk_alloc(mctx);
+		if (!blk) {
+			ret = errno;
+			goto end;
+		}
+		list_add_tail(&mctx->reserved_qpns.blk_list, &blk->entry);
+	}
+
+	*qpn = blk->first_qpn + blk->next_avail_slot;
+	bitmap_set_bit(blk->bmp, blk->next_avail_slot);
+	blk->next_avail_slot++;
+
+end:
+	pthread_mutex_unlock(&mctx->reserved_qpns.mutex);
+	return ret;
+}
+
+/**
+ * Deallocate a reserved QPN. The FW object is destroyed only when all QPNs
+ * in this object were used and freed.
+ */
+int mlx5dv_reserved_qpn_dealloc(struct ibv_context *ctx, uint32_t qpn)
+{
+	struct mlx5_context *mctx = to_mctx(ctx);
+	struct reserved_qpn_blk *blk, *tmp;
+	uint32_t qpns_per_obj;
+	bool found = false;
+	int ret = 0;
+
+	qpns_per_obj = 1 << mctx->hca_cap_2_caps.log_reserved_qpns_per_obj;
+
+	pthread_mutex_lock(&mctx->reserved_qpns.mutex);
+
+	list_for_each_safe(&mctx->reserved_qpns.blk_list,
+			   blk, tmp, entry) {
+		if ((qpn >= blk->first_qpn) &&
+		    (qpn < blk->first_qpn + qpns_per_obj)) {
+			found = true;
+			break;
+		}
+	}
+
+	if (!found || !bitmap_test_bit(blk->bmp, qpn - blk->first_qpn)) {
+		errno = EINVAL;
+		ret = errno;
+		goto end;
+	}
+
+	bitmap_clear_bit(blk->bmp, qpn - blk->first_qpn);
+	if ((blk->next_avail_slot >= qpns_per_obj) &&
+	    (bitmap_empty(blk->bmp, qpns_per_obj))) {
+		list_del(&blk->entry);
+		reserved_qpn_blk_dealloc(blk);
+	}
+
+end:
+	pthread_mutex_unlock(&mctx->reserved_qpns.mutex);
+	return ret;
+}
+
 LATEST_SYMVER_FUNC(mlx5dv_init_obj, 1_2, "MLX5_1.2",
 		   int,
 		   struct mlx5dv_obj *obj, uint64_t obj_type)
@@ -1961,6 +2115,9 @@ bf_done:
 	mlx5_set_singleton_nc_uar(&v_ctx->context);
 	context->cq_uar_reg = context->nc_uar ? context->nc_uar->uar : context->uar[0].reg;
 
+	pthread_mutex_init(&context->reserved_qpns.mutex, NULL);
+	list_head_init(&context->reserved_qpns.blk_list);
+
 	return 0;
 
 err_free_bf:
@@ -2089,6 +2246,7 @@ static void mlx5_free_context(struct ibv_context *ibctx)
 		munmap((void *)context->clock_info_page, page_size);
 	close_debug_file(context);
 	clean_dyn_uars(ibctx);
+	reserved_qpn_blks_free(context);
 
 	verbs_uninit_context(&context->ibv_ctx);
 	free(context);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -272,6 +272,10 @@ struct mlx5_qos_caps {
 	uint32_t nic_tsar_type;
 };
 
+struct mlx5_hca_cap_2_caps {
+	uint32_t log_reserved_qpns_per_obj;
+};
+
 struct mlx5_context {
 	struct verbs_context		ibv_ctx;
 	int				max_num_qps;
@@ -342,6 +346,7 @@ struct mlx5_context {
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	struct mlx5_entropy_caps	entropy_caps;
 	struct mlx5_qos_caps		qos_caps;
+	struct mlx5_hca_cap_2_caps	hca_cap_2_caps;
 	uint8_t				qpc_extension_cap:1;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -43,6 +43,7 @@
 #include <util/udma_barrier.h>
 #include <util/util.h>
 #include "mlx5-abi.h"
+#include <ccan/bitmap.h>
 #include <ccan/list.h>
 #include "bitmap.h"
 #include <ccan/minmax.h>
@@ -276,6 +277,19 @@ struct mlx5_hca_cap_2_caps {
 	uint32_t log_reserved_qpns_per_obj;
 };
 
+struct reserved_qpn_blk {
+	bitmap *bmp;
+	uint32_t first_qpn;
+	struct list_node entry;
+	unsigned int next_avail_slot;
+	struct mlx5dv_devx_obj *obj;
+};
+
+struct mlx5_reserved_qpns {
+	struct list_head blk_list;
+	pthread_mutex_t mutex;
+};
+
 struct mlx5_context {
 	struct verbs_context		ibv_ctx;
 	int				max_num_qps;
@@ -347,6 +361,7 @@ struct mlx5_context {
 	struct mlx5_entropy_caps	entropy_caps;
 	struct mlx5_qos_caps		qos_caps;
 	struct mlx5_hca_cap_2_caps	hca_cap_2_caps;
+	uint64_t			general_obj_types_caps;
 	uint8_t				qpc_extension_cap:1;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
@@ -367,6 +382,7 @@ struct mlx5_context {
 	uint16_t			qp_alloc_shared_uuars;
 	struct mlx5_bf			*nc_uar;
 	void				*cq_uar_reg;
+	struct mlx5_reserved_qpns	reserved_qpns;
 };
 
 struct mlx5_bitmap {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -2446,6 +2446,7 @@ enum {
 	MLX5_OBJ_TYPE_ASO_FLOW_METER = 0x0024,
 	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
 	MLX5_OBJ_TYPE_SCHEDULING_ELEMENT = 0x0026,
+	MLX5_OBJ_TYPE_RESERVED_QPN = 0x002C,
 };
 
 struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
@@ -3485,6 +3486,15 @@ struct mlx5_ifc_modify_sq_in_bits {
 	u8	reserved_at_c0[0x40];
 
 	struct mlx5_ifc_sqc_bits sq_context;
+};
+
+struct mlx5_ifc_reserved_qpn_bits {
+	u8	reserved_at_0[0x80];
+};
+
+struct mlx5_ifc_create_reserved_qpn_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits	hdr;
+	struct mlx5_ifc_reserved_qpn_bits		rqpns;
 };
 
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -621,7 +621,8 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         reserved_at_1[0x1e];
 	u8         vhca_resource_manager[0x1];
 
-	u8         reserved_at_20[0x10];
+	u8         hca_cap_2[0x1];
+	u8         reserved_at_21[0xf];
 	u8         vhca_id[0x10];
 
 	u8         reserved_at_40[0x40];
@@ -1151,6 +1152,16 @@ struct mlx5_ifc_qos_cap_bits {
 	u8         reserved_at_120[0x6e0];
 };
 
+struct mlx5_ifc_cmd_hca_cap_2_bits {
+	u8         reserved_at_0[0x80];
+
+	u8         reserved_at_80[0x13];
+	u8         log_reserved_qpn_granularity[0x5];
+	u8         reserved_at_98[0x8];
+
+	u8         reserved_at_a0[0x760];
+};
+
 union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_atomic_caps_bits atomic_caps;
 	struct mlx5_ifc_cmd_hca_cap_bits cmd_hca_cap;
@@ -1160,6 +1171,7 @@ union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_odp_cap_bits odp_cap;
 	struct mlx5_ifc_roce_cap_bits roce_caps;
 	struct mlx5_ifc_qos_cap_bits qos_caps;
+	struct mlx5_ifc_cmd_hca_cap_2_bits cmd_hca_cap_2;
 	u8         reserved_at_0[0x8000];
 };
 
@@ -1200,6 +1212,7 @@ enum {
 	MLX5_SET_HCA_CAP_OP_MOD_ESW_FLOW_TABLE        = 0x8 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_QOS                   = 0xc << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY         = 0xf << 1,
+	MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2  = 0x20 << 1,
 };
 
 enum {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1657,6 +1657,9 @@ int mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
 				const struct mlx5dv_sched_leaf *requestor,
 				const struct mlx5dv_sched_leaf *responder);
 
+int mlx5dv_reserved_qpn_alloc(struct ibv_context *ctx, uint32_t *qpn);
+int mlx5dv_reserved_qpn_dealloc(struct ibv_context *ctx, uint32_t qpn);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3488,6 +3488,10 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 		DEVX_GET(query_hca_cap_out, out,
 			 capability.cmd_hca_cap.qpc_extension);
 
+	mctx->general_obj_types_caps =
+		DEVX_GET64(query_hca_cap_out, out,
+			   capability.cmd_hca_cap.general_obj_types);
+
 	if (DEVX_GET(query_hca_cap_out, out,
 		     capability.cmd_hca_cap.hca_cap_2))
 		get_hca_general_caps_2(mctx);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3428,6 +3428,27 @@ static void get_pci_atomic_caps(struct ibv_context *context,
 	}
 }
 
+static void get_hca_general_caps_2(struct mlx5_context *mctx)
+{
+	uint16_t opmod = MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2 |
+		HCA_CAP_OPMOD_GET_CUR;
+	uint32_t out[DEVX_ST_SZ_DW(query_hca_cap_out)] = {};
+	uint32_t in[DEVX_ST_SZ_DW(query_hca_cap_in)] = {};
+	int ret;
+
+	DEVX_SET(query_hca_cap_in, in, opcode, MLX5_CMD_OP_QUERY_HCA_CAP);
+	DEVX_SET(query_hca_cap_in, in, op_mod, opmod);
+
+	ret = mlx5dv_devx_general_cmd(&mctx->ibv_ctx.context, in, sizeof(in),
+				      out, sizeof(out));
+	if (ret)
+		return;
+
+	mctx->hca_cap_2_caps.log_reserved_qpns_per_obj =
+		DEVX_GET(query_hca_cap_out, out,
+			 capability.cmd_hca_cap_2.log_reserved_qpn_granularity);
+}
+
 static void get_hca_general_caps(struct mlx5_context *mctx)
 {
 	uint16_t opmod = MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE |
@@ -3466,6 +3487,10 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 	mctx->qpc_extension_cap =
 		DEVX_GET(query_hca_cap_out, out,
 			 capability.cmd_hca_cap.qpc_extension);
+
+	if (DEVX_GET(query_hca_cap_out, out,
+		     capability.cmd_hca_cap.hca_cap_2))
+		get_hca_general_caps_2(mctx);
 }
 
 static void get_qos_caps(struct mlx5_context *mctx)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -129,3 +129,5 @@ cdef extern from 'infiniband/mlx5dv.h':
     int mlx5dv_sched_leaf_destroy(mlx5dv_sched_leaf *leaf)
     int mlx5dv_modify_qp_sched_elem(v.ibv_qp *qp, mlx5dv_sched_leaf *requestor,
                                     mlx5dv_sched_leaf *responder)
+    int mlx5dv_reserved_qpn_alloc(v.ibv_context *context, uint32_t *qpn)
+    int mlx5dv_reserved_qpn_dealloc(v.ibv_context *context, uint32_t qpn)

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -311,11 +311,11 @@ cdef class Mlx5DVQPInitAttr(PyverbsObject):
 
 
 cdef class Mlx5QP(QPEx):
-    def __init__(self, Mlx5Context context, QPInitAttrEx init_attr,
+    def __init__(self, Context context, QPInitAttrEx init_attr,
                  Mlx5DVQPInitAttr dv_init_attr):
         """
         Initializes an mlx5 QP according to the user-provided data.
-        :param context: mlx5 Context object
+        :param context: Context object
         :param init_attr: QPInitAttrEx object
         :param dv_init_attr: Mlx5DVQPInitAttr object
         :return: An initialized Mlx5QP

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2019 Mellanox Technologies, Inc. All rights reserved. See COPYING file
 
-from libc.stdint cimport uintptr_t, uint8_t, uint16_t
+from libc.stdint cimport uintptr_t, uint8_t, uint16_t, uint32_t
 import logging
 
 from pyverbs.pyverbs_error import PyverbsUserError, PyverbsRDMAError
@@ -92,6 +92,30 @@ cdef class Mlx5Context(Context):
             raise PyverbsRDMAErrno('Failed to query mlx5 device {name}, got {rc}'.
                                    format(name=self.name, rc=rc))
         return dv_attr
+
+    @staticmethod
+    def reserved_qpn_alloc(Context ctx):
+        """
+        Allocate a reserved QP number from firmware.
+        :param ctx: The device context to issue the action on.
+        :return: The reserved QP number.
+        """
+        cdef uint32_t qpn
+        rc = dv.mlx5dv_reserved_qpn_alloc(ctx.context, &qpn)
+        if rc != 0:
+            raise PyverbsRDMAError('Failed to alloc reserved QP number.', rc)
+        return qpn
+
+    @staticmethod
+    def reserved_qpn_dealloc(Context ctx, qpn):
+        """
+        Release the reserved QP number to firmware.
+        :param ctx: The device context to issue the action on.
+        :param qpn: The QP number to be deallocated.
+        """
+        rc = dv.mlx5dv_reserved_qpn_dealloc(ctx.context, qpn)
+        if rc != 0:
+            raise PyverbsRDMAError(f'Failed to dealloc QP number {qpn}.', rc)
 
     def __dealloc__(self):
         self.close()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ rdma_python_test(tests
   test_mlx5_dc.py
   test_mlx5_lag_affinity.py
   test_mlx5_pp.py
+  test_mlx5_rdmacm.py
   test_mlx5_sched.py
   test_mlx5_uar.py
   test_mlx5_udp_sport.py

--- a/tests/test_mlx5_rdmacm.py
+++ b/tests/test_mlx5_rdmacm.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia Corporation. All rights reserved. See COPYING file
+
+import unittest
+import errno
+
+from pyverbs.providers.mlx5.mlx5dv import Mlx5DVQPInitAttr, Mlx5QP, \
+    Mlx5DVDCInitAttr, Mlx5Context
+from tests.test_rdmacm import RDMACMBaseTest, CMAsyncConnection
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.srq import SRQ, SrqInitAttr, SrqAttr
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from tests.base_rdmacm import AsyncCMResources
+from pyverbs.qp import QPCap, QPInitAttrEx
+from pyverbs.cmid import ConnParam
+from tests.base import DCT_KEY
+from pyverbs.addr import AH
+import pyverbs.enums as e
+from pyverbs.cq import CQ
+import tests.utils as u
+
+
+class DcCMConnection(CMAsyncConnection):
+    """
+    Implement RDMACM connection management for asynchronous CMIDs using DC as
+    an external QP.
+    """
+    def create_cm_res(self, ip_addr, passive, **kwargs):
+        self.cm_res = DcCMResources(addr=ip_addr, passive=passive, **kwargs)
+        if passive:
+            self.cm_res.create_cmid()
+        else:
+            for conn_idx in range(self.num_conns):
+                self.cm_res.create_cmid(conn_idx)
+
+    def _ext_qp_server_traffic(self):
+        recv_wr = u.get_recv_wr(self.cm_res)
+        for _ in range(self.cm_res.num_msgs):
+            u.post_recv(self.cm_res, recv_wr)
+        self.syncer.wait()
+        for _ in range(self.cm_res.num_msgs):
+            u.poll_cq(self.cm_res.cq)
+
+    def _ext_qp_client_traffic(self):
+        self.cm_res.remote_dct_num = self.cm_res.remote_qpn
+        _, send_wr = u.get_send_elements(self.cm_res, self.cm_res.passive)
+        ah = AH(self.cm_res.cmid.pd, attr=self.cm_res.remote_ah)
+        self.syncer.wait()
+        for send_idx in range(self.cm_res.num_msgs):
+            dci_idx = send_idx % len(self.cm_res.qps)
+            u.post_send_ex(self.cm_res, send_wr, e.IBV_QP_EX_WITH_SEND, ah=ah,
+                           qp_idx=dci_idx)
+            u.poll_cq(self.cm_res.cq)
+
+    def disconnect(self):
+        if self.cm_res.reserved_qp_num and self.cm_res.passive:
+            Mlx5Context.reserved_qpn_dealloc(self.cm_res.child_id.context,
+                                             self.cm_res.reserved_qp_num)
+            self.cm_res.reserved_qp_num = 0
+        super().disconnect()
+
+
+class DcCMResources(AsyncCMResources):
+    """
+    DcCMResources class contains resources for RDMA CM asynchronous
+    communication using DC as an external QP.
+    """
+    def __init__(self, addr=None, passive=None, **kwargs):
+        """
+        Init DcCMResources instance.
+        :param addr: Local address to bind to.
+        :param passive: Indicate if this CM is the passive CM.
+        """
+        super().__init__(addr=addr, passive=passive, **kwargs)
+        self.srq = None
+        self.remote_dct_num = None
+        self.reserved_qp_num = 0
+
+    def create_qp(self, conn_idx=0):
+        """
+        Create an RDMACM QP. If self.with_ext_qp is set, then an external CQ and
+        DC QP will be created. In case that CQ is already created, it is used
+        for the newly created QP.
+        """
+        try:
+            if not self.passive:
+                # Create the DCI QPs.
+                cmid = self.cmids[conn_idx]
+                self.create_cq(cmid)
+                qp_init_attr = self.create_qp_init_attr(cmid, e.IBV_QP_EX_WITH_SEND)
+                attr = Mlx5DVQPInitAttr(comp_mask=dve.MLX5DV_QP_INIT_ATTR_MASK_DC,
+                                        dc_init_attr=Mlx5DVDCInitAttr())
+                self.qps[conn_idx] = Mlx5QP(cmid.context, qp_init_attr, attr)
+
+            if self.passive and conn_idx == 0:
+                # Create the DCT QP only for the first connection.
+                cmid = self.child_id
+                self.create_cq(cmid)
+                self.create_srq(cmid)
+                qp_init_attr = self.create_qp_init_attr(cmid)
+                dc_attr = Mlx5DVDCInitAttr(dc_type=dve.MLX5DV_DCTYPE_DCT,
+                                           dct_access_key=DCT_KEY)
+                attr = Mlx5DVQPInitAttr(comp_mask=dve.MLX5DV_QP_INIT_ATTR_MASK_DC,
+                                        dc_init_attr=dc_attr)
+                self.qps[conn_idx] = Mlx5QP(cmid.context, qp_init_attr, attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create DC QP is not supported')
+            raise ex
+
+    def create_qp_cap(self):
+        return QPCap(self.num_msgs, 0, 1, 0)
+
+    def create_qp_init_attr(self, cmid, send_ops_flags=0):
+        comp_mask = e.IBV_QP_INIT_ATTR_PD
+        if send_ops_flags:
+            comp_mask |= e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+        return QPInitAttrEx(cap=self.create_qp_cap(), pd=cmid.pd, scq=self.cq,
+                            rcq=self.cq, srq=self.srq, qp_type=e.IBV_QPT_DRIVER,
+                            send_ops_flags=send_ops_flags, comp_mask=comp_mask,
+                            sq_sig_all=1)
+
+    def create_srq(self, cmid):
+        srq_init_attr = SrqInitAttr(SrqAttr(max_wr=self.num_msgs))
+        try:
+            self.srq = SRQ(cmid.pd, srq_init_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create SRQ is not supported')
+            raise ex
+
+    def modify_ext_qp_to_rts(self, conn_idx=0):
+        cmids = self.child_ids if self.passive else self.cmids
+        if not self.passive or not conn_idx:
+            qp = self.qps[conn_idx]
+            attr, _ = cmids[conn_idx].init_qp_attr(e.IBV_QPS_INIT)
+            qp.to_init(attr)
+            attr, _ = cmids[conn_idx].init_qp_attr(e.IBV_QPS_RTR)
+            qp.to_rtr(attr)
+            if not self.passive:
+                # The passive QP is DCT which should stay in RTR state.
+                self.remote_ah = attr.ah_attr
+                attr, _ = cmids[conn_idx].init_qp_attr(e.IBV_QPS_RTS)
+                qp.to_rts(attr)
+
+    def create_conn_param(self, qp_num=0, conn_idx=0):
+        if conn_idx and self.passive:
+            try:
+                ctx = self.child_id.context
+                self.reserved_qp_num = Mlx5Context.reserved_qpn_alloc(ctx)
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Alloc reserved QP number is not supported')
+                raise ex
+            qp_num = self.reserved_qp_num
+        else:
+            qp_num = self.qps[conn_idx].qp_num
+        return ConnParam(qp_num=qp_num)
+
+
+class Mlx5CMTestCase(RDMACMBaseTest):
+    """
+    Mlx5 RDMACM test class.
+    """
+    def test_rdmacm_async_traffic_dc_external_qp(self):
+        """
+        Connect multiple RDMACM connections using DC as an external QP for
+        traffic.
+        """
+        self.two_nodes_rdmacm_traffic(DcCMConnection, self.rdmacm_traffic,
+                                      with_ext_qp=True, num_conns=2)

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -16,7 +16,14 @@ NUM_OF_PROCESSES = 2
 MC_IP_PREFIX = '230'
 
 
-class CMTestCase(RDMATestCase):
+class RDMACMBaseTest(RDMATestCase):
+    """
+    Base RDMACM test class.
+    This class does not include any test, but rather implements generic
+    connection and traffic methods that are needed by RDMACM tests in general.
+    Each RDMACM test should have a class that inherits this class and extends
+    its functionalities if needed.
+    """
     def setUp(self):
         super().setUp()
         if not self.ip_addr:
@@ -153,6 +160,10 @@ class CMTestCase(RDMATestCase):
             self.notifier.put((ex, side))
 
 
+class CMTestCase(RDMACMBaseTest):
+    """
+    RDMACM Test class. Include all the native RDMACM functionalities.
+    """
     def test_rdmacm_sync_traffic(self):
         self.two_nodes_rdmacm_traffic(CMSyncConnection, self.rdmacm_traffic)
 

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -101,9 +101,7 @@ class CMTestCase(RDMATestCase):
             player.disconnect()
         except Exception as ex:
             side = 'passive' if passive else 'active'
-            self.notifier.put('Caught exception in {side} side process: pid '
-                              '{pid}\n'.format(side=side, pid=os.getpid()) +
-                              'Exception message: {ex}'.format(ex=str(ex)))
+            self.notifier.put((ex, side))
 
     def rdmacm_multicast_traffic(self, connection_resources=None, passive=None,
                                  extended=False, **kwargs):
@@ -127,9 +125,7 @@ class CMTestCase(RDMATestCase):
             player.leave_multicast(mc_addr=mc_addr)
         except Exception as ex:
             side = 'passive' if passive else 'active'
-            self.notifier.put('Caught exception in {side} side process: pid {pid}\n'
-                        .format(side=side, pid=os.getpid()) +
-                        'Exception message: {ex}'.format(ex=str(ex)))
+            self.notifier.put((ex, side))
 
     def rdmacm_remote_traffic(self, connection_resources=None, passive=None,
                               remote_op='write', **kwargs):
@@ -154,9 +150,7 @@ class CMTestCase(RDMATestCase):
             while not self.notifier.empty():
                 self.notifier.get()
             side = 'passive' if passive else 'active'
-            msg = f'Caught exception in {side} side process: pid {os.getpid()}\n' \
-                  f'Exception message: {str(ex)}'
-            self.notifier.put(msg)
+            self.notifier.put((ex, side))
 
 
     def test_rdmacm_sync_traffic(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -395,7 +395,7 @@ def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
         qp.wr_set_ud_addr(ah, agr_obj.rqps_num[qp_idx], agr_obj.SRD_QKEY)
     if qp_type == e.IBV_QPT_XRC_SEND:
         qp.wr_set_xrc_srqn(agr_obj.remote_srqn)
-    if isinstance(agr_obj, Mlx5DcResources):
+    if hasattr(agr_obj, 'remote_dct_num'):
         qp.wr_set_dc_addr(ah, agr_obj.remote_dct_num, DCT_KEY)
     qp.wr_set_sge(send_object)
     qp.wr_complete()


### PR DESCRIPTION
This series exposes DV APIs to allocate/deallocate reserved QPNs over DEVX.

When working with RDMA-CM over TCP_PS and external QP support, a client node needs GUID level unique QP numbers to comply with the CM's timewait logic.

If a real unique QP is not allocated, a device global QPN value is required and can be allocated via this interface.
The mlx5 DCI QP is such an example.

The series includes also some pyverbs fixes and tests in the RDMA-CM area to use those new DV APIs.