### PR TITLE
libhns: Add RoCE VF device ID for HIP08

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -59,6 +59,7 @@ static const struct verbs_match_ent hca_table[] = {
 	VERBS_PCI_MATCH(PCI_VENDOR_ID_HUAWEI, 0xA226, &hns_roce_u_hw_v2),
 	VERBS_PCI_MATCH(PCI_VENDOR_ID_HUAWEI, 0xA227, &hns_roce_u_hw_v2),
 	VERBS_PCI_MATCH(PCI_VENDOR_ID_HUAWEI, 0xA228, &hns_roce_u_hw_v2),
+	VERBS_PCI_MATCH(PCI_VENDOR_ID_HUAWEI, 0xA22F, &hns_roce_u_hw_v2),
 	{}
 };
 


### PR DESCRIPTION
Add device ID for VF to support VF initialization.

Signed-off-by: Wei Xu <xuwei5@hisilicon.com>
Signed-off-by: Weihang Li <liweihang@huawei.com>