### PR TITLE
Report when ibv_fork_init() is not needed

### DIFF
--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -533,6 +533,8 @@ enum rdma_nldev_attr {
 
 	RDMA_NLDEV_ATTR_RES_RAW,	/* binary */
 
+	RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK,	/* u8 */
+
 	/*
 	 * Always the end
 	 */

--- a/libibverbs/ibdev_nl.c
+++ b/libibverbs/ibdev_nl.c
@@ -217,3 +217,39 @@ err:
 	nl_socket_free(nl);
 	return EINVAL;
 }
+
+static int get_copy_on_fork_cb(struct nl_msg *msg, void *data)
+{
+	struct nlattr *tb[RDMA_NLDEV_ATTR_MAX];
+	int ret;
+
+	ret = nlmsg_parse(nlmsg_hdr(msg), 0, tb, RDMA_NLDEV_ATTR_MAX - 1,
+			  rdmanl_policy);
+	if (ret < 0)
+		return ret;
+
+	/* Older kernels don't support COF and don't report it through nl */
+	if (!tb[RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK]) {
+		*(uint8_t *)data = 0;
+		return NL_OK;
+	}
+
+	*(uint8_t *)data = nla_get_u8(tb[RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK]);
+	return NL_OK;
+}
+
+bool get_copy_on_fork(void)
+{
+	struct nl_sock *nl;
+	uint8_t cof;
+
+	nl = rdmanl_socket_alloc();
+	if (!nl)
+		return false;
+
+	if (rdmanl_get_copy_on_fork(nl, get_copy_on_fork_cb, &cof))
+		cof = false;
+
+	nl_socket_free(nl);
+	return cof;
+}

--- a/libibverbs/man/ibv_is_fork_initialized.3.md
+++ b/libibverbs/man/ibv_is_fork_initialized.3.md
@@ -38,6 +38,13 @@ disabled, or IBV_FORK_ENABLED if enabled. IBV_FORK_UNNEEDED return value
 indicates that the kernel copies DMA pages on fork, hence a call to
 **ibv_fork_init()** is unneeded.
 
+# NOTES
+
+The IBV_FORK_UNNEEDED return value takes precedence over IBV_FORK_DISABLED
+and IBV_FORK_ENABLED. If the kernel supports copy-on-fork for DMA pages then
+IBV_FORK_UNNEEDED will be returned regardless of whether **ibv_fork_init()**
+was called or not.
+
 # SEE ALSO
 
 **fork**(2),

--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -45,6 +45,7 @@
 #include <inttypes.h>
 
 #include "ibverbs.h"
+#include "util/rdma_nl.h"
 
 struct ibv_mem_node {
 	enum {
@@ -176,6 +177,9 @@ int ibv_fork_init(void)
 
 enum ibv_fork_status ibv_is_fork_initialized(void)
 {
+	if (get_copy_on_fork())
+		return IBV_FORK_UNNEEDED;
+
 	return mm_root ? IBV_FORK_ENABLED : IBV_FORK_DISABLED;
 }
 

--- a/util/rdma_nl.c
+++ b/util/rdma_nl.c
@@ -47,6 +47,7 @@ struct nla_policy rdmanl_policy[RDMA_NLDEV_ATTR_MAX] = {
 	[RDMA_NLDEV_ATTR_DEV_NAME] = { .type = NLA_NUL_STRING },
 	[RDMA_NLDEV_ATTR_DEV_PROTOCOL] = { .type = NLA_NUL_STRING },
 #endif /* NLA_NUL_STRING */
+	[RDMA_NLDEV_SYS_ATTR_COPY_ON_FORK] = { .type = NLA_U8 },
 };
 
 static int rdmanl_saw_err_cb(struct sockaddr_nl *nla, struct nlmsgerr *nlerr,
@@ -73,6 +74,33 @@ struct nl_sock *rdmanl_socket_alloc(void)
 		return NULL;
 	}
 	return nl;
+}
+
+int rdmanl_get_copy_on_fork(struct nl_sock *nl, nl_recvmsg_msg_cb_t cb_func,
+			    void *data)
+{
+	bool failed = false;
+	int ret;
+
+	if (nl_send_simple(nl,
+			   RDMA_NL_GET_TYPE(RDMA_NL_NLDEV,
+					    RDMA_NLDEV_CMD_SYS_GET),
+			   0, NULL, 0) < 0)
+		return -1;
+
+	if (nl_socket_modify_err_cb(nl, NL_CB_CUSTOM, rdmanl_saw_err_cb,
+				    &failed))
+		return -1;
+	if (nl_socket_modify_cb(nl, NL_CB_VALID, NL_CB_CUSTOM, cb_func, data))
+		return -1;
+	do {
+		ret = nl_recvmsgs_default(nl);
+	} while (ret > 0);
+	nl_socket_modify_err_cb(nl, NL_CB_CUSTOM, NULL, NULL);
+
+	if (ret || failed)
+		return -1;
+	return 0;
 }
 
 int rdmanl_get_devices(struct nl_sock *nl, nl_recvmsg_msg_cb_t cb_func,

--- a/util/rdma_nl.h
+++ b/util/rdma_nl.h
@@ -32,6 +32,8 @@
 #ifndef UTIL_RDMA_NL_H
 #define UTIL_RDMA_NL_H
 
+#include <stdbool.h>
+
 #include <rdma/rdma_netlink.h>
 #include <netlink/netlink.h>
 #include <netlink/msg.h>
@@ -43,5 +45,8 @@ int rdmanl_get_devices(struct nl_sock *nl, nl_recvmsg_msg_cb_t cb_func,
 		       void *data);
 int rdmanl_get_chardev(struct nl_sock *nl, int ibidx, const char *name,
 		       nl_recvmsg_msg_cb_t cb_func, void *data);
+bool get_copy_on_fork(void);
+int rdmanl_get_copy_on_fork(struct nl_sock *nl, nl_recvmsg_msg_cb_t cb_func,
+			    void *data);
 
 #endif


### PR DESCRIPTION
Followup from #883, this series identifies kernel with copy-on-fork support and reports that through the recently introduced ibv_is_fork_initialized() verb.

Kernel submission:
v1: https://lore.kernel.org/linux-rdma/20210405114722.98904-1-galpress@amazon.com/
v2: https://lore.kernel.org/linux-rdma/20210407101606.80737-1-galpress@amazon.com/
v3: https://lore.kernel.org/linux-rdma/20210412064150.40064-1-galpress@amazon.com/
v4: https://lore.kernel.org/linux-rdma/20210418121025.66849-1-galpress@amazon.com/