### PR TITLE
verbs: Add an API to retrieve IB device number of ports via netlink

### DIFF
--- a/libibverbs/cmd_device.c
+++ b/libibverbs/cmd_device.c
@@ -666,6 +666,15 @@ int ibv_cmd_query_device_any(struct ibv_context *context,
 
 	if (CAN_COPY(xrc_odp_caps, xrc_odp_caps))
 		attr->xrc_odp_caps = resp->xrc_odp_caps;
+
+	if (attr_size >= offsetofend(struct ibv_device_attr_ex, phys_port_cnt_ex)) {
+		struct verbs_sysfs_dev *sysfs_dev = verbs_get_device(context->device)->sysfs;
+
+		if (sysfs_dev->num_ports)
+			attr->phys_port_cnt_ex = sysfs_dev->num_ports;
+		else
+			attr->phys_port_cnt_ex = attr->orig_attr.phys_port_cnt;
+	}
 #undef CAN_COPY
 
 	return 0;

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -210,6 +210,7 @@ struct verbs_sysfs_dev {
 	uint32_t driver_id;
 	enum ibv_node_type node_type;
 	int ibdev_idx;
+	uint32_t num_ports;
 	uint32_t abi_ver;
 	struct timespec time_created;
 };

--- a/libibverbs/ibdev_nl.c
+++ b/libibverbs/ibdev_nl.c
@@ -150,7 +150,8 @@ static int find_sysfs_devs_nl_cb(struct nl_msg *msg, void *data)
 	if (!tb[RDMA_NLDEV_ATTR_DEV_NAME] ||
 	    !tb[RDMA_NLDEV_ATTR_DEV_NODE_TYPE] ||
 	    !tb[RDMA_NLDEV_ATTR_DEV_INDEX] ||
-	    !tb[RDMA_NLDEV_ATTR_NODE_GUID])
+	    !tb[RDMA_NLDEV_ATTR_NODE_GUID] ||
+	    !tb[RDMA_NLDEV_ATTR_PORT_INDEX])
 		return NLE_PARSE_ERR;
 
 	sysfs_dev = calloc(1, sizeof(*sysfs_dev));
@@ -158,6 +159,7 @@ static int find_sysfs_devs_nl_cb(struct nl_msg *msg, void *data)
 		return NLE_NOMEM;
 
 	sysfs_dev->ibdev_idx = nla_get_u32(tb[RDMA_NLDEV_ATTR_DEV_INDEX]);
