### PR TITLE
mlx5: Add a DV API to map between AH to QP

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -27,6 +27,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.17@MLX5_1.17 33
  MLX5_1.18@MLX5_1.18 34
  MLX5_1.19@MLX5_1.19 35
+ MLX5_1.20@MLX5_1.20 36
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -128,6 +129,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_umem_reg_ex@MLX5_1.19 35
  mlx5dv_dm_map_op_addr@MLX5_1.19 35
  _mlx5dv_query_port@MLX5_1.19 35
+ mlx5dv_map_ah_to_qp@MLX5_1.20 36
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.19.${PACKAGE_VERSION}
+  1 1.20.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -181,3 +181,8 @@ MLX5_1.19 {
 		mlx5dv_dm_map_op_addr;
 		_mlx5dv_query_port;
 } MLX5_1.18;
+
+MLX5_1.20 {
+	global:
+		mlx5dv_map_ah_to_qp;
+} MLX5_1.19;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -24,6 +24,7 @@ rdma_man_pages(
   mlx5dv_get_clock_info.3
   mlx5dv_init_obj.3
   mlx5dv_is_supported.3.md
+  mlx5dv_map_ah_to_qp.3.md
   mlx5dv_modify_qp_lag_port.3.md
   mlx5dv_modify_qp_sched_elem.3.md
   mlx5dv_modify_qp_udp_sport.3.md

--- a/providers/mlx5/man/mlx5dv_map_ah_to_qp.3.md
+++ b/providers/mlx5/man/mlx5dv_map_ah_to_qp.3.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: mlx5dv_map_ah_to_qp
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_map_ah_to_qp - Map the destination path information in address handle (AH) to the
+information extracted from the qp.
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_map_ah_to_qp(struct ibv_ah *ah, uint32_t qp_num);
+```
+
+# DESCRIPTION
+
+This API maps the destination path information in address handle (*ah*) to the information
+extracted from the qp (e.g. congestion control from ECE).
+
+This API serves as an enhancement to DC and UD QPs to achieve better performance by using per-address
+congestion control (CC) algorithms, enabling DC/UD QPs to use multiple CC algorithms in the same datacenter.
+
+The mapping created by this API is implicitly destroyed when the address handle is destroyed.
+It is not affected by the destruction of QP *qp_num*.
+
+A duplicate mapping to the same address handle is ignored. As this API is just a hint for the hardware in this
+case it would do nothing and return success regardless of the new qp_num ECE.
+
+The function must be called after ECE negotiation/preconfiguration was done by some external means.
+
+# ARGUMENTS
+
+*ah*
+:	The target’s address handle.
+
+*qp_num*
+:	The initiator QP from which congestion control information is extracted from its ECE.
+
+# RETURN VALUE
+
+Upon success, returns 0; Upon failure, the value of errno is returned.
+
+# SEE ALSO
+
+*rdma_cm(7)*, *rdma_get_remote_ece(3)*, *ibv_query_ece(3)*, *ibv_set_ece(3)*
+
+# AUTHOR
+
+Yochai Cohen <yochai@nvidia.com>
+
+Patrisious Haddad <phaddad@nvidia.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -671,6 +671,9 @@ struct mlx5_ah {
 	struct ibv_ah			ibv_ah;
 	struct mlx5_wqe_av		av;
 	bool				kern_ah;
+	pthread_mutex_t			mutex;
+	uint8_t				is_global;
+	struct mlx5dv_devx_obj		*ah_qp_mapping;
 };
 
 struct mlx5_rwq {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -2481,6 +2481,7 @@ enum {
 	MLX5_OBJ_TYPE_SCHEDULING_ELEMENT = 0x0026,
 	MLX5_OBJ_TYPE_RESERVED_QPN = 0x002C,
 	MLX5_OBJ_TYPE_ASO_CT = 0x0031,
+	MLX5_OBJ_TYPE_AV_QP_MAPPING = 0x003A,
 };
 
 struct mlx5_ifc_general_obj_in_cmd_hdr_bits {
@@ -2651,6 +2652,22 @@ enum {
 
 enum {
 	MLX5_QPC_PM_STATE_MIGRATED  = 0x3,
+};
+
+struct mlx5_ifc_ud_av_bits {
+	u8         reserved_at_0[0x60];
+
+	u8         reserved_at_60[0x4];
+	u8         sl_or_eth_prio[0x4];
+	u8         reserved_at_68[0x18];
+
+	u8         reserved_at_80[0x60];
+
+	u8         reserved_at_e0[0x4];
+	u8         src_addr_index[0x8];
+	u8         reserved_at_ec[0x14];
+
+	u8         rgid_or_rip[16][0x8];
 };
 
 struct mlx5_ifc_ads_bits {
@@ -3172,6 +3189,27 @@ struct mlx5_ifc_query_lag_in_bits {
 
 	u8         reserved_at_40[0x40];
 };
+
+struct mlx5_ifc_av_qp_mapping_bits {
+	u8         modify_field_select[0x40];
+
+	u8         reserved_at_40[0x20];
+
+	u8         qpn[0x20];
+
+	struct mlx5_ifc_ud_av_bits remote_address_vector;
+};
+
+struct mlx5_ifc_create_av_qp_mapping_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits   hdr;
+	struct mlx5_ifc_av_qp_mapping_bits            mapping;
+};
+
+struct mlx5_ifc_query_av_qp_mapping_out_bits {
+	struct mlx5_ifc_general_obj_out_cmd_hdr_bits  hdr;
+	struct mlx5_ifc_av_qp_mapping_bits            obj;
+};
+
 
 struct mlx5_ifc_modify_tis_out_bits {
 	u8         status[0x8];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -401,6 +401,8 @@ mlx5dv_create_flow_action_packet_reformat(struct ibv_context *ctx,
 int mlx5dv_query_device(struct ibv_context *ctx_in,
 			struct mlx5dv_context *attrs_out);
 
+int mlx5dv_map_ah_to_qp(struct ibv_ah *ah, uint32_t qp_num);
+
 enum mlx5dv_qp_comp_mask {
 	MLX5DV_QP_MASK_UAR_MMAP_OFFSET		= 1 << 0,
 	MLX5DV_QP_MASK_RAW_QP_HANDLES		= 1 << 1,

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -211,6 +211,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     uint64_t mlx5dv_ts_to_ns(mlx5dv_clock_info *clock_info,
                              uint64_t device_timestamp)
     int mlx5dv_get_clock_info(v.ibv_context *ctx_in, mlx5dv_clock_info *clock_info)
+    int mlx5dv_map_ah_to_qp(v.ibv_ah *ah, uint32_t qp_num)
 
     # DevX APIs
     mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(v.ibv_context *context,

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -576,6 +576,18 @@ cdef class Mlx5QP(QPEx):
             raise PyverbsRDMAError(f'Failed to modify UDP source port of QP '
                                    f'#{qp.qp.qp_num}', rc)
 
+    @staticmethod
+    def map_ah_to_qp(AH ah, qp_num):
+        """
+        Map the destination path information in ah to the information extracted
+        from the qp.
+        :param ah: The target’s address handle.
+        :param qp_num: The traffic initiator QP number.
+        """
+        rc = dv.mlx5dv_map_ah_to_qp(ah.ah, qp_num)
+        if rc != 0:
+            raise PyverbsRDMAError(f'Failed to map AH to QP #{qp_num}', rc)
+
 
 cdef class Mlx5DVCQInitAttr(PyverbsObject):
     """


### PR DESCRIPTION
This series exposes a DV API to enable mapping the destination path information in address handle (AH) to the information extracted from the QP.

This enables DC/UD QPs to use multiple CC algorithms in the same data center.