### PR TITLE
ibtracert: Change fdb data member in Switch structure to uint8_t

### DIFF
--- a/infiniband-diags/ibtracert.c
+++ b/infiniband-diags/ibtracert.c
@@ -90,7 +90,7 @@ struct Switch {
 	int linearFDBtop;
 	int fdb_base;
 	int enhsp0;
-	int8_t fdb[64];
+	uint8_t fdb[64];
 	char switchinfo[64];
 };
 


### PR DESCRIPTION
Change fdb data member in Switch structure to uint8_t instead of
int8_t in case we have 128 ports and up.

Signed-off-by: Haim Boozaglo <haimbo@nvidia.com>