### PR TITLE
cmake: Bump minimal cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,12 @@
 #      (without man pages) when neither pandoc/rst2man nor the pandoc-prebuilt
 #      directory are available.
 
-cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
+if (${CMAKE_VERSION} VERSION_LESS "3.18.1")
+	# Centos 6 support
+	cmake_minimum_required(VERSION 2.8.11 FATAL_ERROR)
+else()
+	cmake_minimum_required(VERSION 3.18.1 FATAL_ERROR)
+endif()
 project(rdma-core C)
 
 # CMake likes to use -rdynamic too much, they fixed it in 3.4.

--- a/infiniband-diags/CMakeLists.txt
+++ b/infiniband-diags/CMakeLists.txt
@@ -16,7 +16,7 @@ add_library(ibdiags_tools STATIC
 function(ibdiag_programs)
   foreach(I ${ARGN})
     rdma_sbin_executable(${I} "${I}.c")
-    target_link_libraries(${I} LINK_PRIVATE ${RT_LIBRARIES} ibumad ibmad ibdiags_tools ibnetdisc)
+    target_link_libraries(${I} LINK_PRIVATE ${RT_LIBRARIES} ibdiags_tools ibumad ibmad ibnetdisc)
   endforeach()
 endfunction()
 
@@ -44,6 +44,6 @@ ibdiag_programs(
   )
 
 rdma_test_executable(ibsendtrap "ibsendtrap.c")
-target_link_libraries(ibsendtrap LINK_PRIVATE ibumad ibmad ibdiags_tools)
+target_link_libraries(ibsendtrap LINK_PRIVATE ibdiags_tools ibumad ibmad)
 rdma_test_executable(mcm_rereg_test "mcm_rereg_test.c")
-target_link_libraries(mcm_rereg_test LINK_PRIVATE ibumad ibmad ibdiags_tools)
+target_link_libraries(mcm_rereg_test LINK_PRIVATE ibdiags_tools ibumad ibmad)


### PR DESCRIPTION
The rdma-core doesn't really need anything specific from 2.8.11, so
simply raise the minimal level to be 2.8.12 and silence the warning
below.

 CMake Deprecation Warning at CMakeLists.txt:7 (cmake_minimum_required):
   Compatibility with CMake < 2.8.12 will be removed from a future version of
   CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.

Signed-off-by: Leon Romanovsky <leonro@nvidia.com>