### PR TITLE
tests: Set port_space based on link_layer

### DIFF
--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -10,6 +10,8 @@ from pyverbs.pyverbs_error import PyverbsError
 from tests.utils import requires_mcast_support
 from tests.base import RDMATestCase
 import pyverbs.cm_enums as ce
+import pyverbs.device as d
+import pyverbs.enums as e
 
 
 NUM_OF_PROCESSES = 2
@@ -164,6 +166,15 @@ class CMTestCase(RDMACMBaseTest):
     """
     RDMACM Test class. Include all the native RDMACM functionalities.
     """
+    def get_port_space(self):
+        ctx = d.Context(name=self.dev_name)
+        dev_attrs = ctx.query_port(self.ib_port)
+        port_space = ce.RDMA_PS_IPOIB \
+            if dev_attrs.link_layer == e.IBV_LINK_LAYER_INFINIBAND \
+                else ce.RDMA_PS_UDP
+        return port_space
+
+
     def test_rdmacm_sync_traffic(self):
         self.two_nodes_rdmacm_traffic(CMSyncConnection, self.rdmacm_traffic)
 
@@ -174,13 +185,13 @@ class CMTestCase(RDMACMBaseTest):
     def test_rdmacm_async_multicast_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,
                                       self.rdmacm_multicast_traffic,
-                                      port_space=ce.RDMA_PS_UDP)
+                                      port_space=self.get_port_space())
 
     @requires_mcast_support()
     def test_rdmacm_async_ex_multicast_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,
                                       self.rdmacm_multicast_traffic,
-                                      port_space=ce.RDMA_PS_UDP, extended=True)
+                                      port_space=self.get_port_space(), extended=True)
 
     def test_rdmacm_async_traffic_external_qp(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection, self.rdmacm_traffic,
@@ -188,7 +199,7 @@ class CMTestCase(RDMACMBaseTest):
 
     def test_rdmacm_async_udp_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection, self.rdmacm_traffic,
-                                      port_space=ce.RDMA_PS_UDP)
+                                      port_space=self.get_port_space())
 
     def test_rdmacm_async_read(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,


### PR DESCRIPTION
To avoid the following failure when running test_rdmacm over ib_qib,
make sure to set the port_space to RDMA_PS_IPOIB when the port is set to
INFINIBAND.

```
======================================================================
ERROR: test_rdmacm_async_ex_multicast_traffic (tests.test_rdmacm.CMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rdma-core/tests/utils.py", line 912, in inner
    return func(instance)
  File "/home/rdma-core/tests/test_rdmacm.py", line 181, in test_rdmacm_async_ex_multicast_traffic
    self.two_nodes_rdmacm_traffic(CMAsyncConnection,
  File "/home/rdma-core/tests/test_rdmacm.py", line 88, in two_nodes_rdmacm_traffic
    raise(res)
threading.BrokenBarrierError
```

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>