### PR TITLE
tests: Avoid setting max_inline_data

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -194,8 +194,7 @@ def random_qp_cap(attr):
     recv_wr = random.randint(1, int(attr.max_qp_wr / 8))
     send_sge = random.randint(1, int(attr.max_sge / 2))
     recv_sge = random.randint(1, int(attr.max_sge / 2))
-    inline = random.randint(0, 16)
-    return QPCap(send_wr, recv_wr, send_sge, recv_sge, inline)
+    return QPCap(send_wr, recv_wr, send_sge, recv_sge)
 
 
 def random_qp_create_mask(qpt, attr_ex):


### PR DESCRIPTION
max_inline_data is not supported by all providers, to avoid the failures
of the query QP tests over devices that don't support it, change the
random_qp_cap() to return the QPCap without setting the max_inline_data.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>