### PR TITLE
rdma-ndd: fix udev racy issue for system with multiple InfiniBand HCAs

### DIFF
--- a/rdma-ndd/rdma-ndd.c
+++ b/rdma-ndd/rdma-ndd.c
@@ -253,7 +253,6 @@ static void monitor(bool systemd)
 	}
 
 	read_hostname(hn_fd, hostname, sizeof(hostname));
-	set_rdma_node_desc((const char *)hostname, 1);
 
 	fds[0].fd = hn_fd;
 	fds[0].events = 0;
@@ -267,6 +266,8 @@ static void monitor(bool systemd)
 
 	if (systemd)
 		sd_notify(0, "READY=1");
+
+	set_rdma_node_desc((const char *)hostname, 1);
 
 	while (1) {
 		if (poll(fds, numfds, -1) <= 0) {


### PR DESCRIPTION
After read the system hostname, the function `monitor` calls function
`set_rdma_node_desc` to initialize the node description for HCAs had
been detected by kernel.

For system with multiple InfiniBand HCAs, only the first HCA is
guaranteed to be detected by kernel at this point. The systemd udev
"add" event for the rest HCAs may be emitted before rdma-ndd listen
udev event via function `get_udev_fd`. That means the "add" event
will never be sent to rdma-ndd service, as rdma-ndd not ready for udev
even yet. So, the node description for those HCAs may not be updated
by rdma-ndd during system boot.

With this patch, rdma-ndd will initialize the node description after
it listen to udev. InfiniBand HCAs detected after the initialization
will be handled by udev even.

Reported-by: Georg Sauthoff <georg.sauthoff@deutsche-boerse.com>
Tested-by: Georg Sauthoff <georg.sauthoff@deutsche-boerse.com>
Signed-off-by: Honggang Li <honli@redhat.com>