### PR TITLE
tests: Close device contexts in RDMATestCase tests

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -124,6 +124,8 @@ class RDMATestCase(unittest.TestCase):
         self.gid_type = gid_type if gid_index is None else None
         self.ip_addr = None
         self.pre_environment = {}
+        self.server = None
+        self.client = None
 
     def set_env_variable(self, var, value):
         """
@@ -135,17 +137,6 @@ class RDMATestCase(unittest.TestCase):
         if var not in self.pre_environment.keys():
             self.pre_environment[var] = os.environ.get(var)
         os.environ[var] = value
-
-    def tearDown(self):
-        """
-        Restore the previous environment variables values before ending the test.
-        """
-        for k, v in self.pre_environment.items():
-            if v is None:
-                os.environ.pop(k)
-            else:
-                os.environ[k] = v
-        super().tearDown()
 
     def is_eth_and_has_roce_hw_bug(self):
         """
@@ -286,7 +277,12 @@ class RDMATestCase(unittest.TestCase):
                 os.environ.pop(k)
             else:
                 os.environ[k] = v
+        if self.server:
+            self.server.ctx.close()
+        if self.client:
+            self.client.ctx.close()
         super().tearDown()
+
 
 class BaseResources(object):
     """

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -98,11 +98,6 @@ class FlowTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def tearDown(self):
-        super().tearDown()
-        del self.server
-        del self.client
-
     def create_players(self, resource, **resource_arg):
         """
         Init Flow tests resources.

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -29,12 +29,6 @@ class DCTest(RDMATestCase):
         self.client = None
         self.traffic_args = None
 
-    def tearDown(self):
-        if self.server:
-            self.server.ctx.close()
-        if self.client:
-            self.client.ctx.close()
-
     def sync_remote_attr(self):
         """
         Exchange the remote attributes between the server and the client.

--- a/tests/test_mlx5_lag_affinity.py
+++ b/tests/test_mlx5_lag_affinity.py
@@ -41,11 +41,6 @@ class LagPortTestCase(RDMATestCase):
         self.server = None
         self.client = None
 
-    def tearDown(self):
-        super().tearDown()
-        del self.server
-        del self.client
-
     def modify_lag(self, resources):
         try:
             port_num, active_port_num = Mlx5QP.query_lag_port(resources.qp)

--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -145,12 +145,6 @@ class ParentDomainTrafficTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def tearDown(self):
-        if self.server:
-            self.server.pd.close()
-        if self.client:
-            self.client.pd.close()
-
     def create_players(self, resource, **resource_arg):
         """
         Init Parent Domain tests resources.


### PR DESCRIPTION
Close device contexts of server/client (if they exist) in RDMATestCase's
tearDown() method.
Remove redundant tearDowns after this change.
Remove a previous tearDown duplicated method.