### PR TITLE
verbs: Fix possible port loop overflow

### DIFF
--- a/ibacm/src/acme.c
+++ b/ibacm/src/acme.c
@@ -461,7 +461,7 @@ static int gen_addr_names(FILE *f)
 	struct ibv_port_attr port_attr;
 	int i, index, ret, found_active;
 	char host_name[256];
-	uint8_t p;
+	uint32_t p;
 
 	ret = gethostname(host_name, sizeof host_name);
 	if (ret) {
@@ -481,17 +481,17 @@ static int gen_addr_names(FILE *f)
 			if (!found_active) {
 				ret = ibv_query_port(verbs[i], p, &port_attr);
 				if (!ret && port_attr.state == IBV_PORT_ACTIVE) {
-					VPRINT("%s %s %d default\n",
+					VPRINT("%s %s %u default\n",
 						host_name, verbs[i]->device->name, p);
-					fprintf(f, "%s %s %d default\n",
+					fprintf(f, "%s %s %u default\n",
 						host_name, verbs[i]->device->name, p);
 					found_active = 1;
 				}
 			}
 
-			VPRINT("%s-%d %s %d default\n",
+			VPRINT("%s-%d %s %u default\n",
 				host_name, index, verbs[i]->device->name, p);
-			fprintf(f, "%s-%d %s %d default\n",
+			fprintf(f, "%s-%d %s %u default\n",
 				host_name, index++, verbs[i]->device->name, p);
 		}
 	}

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -198,7 +198,7 @@ static void print_formated_gid(union ibv_gid *gid, int i,
 
 static int print_all_port_gids(struct ibv_context *ctx,
 			       struct ibv_port_attr *port_attr,
-			       uint8_t port_num)
+			       uint32_t port_num)
 {
 	enum ibv_gid_type_sysfs type;
 	union ibv_gid gid;
@@ -210,7 +210,7 @@ static int print_all_port_gids(struct ibv_context *ctx,
 	for (i = 0; i < tbl_len; i++) {
 		rc = ibv_query_gid(ctx, port_num, i, &gid);
 		if (rc) {
-			fprintf(stderr, "Failed to query gid to port %d, index %d\n",
+			fprintf(stderr, "Failed to query gid to port %u, index %d\n",
 			       port_num, i);
 			return rc;
 		}
@@ -499,7 +499,7 @@ static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)
 	struct ibv_device_attr_ex device_attr = {};
 	struct ibv_port_attr port_attr;
 	int rc = 0;
-	uint8_t port;
+	uint32_t port;
 	char buf[256];
 
 	ctx = ibv_open_device(ib_dev);
@@ -618,7 +618,7 @@ static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)
 			fprintf(stderr, "Failed to query port %u props\n", port);
 			goto cleanup;
 		}
-		printf("\t\tport:\t%d\n", port);
+		printf("\t\tport:\t%u\n", port);
 		printf("\t\t\tstate:\t\t\t%s (%d)\n",
 		       port_state_str(port_attr.state), port_attr.state);
 		printf("\t\t\tmax_mtu:\t\t%s (%d)\n",


### PR DESCRIPTION
This series includes two fixes to prevent a possible port loop overflow when calling ibv_query_port().