### PR TITLE
Dma-buf related fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -515,6 +515,20 @@ find_package(Systemd)
 include_directories(${SYSTEMD_INCLUDE_DIRS})
 RDMA_DoFixup("${SYSTEMD_FOUND}" "systemd/sd-daemon.h")
 
+# drm headers
+
+# Check if the headers have been installed by kernel-headers
+find_path(DRM_INCLUDE_DIRS "drm.h" PATH_SUFFIXES "drm")
+
+# Alternatively the headers could have been installed by libdrm
+if (NOT DRM_INCLUDE_DIRS)
+  pkg_check_modules(DRM libdrm)
+endif()
+
+if (DRM_INCLUDE_DIRS)
+  include_directories(${DRM_INCLUDE_DIRS})
+endif()
+
 #-------------------------
 # Apply fixups
 
@@ -785,4 +799,7 @@ if (NOT HAVE_GLIBC_UAPI_COMPAT)
 endif()
 if (NOT HAVE_TARGET_SSE)
   message(STATUS " attribute(target(\"sse\")) does NOT work")
+endif()
+if (NOT DRM_INCLUDE_DIRS)
+  message(STATUS " DMABUF NOT supported (disabling some tests)")
 endif()

--- a/libibverbs/cmd_mr.c
+++ b/libibverbs/cmd_mr.c
@@ -149,7 +149,7 @@ int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 	vmr->ibv_mr.lkey = lkey;
 	vmr->ibv_mr.rkey = rkey;
 	vmr->ibv_mr.pd = pd;
-	vmr->ibv_mr.addr = (void *)offset;
+	vmr->ibv_mr.addr = (void *)(uintptr_t)offset;
 	vmr->ibv_mr.length = length;
 	vmr->mr_type = IBV_MR_TYPE_DMABUF_MR;
 	return 0;

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -384,7 +384,7 @@ struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 
 	mr->context = pd->context;
 	mr->pd = pd;
-	mr->addr = (void *)offset;
+	mr->addr = (void *)(uintptr_t)offset;
 	mr->length = length;
 	return mr;
 }

--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -6,6 +6,12 @@ publish_internal_headers(""
   dmabuf_alloc.h
 )
 
