### PR TITLE
Set correct errno in rdma_get_request

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -1861,8 +1861,13 @@ int rdma_get_request(struct rdma_cm_id *listen, struct rdma_cm_id **id)
 	if (ret)
 		return ret;
 
+	if (event->event == RDMA_CM_EVENT_REJECTED) {
+		ret = ERR(ECONNREFUSED);
+		goto err;
+	}
+
 	if (event->status) {
-		ret = ERR(event->status);
+		ret = ERR(-event->status);
 		goto err;
 	}
 


### PR DESCRIPTION
Fix `rdma_get_request()` function according to `rdma_get_request` man:
```
RETURN VALUE
       Returns 0 on success, or -1 on error.  If an error occurs, errno will be set to indicate the failure reason.”
```
If event is `RDMA_CM_EVENT_REJECTED`, set `ECONNREFUSED` to errno.
If event's status is set to any value (i.e. a non-zero value), set errno to `-event->status`.