### PR TITLE
libhns: Correct definition of DB_BYTE_4_TAG_M

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -291,11 +291,10 @@ static void hns_roce_update_rq_db(struct hns_roce_context *ctx,
 {
 	struct hns_roce_db rq_db = {};
 
-	roce_set_field(rq_db.byte_4, DB_BYTE_4_TAG_M, DB_BYTE_4_TAG_S, qpn);
+	rq_db.byte_4 = htole32(qpn);
 	roce_set_field(rq_db.byte_4, DB_BYTE_4_CMD_M, DB_BYTE_4_CMD_S,
 		       HNS_ROCE_V2_RQ_DB);
-	roce_set_field(rq_db.parameter, DB_PARAM_RQ_PRODUCER_IDX_M,
-		       DB_PARAM_RQ_PRODUCER_IDX_S, rq_head);
+	rq_db.parameter = htole32(rq_head);
 
 	hns_roce_write64((uint32_t *)&rq_db, ctx, ROCEE_VF_DB_CFG0_OFFSET);
 }
@@ -306,13 +305,10 @@ static void hns_roce_update_sq_db(struct hns_roce_context *ctx,
 {
 	struct hns_roce_db sq_db = {};
 
-	/* cmd: 0 sq db; 1 rq db; 2; 2 srq db; 3 cq db ptr; 4 cq db ntr */
+	sq_db.byte_4 = htole32(qpn);
 	roce_set_field(sq_db.byte_4, DB_BYTE_4_CMD_M, DB_BYTE_4_CMD_S,
 		       HNS_ROCE_V2_SQ_DB);
-	roce_set_field(sq_db.byte_4, DB_BYTE_4_TAG_M, DB_BYTE_4_TAG_S, qpn);
-
-	roce_set_field(sq_db.parameter, DB_PARAM_SQ_PRODUCER_IDX_M,
-		       DB_PARAM_SQ_PRODUCER_IDX_S, sq_head);
+	sq_db.parameter = htole32(sq_head);
 	roce_set_field(sq_db.parameter, DB_PARAM_SL_M, DB_PARAM_SL_S, sl);
 
 	hns_roce_write64((uint32_t *)&sq_db, ctx, ROCEE_VF_DB_CFG0_OFFSET);

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -127,36 +127,24 @@ struct hns_roce_db {
 	__le32	parameter;
 };
 #define DB_BYTE_4_TAG_S 0
-#define DB_BYTE_4_TAG_M   (((1UL << 23) - 1) << DB_BYTE_4_TAG_S)
+#define DB_BYTE_4_TAG_M GENMASK(23, 0)
 
 #define DB_BYTE_4_CMD_S 24
-#define DB_BYTE_4_CMD_M   (((1UL << 4) - 1) << DB_BYTE_4_CMD_S)
-
-#define DB_PARAM_SQ_PRODUCER_IDX_S 0
-#define DB_PARAM_SQ_PRODUCER_IDX_M \
-	(((1UL << 16) - 1) << DB_PARAM_SQ_PRODUCER_IDX_S)
-
-#define DB_PARAM_RQ_PRODUCER_IDX_S 0
-#define DB_PARAM_RQ_PRODUCER_IDX_M \
-	(((1UL << 16) - 1) << DB_PARAM_RQ_PRODUCER_IDX_S)
+#define DB_BYTE_4_CMD_M GENMASK(27, 24)
 
 #define DB_PARAM_SRQ_PRODUCER_COUNTER_S 0
-#define DB_PARAM_SRQ_PRODUCER_COUNTER_M \
-	(((1UL << 16) - 1) << DB_PARAM_SRQ_PRODUCER_COUNTER_S)
+#define DB_PARAM_SRQ_PRODUCER_COUNTER_M GENMASK(16, 0)
 
 #define DB_PARAM_SL_S 16
-#define DB_PARAM_SL_M \
-	(((1UL << 3) - 1) << DB_PARAM_SL_S)
+#define DB_PARAM_SL_M GENMASK(18, 16)
 
 #define DB_PARAM_CQ_CONSUMER_IDX_S 0
-#define DB_PARAM_CQ_CONSUMER_IDX_M \
-	(((1UL << 24) - 1) << DB_PARAM_CQ_CONSUMER_IDX_S)
+#define DB_PARAM_CQ_CONSUMER_IDX_M GENMASK(23, 0)
 
 #define DB_PARAM_CQ_NOTIFY_S 24
 
 #define DB_PARAM_CQ_CMD_SN_S 25
-#define DB_PARAM_CQ_CMD_SN_M \
-	(((1UL << 2) - 1) << DB_PARAM_CQ_CMD_SN_S)
+#define DB_PARAM_CQ_CMD_SN_M GENMASK(26, 25)
 
 struct hns_roce_v2_cqe {
 	__le32	byte_4;


### PR DESCRIPTION
The width of tag field of normal doorbell should be 24 bits, and some other
fields of doorbell can be adjusted.

Fixes: 6fe30a1a705f ("libhns: Introduce QP operations referred to hip08 RoCE device")
Signed-off-by: Lang Cheng <chenglang@huawei.com>
Signed-off-by: Weihang Li <liweihang@huawei.com>