### PR TITLE
rdma-ndd: fix 'debug' long opt in manpage

### DIFF
--- a/rdma-ndd/rdma-ndd.8.in
+++ b/rdma-ndd/rdma-ndd.8.in
@@ -76,7 +76,7 @@ NOTE: Systemd requires an extra \(aq%\(aq.
 \fB\-f, \-\-foreground\fP
 Run in the foreground instead of as a daemon
 .sp
-\fB\-d, \-\-debugging\fP
+\fB\-d, \-\-debug\fP
 Log additional debugging information to syslog
 .sp
 \fB\-\-systemd\fP

--- a/rdma-ndd/rdma-ndd.8.in.rst
+++ b/rdma-ndd/rdma-ndd.8.in.rst
@@ -71,7 +71,7 @@ OPTIONS
 **-f, --foreground**
 Run in the foreground instead of as a daemon
 
-**-d, --debugging**
+**-d, --debug**
 Log additional debugging information to syslog
 
 **--systemd**


### PR DESCRIPTION
rdma-core/rdma-ndd/rdma-ndd.c
  296                 static const struct option long_opts[] = {
  297                         { "foreground",   0, NULL, 'f' },
  298                         { "systemd",      0, NULL, 's' },
  299                         { "help",         0, NULL, 'h' },
  300                         { "debug",        0, NULL, 'd' },
  301                         { }
  302                 };

Signed-off-by: Honggang Li <honli@redhat.com>