### PR TITLE
verbs: Fix data races in multithreaded calling ibv_reg_mr

### DIFF
--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -713,7 +713,7 @@ int ibv_dontfork_range(void *base, size_t size)
 	if (mm_root)
 		return ibv_madvise_range(base, size, MADV_DONTFORK);
 	else {
-		too_late = 1;
+		atomic_store(&too_late, 1);
 		return 0;
 	}
 }
@@ -723,7 +723,7 @@ int ibv_dofork_range(void *base, size_t size)
 	if (mm_root)
 		return ibv_madvise_range(base, size, MADV_DOFORK);
 	else {
-		too_late = 1;
+		atomic_store(&too_late, 1);
 		return 0;
 	}
 }


### PR DESCRIPTION
When calling ibv_reg_mr in valgrind --tool=helgrind or --tool=drd under multihreaded test, there were  data race or conflicting store reported. By changing the variable too_late writting into atomic_store, it can pass the valgrind test.