### PR TITLE
configure: Check the existence of all needed DRM headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,7 +526,11 @@ if (NOT DRM_INCLUDE_DIRS)
 endif()
 
 if (DRM_INCLUDE_DIRS)
-  include_directories(${DRM_INCLUDE_DIRS})
+  if (EXISTS ${DRM_INCLUDE_DIRS}/i915_drm.h AND EXISTS ${DRM_INCLUDE_DIRS}/amdgpu_drm.h)
+    include_directories(${DRM_INCLUDE_DIRS})
+  else()
+    unset(DRM_INCLUDE_DIRS CACHE)
+  endif()
 endif()
 
 #-------------------------

--- a/pyverbs/dmabuf_alloc.c
+++ b/pyverbs/dmabuf_alloc.c
@@ -14,7 +14,6 @@
 #include <drm.h>
 #include <i915_drm.h>
 #include <amdgpu_drm.h>
-#include <radeon_drm.h>
 #include "dmabuf_alloc.h"
 
 /*


### PR DESCRIPTION
Some vendor specific DRM headers may be missing on systems with old
kernels. Make sure that all headers needed by pyverbs/dmabuf_alloc.c
are present before enabling that module.

Remove unused reference of "radeon_drm.h" from pyverbs/dmabuf_alloc.c.

Signed-off-by: Jianxin Xiong <jianxin.xiong@intel.com>