### PR TITLE
tests: Make sure to set dlid when creating AH

### DIFF
--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -39,7 +39,9 @@ class AHTest(PyverbsAPITestCase):
         """
         self.verify_state(self.ctx)
         gr = u.get_global_route(self.ctx, port_num=self.ib_port)
-        ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
+        port_attrs = self.ctx.query_port(self.ib_port)
+        dlid = port_attrs.lid if port_attrs.link_layer == e.IBV_LINK_LAYER_INFINIBAND else 0
+        ah_attr = AHAttr(dlid=dlid, gr=gr, is_global=1, port_num=self.ib_port)
         pd = PD(self.ctx)
         try:
             AH(pd, attr=ah_attr)
@@ -71,7 +73,9 @@ class AHTest(PyverbsAPITestCase):
         """
         self.verify_state(self.ctx)
         gr = u.get_global_route(self.ctx, port_num=self.ib_port)
-        ah_attr = AHAttr(gr=gr, is_global=1, port_num=self.ib_port)
+        port_attrs = self.ctx.query_port(self.ib_port)
+        dlid = port_attrs.lid if port_attrs.link_layer == e.IBV_LINK_LAYER_INFINIBAND else 0
+        ah_attr = AHAttr(dlid=dlid, gr=gr, is_global=1, port_num=self.ib_port)
         pd = PD(self.ctx)
         try:
             with AH(pd, attr=ah_attr) as ah:


### PR DESCRIPTION
To avoid the following failure when running test_addr over ib_qib,
make sure to set the dlid when the port is set to INFINIBAND.

```
======================================================================
ERROR: test_create_ah (tests.test_addr.AHTest)
Test ibv_create_ah.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rdma-core/tests/test_addr.py", line 49, in test_create_ah
    raise ex
  File "/home/rdma-core/tests/test_addr.py", line 45, in test_create_ah
    AH(pd, attr=ah_attr)
  File "addr.pyx", line 410, in pyverbs.addr.AH.__init__
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to create AH. Errno: 22, Invalid argument
```

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>