### PR TITLE
Fix status field description in rdma_cm_event structure

### DIFF
--- a/librdmacm/man/rdma_get_cm_event.3
+++ b/librdmacm/man/rdma_get_cm_event.3
@@ -43,7 +43,7 @@ below.
 .IP "status" 12
 Returns any asynchronous error information associated with an event.  The
 status is zero if the operation was successful, otherwise the status value
-is non-zero and is either set to an errno or a transport specific value.
+is non-zero and is either set to a negative errno or a transport specific value.
 For details on transport specific status values, see the event type information
 below.
 .IP "param" 12


### PR DESCRIPTION
`rdma_get_cm_event()` function sets a negative errno in `rdma_cm_event` structure.