### PR TITLE
suse: trigger udev rules after installing rdma-ndd

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -558,6 +558,8 @@ rm -rf %{buildroot}/%{_sbindir}/srp_daemon.sh
 
 %post -n rdma-ndd
 %service_add_post rdma-ndd.service
+# we ship udev rules, so trigger an update.
+%{_bindir}/udevadm trigger --subsystem-match=infiniband --action=change || true
 
 %postun -n rdma-ndd
 %service_del_postun rdma-ndd.service


### PR DESCRIPTION
Without the udev trigger, the node description does not get updated until the next reboot.

Fixes: f5b6677a311a (suse: trigger udev update in post install)
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>