### PR TITLE
kernel-boot: Fix VF lookup

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -338,7 +338,8 @@ static int get_virtfn_info(struct data *d, struct pci_info *p)
 			ret = -ENOMEM;
 			goto err_dir;
 		}
-		if (vf.func == v.func) {
+		if (vf.func == v.func &&
+		    vf.slot == v.slot) {
 			p->vf = atoi(&dent->d_name[6]);
 			break;
 		}


### PR DESCRIPTION
In function get_virtfn_info() we only compared the PCI function
number. That is not enough as we can match with wrong device.
This issue can be seen on systems with a large numbers of VFs.

Fix it by also comparing the PCI slot numbers.

Fixes: 72f852c72a78 ("kernel-boot: Separate PCI fill function")
Signed-off-by: Alaa Hleihel <alaa@nvidia.com>
Reviewed-by: Leon Romanovsky <leonro@nvidia.com>