### PR TITLE
libhns: Avoid double release of a pointer

### DIFF
--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -604,10 +604,8 @@ static int qp_alloc_recv_inl_buf(struct ibv_qp_cap *cap,
 
 	qp->rq_rinl_buf.wqe_list[0].sg_list = calloc(cnt * cap->max_recv_sge,
 					sizeof(struct hns_roce_rinl_sge));
-	if (!qp->rq_rinl_buf.wqe_list[0].sg_list) {
-		free(qp->rq_rinl_buf.wqe_list);
+	if (!qp->rq_rinl_buf.wqe_list[0].sg_list)
 		return ENOMEM;
-	}
 
 	for (i = 0; i < cnt; i++) {
 		int wqe_size = i * cap->max_recv_sge;


### PR DESCRIPTION
The memory of wqe_list will be freed in hns_roce_free_recv_inl_buf() if we
fail to allocate memory for sg_list in hns_roce_alloc_recv_inl_buf(). So
the codes to free wqe_list should be removed, or the pointer will be double
freed.

Fixes: 9a6132e4178a ("libhns: Package some lines for calculating qp buffer size")
Signed-off-by: Weihang Li <liweihang@huawei.com>