+if (DRM_INCLUDE_DIRS)
+  set(DMABUF_ALLOC dmabuf_alloc.c)
+else()
+  set(DMABUF_ALLOC dmabuf_alloc_stub.c)
+endif()
+
 rdma_cython_module(pyverbs ""
   addr.pyx
   base.pyx
@@ -14,7 +20,7 @@ rdma_cython_module(pyverbs ""
   cq.pyx
   device.pyx
   dmabuf.pyx
-  dmabuf_alloc.c
+  ${DMABUF_ALLOC}
   enums.pyx
   mem_alloc.pyx
   mr.pyx

--- a/pyverbs/dmabuf.pyx
+++ b/pyverbs/dmabuf.pyx
@@ -12,7 +12,7 @@ from pyverbs.mr cimport DmaBufMR
 cdef extern from "dmabuf_alloc.h":
     cdef struct dmabuf:
         pass
-    dmabuf *dmabuf_alloc(unsigned long size, int unit, int gtt)
+    dmabuf *dmabuf_alloc(unsigned long size, int gpu, int gtt)
     void dmabuf_free(dmabuf *dmabuf)
     int dmabuf_get_drm_fd(dmabuf *dmabuf)
     int dmabuf_get_fd(dmabuf *dmabuf)
@@ -20,20 +20,20 @@ cdef extern from "dmabuf_alloc.h":
 
 
 cdef class DmaBuf:
-    def __init__(self, size, unit=0, gtt=0):
+    def __init__(self, size, gpu=0, gtt=0):
         """
         Allocate DmaBuf object from a GPU device. This is done through the
         DRI device interface. Usually this requires the effective user id
         being a member of the 'render' group.
         :param size: The size (in number of bytes) of the buffer.
-        :param unit: The unit number of the GPU to allocate the buffer from.
-        :param gtt: Allocate from GTT instead of VRAM.
+        :param gpu: The GPU unit to allocate the buffer from.
+        :param gtt: Allocate from GTT (Graphics Translation Table) instead of VRAM.
         :return: The newly created DmaBuf object on success.
         """
         self.dmabuf_mrs = weakref.WeakSet()
-        self.dmabuf = dmabuf_alloc(size, unit, gtt)
+        self.dmabuf = dmabuf_alloc(size, gpu, gtt)
         if self.dmabuf == NULL:
-            raise PyverbsRDMAErrno(f'Failed to allocate dmabuf of size {size} on unit {unit}')
+            raise PyverbsRDMAErrno(f'Failed to allocate dmabuf of size {size} on gpu {gpu}')
         self.drm_fd = dmabuf_get_drm_fd(<dmabuf *>self.dmabuf)
         self.fd = dmabuf_get_fd(<dmabuf *>self.dmabuf)
         self.map_offset = dmabuf_get_offset(<dmabuf *>self.dmabuf)

--- a/pyverbs/dmabuf_alloc.c
+++ b/pyverbs/dmabuf_alloc.c
@@ -95,7 +95,7 @@ static int amdgpu_mmap_offset(struct drm *drm, uint32_t handle,
 	return 0;
 }
 
-static struct drm *drm_open(int unit)
+static struct drm *drm_open(int gpu)
 {
 	char path[32];
 	struct drm_version version = {};
@@ -107,7 +107,7 @@ static struct drm *drm_open(int unit)
 	if (!drm)
 		return NULL;
 
-	snprintf(path, sizeof(path), "/dev/dri/renderD%d", unit + 128);
+	snprintf(path, sizeof(path), "/dev/dri/renderD%d", gpu + 128);
 
 	drm->fd = open(path, O_RDWR);
 	if (drm->fd < 0)
@@ -204,10 +204,10 @@ struct dmabuf {
 /*
  * dmabuf_alloc - allocate a dmabuf from GPU
  * @size - byte size of the buffer to allocate
- * @unit - the GPU unit to use
- * @gtt - if true, allocate from GTT instead of VRAM
+ * @gpu - the GPU unit to use
+ * @gtt - if true, allocate from GTT (Graphics Translation Table) instead of VRAM
  */
-struct dmabuf *dmabuf_alloc(uint64_t size, int unit, int gtt)
+struct dmabuf *dmabuf_alloc(uint64_t size, int gpu, int gtt)
 {
 	struct dmabuf *dmabuf;
 	int err;
@@ -216,7 +216,7 @@ struct dmabuf *dmabuf_alloc(uint64_t size, int unit, int gtt)
 	if (!dmabuf)
 		return NULL;
 
-	dmabuf->drm = drm_open(unit);
+	dmabuf->drm = drm_open(gpu);
 	if (!dmabuf->drm)
 		goto out_free;
 

--- a/pyverbs/dmabuf_alloc.c
+++ b/pyverbs/dmabuf_alloc.c
@@ -9,12 +9,12 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
-#include <drm/drm.h>
-#include <drm/i915_drm.h>
-#include <drm/amdgpu_drm.h>
-#include <drm/radeon_drm.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <drm.h>
+#include <i915_drm.h>
+#include <amdgpu_drm.h>
+#include <radeon_drm.h>
 #include "dmabuf_alloc.h"
 
 /*

--- a/pyverbs/dmabuf_alloc.h
+++ b/pyverbs/dmabuf_alloc.h
@@ -10,7 +10,7 @@
 
 struct dmabuf;
 
-struct dmabuf *dmabuf_alloc(uint64_t size, int unit, int gtt);
+struct dmabuf *dmabuf_alloc(uint64_t size, int gpu, int gtt);
 void dmabuf_free(struct dmabuf *dmabuf);
 int dmabuf_get_drm_fd(struct dmabuf *dmabuf);
 int dmabuf_get_fd(struct dmabuf *dmabuf);

--- a/pyverbs/dmabuf_alloc_stub.c
+++ b/pyverbs/dmabuf_alloc_stub.c
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-2.0 OR Linux-OpenIB
+/*
+ * Copyright 2021 Intel Corporation. All rights reserved. See COPYING file
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <errno.h>
+#include "dmabuf_alloc.h"
+
+struct dmabuf *dmabuf_alloc(uint64_t size, int gpu, int gtt)
+{
+	errno = EOPNOTSUPP;
+	return NULL;
+}
+
+void dmabuf_free(struct dmabuf *dmabuf)
+{
+	errno = EOPNOTSUPP;
+}
+
+int dmabuf_get_drm_fd(struct dmabuf *dmabuf)
+{
+	errno = EOPNOTSUPP;
+	return -1;
+}
+
+int dmabuf_get_fd(struct dmabuf *dmabuf)
+{
+	errno = EOPNOTSUPP;
+	return -1;
+}
+
+uint64_t dmabuf_get_offset(struct dmabuf *dmabuf)
+{
+	errno = EOPNOTSUPP;
+	return -1;
+}
+

--- a/pyverbs/mr.pyx
+++ b/pyverbs/mr.pyx
@@ -384,7 +384,7 @@ cdef class DMMR(MR):
 
 cdef class DmaBufMR(MR):
     def __init__(self, PD pd not None, length, access, DmaBuf dmabuf=None,
-                 offset=0, unit=0, gtt=0):
+                 offset=0, gpu=0, gtt=0):
         """
         Initializes a DmaBufMR (DMA-BUF Memory Region) of the given length
         and access flags using the given PD and DmaBuf objects.
@@ -393,14 +393,14 @@ cdef class DmaBufMR(MR):
         :param access: Access flags, see ibv_access_flags enum
         :param dmabuf: A DmaBuf object. One will be allocated if absent
         :param offset: Byte offset from the beginning of the dma-buf
-        :param unit: GPU unit for internal dmabuf allocation
+        :param gpu: GPU unit for internal dmabuf allocation
         :param gtt: If true allocate internal dmabuf from GTT instead of VRAM
         :return: The newly created DMABUFMR
         """
         self.logger = logging.getLogger(self.__class__.__name__)
         if dmabuf is None:
             self.is_dmabuf_internal = True
-            dmabuf = DmaBuf(length + offset, unit, gtt)
+            dmabuf = DmaBuf(length + offset, gpu, gtt)
         self.mr = v.ibv_reg_dmabuf_mr(pd.pd, offset, length, offset, dmabuf.fd, access)
         if self.mr == NULL:
             raise PyverbsRDMAErrno(f'Failed to register a dma-buf MR. length: {length}, access flags: {access}')

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -429,14 +429,14 @@ class DMMRTest(PyverbsAPITestCase):
                         dm_mr.close()
 
 
-def check_dmabuf_support(unit=0):
+def check_dmabuf_support(gpu=0):
     """
     Check if dma-buf allocation is supported by the system.
     Skip the test on failure.
     """
-    device_num = 128 + unit
+    device_num = 128 + gpu
     try:
-        DmaBuf(1, unit=unit)
+        DmaBuf(1, gpu=gpu)
     except PyverbsRDMAError as ex:
         if ex.error_code == errno.ENOENT:
             raise unittest.SkipTest(f'Device /dev/dri/renderD{device_num} is not present')
@@ -446,13 +446,13 @@ def check_dmabuf_support(unit=0):
             raise unittest.SkipTest(f'Allocating dmabuf is not supported by /dev/dri/renderD{device_num}')
 
 
-def check_dmabuf_mr_support(pd, unit=0):
+def check_dmabuf_mr_support(pd, gpu=0):
     """
     Check if dma-buf MR registration is supported by the driver.
     Skip the test on failure
     """
     try:
-        DmaBufMR(pd, 1, 0, unit=unit)
+        DmaBufMR(pd, 1, 0, gpu=gpu)
     except PyverbsRDMAError as ex:
         if ex.error_code == errno.EOPNOTSUPP:
             raise unittest.SkipTest('Reg dma-buf MR is not supported by the RDMA driver')
@@ -464,22 +464,22 @@ class DmaBufMRTest(PyverbsAPITestCase):
     """
     def setUp(self):
         super().setUp()
-        self.unit = self.config['gpu']
+        self.gpu = self.config['gpu']
         self.gtt = self.config['gtt']
 
     def test_dmabuf_reg_mr(self):
         """
         Test ibv_reg_dmabuf_mr()
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 flags = u.get_dmabuf_access_flags(ctx)
                 for f in flags:
                     len = u.get_mr_length()
                     for off in [0, len//2]:
-                        with DmaBufMR(pd, len, f, offset=off, unit=self.unit,
+                        with DmaBufMR(pd, len, f, offset=off, gpu=self.gpu,
                                       gtt=self.gtt) as mr:
                             pass
 
@@ -487,15 +487,15 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Test ibv_dereg_mr() with DmaBufMR
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 flags = u.get_dmabuf_access_flags(ctx)
                 for f in flags:
                     len = u.get_mr_length()
                     for off in [0, len//2]:
-                        with DmaBufMR(pd, len, f, offset=off, unit=self.unit,
+                        with DmaBufMR(pd, len, f, offset=off, gpu=self.gpu,
                                       gtt=self.gtt) as mr:
                             mr.close()
 
@@ -503,15 +503,15 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Verify that explicit call to DmaBufMR's close() doesn't fail
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 flags = u.get_dmabuf_access_flags(ctx)
                 for f in flags:
                     len = u.get_mr_length()
                     for off in [0, len//2]:
-                        with DmaBufMR(pd, len, f, offset=off, unit=self.unit,
+                        with DmaBufMR(pd, len, f, offset=off, gpu=self.gpu,
                                       gtt=self.gtt) as mr:
                             # Pyverbs supports multiple destruction of objects,
                             # we are not expecting an exception here.
@@ -522,10 +522,10 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Verify that illegal flags combination fails as expected
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 for i in range(5):
                     flags = random.sample([e.IBV_ACCESS_REMOTE_WRITE,
                                            e.IBV_ACCESS_REMOTE_ATOMIC],
@@ -535,7 +535,7 @@ class DmaBufMRTest(PyverbsAPITestCase):
                         mr_flags += i.value
                     try:
                         DmaBufMR(pd, u.get_mr_length(), mr_flags,
-                                 unit=self.unit, gtt=self.gtt)
+                                 gpu=self.gpu, gtt=self.gtt)
                     except PyverbsRDMAError as err:
                         assert 'Failed to register a dma-buf MR' in err.args[0]
                     else:
@@ -545,17 +545,17 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Test writing to DmaBufMR's buffer
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 for i in range(10):
                     mr_len = u.get_mr_length()
                     flags = u.get_dmabuf_access_flags(ctx)
                     for f in flags:
                         for mr_off in [0, mr_len//2]:
                             with DmaBufMR(pd, mr_len, f, offset=mr_off,
-                                          unit=self.unit, gtt=self.gtt) as mr:
+                                          gpu=self.gpu, gtt=self.gtt) as mr:
                                 write_len = min(random.randint(1, MAX_IO_LEN),
                                                 mr_len)
                                 mr.write('a' * write_len, write_len)
@@ -564,17 +564,17 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Test reading from DmaBufMR's buffer
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 for i in range(10):
                     mr_len = u.get_mr_length()
                     flags = u.get_dmabuf_access_flags(ctx)
                     for f in flags:
                         for mr_off in [0, mr_len//2]:
                             with DmaBufMR(pd, mr_len, f, offset=mr_off,
-                                          unit=self.unit, gtt=self.gtt) as mr:
+                                          gpu=self.gpu, gtt=self.gtt) as mr:
                                 write_len = min(random.randint(1, MAX_IO_LEN),
                                                 mr_len)
                                 write_str = 'a' * write_len
@@ -588,14 +588,14 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Test reading lkey property
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 length = u.get_mr_length()
                 flags = u.get_dmabuf_access_flags(ctx)
                 for f in flags:
-                    with DmaBufMR(pd, length, f, unit=self.unit,
+                    with DmaBufMR(pd, length, f, gpu=self.gpu,
                                   gtt=self.gtt) as mr:
                         mr.lkey
 
@@ -603,38 +603,38 @@ class DmaBufMRTest(PyverbsAPITestCase):
         """
         Test reading rkey property
         """
-        check_dmabuf_support(self.unit)
+        check_dmabuf_support(self.gpu)
         for ctx, attr, attr_ex in self.devices:
             with PD(ctx) as pd:
-                check_dmabuf_mr_support(pd, self.unit)
+                check_dmabuf_mr_support(pd, self.gpu)
                 length = u.get_mr_length()
                 flags = u.get_dmabuf_access_flags(ctx)
                 for f in flags:
-                    with DmaBufMR(pd, length, f, unit=self.unit,
+                    with DmaBufMR(pd, length, f, gpu=self.gpu,
                                   gtt=self.gtt) as mr:
                         mr.rkey
 
 
 class DmaBufRC(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index, unit, gtt):
+    def __init__(self, dev_name, ib_port, gid_index, gpu, gtt):
         """
         Initialize an DmaBufRC object.
         :param dev_name: Device name to be used
         :param ib_port: IB port of the device to use
         :param gid_index: Which GID index to use
-        :param unit: GPU unit to allocate dmabuf from
+        :param gpu: GPU unit to allocate dmabuf from
         :gtt: Allocate dmabuf from GTT instead og VRAM
         """
-        self.unit = unit
+        self.gpu = gpu
         self.gtt = gtt
         super(DmaBufRC, self).__init__(dev_name=dev_name, ib_port=ib_port,
                                        gid_index=gid_index)
 
     def create_mr(self):
-        check_dmabuf_support(self.unit)
-        check_dmabuf_mr_support(self.pd, self.unit)
+        check_dmabuf_support(self.gpu)
+        check_dmabuf_mr_support(self.pd, self.gpu)
         access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
-        mr = DmaBufMR(self.pd, self.msg_size, access, unit=self.unit,
+        mr = DmaBufMR(self.pd, self.msg_size, access, gpu=self.gpu,
                       gtt=self.gtt)
         self.mr = mr
 
@@ -649,7 +649,7 @@ class DmaBufTestCase(RDMATestCase):
     def setUp(self):
         super(DmaBufTestCase, self).setUp()
         self.iters = 100
-        self.unit = self.config['gpu']
+        self.gpu = self.config['gpu']
         self.gtt = self.config['gtt']
 
     def create_players(self, resource, **resource_arg):
@@ -671,7 +671,7 @@ class DmaBufTestCase(RDMATestCase):
         """
         Test send/recv using dma-buf MR over RC
         """
-        client, server = self.create_players(DmaBufRC, unit=self.unit,
+        client, server = self.create_players(DmaBufRC, gpu=self.gpu,
                                              gtt=self.gtt)
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
@@ -679,7 +679,7 @@ class DmaBufTestCase(RDMATestCase):
         """
         Test rdma write using dma-buf MR
         """
-        client, server = self.create_players(DmaBufRC, unit=self.unit,
+        client, server = self.create_players(DmaBufRC, gpu=self.gpu,
                                              gtt=self.gtt)
         server.rkey = client.mr.rkey
         server.remote_addr = client.mr.offset


### PR DESCRIPTION
This series fixes a few issues related to the dma-buf support. It consists
of three patches. The first patch fixes a compilation warning for 32-bit 
builds. Patch 2 renames a function parameter and expands an abbreviation.   
Patch 3 adds check for DRM headers. 