### PR TITLE
redhat/spec: Don't trigger udev if socket doesn't exist

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -346,7 +346,7 @@ rm -rf %{buildroot}/%{_initrddir}/
 rm -f %{buildroot}/%{_sbindir}/srp_daemon.sh
 
 %post -n rdma-core
-if [ -x /sbin/udevadm ]; then
+if [ -x /sbin/udevadm ] && [ -S /run/udev/control ]; then
 /sbin/udevadm trigger --subsystem-match=infiniband --action=change || true
 /sbin/udevadm trigger --subsystem-match=net --action=change || true
 /sbin/udevadm trigger --subsystem-match=infiniband_mad --action=change || true


### PR DESCRIPTION
On rpm-ostree systems, we don't want scriptlets to affect the running
system because a major part of the value is "background updates".
Scriptlets are run in a containerized environment where e.g. udev is not
available.

Add a check for the udev socket before triggering it to handle this.
This also helps the container use case.

This doesn't break rpm-ostree strictly, because it uses `|| true`, but
it still spams error messages during the compose. I kept the `|| true`
to be safe, but it's likely fine to remove them now.

See also: https://bugzilla.redhat.com/show_bug.cgi?id=1352154
See also: https://src.fedoraproject.org/rpms/udisks2/pull-request/3
See also: https://github.com/coreos/fedora-coreos-tracker/issues/703