### PR TITLE
redhat: Add missing rdma-ndd binary to initramfs

### DIFF
--- a/redhat/rdma.modules-setup.sh
+++ b/redhat/rdma.modules-setup.sh
@@ -19,7 +19,7 @@ install() {
 	inst /etc/rdma/modules/roce.conf
 	inst /usr/libexec/mlx4-setup.sh
 	inst /usr/lib/modprobe.d/libmlx4.conf
-	inst_multiple lspci setpci awk sleep
+	inst_multiple lspci setpci awk sleep rdma-ndd
 	inst_multiple -o /etc/modprobe.d/mlx4.conf
 	inst_rules 60-rdma-ndd.rules 60-rdma-persistent-naming.rules 70-persistent-ipoib.rules 75-rdma-description.rules 90-rdma-hw-modules.rules 90-rdma-ulp-modules.rules 90-rdma-umad.rules
 	inst_multiple -o \


### PR DESCRIPTION
The dracut modules-setup.sh for Red Hat installs rdma-ndd.service, but misses to install the required rdma-ndd binary. This causes the service to fail:
```
systemd[1]: Starting RDMA Node Description Daemon...
systemd[2512]: rdma-ndd.service: Failed to execute command: No such file or directory
systemd[2512]: rdma-ndd.service: Failed at step EXEC spawning /usr/sbin/rdma-ndd: No such file or directory
systemd[1]: rdma-ndd.service: Main process exited, code=exited, status=203/EXEC
systemd[1]: rdma-ndd.service: Failed with result 'exit-code'.
systemd[1]: Failed to start RDMA Node Description Daemon.
```

Fix by also installing the missing rdma-ndd binary.

Note: The suse/module-setup.sh is not affected by this issue as it does not install the rdma-ndd.service
