### PR TITLE
pyverbs: Add flow steering support and tests

### DIFF
--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -22,10 +22,12 @@ rdma_cython_module(pyverbs ""
   dmabuf.pyx
   ${DMABUF_ALLOC}
   enums.pyx
+  flow.pyx
   mem_alloc.pyx
   mr.pyx
   pd.pyx
   qp.pyx
+  spec.pyx
   srq.pyx
   wr.pyx
   xrcd.pyx

--- a/pyverbs/flow.pxd
+++ b/pyverbs/flow.pxd
@@ -1,0 +1,16 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia All rights reserved.
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+cimport pyverbs.libibverbs as v
+
+cdef class FlowAttr(PyverbsObject):
+    cdef v.ibv_flow_attr attr
+    cdef object specs
+
+cdef class Flow(PyverbsCM):
+    cdef v.ibv_flow *flow
+    cdef object qp
+    cpdef close(self)

--- a/pyverbs/flow.pyx
+++ b/pyverbs/flow.pyx
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia All rights reserved.
+
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
+from pyverbs.base import PyverbsRDMAErrno
+from libc.stdlib cimport calloc, free
+from libc.string cimport memcpy
+from pyverbs.qp cimport QP
+
+
+cdef class FlowAttr(PyverbsObject):
+    def __init__(self, num_of_specs=0, flow_type=v.IBV_FLOW_ATTR_NORMAL,
+                 priority=0, port=1, flags=0):
+        """
+        Initialize a FlowAttr object over an underlying ibv_flow_attr C object
+        which contains attributes for creating a steering flow.
+        :param num_of_specs: number of specs
+        :param flow_type: flow type
+        :param priority: flow priority
+        :param port: port number
+        :param flags: flow flags
+        """
+        super().__init__()
+        self.attr.type = flow_type
+        self.attr.size = sizeof(v.ibv_flow_attr)
+        self.attr.priority = priority
+        self.attr.num_of_specs = num_of_specs
+        self.attr.port = port
+        self.attr.flags = flags
+        self.specs = list()
+
+    @property
+    def type(self):
+        return self.attr.type
+
+    @type.setter
+    def type(self, val):
+        self.attr.type = val
+
+    @property
+    def priority(self):
+        return self.attr.priority
+
+    @priority.setter
+    def priority(self, val):
+        self.attr.priority = val
+
+    @property
+    def num_of_specs(self):
+        return self.attr.num_of_specs
+
+    @num_of_specs.setter
+    def num_of_specs(self, val):
+        self.attr.num_of_specs = val
+
+    @property
+    def port(self):
+        return self.attr.port
+
+    @port.setter
+    def port(self, val):
+        self.attr.port = val
+
+    @property
+    def flags(self):
+        return self.attr.flags
+
+    @flags.setter
+    def flags(self, val):
+        self.attr.flags = val
+
+    @property
+    def specs(self):
+        return self.specs
+
+
+cdef class Flow(PyverbsCM):
+    def __init__(self, QP qp, FlowAttr flow_attr):
+        """
+        Initialize a Flow object over an underlying ibv_flow C object which
+        represents a steering flow.
+        :param qp: QP to create flow for
+        :param flow_attr: Flow attributes for flow creation
+        """
+        super().__init__()
+        cdef char *flow_addr
+        cdef char *dst_addr
+        cdef v.ibv_flow_attr attr = flow_attr.attr
+        if flow_attr.num_of_specs != len(flow_attr.specs):
+            self.logger.warn(f'The number of appended specs '
+                             f'({len(flow_attr.specs)}) is not equal to the '
+                             f'number of declared specs '
+                             f'({flow_attr.flow_attr.num_of_specs})')
+        # Calculate total size for allocation
+        total_size = sizeof(v.ibv_flow_attr)
+        for spec in flow_attr.specs:
+            total_size += spec.size
+        flow_addr = <char*>calloc(1, total_size)
+        if flow_addr == NULL:
+            raise PyverbsError(f'Failed to allocate memory of size '
+                               f'{total_size}')
+        dst_addr = flow_addr
+        # Copy flow_attr at the beginning of the allocated memory
+        memcpy(dst_addr, &attr, sizeof(v.ibv_flow_attr))
+        dst_addr = <char*>(dst_addr + sizeof(v.ibv_flow_attr))
+        # Copy specs one after another into the allocated memory after flow_attr
+        for spec in flow_attr.specs:
+            spec._copy_data(<unsigned long>dst_addr)
+            dst_addr += spec.size
+
+        self.flow = v.ibv_create_flow(qp.qp, <v.ibv_flow_attr*>flow_addr)
+        free(flow_addr)
+        if self.flow == NULL:
+            raise PyverbsRDMAErrno('Flow creation failed')
+        self.qp = qp
+        qp.add_ref(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.flow != NULL:
+            self.logger.debug('Closing Flow')
+            rc = v.ibv_destroy_flow(self.flow)
+            if rc != 0:
+                raise PyverbsRDMAError('Failed to destroy Flow', rc)
+            self.flow = NULL
+            self.qp = None

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -516,6 +516,44 @@ cdef extern from 'infiniband/verbs.h':
         ibv_flow_eth_filter val
         ibv_flow_eth_filter mask
 
+    cdef struct ibv_flow_ipv4_ext_filter:
+        uint32_t  src_ip
+        uint32_t  dst_ip
+        uint8_t   proto
+        uint8_t   tos
+        uint8_t   ttl
+        uint8_t   flags
+
+    cdef struct ibv_flow_spec_ipv4_ext:
+        ibv_flow_spec_type       type
+        uint16_t                 size
+        ibv_flow_ipv4_ext_filter val
+        ibv_flow_ipv4_ext_filter mask
+
+    cdef struct ibv_flow_tcp_udp_filter:
+        uint16_t dst_port
+        uint16_t src_port
+
+    cdef struct ibv_flow_spec_tcp_udp:
+        ibv_flow_spec_type      type
+        uint16_t                size
+        ibv_flow_tcp_udp_filter val
+        ibv_flow_tcp_udp_filter mask
+
+    cdef struct ibv_flow_ipv6_filter:
+        uint8_t  src_ip[16]
+        uint8_t  dst_ip[16]
+        uint32_t flow_label
+        uint8_t  next_hdr
+        uint8_t  traffic_class
+        uint8_t  hop_limit
+
+    cdef struct ibv_flow_spec_ipv6:
+        ibv_flow_spec_type   type
+        uint16_t             size
+        ibv_flow_ipv6_filter val
+        ibv_flow_ipv6_filter mask
+
     ibv_device **ibv_get_device_list(int *n)
     int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -490,6 +490,32 @@ cdef extern from 'infiniband/verbs.h':
         uint32_t gid_type
         uint32_t ndev_ifindex
 
+    cdef struct ibv_flow:
+        uint32_t    comp_mask
+        ibv_context *context
+        uint32_t    handle
+
+    cdef struct ibv_flow_attr:
+        uint32_t           comp_mask
+        ibv_flow_attr_type type
+        uint16_t           size
+        uint16_t           priority
+        uint8_t            num_of_specs
+        uint8_t            port
+        uint32_t           flags
+
+    cdef struct ibv_flow_eth_filter:
+        uint8_t  dst_mac[6]
+        uint8_t  src_mac[6]
+        uint16_t ether_type
+        uint16_t vlan_tag
+
+    cdef struct ibv_flow_spec_eth:
+        ibv_flow_spec_type  type
+        uint16_t            size
+        ibv_flow_eth_filter val
+        ibv_flow_eth_filter mask
+
     ibv_device **ibv_get_device_list(int *n)
     int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)
@@ -631,7 +657,8 @@ cdef extern from 'infiniband/verbs.h':
     ssize_t ibv_query_gid_table(ibv_context *context,
                                 ibv_gid_entry *entries, size_t max_entries,
                                 uint32_t flags)
-
+    ibv_flow *ibv_create_flow(ibv_qp *qp, ibv_flow_attr *flow)
+    int ibv_destroy_flow(ibv_flow *flow_id)
 
 cdef extern from 'infiniband/driver.h':
     int ibv_query_gid_type(ibv_context *context, uint8_t port_num,

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -39,6 +39,7 @@ cdef class QP(PyverbsCM):
     cdef object rcq
     cdef object mws
     cdef object srq
+    cdef object flows
     cdef add_ref(self, obj)
 
 cdef class DataBuffer(PyverbsCM):

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -12,6 +12,7 @@ from pyverbs.mr cimport MW, MWBindInfo, MWBind
 from pyverbs.wr cimport RecvWR, SendWR, SGE
 from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.addr cimport AHAttr, GID, AH
+from pyverbs.flow cimport FlowAttr, Flow
 from pyverbs.base cimport close_weakrefs
 cimport pyverbs.libibverbs_enums as e
 from pyverbs.addr cimport GlobalRoute
@@ -943,6 +944,7 @@ cdef class QP(PyverbsCM):
         cdef Context ctx
         super().__init__()
         self.mws = weakref.WeakSet()
+        self.flows = weakref.WeakSet()
         self.update_cqs(init_attr)
         # QP initialization was not done by the provider, we should do it here
         if self.qp == NULL:
@@ -1016,6 +1018,8 @@ cdef class QP(PyverbsCM):
     cdef add_ref(self, obj):
         if isinstance(obj, MW):
             self.mws.add(obj)
+        elif isinstance(obj, Flow):
+            self.flows.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 
@@ -1025,7 +1029,7 @@ cdef class QP(PyverbsCM):
     cpdef close(self):
         if self.qp != NULL:
             self.logger.debug('Closing QP')
-            close_weakrefs([self.mws])
+            close_weakrefs([self.mws, self.flows])
             rc = v.ibv_destroy_qp(self.qp)
             if rc:
                 raise PyverbsRDMAError('Failed to destroy QP', rc)

--- a/pyverbs/spec.pxd
+++ b/pyverbs/spec.pxd
@@ -15,3 +15,15 @@ cdef class EthSpec(Spec):
     cdef v.ibv_flow_eth_filter val
     cdef v.ibv_flow_eth_filter mask
     cdef _mac_to_str(self, unsigned char mac[6])
+
+cdef class Ipv4ExtSpec(Spec):
+    cdef v.ibv_flow_ipv4_ext_filter val
+    cdef v.ibv_flow_ipv4_ext_filter mask
+
+cdef class TcpUdpSpec(Spec):
+    cdef v.ibv_flow_tcp_udp_filter val
+    cdef v.ibv_flow_tcp_udp_filter mask
+
+cdef class Ipv6Spec(Spec):
+    cdef v.ibv_flow_ipv6_filter val
+    cdef v.ibv_flow_ipv6_filter mask

--- a/pyverbs/spec.pxd
+++ b/pyverbs/spec.pxd
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia All rights reserved.
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsObject
+cimport pyverbs.libibverbs as v
+
+cdef class Spec(PyverbsObject):
+    cdef object spec_type
+    cdef unsigned short size
+    cpdef _copy_data(self, unsigned long ptr)
+
+cdef class EthSpec(Spec):
+    cdef v.ibv_flow_eth_filter val
+    cdef v.ibv_flow_eth_filter mask
+    cdef _mac_to_str(self, unsigned char mac[6])

--- a/pyverbs/spec.pyx
+++ b/pyverbs/spec.pyx
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia. All rights reserved.
+
+from pyverbs.pyverbs_error import PyverbsError
+from libc.string cimport memcpy
+import socket
+
+U32_MASK = 0xffffffff
+
+
+cdef class Spec(PyverbsObject):
+    """
+    Abstract class for all the specs to derive from.
+    """
+    def __init__(self):
+        raise NotImplementedError('This class is abstract.')
+
+    @property
+    def size(self):
+        return self.size
+
+    cpdef _copy_data(self, unsigned long ptr):
+        """
+        memcpy the spec to the provided address in proper order.
+        This function must be implemented in each subclass.
+        :param addr: address to copy spec to
+        """
+        raise NotImplementedError('Must be implemented in subclass.')
+
+    def __str__(self):
+        return f"{'Spec type':<16}: {self.type_to_str(self.spec_type):<20}\n" \
+               f"{'Size':<16}: {self.size:<20}\n"
+
+    @staticmethod
+    def type_to_str(spec_type):
+        types = {v.IBV_FLOW_SPEC_ETH : 'IBV_FLOW_SPEC_ETH'}
+        res_str = ""
+        if spec_type & v.IBV_FLOW_SPEC_INNER:
+            res_str += 'IBV_FLOW_SPEC_INNER '
+        try:
+            s_type = spec_type & ~v.IBV_FLOW_SPEC_INNER
+            res_str += types[s_type]
+        except IndexError:
+            raise PyverbsError(f'This type {s_type} is not implemented yet')
+        return res_str
+
+    @staticmethod
+    def _set_val_mask(default_mask, val=None, val_mask=None):
+        """
+        If value is given without val_mask, default_mask will be returned.
+        :param default_mask: default mask to set if not provided
+        :param val: user provided value
+        :param val_mask: user provided mask
+        :return: resulting value and mask
+        """
+        res_val = 0
+        res_mask = 0
+        if val is not None:
+            res_val = val
+            res_mask = default_mask if val_mask is None else val_mask
+        return res_val, res_mask
+
+
+cdef class EthSpec(Spec):
+    MAC_LEN = 6
+    MAC_MASK = ('ff:' * MAC_LEN)[:-1]
+    ZERO_MAC = [0] * MAC_LEN
+
+    def __init__(self, dst_mac=None, dst_mac_mask=None, src_mac=None,
+                 src_mac_mask=None, ether_type=None, ether_type_mask=None,
+                 vlan_tag=None, vlan_tag_mask=None, is_inner=0):
+        """
+        Initialize a EthSpec object over an underlying ibv_flow_spec_eth C
+        object that defines Ethernet header specifications for steering flow to
+        match on.
+        :param dst_mac: destination mac to match on (e.g. 'aa:bb:12:13:14:fe')
+        :param dst_mac_mask: destination mac mask (e.g. 'ff:ff:ff:ff:ff:ff')
+        :param src_mac: source mac to match on
+        :param src_mac_mask: source mac mask
+        :param ether_type: ethertype to match on
+        :param ether_type_mask: ethertype mask
+        :param vlan_tag: VLAN tag to match on
+        :param vlan_tag_mask: VLAN tag mask
+        :param is_inner: is inner spec
+        """
+        self.spec_type = v.IBV_FLOW_SPEC_ETH
+        if is_inner:
+            self.spec_type |= v.IBV_FLOW_SPEC_INNER
+        self.size = sizeof(v.ibv_flow_spec_eth)
+        self.dst_mac, self.dst_mac_mask = self._set_val_mask(self.MAC_MASK,
+                                                             dst_mac,
+                                                             dst_mac_mask)
+        self.src_mac, self.src_mac_mask = self._set_val_mask(self.MAC_MASK,
+                                                             src_mac,
+                                                             src_mac_mask)
+        self.val.ether_type, self.mask.ether_type =  \
+            map(socket.htons, self._set_val_mask(0xffff, ether_type,
+                                                 ether_type_mask))
+        self.val.vlan_tag, self.mask.vlan_tag = \
+            map(socket.htons, self._set_val_mask(0xffff, vlan_tag,
+                                                 vlan_tag_mask))
+
+    cdef _mac_to_str(self, unsigned char mac[6]):
+        s = ''
+        if len(mac) == 0:
+            return s
+        # Building string from array
+        # [0xa, 0x1b, 0x2c, 0x3c, 0x4d, 0x5e] -> "0a:1b:2c:3c:4d:5e"
+        for i in range(self.MAC_LEN):
+            s += hex(mac[i])[2:].zfill(2) + ':'
+        return s[:-1]
+
+    def _set_mac(self, val):
+        mac = EthSpec.ZERO_MAC[:]
+        if val:
+            s = val.split(':')
+            for i in range(self.MAC_LEN):
+                mac[i] = int(s[i], 16)
+        return mac
+
+    @property
+    def dst_mac(self):
+        return self._mac_to_str(self.val.dst_mac)
+
+    @dst_mac.setter
+    def dst_mac(self, val):
+        self.val.dst_mac = self._set_mac(val)
+
+    @property
+    def dst_mac_mask(self):
+        return self._mac_to_str(self.mask.dst_mac)
+
+    @dst_mac_mask.setter
+    def dst_mac_mask(self, val):
+        self.mask.dst_mac = self._set_mac(val)
+
+    @property
+    def src_mac(self):
+        return self._mac_to_str(self.val.src_mac)
+
+    @src_mac.setter
+    def src_mac(self, val):
+        self.val.src_mac = self._set_mac(val)
+
+    @property
+    def src_mac_mask(self):
+        return self._mac_to_str(self.mask.src_mac)
+
+    @src_mac_mask.setter
+    def src_mac_mask(self, val):
+        self.mask.src_mac = self._set_mac(val)
+
+    @property
+    def ether_type(self):
+        return socket.ntohs(self.val.ether_type)
+
+    @ether_type.setter
+    def ether_type(self, val):
+        self.val.ether_type = socket.htons(val)
+
+    @property
+    def ether_type_mask(self):
+        return socket.ntohs(self.mask.ether_type)
+
+    @ether_type_mask.setter
+    def ether_type_mask(self, val):
+        self.mask.ether_type =  socket.htons(val)
+
+    @property
+    def vlan_tag(self):
+        return socket.ntohs(self.val.vlan_tag)
+
+    @vlan_tag.setter
+    def vlan_tag(self, val):
+        self.val.vlan_tag = socket.htons(val)
+
+    @property
+    def vlan_tag_mask(self):
+        return socket.ntohs(self.mask.vlan_tag)
+
+    @vlan_tag_mask.setter
+    def vlan_tag_mask(self, val):
+        self.mask.vlan_tag =  socket.htons(val)
+
+    def __str__(self):
+        return super().__str__() + \
+           f"{'Src mac':<16}: {self.src_mac:<20} {self.src_mac_mask:<20}\n" \
+           f"{'Dst mac':<16}: {self.dst_mac:<20} {self.dst_mac_mask:<20}\n" \
+           f"{'Ether type':<16}: {self.val.ether_type:<20} " \
+           f"{self.mask.ether_type:<20}\n" \
+           f"{'Vlan tag':<16}: {self.val.vlan_tag:<20} " \
+           f"{self.mask.vlan_tag:<20}\n"
+
+    cpdef _copy_data(self, unsigned long ptr):
+        cdef v.ibv_flow_spec_eth eth
+        eth.size = self.size
+        eth.type = self.spec_type
+        eth.val = self.val
+        eth.mask = self.mask
+        memcpy(<void*>ptr, &eth, self.size)

--- a/pyverbs/spec.pyx
+++ b/pyverbs/spec.pyx
@@ -3,7 +3,7 @@
 
 from pyverbs.pyverbs_error import PyverbsError
 from libc.string cimport memcpy
-import socket
+import socket, struct
 
 U32_MASK = 0xffffffff
 
@@ -33,7 +33,11 @@ cdef class Spec(PyverbsObject):
 
     @staticmethod
     def type_to_str(spec_type):
-        types = {v.IBV_FLOW_SPEC_ETH : 'IBV_FLOW_SPEC_ETH'}
+        types = {v.IBV_FLOW_SPEC_ETH      : 'IBV_FLOW_SPEC_ETH',
+                 v.IBV_FLOW_SPEC_IPV4_EXT : "IBV_FLOW_SPEC_IPV4_EXT",
+                 v.IBV_FLOW_SPEC_IPV6     : "IBV_FLOW_SPEC_IPV6",
+                 v.IBV_FLOW_SPEC_TCP      : "IBV_FLOW_SPEC_TCP",
+                 v.IBV_FLOW_SPEC_UDP      : "IBV_FLOW_SPEC_UDP"}
         res_str = ""
         if spec_type & v.IBV_FLOW_SPEC_INNER:
             res_str += 'IBV_FLOW_SPEC_INNER '
@@ -198,3 +202,403 @@ cdef class EthSpec(Spec):
         eth.val = self.val
         eth.mask = self.mask
         memcpy(<void*>ptr, &eth, self.size)
+
+cdef class Ipv4ExtSpec(Spec):
+    def __init__(self, dst_ip=None, dst_ip_mask=None, src_ip=None,
+                 src_ip_mask=None, proto=None, proto_mask=None, tos=None,
+                 tos_mask=None, ttl=None, ttl_mask=None, flags=None,
+                 flags_mask=None, is_inner=False):
+        """
+        Initialize an Ipv4ExtSpec object over an underlying ibv_flow_ipv4_ext C
+        object that defines IPv4 header specifications for steering flow to
+        match on.
+        :param dst_ip: Destination IP to match on (e.g. '1.2.3.4')
+        :param dst_ip_mask: Destination IP mask (e.g. '255.255.255.255')
+        :param src_ip: source IP to match on
+        :param src_ip_mask: Source IP mask
+        :param proto: Protocol to match on
+        :param proto_mask: Protocol mask
+        :param tos: Type of service to match on
+        :param tos_mask: Type of service mask
+        :param ttl: Time to live to match on
+        :param ttl_mask: Time to live mask
+        :param flags: Flags to match on
+        :param flags_mask: Flags mask
+        :param is_inner: Is inner spec
+        """
+        self.spec_type = v.IBV_FLOW_SPEC_IPV4_EXT
+        if is_inner:
+            self.spec_type |= v.IBV_FLOW_SPEC_INNER
+        self.size = sizeof(v.ibv_flow_spec_ipv4_ext)
+
+        self.val.dst_ip, self.mask.dst_ip = \
+            map(socket.htonl, self._set_val_mask(U32_MASK,
+                                                 self._str_to_ip(dst_ip),
+                                                 self._str_to_ip(dst_ip_mask)))
+        self.val.src_ip, self.mask.src_ip = \
+            map(socket.htonl, self._set_val_mask(U32_MASK,
+                                                 self._str_to_ip(src_ip),
+                                                 self._str_to_ip(src_ip_mask)))
+        self.val.proto, self.mask.proto = self._set_val_mask(0xff, proto,
+                                                             proto_mask)
+        self.val.tos, self.mask.tos = self._set_val_mask(0xff, tos, tos_mask)
+        self.val.ttl, self.mask.ttl = self._set_val_mask(0xff, ttl, ttl_mask)
+        self.val.flags, self.mask.flags = self._set_val_mask(0xff, flags,
+                                                             flags_mask)
+    @staticmethod
+    def _str_to_ip(ip_str):
+        return None if ip_str is None else \
+            struct.unpack('!L', socket.inet_aton(ip_str))[0]
+
+    @staticmethod
+    def _ip_to_str(ip):
+        return socket.inet_ntoa(struct.pack('!L', ip))
+
+    @property
+    def dst_ip(self):
+        return self._ip_to_str(socket.ntohl(self.val.dst_ip))
+
+    @dst_ip.setter
+    def dst_ip(self, val):
+        self.val.dst_ip = socket.htonl(self._str_to_ip(val))
+
+    @property
+    def dst_ip_mask(self):
+        return self._ip_to_str(socket.ntohl(self.mask.dst_ip))
+
+    @dst_ip_mask.setter
+    def dst_ip_mask(self, val):
+        self.mask.dst_ip = socket.htonl(self._str_to_ip(val))
+
+    @property
+    def src_ip(self):
+        return self._ip_to_str(socket.ntohl(self.val.src_ip))
+
+    @src_ip.setter
+    def src_ip(self, val):
+        self.val.src_ip = socket.htonl(self._str_to_ip(val))
+
+    @property
+    def src_ip_mask(self):
+        return self._ip_to_str(socket.ntohl(self.mask.src_ip))
+
+    @src_ip_mask.setter
+    def src_ip_mask(self, val):
+        self.mask.src_ip = socket.htonl(self._str_to_ip(val))
+
+    @property
+    def proto(self):
+        return self.val.proto
+
+    @proto.setter
+    def proto(self, val):
+        self.val.proto = val
+
+    @property
+    def proto_mask(self):
+        return self.mask.proto
+
+    @proto_mask.setter
+    def proto_mask(self, val):
+        self.mask.proto = val
+
+    @property
+    def tos(self):
+        return self.val.tos
+
+    @tos.setter
+    def tos(self, val):
+        self.val.tos = val
+
+    @property
+    def tos_mask(self):
+        return self.mask.tos
+
+    @tos_mask.setter
+    def tos_mask(self, val):
+        self.mask.tos = val
+
+    @property
+    def ttl(self):
+        return self.val.ttl
+
+    @ttl.setter
+    def ttl(self, val):
+        self.val.ttl = val
+
+    @property
+    def ttl_mask(self):
+        return self.mask.ttl
+
+    @ttl_mask.setter
+    def ttl_mask(self, val):
+        self.mask.ttl = val
+
+    @property
+    def flags(self):
+        return self.val.flags
+
+    @flags.setter
+    def flags(self, val):
+        self.val.flags = val
+
+    @property
+    def flags_mask(self):
+        return self.mask.flags
+
+    @flags_mask.setter
+    def flags_mask(self, val):
+        self.mask.flags = val
+
+    def __str__(self):
+        return super().__str__() + \
+           f"{'Src IP':<16}: {self.src_ip:<20} {self.src_ip_mask:<20}\n" \
+           f"{'Dst IP':<16}: {self.dst_ip:<20} {self.dst_ip_mask:<20}\n" \
+           f"{'Proto':<16}: {self.val.proto:<20} {self.mask.proto:<20}\n" \
+           f"{'ToS':<16}: {self.val.tos:<20} {self.mask.tos:<20}\n" \
+           f"{'TTL':<16}: {self.val.ttl:<20} {self.mask.ttl:<20}\n" \
+           f"{'Flags':<16}: {self.val.flags:<20} {self.mask.flags:<20}\n"
+
+    cpdef _copy_data(self, unsigned long ptr):
+        cdef v.ibv_flow_spec_ipv4_ext ipv4
+        ipv4.size = self.size
+        ipv4.type = self.spec_type
+        ipv4.val = self.val
+        ipv4.mask = self.mask
+        memcpy(<void*>ptr, &ipv4, self.size)
+
+
+cdef class TcpUdpSpec(Spec):
+    def __init__(self, v.ibv_flow_spec_type spec_type, dst_port=None,
+                 dst_port_mask=None, src_port=None, src_port_mask=None,
+                 is_inner=False):
+        """
+        Initialize a TcpUdpSpec object over an underlying ibv_flow_tcp_udp C
+        object that defines TCP or UDP header specifications for steering flow
+        to match on.
+        :param spec_type: IBV_FLOW_SPEC_TCP or IBV_FLOW_SPEC_UDP
+        :param dst_port: Destination port to match on
+        :param dst_port_mask: Destination port mask
+        :param src_port: Source port to match on
+        :param src_port_mask: Source port mask
+        :param is_inner: Is inner spec
+        """
+        if spec_type is not v.IBV_FLOW_SPEC_TCP and spec_type is not\
+                v.IBV_FLOW_SPEC_UDP:
+            raise PyverbsError('Spec type must be IBV_FLOW_SPEC_TCP or'
+                               ' IBV_FLOW_SPEC_UDP')
+        self.spec_type = spec_type
+        if is_inner:
+            self.spec_type |= v.IBV_FLOW_SPEC_INNER
+        self.size = sizeof(v.ibv_flow_spec_tcp_udp)
+        self.val.dst_port, self.mask.dst_port = \
+            map(socket.htons, self._set_val_mask(0xffff, dst_port,
+                                                 dst_port_mask))
+        self.val.src_port, self.mask.src_port = \
+            map(socket.htons, self._set_val_mask(0xffff, src_port,
+                                                 src_port_mask))
+    @property
+    def dst_port(self):
+        return socket.ntohs(self.val.dst_port)
+
+    @dst_port.setter
+    def dst_port(self, val):
+        self.val.dst_port = socket.htons(val)
+
+    @property
+    def dst_port_mask(self):
+        return socket.ntohs(self.mask.dst_port)
+
+    @dst_port_mask.setter
+    def dst_port_mask(self, val):
+        self.mask.dst_port = socket.htons(val)
+
+    @property
+    def src_port(self):
+        return socket.ntohs(self.val.src_port)
+
+    @src_port.setter
+    def src_port(self, val):
+        self.val.src_port = socket.htons(val)
+
+    @property
+    def src_port_mask(self):
+        return socket.ntohs(self.mask.src_port)
+
+    @src_port_mask.setter
+    def src_port_mask(self, val):
+        self.mask.src_port = socket.htons(val)
+
+    def __str__(self):
+        return super().__str__() + \
+           f"{'Src port':<16}: {self.src_port:<20} {self.src_port_mask:<20}\n" \
+           f"{'Dst port':<16}: {self.dst_port:<20} {self.dst_port_mask:<20}\n"
+
+    cpdef _copy_data(self, unsigned long ptr):
+        cdef v.ibv_flow_spec_tcp_udp tcp_udp
+        tcp_udp.size = self.size
+        tcp_udp.type = self.spec_type
+        tcp_udp.val = self.val
+        tcp_udp.mask = self.mask
+        memcpy(<void*>ptr, &tcp_udp, self.size)
+
+
+cdef class Ipv6Spec(Spec):
+    EMPTY_IPV6 = [0] * 16
+    IPV6_MASK = ("ffff:" * 8)[:-1]
+    FLOW_LABEL_MASK = 0xfffff
+
+    def __init__(self, dst_ip=None, dst_ip_mask=None, src_ip=None,
+                 src_ip_mask=None, flow_label=None, flow_label_mask=None,
+                 next_hdr=None, next_hdr_mask=None, traffic_class=None,
+                 traffic_class_mask=None, hop_limit=None, hop_limit_mask=None,
+                 is_inner=False):
+        """
+        Initialize an Ipv6Spec object over an underlying ibv_flow_ipv6 C
+        object that defines IPv6 header specifications for steering flow to
+        match on.
+        :param dst_ip: Destination IPv6 to match on (e.g. 'a0a1::a2a3:a4a5:a6a7:a8a9')
+        :param dst_ip_mask: Destination IPv6 mask (e.g. 'ffff::ffff:ffff:ffff:ffff')
+        :param src_ip: Source IPv6 to match on
+        :param src_ip_mask: Source IPv6 mask
+        :param flow_label: Flow label to match on
+        :param flow_label_mask: Flow label mask
+        :param next_hdr: Next header to match on
+        :param next_hdr_mask: Next header mask
+        :param traffic_class: Traffic class to match on
+        :param traffic_class_mask: Traffic class mask
+        :param hop_limit: Hop limit to match on
+        :param hop_limit_mask: Hop limit mask
+        :param is_inner: Is inner spec
+        """
+        self.spec_type = v.IBV_FLOW_SPEC_IPV6
+        if is_inner:
+            self.spec_type |= v.IBV_FLOW_SPEC_INNER
+        self.size = sizeof(v.ibv_flow_spec_ipv6)
+
+        self.dst_ip, self.dst_ip_mask = self._set_val_mask(self.IPV6_MASK,
+                                                           dst_ip, dst_ip_mask)
+        self.src_ip, self.src_ip_mask = self._set_val_mask(self.IPV6_MASK,
+                                                           src_ip, src_ip_mask)
+        self.val.flow_label, self.mask.flow_label = \
+            map(socket.htonl, self._set_val_mask(self.FLOW_LABEL_MASK,
+                                                 flow_label, flow_label_mask))
+        self.val.next_hdr, self.mask.next_hdr = \
+            self._set_val_mask(0xff, next_hdr, next_hdr_mask)
+        self.val.traffic_class, self.mask.traffic_class = \
+            self._set_val_mask(0xff, traffic_class, traffic_class_mask)
+        self.val.hop_limit, self.mask.hop_limit = \
+            self._set_val_mask(0xff, hop_limit, hop_limit_mask)
+
+    @property
+    def dst_ip(self):
+        return socket.inet_ntop(socket.AF_INET6, self.val.dst_ip)
+
+    @dst_ip.setter
+    def dst_ip(self, val):
+        self.val.dst_ip = socket.inet_pton(socket.AF_INET6, val)
+
+    @property
+    def dst_ip_mask(self):
+        return socket.inet_ntop(socket.AF_INET6, self.mask.dst_ip)
+
+    @dst_ip_mask.setter
+    def dst_ip_mask(self, val):
+        self.mask.dst_ip = socket.inet_pton(socket.AF_INET6, val)
+
+    @property
+    def src_ip(self):
+        return socket.inet_ntop(socket.AF_INET6, self.val.src_ip)
+
+    @src_ip.setter
+    def src_ip(self, val):
+        self.val.src_ip = socket.inet_pton(socket.AF_INET6, val)
+
+    @property
+    def src_ip_mask(self):
+        return socket.inet_ntop(socket.AF_INET6, self.mask.src_ip)
+
+    @src_ip_mask.setter
+    def src_ip_mask(self, val):
+        self.mask.src_ip = socket.inet_pton(socket.AF_INET6, val)
+
+    @property
+    def flow_label(self):
+        return socket.ntohl(self.val.flow_label)
+
+    @flow_label.setter
+    def flow_label(self, val):
+        self.val.flow_label = socket.htonl(val)
+
+    @property
+    def flow_label_mask(self):
+        return socket.ntohl(self.mask.flow_label)
+
+    @flow_label_mask.setter
+    def flow_label_mask(self, val):
+        self.mask.flow_label = socket.htonl(val)
+
+    @property
+    def next_hdr(self):
+        return self.val.next_hdr
+
+    @next_hdr.setter
+    def next_hdr(self, val):
+        self.val.next_hdr = val
+
+    @property
+    def next_hdr_mask(self):
+        return self.mask.next_hdr
+
+    @next_hdr_mask.setter
+    def next_hdr_mask(self, val):
+        self.mask.next_hdr = val
+
+    @property
+    def traffic_class(self):
+        return self.val.traffic_class
+
+    @traffic_class.setter
+    def traffic_class(self, val):
+        self.val.traffic_class = val
+
+    @property
+    def traffic_class_mask(self):
+        return self.mask.traffic_class
+
+    @traffic_class_mask.setter
+    def traffic_class_mask(self, val):
+        self.mask.traffic_class = val
+
+    @property
+    def hop_limit(self):
+        return self.val.hop_limit
+
+    @hop_limit.setter
+    def hop_limit(self, val):
+        self.val.hop_limit = val
+
+    @property
+    def hop_limit_mask(self):
+        return self.mask.hop_limit
+
+    @hop_limit_mask.setter
+    def hop_limit_mask(self, val):
+        self.mask.hop_limit = val
+
+    def __str__(self):
+        return super().__str__() + \
+           f"{'Src IP':<16}: {self.src_ip:<20} {self.src_ip_mask:<20}\n" \
+           f"{'Dst IP':<16}: {self.dst_ip:<20} {self.dst_ip_mask:<20}\n" \
+           f"{'Flow label':<16}: {self.flow_label:<20} {self.flow_label_mask:<20}\n" \
+           f"{'Next header':<16}: {self.next_hdr:<20} {self.next_hdr_mask:<20}\n" \
+           f"{'Traffic class':<16}: {self.traffic_class:<20} {self.traffic_class_mask:<20}\n" \
+           f"{'Hop limit':<16}: {self.hop_limit:<20} {self.hop_limit_mask:<20}\n"
+
+    cpdef _copy_data(self, unsigned long ptr):
+        cdef v.ibv_flow_spec_ipv6 ipv6
+        ipv6.size = self.size
+        ipv6.type = self.spec_type
+        ipv6.val = self.val
+        ipv6.mask = self.mask
+        memcpy(<void*>ptr, &ipv6, self.size)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,7 @@ rdma_python_test(tests
   test_device.py
   test_efa_srd.py
   test_efadv.py
+  test_flow.py
   test_mlx5_cq.py
   test_mlx5_dc.py
   test_mlx5_lag_affinity.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -502,6 +502,12 @@ class UDResources(TrafficResources):
         self.rqps_num = rqps_num
 
 
+class RawResources(TrafficResources):
+    def create_qp_init_attr(self):
+        return QPInitAttr(qp_type=e.IBV_QPT_RAW_PACKET, scq=self.cq,
+                          rcq=self.cq, srq=self.srq, cap=self.create_qp_cap())
+
+
 class XRCResources(TrafficResources):
     def __init__(self, dev_name, ib_port, gid_index, qp_count=2):
         self.temp_file = None

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -1,0 +1,89 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2020 Nvidia All rights reserved. See COPYING file
+"""
+Test module for pyverbs' flow module.
+"""
+from tests.base import RDMATestCase, RawResources, PyverbsRDMAError
+from tests.utils import requires_root_on_eth
+from pyverbs.flow import FlowAttr, Flow
+from pyverbs.spec import EthSpec
+import tests.utils as u
+import unittest
+import errno
+
+
+class FlowRes(RawResources):
+    def __init__(self, dev_name, ib_port, gid_index):
+        """
+        Initialize Flow resources based on Raw resources that include Raw QP.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        """
+        super().__init__(dev_name=dev_name, ib_port=ib_port,
+                         gid_index=gid_index)
+
+    @requires_root_on_eth()
+    def create_qps(self):
+        super().create_qps()
+
+    @staticmethod
+    def create_eth_spec():
+        """
+        Creates ethernet spec that matches on ethertype, source and destination
+        macs.
+        :return: created ethernet spec
+        """
+        eth_spec = EthSpec(ether_type=u.PacketConsts.ETHER_TYPE_IPV4,
+                           dst_mac=u.PacketConsts.DST_MAC)
+        eth_spec.src_mac = u.PacketConsts.SRC_MAC
+        eth_spec.src_mac_mask = u.PacketConsts.MAC_MASK
+        return eth_spec
+
+    def create_flow(self, specs=[]):
+        """
+        Creates flow to match on provided specs.
+        :param specs: list of specs to match on
+        :return: created flow
+        """
+        flow_attr = FlowAttr(num_of_specs=len(specs), port=self.ib_port)
+        for spec in specs:
+            flow_attr.specs.append(spec)
+        try:
+            flow = Flow(self.qp, flow_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Flow creation is not supported')
+            raise ex
+        return flow
+
+
+class FlowTest(RDMATestCase):
+    """
+    Test various functionalities of the Flow class.
+    """
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init Flow tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+
+    def test_eth_spec_flow_traffic(self):
+        """
+        Test raw ethernet traffic with eth spec flow.
+        """
+        self.create_players(FlowRes)
+        eth_spec = self.server.create_eth_spec()
+        self.flow = self.server.create_flow([eth_spec])
+        u.raw_traffic(self.client, self.server, self.iters)

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -4,11 +4,13 @@
 Test module for pyverbs' flow module.
 """
 from tests.base import RDMATestCase, RawResources, PyverbsRDMAError
-from tests.utils import requires_root_on_eth
+from pyverbs.spec import EthSpec, Ipv4ExtSpec, Ipv6Spec, TcpUdpSpec
+from tests.utils import requires_root_on_eth, PacketConsts
 from pyverbs.flow import FlowAttr, Flow
-from pyverbs.spec import EthSpec
+import pyverbs.enums as e
 import tests.utils as u
 import unittest
+import socket
 import errno
 
 
@@ -28,17 +30,45 @@ class FlowRes(RawResources):
         super().create_qps()
 
     @staticmethod
-    def create_eth_spec():
+    def create_eth_spec(ether_type=PacketConsts.ETHER_TYPE_IPV4):
         """
         Creates ethernet spec that matches on ethertype, source and destination
         macs.
+        :param ether_type: IPv4 or IPv6
         :return: created ethernet spec
         """
-        eth_spec = EthSpec(ether_type=u.PacketConsts.ETHER_TYPE_IPV4,
-                           dst_mac=u.PacketConsts.DST_MAC)
-        eth_spec.src_mac = u.PacketConsts.SRC_MAC
-        eth_spec.src_mac_mask = u.PacketConsts.MAC_MASK
+        eth_spec = EthSpec(ether_type=ether_type, dst_mac=PacketConsts.DST_MAC)
+        eth_spec.src_mac = PacketConsts.SRC_MAC
+        eth_spec.src_mac_mask = PacketConsts.SRC_MAC
         return eth_spec
+
+    def create_ip_spec(self, ver=PacketConsts.IP_V4,
+                       next_hdr=socket.IPPROTO_UDP):
+        """
+        Creates IPv4 or IPv6 spec that matches on source and destination ips.
+        :param ver: IP version
+        :param next_hdr: Next header type
+        :return: created IPv4 or IPv6 spec
+        """
+        if ver == PacketConsts.IP_V4:
+            ip_spec = Ipv4ExtSpec(src_ip=PacketConsts.SRC_IP,
+                                  dst_ip=PacketConsts.DST_IP, proto=next_hdr)
+        else:
+            ip_spec = Ipv6Spec(src_ip=PacketConsts.SRC_IP6,
+                               dst_ip=PacketConsts.DST_IP6, next_hdr=next_hdr)
+        return ip_spec
+
+    @staticmethod
+    def create_tcp_udp_spec(spec_type):
+        """
+        Creates TcpUdp spec that matches on ethertype, source and destination
+        macs.
+        :param spec_type: Spec type TCP or UDP
+        :return: TCP or UDP spec
+        """
+        spec = TcpUdpSpec(spec_type, src_port=PacketConsts.SRC_PORT,
+                          dst_port=PacketConsts.DST_PORT)
+        return spec
 
     def create_flow(self, specs=[]):
         """
@@ -68,6 +98,11 @@ class FlowTest(RDMATestCase):
         self.server = None
         self.client = None
 
+    def tearDown(self):
+        super().tearDown()
+        del self.server
+        del self.client
+
     def create_players(self, resource, **resource_arg):
         """
         Init Flow tests resources.
@@ -79,11 +114,53 @@ class FlowTest(RDMATestCase):
         self.client = resource(**self.dev_info, **resource_arg)
         self.server = resource(**self.dev_info, **resource_arg)
 
+    def flow_traffic(self, specs, l3=PacketConsts.IP_V4,
+                     l4=PacketConsts.UDP_PROTO):
+        """
+        Execute raw ethernet traffic with given specs flow.
+        :param specs: list of specs
+        :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
+        :param l4: Packet layer 4 type: 'tcp' or 'udp'
+        :return: None
+        """
+        self.flow = self.server.create_flow(specs)
+        u.raw_traffic(self.client, self.server, self.iters, l3, l4)
+
     def test_eth_spec_flow_traffic(self):
-        """
-        Test raw ethernet traffic with eth spec flow.
-        """
+        self.create_players(FlowRes)
+        self.flow_traffic([self.server.create_eth_spec()])
+
+    def test_ipv4_spec_flow_traffic(self):
+        self.create_players(FlowRes)
+        if self.is_eth_and_has_roce_hw_bug():
+            raise unittest.SkipTest(f'Device {self.dev_name} doesn\'t support Ipv4ExtSpec')
+        self.flow_traffic([self.server.create_ip_spec()])
+
+    def test_ipv6_spec_flow_traffic(self):
+        self.create_players(FlowRes)
+        eth_spec = self.server.create_eth_spec(PacketConsts.ETHER_TYPE_IPV6)
+        if self.is_eth_and_has_roce_hw_bug():
+            raise unittest.SkipTest(f'Device {self.dev_name} doesn\'t support Ipv6Spec')
+        ip_spec = self.server.create_ip_spec(PacketConsts.IP_V6)
+        self.flow_traffic([eth_spec, ip_spec], PacketConsts.IP_V6)
+
+    def test_udp_spec_flow_traffic(self):
         self.create_players(FlowRes)
         eth_spec = self.server.create_eth_spec()
-        self.flow = self.server.create_flow([eth_spec])
-        u.raw_traffic(self.client, self.server, self.iters)
+        if self.is_eth_and_has_roce_hw_bug():
+            raise unittest.SkipTest(f'Device {self.dev_name} doesn\'t support Ipv4ExtSpec')
+        ip_spec = self.server.create_ip_spec()
+        udp_spec = self.server.create_tcp_udp_spec(e.IBV_FLOW_SPEC_UDP)
+        self.flow_traffic([eth_spec, ip_spec, udp_spec], PacketConsts.IP_V4,
+                          PacketConsts.UDP_PROTO)
+
+    def test_tcp_spec_flow_traffic(self):
+        self.create_players(FlowRes)
+        eth_spec = self.server.create_eth_spec(PacketConsts.ETHER_TYPE_IPV6)
+        if self.is_eth_and_has_roce_hw_bug():
+            raise unittest.SkipTest(f'Device {self.dev_name} doesn\'t support Ipv6Spec')
+        ip_spec = self.server.create_ip_spec(PacketConsts.IP_V6,
+                                             socket.IPPROTO_TCP)
+        tcp_spec = self.server.create_tcp_udp_spec(e.IBV_FLOW_SPEC_TCP)
+        self.flow_traffic([eth_spec, ip_spec, tcp_spec], PacketConsts.IP_V6,
+                          PacketConsts.TCP_PROTO)


### PR DESCRIPTION
The series introduces ibv_flow support and tests.
Flow steering rules define packet matching done by the hardware.
Multiple matching specifications, that describe packet matching on a specific layer (L2, L3, etc.), were added, including extended IPv4, IPv6, Ethernet, TCP, and UDP.
Traffic tests were added to cover each one of the newly added specs.