### PR TITLE
buildlib: Continue build on old GCC versions without SSE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -233,26 +233,21 @@ RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WNESTED_EXTERNS "-Wnested-externs")
 
 # At some point after 4.4 gcc fixed shadow to ignore function vs variable
 # conflicts
-set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
-  set(CMAKE_REQUIRED_FLAGS "-Wshadow")
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_C_WORKING_SHADOW "
  #include <unistd.h>
  int main(int argc,const char *argv[]) { int access = 1; return access; }"
-  HAVE_C_WORKING_SHADOW
-  FAIL_REGEX "warning")
+  "-Wshadow")
 if (HAVE_C_WORKING_SHADOW)
   RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WORKING_SHADOW "-Wshadow")
 endif()
-set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
 
 # At some point around 5.4 gcc fixed missing-field-initializers to ignore this
 # common idiom we use extensively. Since this is a useful warning for
 # developers try and leave it on if the compiler supports it.
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_C_WORKING_MISSING_FIELD_INITIALIZERS "
  struct foo { int a; int b; };
  int main(int argc,const char *argv[]) { struct foo tmp = {}; return tmp.a; }"
-  HAVE_C_WORKING_MISSING_FIELD_INITIALIZERS
-  FAIL_REGEX "warning")
+)
 if (NOT HAVE_C_WORKING_MISSING_FIELD_INITIALIZERS)
   RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WNO_MISSING_FIELD_INITIALIZERS "-Wno-missing-field-initializers")
 endif()
@@ -268,7 +263,7 @@ set(NO_VAR_TRACKING_FLAGS "")
 RDMA_AddOptCFlag(NO_VAR_TRACKING_FLAGS HAVE_NO_VAR_TRACKING_ASSIGNMENTS
   "-fno-var-tracking-assignments")
 
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_FUNC_ATTRIBUTE_IFUNC "
  #include <unistd.h>
 
  void entry(void);
@@ -279,18 +274,16 @@ CHECK_C_SOURCE_COMPILES("
  static fn_t resolve_entry(void) {return &do_entry;}
 
  int main(int argc,const char *argv[]) { entry(); }"
-  HAVE_FUNC_ATTRIBUTE_IFUNC
-  FAIL_REGEX "warning")
+)
 
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_FUNC_ATTRIBUTE_SYMVER "
  #include <unistd.h>
 
  void _sym(void);
  __attribute__((__symver__(\"sym@TEST_1.1\"))) void _sym(void) {}
 
  int main(int argc,const char *argv[]) { _sym(); }"
-  HAVE_FUNC_ATTRIBUTE_SYMVER
-  FAIL_REGEX "warning")
+)
 
 # The code does not do the racy fcntl if the various CLOEXEC's are not
 # supported so it really doesn't work right if this isn't available. Thus hard
@@ -330,19 +323,17 @@ if (NOT HAS_CLOEXEC)
 endif()
 
 # always_inline is supported
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE "
  int foo(void);
  inline __attribute__((always_inline)) int foo(void) {return 0;}
  int main(int argc,const char *argv[]) { return foo(); }"
-  HAVE_FUNC_ATTRIBUTE_ALWAYS_INLINE
-  FAIL_REGEX "warning")
+)
 
 # Linux __u64 is an unsigned long long
-CHECK_C_SOURCE_COMPILES("
+RDMA_Check_C_Compiles(HAVE_LONG_LONG_U64 "
 #include <linux/types.h>
  int main(int argc,const char *argv[]) { __u64 tmp = 0; unsigned long long *tmp2 = &tmp; return *tmp2; }"
-  HAVE_LONG_LONG_U64
-  FAIL_REGEX "warning")
+)
 
 if (NOT HAVE_LONG_LONG_U64)
   # Modern Linux has switched to use ull in all cases, but to avoid disturbing
@@ -585,17 +576,13 @@ endif()
 # Old versions of libnl have a duplicated rtnl_route_put, disbale the warning on those
 # systems
 if (NOT NL_KIND EQUAL 0)
-  set(SAFE_CMAKE_REQUIRED_INCLUDES "${CMAKE_REQUIRED_INCLUDES}")
   set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
   set(CMAKE_REQUIRED_INCLUDES "${NL_INCLUDE_DIRS}")
