### PR TITLE
librdmacm: reimplement rdma_lib_reset()

### DIFF
--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -69,6 +69,7 @@ RDMACM_1.0 {
 		riowrite;
 		rdma_create_srq_ex;
 		rdma_create_qp_ex;
+		rdma_lib_reset;
 	local: *;
 };
 

--- a/librdmacm/rdma_cma.h
+++ b/librdmacm/rdma_cma.h
@@ -565,6 +565,15 @@ int rdma_notify(struct rdma_cm_id *id, enum ibv_event_type event);
  */
 int rdma_disconnect(struct rdma_cm_id *id);
 
+
+/**
+ * rdma_lib_reset - This function restores a clean state after fork
+ * Description:
+ *   Attempt to close and reopen in-use devices. Applications can call this
+ *   after a fork()
+ */
+void rdma_lib_reset(void);
+
 /**
  * rdma_join_multicast - Joins a multicast group.
  * @id: Communication identifier associated with the request.


### PR DESCRIPTION
Older mofed packages used to have a rdma_lib_reset() function which
could be called by applications and helped after a fork().

This function was then removed because it was apparently not needed
anymore. But our experience shows that it's still needed in some cases to
force the lib to close and reopen devices.

Without this function, after fork(), sometimes ibv_poll_cq() will return work completion entries whose wr_id field does not match any of the work requests that were posted earlier with ibv_post_recv() or ibv_post_send(). It looks like this wr_id was corrupted somehow. This results in application hangs or crashes.