### PR TITLE
tests: Statically choose default device for tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -180,7 +180,7 @@ class RDMATestCase(unittest.TestCase):
     def setUp(self):
         """
         Verify that the test case has dev_name, ib_port, gid_index and pkey index.
-        If not provided by the user, a random valid combination will be used.
+        If not provided by the user, the first valid combination will be used.
         """
         if self.pkey_index is None:
             # To avoid iterating the entire pkeys table, if a pkey index wasn't
@@ -258,9 +258,9 @@ class RDMATestCase(unittest.TestCase):
             if arg[3]:
                 args_with_inet_ip.append(arg)
         if args_with_inet_ip:
-            args = random.choice(args_with_inet_ip)
+            args = args_with_inet_ip[0]
         else:
-            args = random.choice(self.args)
+            args = self.args[0]
         self.dev_name = args[0]
         self.ib_port = args[1]
         self.gid_index = args[2]

--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -37,49 +37,46 @@ class AHTest(PyverbsAPITestCase):
         """
         Test ibv_create_ah.
         """
-        for ctx, _, _ in self.devices:
-            self.verify_state(ctx)
-            gr = u.get_global_route(ctx, port_num=self.ib_port)
-            ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
-            pd = PD(ctx)
-            try:
-                AH(pd, attr=ah_attr)
-            except PyverbsRDMAError as ex:
-                if ex.error_code == errno.EOPNOTSUPP:
-                    raise unittest.SkipTest('Create AH is not supported')
-                raise ex
+        self.verify_state(self.ctx)
+        gr = u.get_global_route(self.ctx, port_num=self.ib_port)
+        ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
+        pd = PD(self.ctx)
+        try:
+            AH(pd, attr=ah_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create AH is not supported')
+            raise ex
 
     def test_create_ah_roce(self):
         """
         Verify that AH can't be created without GRH in RoCE
         """
-        for ctx, _, _ in self.devices:
-            self.verify_link_layer_ether(ctx)
-            self.verify_state(ctx)
-            pd = PD(ctx)
-            ah_attr = AHAttr(is_global=0, port_num=self.ib_port)
-            try:
-                AH(pd, attr=ah_attr)
-            except PyverbsRDMAError as ex:
-                if ex.error_code == errno.EOPNOTSUPP:
-                    raise unittest.SkipTest('Create AH is not supported')
-                assert 'Failed to create AH' in str(ex)
-            else:
-                raise PyverbsError(f'Successfully created a non-global AH on RoCE port={self.ib_port}')
+        self.verify_link_layer_ether(self.ctx)
+        self.verify_state(self.ctx)
+        pd = PD(self.ctx)
+        ah_attr = AHAttr(is_global=0, port_num=self.ib_port)
+        try:
+            AH(pd, attr=ah_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create AH is not supported')
+            assert 'Failed to create AH' in str(ex)
+        else:
+            raise PyverbsError(f'Successfully created a non-global AH on RoCE port={self.ib_port}')
 
     def test_destroy_ah(self):
         """
         Test ibv_destroy_ah.
         """
-        for ctx, _, _ in self.devices:
-            self.verify_state(ctx)
-            gr = u.get_global_route(ctx, port_num=self.ib_port)
-            ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
-            pd = PD(ctx)
-            try:
-                with AH(pd, attr=ah_attr) as ah:
-                    ah.close()
-            except PyverbsRDMAError as ex:
-                if ex.error_code == errno.EOPNOTSUPP:
-                    raise unittest.SkipTest('Create AH is not supported')
-                raise ex
+        self.verify_state(self.ctx)
+        gr = u.get_global_route(self.ctx, port_num=self.ib_port)
+        ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
+        pd = PD(self.ctx)
+        try:
+            with AH(pd, attr=ah_attr) as ah:
+                ah.close()
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create AH is not supported')
+            raise ex

--- a/tests/test_cq.py
+++ b/tests/test_cq.py
@@ -40,11 +40,9 @@ class CQAPITest(PyverbsAPITestCase):
     """
     def setUp(self):
         super().setUp()
-        self.ctx, attr, _ = self.devices[0]
-        self.max_cqe = attr.max_cqe
 
     def test_create_cq(self):
-        for cq_size in [1, self.max_cqe/2, self.max_cqe]:
+        for cq_size in [1, self.attr.max_cqe/2, self.attr.max_cqe]:
             for comp_vector in range(0, min(2, self.ctx.num_comp_vectors)):
                 try:
                     cq = CQ(self.ctx, cq_size, None, None, comp_vector)
@@ -59,7 +57,7 @@ class CQAPITest(PyverbsAPITestCase):
 
 
     def test_create_cq_with_comp_channel(self):
-        for cq_size in [1, self.max_cqe/2, self.max_cqe]:
+        for cq_size in [1, self.attr.max_cqe/2, self.attr.max_cqe]:
             cc = CompChannel(self.ctx)
             CQ(self.ctx, cq_size, None, cc, 0)
             cc.close()
@@ -69,7 +67,7 @@ class CQAPITest(PyverbsAPITestCase):
         Test ibv_create_cq() with wrong comp_vector / number of cqes
         """
         with self.assertRaises(PyverbsRDMAError) as ex:
-            CQ(self.ctx, self.max_cqe + 1, None, None, 0)
+            CQ(self.ctx, self.attr.max_cqe + 1, None, None, 0)
         self.assertEqual(ex.exception.error_code, errno.EINVAL)
 
         with self.assertRaises(PyverbsRDMAError) as ex:

--- a/tests/test_cqex.py
+++ b/tests/test_cqex.py
@@ -84,7 +84,6 @@ class CQEXAPITest(PyverbsAPITestCase):
     """
     def setUp(self):
         super().setUp()
-        self.ctx, self.attr, self.attr_ex = self.devices[0]
         self.max_cqe = self.attr.max_cqe
 
     def test_create_cq_ex(self):

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -27,16 +27,15 @@ class EfaQueryDeviceTest(PyverbsAPITestCase):
         """
         Verify that it's possible to read EFA direct-verbs.
         """
-        for ctx, attr, attr_ex in self.devices:
-            with efa.EfaContext(name=ctx.name) as efa_ctx:
-                try:
-                    efa_attrs = efa_ctx.query_efa_device()
-                    if self.config['verbosity']:
-                        print(f'\n{efa_attrs}')
-                except PyverbsRDMAError as ex:
-                    if ex.error_code == errno.EOPNOTSUPP:
-                        raise unittest.SkipTest('Not supported on non EFA devices')
-                    raise ex
+        with efa.EfaContext(name=self.ctx.name) as efa_ctx:
+            try:
+                efa_attrs = efa_ctx.query_efa_device()
+                if self.config['verbosity']:
+                    print(f'\n{efa_attrs}')
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest('Not supported on non EFA devices')
+                raise ex
 
 
 class EfaAHTest(PyverbsAPITestCase):
@@ -47,19 +46,18 @@ class EfaAHTest(PyverbsAPITestCase):
         """
         Test efadv_query_ah()
         """
-        for ctx, attr, attr_ex in self.devices:
-            pd = PD(ctx)
-            try:
-                gr = u.get_global_route(ctx, port_num=self.ib_port)
-                ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
-                ah = efa.EfaAH(pd, attr=ah_attr)
-                query_ah_attr = ah.query_efa_ah()
-                if self.config['verbosity']:
-                    print(f'\n{query_ah_attr}')
-            except PyverbsRDMAError as ex:
-                if ex.error_code == errno.EOPNOTSUPP:
-                    raise unittest.SkipTest('Not supported on non EFA devices')
-                raise ex
+        pd = PD(self.ctx)
+        try:
+            gr = u.get_global_route(self.ctx, port_num=self.ib_port)
+            ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
+            ah = efa.EfaAH(pd, attr=ah_attr)
+            query_ah_attr = ah.query_efa_ah()
+            if self.config['verbosity']:
+                print(f'\n{query_ah_attr}')
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Not supported on non EFA devices')
+            raise ex
 
 
 class EfaQPTest(PyverbsAPITestCase):
@@ -70,17 +68,16 @@ class EfaQPTest(PyverbsAPITestCase):
         """
         Test efadv_create_driver_qp()
         """
-        for ctx, attr, attr_ex in self.devices:
-            with PD(ctx) as pd:
-                with CQ(ctx, 100) as cq:
-                    qia = u.get_qp_init_attr(cq, attr)
-                    qia.qp_type = e.IBV_QPT_DRIVER
-                    try:
-                        qp = efa.SRDQP(pd, qia)
-                    except PyverbsRDMAError as ex:
-                        if ex.error_code == errno.EOPNOTSUPP:
-                            raise unittest.SkipTest("Create SRD QP is not supported")
-                        raise ex
+        with PD(self.ctx) as pd:
+            with CQ(self.ctx, 100) as cq:
+                qia = u.get_qp_init_attr(cq, self.attr)
+                qia.qp_type = e.IBV_QPT_DRIVER
+                try:
+                    qp = efa.SRDQP(pd, qia)
+                except PyverbsRDMAError as ex:
+                    if ex.error_code == errno.EOPNOTSUPP:
+                        raise unittest.SkipTest("Create SRD QP is not supported")
+                    raise ex
 
 
 class EfaQPExTest(PyverbsAPITestCase):
@@ -91,18 +88,17 @@ class EfaQPExTest(PyverbsAPITestCase):
         """
         Test efadv_create_qp_ex()
         """
-        for ctx, attr, attr_ex in self.devices:
-            with PD(ctx) as pd:
-                with CQ(ctx, 100) as cq:
-                    qiaEx = get_qp_init_attr_ex(cq, pd, attr)
-                    efaqia = efa.EfaQPInitAttr()
-                    efaqia.driver_qp_type = efa_e.EFADV_QP_DRIVER_TYPE_SRD
-                    try:
-                        qp = efa.SRDQPEx(ctx, qiaEx, efaqia)
-                    except PyverbsRDMAError as ex:
-                        if ex.error_code == errno.EOPNOTSUPP:
-                            raise unittest.SkipTest("Create SRD QPEx is not supported")
-                        raise ex
+        with PD(self.ctx) as pd:
+            with CQ(self.ctx, 100) as cq:
+                qiaEx = get_qp_init_attr_ex(cq, pd, self.attr)
+                efaqia = efa.EfaQPInitAttr()
+                efaqia.driver_qp_type = efa_e.EFADV_QP_DRIVER_TYPE_SRD
+                try:
+                    qp = efa.SRDQPEx(self.ctx, qiaEx, efaqia)
+                except PyverbsRDMAError as ex:
+                    if ex.error_code == errno.EOPNOTSUPP:
+                        raise unittest.SkipTest("Create SRD QPEx is not supported")
+                    raise ex
 
 
 def get_random_send_op_flags():

--- a/tests/test_mlx5_rdmacm.py
+++ b/tests/test_mlx5_rdmacm.py
@@ -179,26 +179,25 @@ class ReservedQPTest(PyverbsAPITestCase):
         the test includes bad flows where a fake qpn gets deallocated, and a
         real qpn gets deallocated twice.
         """
-        ctx, _, _ = self.devices[0]
         try:
             # Alloc qp number multiple times.
             qpns = []
             for i in range(1000):
-                qpns.append(Mlx5Context.reserved_qpn_alloc(ctx))
+                qpns.append(Mlx5Context.reserved_qpn_alloc(self.ctx))
             for i in range(1000):
-                Mlx5Context.reserved_qpn_dealloc(ctx, qpns[i])
+                Mlx5Context.reserved_qpn_dealloc(self.ctx, qpns[i])
 
             # Dealloc qp number that was not allocated.
-            qpn = Mlx5Context.reserved_qpn_alloc(ctx)
+            qpn = Mlx5Context.reserved_qpn_alloc(self.ctx)
             with self.assertRaises(PyverbsRDMAError) as ex:
                 fake_qpn = qpn - 1
-                Mlx5Context.reserved_qpn_dealloc(ctx, fake_qpn)
+                Mlx5Context.reserved_qpn_dealloc(self.ctx, fake_qpn)
             self.assertEqual(ex.exception.error_code, errno.EINVAL)
 
             # Try to dealloc same qp number twice.
-            Mlx5Context.reserved_qpn_dealloc(ctx, qpn)
+            Mlx5Context.reserved_qpn_dealloc(self.ctx, qpn)
             with self.assertRaises(PyverbsRDMAError) as ex:
-                Mlx5Context.reserved_qpn_dealloc(ctx, qpn)
+                Mlx5Context.reserved_qpn_dealloc(self.ctx, qpn)
             self.assertEqual(ex.exception.error_code, errno.EINVAL)
 
         except PyverbsRDMAError as ex:

--- a/tests/test_mlx5_sched.py
+++ b/tests/test_mlx5_sched.py
@@ -18,25 +18,24 @@ class Mlx5SchedTest(PyverbsAPITestCase):
         them with schedule leaves. In addition, modify some nodes with
         different BW share and max BW.
         """
-        ctx, _, _ = self.devices[0]
         try:
-            root_node = Mlx5dvSchedNode(ctx, Mlx5dvSchedAttr())
+            root_node = Mlx5dvSchedNode(self.ctx, Mlx5dvSchedAttr())
             # Create a node with only max_avg_bw argument.
             max_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=10,
                                              flags=dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW)
-            max_bw_node = Mlx5dvSchedNode(ctx, max_sched_attr)
+            max_bw_node = Mlx5dvSchedNode(self.ctx, max_sched_attr)
 
             # Create a node with only bw_share argument.
             weighed_sched_attr = Mlx5dvSchedAttr(root_node, bw_share=10,
                                                  flags=dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE)
-            max_bw_node = Mlx5dvSchedNode(ctx, weighed_sched_attr)
+            max_bw_node = Mlx5dvSchedNode(self.ctx, weighed_sched_attr)
 
             # Create a node with max_avg_bw and bw_share arguments.
             mixed_flags = dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW | \
                 dve.MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE
             mixed_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=10, bw_share=2,
                                                flags=mixed_flags)
-            mixed_bw_node = Mlx5dvSchedNode(ctx, mixed_sched_attr)
+            mixed_bw_node = Mlx5dvSchedNode(self.ctx, mixed_sched_attr)
 
             # Modify a node.
             modify_sched_attr = Mlx5dvSchedAttr(root_node, max_avg_bw=4, bw_share=1,
@@ -45,7 +44,7 @@ class Mlx5SchedTest(PyverbsAPITestCase):
 
             # Attach sched leaf to mixed_bw_node
             max_sched_attr = Mlx5dvSchedAttr(mixed_bw_node)
-            sched_leaf = Mlx5dvSchedLeaf(ctx, max_sched_attr)
+            sched_leaf = Mlx5dvSchedLeaf(self.ctx, max_sched_attr)
 
             # Modify a leaf.
             modify_sched_attr = Mlx5dvSchedAttr(mixed_bw_node, max_avg_bw=3, bw_share=3,

--- a/tests/test_pd.py
+++ b/tests/test_pd.py
@@ -17,34 +17,30 @@ class PDTest(PyverbsAPITestCase):
         """
         Test ibv_alloc_pd()
         """
-        for ctx, attr, attr_ex in self.devices:
-            with PD(ctx):
-                pass
+        with PD(self.ctx):
+            pass
 
     def test_dealloc_pd(self):
         """
         Test ibv_dealloc_pd()
         """
-        for ctx, attr, attr_ex in self.devices:
-            with PD(ctx) as pd:
-                pd.close()
+        with PD(self.ctx) as pd:
+            pd.close()
 
     def test_multiple_pd_creation(self):
         """
         Test multiple creations and destructions of a PD object
         """
-        for ctx, attr, attr_ex in self.devices:
-            for i in range(random.randint(1, 200)):
-                with PD(ctx) as pd:
-                    pd.close()
+        for i in range(random.randint(1, 200)):
+            with PD(self.ctx) as pd:
+                pd.close()
 
     def test_destroy_pd_twice(self):
         """
         Test bad flow cases in destruction of a PD object
         """
-        for ctx, attr, attr_ex in self.devices:
-            with PD(ctx) as pd:
-                # Pyverbs supports multiple destruction of objects, we are
-                # not expecting an exception here.
-                pd.close()
-                pd.close()
+        with PD(self.ctx) as pd:
+            # Pyverbs supports multiple destruction of objects, we are
+            # not expecting an exception here.
+            pd.close()
+            pd.close()


### PR DESCRIPTION
Modify the base test classes (PyverbsAPITestCase and RDMATestCase) to statically pick one device by default, in case --dev was not passed.
Tests that were affected by the PyverbsAPITestCase change were modified accordingly to run over the selected device.