-  set(CMAKE_REQUIRED_FLAGS "-Wredundant-decls")
-  CHECK_C_SOURCE_COMPILES("
+  RDMA_Check_C_Compiles(HAVE_C_WREDUNDANT_DECLS "
  #include <netlink/route/route.h>
  int main(int argc,const char *argv[]) { return 0; }"
-  HAVE_C_WREDUNDANT_DECLS
-  FAIL_REGEX "warning")
+  "-Wredundant-decls")
   set(CMAKE_REQUIRED_INCLUDES "${SAFE_CMAKE_REQUIRED_INCLUDES}")
-  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
 endif()
 RDMA_AddOptCFlag(CMAKE_C_FLAGS HAVE_C_WREDUNDANT_DECLS "-Wredundant-decls")
 

--- a/buildlib/RDMA_EnableCStd.cmake
+++ b/buildlib/RDMA_EnableCStd.cmake
@@ -58,9 +58,15 @@ function(RDMA_EnableCStd)
   endif()
 endfunction()
 
+function(RDMA_Check_C_Compiles TO_VAR CHECK_PROGRAM)
+  set(CMAKE_REQUIRED_FLAGS "${ARGV2} -Werror")
+  CHECK_C_SOURCE_COMPILES("${CHECK_PROGRAM}" ${TO_VAR})
+  set(${TO_VAR} ${${TO_VAR}} PARENT_SCOPE)
+endfunction()
+
 function(RDMA_Check_Aliasing TO_VAR)
   SET(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
-  CHECK_C_SOURCE_COMPILES("
+  RDMA_Check_C_Compiles(HAVE_WORKING_STRICT_ALIASING "
 struct in6_addr {unsigned int u6_addr32[4];};
 struct iphdr {unsigned int daddr;};
 union ibv_gid {unsigned char raw[16];};
@@ -80,8 +86,7 @@ int main(int argc, char *argv[])
 	map_ipv4_addr_to_ipv6(&a);
 	return set_ah_attr_by_ipv4(&h);
 }"
-    HAVE_WORKING_STRICT_ALIASING
-    FAIL_REGEX "warning")
+  )
 
   set(${TO_VAR} "${HAVE_WORKING_STRICT_ALIASING}" PARENT_SCOPE)
 endfunction()
@@ -107,20 +112,12 @@ int main(int argc, char *argv[])
 #endif
 ")
 
-  CHECK_C_SOURCE_COMPILES(
-    "${SSE_CHECK_PROGRAM}"
-    HAVE_TARGET_SSE
-    FAIL_REGEX "warning")
+  RDMA_Check_C_Compiles(HAVE_TARGET_SSE "${SSE_CHECK_PROGRAM}")
 
   if(NOT HAVE_TARGET_SSE)
     # Older compiler, we can work around this by adding -msse instead of
     # relying on the function attribute.
-    set(CMAKE_REQUIRED_FLAGS "-msse")
-    CHECK_C_SOURCE_COMPILES(
-      "${SSE_CHECK_PROGRAM}"
-      NEED_MSSE_FLAG
-      FAIL_REGEX "warning")
-    set(CMAKE_REQUIRED_FLAGS)
+    RDMA_Check_C_Compiles(NEED_MSSE_FLAG "${SSE_CHECK_PROGRAM}" "-msse")
 
     if(NEED_MSSE_FLAG)
       set(SSE_FLAGS "-msse" PARENT_SCOPE)


### PR DESCRIPTION
The gcc version 4.8.5 in Centos 7 fails to compile rdma-core with
the following error:

-- Performing Test HAVE_TARGET_SSE
-- Performing Test HAVE_TARGET_SSE - Failed
-- Performing Test NEED_MSSE_FLAG
-- Performing Test NEED_MSSE_FLAG - Failed
CMake Error at buildlib/RDMA_EnableCStd.cmake:128 (message):
  Can not figure out how to turn on sse instructions for i386
Call Stack (most recent call first):
  CMakeLists.txt:398 (RDMA_Check_SSE)

Instead of aborting the compilation, compile the library without that flag.

Fixes: bf343ecc783c ("buildlib: Use -msse if the compiler does not support target(sse)")
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>