### PR TITLE
efa: Fix use of uninitialized query device response

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -96,7 +96,7 @@ int efa_query_device_ex(struct ibv_context *context,
 
 int efa_query_device_ctx(struct efa_context *ctx)
 {
-	struct efa_query_device_ex_resp resp;
+	struct efa_query_device_ex_resp resp = {};
 	struct ibv_device_attr_ex attr;
 	size_t resp_size = sizeof(resp);
 	unsigned int qp_table_sz;


### PR DESCRIPTION
The query device response struct must be cleared before passing it to
the kernel ioctl call. Otherwise, old drivers that do not fill the
entire response would cause the userspace to read uninitialized data.

Fixes: c95038eb598f ("efa: Move the context initialization out of efa_query_device_ex()")
Signed-off-by: Gal Pressman <galpress@amazon.com>