+	sysfs_dev->num_ports = nla_get_u32(tb[RDMA_NLDEV_ATTR_PORT_INDEX]);
 	sysfs_dev->node_guid = nla_get_u64(tb[RDMA_NLDEV_ATTR_NODE_GUID]);
 	sysfs_dev->flags |= VSYSFS_READ_NODE_GUID;
 	if (!check_snprintf(sysfs_dev->ibdev_name,

--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -43,6 +43,7 @@ struct ibv_cq_moderation_caps  cq_mod_caps;        /* CQ moderation max capabili
 uint64_t     	       max_dm_size;		   /* Max Device Memory size (in bytes) available for allocation */
 struct ibv_pci_atomic_caps atomic_caps;            /* PCI atomic operations capabilities, use enum ibv_pci_atomic_op_size */
 uint32_t               xrc_odp_caps;               /* Mask with enum ibv_odp_transport_cap_bits to know which operations are supported. */
+uint32_t	       phys_port_cnt_ex		   /* Extended number of physical port count, allows to expose more than 255 ports device */
 .in -8
 };
 

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -352,6 +352,7 @@ struct ibv_device_attr_ex {
 	uint64_t max_dm_size;
 	struct ibv_pci_atomic_caps pci_atomic_caps;
 	uint32_t xrc_odp_caps;
+	uint32_t phys_port_cnt_ex;
 };
 
 enum ibv_mtu {

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -627,16 +627,16 @@ static int dr_dump_domain_info_caps(FILE *f, struct dr_devx_caps *caps,
 	return 0;
 }
 
-static int dr_dump_domain_info_dev_attr(FILE *f, struct ibv_device_attr *attr,
+static int dr_dump_domain_info_dev_attr(FILE *f, struct dr_domain_info *info,
 					const uint64_t domain_id)
 {
 	int ret;
 
-	ret = fprintf(f, "%d,0x%" PRIx64 ",%d,%s\n",
+	ret = fprintf(f, "%d,0x%" PRIx64 ",%u,%s\n",
 		      DR_DUMP_REC_TYPE_DOMAIN_INFO_DEV_ATTR,
 		      domain_id,
-		      attr->phys_port_cnt,
-		      attr->fw_ver);
+		      info->caps.num_vports + 1,
+		      info->attr.orig_attr.fw_ver);
 	if (ret < 0)
 		return ret;
 
@@ -647,7 +647,7 @@ static int dr_dump_domain_info(FILE *f, struct dr_domain_info *info,
 {
 	int ret;
 
-	ret = dr_dump_domain_info_dev_attr(f, &info->attr, domain_id);
+	ret = dr_dump_domain_info_dev_attr(f, info, domain_id);
 	if (ret < 0)
 		return ret;
 

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -136,14 +136,14 @@ static int dr_domain_query_fdb_caps(struct ibv_context *ctx,
 				    struct mlx5dv_dr_domain *dmn)
 {
 	struct dr_esw_caps esw_caps = {};
-	int num_vports;
+	uint32_t num_vports;
 	int ret;
 	int i;
 
 	if (!dmn->info.caps.eswitch_manager)
 		return 0;
 
-	num_vports = dmn->info.attr.phys_port_cnt - 1;
+	num_vports = dmn->info.attr.phys_port_cnt_ex - 1;
 	dmn->info.caps.vports_caps = calloc(num_vports + 1,
 					    sizeof(struct dr_devx_vport_cap));
 	if (!dmn->info.caps.vports_caps) {
@@ -198,7 +198,7 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 		return errno;
 	}
 
-	ret = ibv_query_device(ctx, &dmn->info.attr);
+	ret = ibv_query_device_ex(ctx, NULL, &dmn->info.attr);
 	if (ret)
 		return ret;
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -815,7 +815,7 @@ struct dr_domain_info {
 	uint32_t		max_log_action_icm_sz;
 	struct dr_domain_rx_tx	rx;
 	struct dr_domain_rx_tx	tx;
-	struct ibv_device_attr	attr;
+	struct ibv_device_attr_ex attr;
 	struct dr_devx_caps	caps;
 };
 

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -674,6 +674,9 @@ cdef class DeviceAttrEx(PyverbsObject):
     @property
     def max_dm_size(self):
         return self.dev_attr.max_dm_size
+    @property
+    def phys_port_cnt_ex(self):
+        return self.dev_attr.phys_port_cnt_ex
 
 
 cdef class AllocDmAttr(PyverbsObject):

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -140,6 +140,7 @@ cdef extern from 'infiniband/verbs.h':
         unsigned long           max_dm_size
         ibv_pci_atomic_caps     pci_atomic_caps
         uint32_t                xrc_odp_caps
+        uint32_t                phys_port_cnt_ex
 
     cdef struct ibv_mw:
         ibv_context     *context

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -196,6 +196,25 @@ class DeviceTest(PyverbsAPITestCase):
                 attr_ex = ctx.query_device_ex()
                 self.verify_device_attr(attr_ex.orig_attr, dev)
 
+    def test_phys_port_cnt_ex(self):
+        """
+        Test phys_port_cnt_ex
+        """
+        for dev in self.get_device_list():
+            with d.Context(name=dev.name.decode()) as ctx:
+                attr_ex = ctx.query_device_ex()
+                phys_port_cnt = attr_ex.orig_attr.phys_port_cnt
+                phys_port_cnt_ex = attr_ex.phys_port_cnt_ex
+                if phys_port_cnt_ex > 255:
+                    self.assertEqual(phys_port_cnt, 255,
+                                     f'phys_port_cnt should be 255 if ' +
+                                     f'phys_port_cnt_ex is bigger than 255')
+                else:
+                    self.assertEqual(phys_port_cnt, phys_port_cnt_ex,
+                                     f'phys_port_cnt_ex and phys_port_cnt ' +
+                                     f'should be equal if number of ports is ' +
+                                     f'less than 256')
+
     @staticmethod
     def verify_port_attr(attr):
         """

--- a/util/rdma_nl.c
+++ b/util/rdma_nl.c
@@ -42,6 +42,7 @@ struct nla_policy rdmanl_policy[RDMA_NLDEV_ATTR_MAX] = {
 	[RDMA_NLDEV_ATTR_DEV_NODE_TYPE] = { .type = NLA_U8 },
 	[RDMA_NLDEV_ATTR_NODE_GUID] = { .type = NLA_U64 },
 	[RDMA_NLDEV_ATTR_UVERBS_DRIVER_ID] = { .type = NLA_U32 },
+	[RDMA_NLDEV_ATTR_PORT_INDEX] = { .type = NLA_U32 },
 #ifdef NLA_NUL_STRING
 	[RDMA_NLDEV_ATTR_CHARDEV_NAME] = { .type = NLA_NUL_STRING },
 	[RDMA_NLDEV_ATTR_DEV_NAME] = { .type = NLA_NUL_STRING },


### PR DESCRIPTION
This series adds a verbs API to retrieve IB device number of ports via netlink.

The new API is used by mlx5 in the DR area.