### PR TITLE
mlx5: DR, Add definers support

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -538,7 +538,7 @@ dr_action_reformat_to_action_type(enum mlx5dv_flow_action_packet_reformat_type t
  * Actions might require more than one STE, new_num_stes will return
  * the new size of the STEs array, rule with actions. */
 static void dr_actions_apply(struct mlx5dv_dr_domain *dmn,
-			     enum dr_ste_entry_type ste_type,
+			     enum dr_domain_nic_type nic_type,
 			     uint8_t *action_type_set,
 			     uint8_t *last_ste,
 			     struct dr_ste_actions_attr *attr,
@@ -547,7 +547,7 @@ static void dr_actions_apply(struct mlx5dv_dr_domain *dmn,
 	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
 	uint32_t added_stes = 0;
 
-	if (ste_type == DR_STE_TYPE_RX)
+	if (nic_type == DR_DOMAIN_NIC_TYPE_RX)
 		dr_ste_set_actions_rx(ste_ctx, action_type_set,
 				      last_ste, attr, &added_stes);
 	else
@@ -559,7 +559,7 @@ static void dr_actions_apply(struct mlx5dv_dr_domain *dmn,
 
 static enum dr_action_domain
 dr_action_get_action_domain(enum mlx5dv_dr_domain_type domain,
-			    enum dr_ste_entry_type ste_type)
+			    enum dr_domain_nic_type nic_type)
 {
 	if (domain == MLX5DV_DR_DOMAIN_TYPE_NIC_RX) {
 		return DR_ACTION_DOMAIN_NIC_INGRESS;
@@ -567,7 +567,7 @@ dr_action_get_action_domain(enum mlx5dv_dr_domain_type domain,
 		return DR_ACTION_DOMAIN_NIC_EGRESS;
 	} else {
 		/* FDB domain */
-		if (ste_type == DR_STE_TYPE_RX)
+		if (nic_type == DR_DOMAIN_NIC_TYPE_RX)
 			return DR_ACTION_DOMAIN_FDB_INGRESS;
 		else
 			return DR_ACTION_DOMAIN_FDB_EGRESS;
@@ -602,7 +602,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			     uint32_t *new_hw_ste_arr_sz)
 {
 	struct dr_domain_rx_tx *nic_dmn = nic_matcher->nic_tbl->nic_dmn;
-	bool rx_rule = nic_dmn->ste_type == DR_STE_TYPE_RX;
+	bool rx_rule = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
 	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
 	uint8_t action_type_set[DR_ACTION_TYP_MAX] = {};
 	uint32_t state = DR_ACTION_STATE_NO_ACTION;
@@ -613,7 +613,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 
 	attr.gvmi = dmn->info.caps.gvmi;
 	attr.final_icm_addr = nic_dmn->default_icm_addr;
-	action_domain = dr_action_get_action_domain(dmn->type, nic_dmn->ste_type);
+	action_domain = dr_action_get_action_domain(dmn->type, nic_dmn->type);
 
 	for (i = 0; i < num_actions; i++) {
 		struct mlx5dv_dr_action *action;
@@ -811,7 +811,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 	last_ste = ste_arr + DR_STE_SIZE * (nic_matcher->num_of_builders - 1);
 
 	dr_actions_apply(dmn,
-			 nic_dmn->ste_type,
+			 nic_dmn->type,
 			 action_type_set,
 			 last_ste,
 			 &attr,

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -250,7 +250,7 @@ static int dr_dump_rule_mem(FILE *f, struct dr_ste *ste,
 				       DR_DUMP_REC_TYPE_RULE_TX_ENTRY_V1;
 	}
 
-	dump_hex_print(hw_ste_dump, (char *)ste->hw_ste, DR_STE_SIZE_REDUCED);
+	dump_hex_print(hw_ste_dump, (char *)ste->hw_ste, ste->size);
 	ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",%s\n",
 		      mem_rec_type,
 		      dr_dump_icm_to_idx(dr_ste_get_icm_addr(ste)),

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -392,14 +392,16 @@ static int dr_dump_matcher_builder(FILE *f, struct dr_ste_build *builder,
 				   uint32_t index, bool is_rx,
 				   const uint64_t matcher_id)
 {
+	bool is_match = builder->htbl_type == DR_STE_HTBL_TYPE_MATCH;
 	int ret;
 
-	ret = fprintf(f, "%d,0x%" PRIx64 "%d,%d,0x%x\n",
+	ret = fprintf(f, "%d,0x%" PRIx64 "%d,%d,0x%x,%d\n",
 		      DR_DUMP_REC_TYPE_MATCHER_BUILDER,
 		      matcher_id,
 		      index,
 		      is_rx,
-		      builder->lu_type);
+		      builder->lu_type,
+		      is_match ? builder->format_id : -1);
 	if (ret < 0)
 		return ret;
 

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -290,6 +290,15 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->max_ft_level = DEVX_GET(query_hca_cap_out, out,
 				      capability.flow_table_nic_cap.
 				      flow_table_properties_nic_receive.max_ft_level);
+
+	/* l4_csum_ok is the indication for definer support csum and ok bits.
+	 * Since we don't have definer versions we rely on new field support
+	 */
+	caps->definer_supp_checksum = DEVX_GET(query_hca_cap_out, out,
+					       capability.flow_table_nic_cap.
+					       ft_field_bitmask_support_2_nic_receive.
+					       outer_l4_checksum_ok);
+
 	DEVX_SET(query_hca_cap_in, in, op_mod,
 		 MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY |
 		 HCA_CAP_OPMOD_GET_CUR);

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -228,7 +228,7 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 			return 0;
 
 		dmn->info.supp_sw_steering = true;
-		dmn->info.rx.ste_type = DR_STE_TYPE_RX;
+		dmn->info.rx.type = DR_DOMAIN_NIC_TYPE_RX;
 		dmn->info.rx.default_icm_addr = dmn->info.caps.nic_rx_drop_address;
 		dmn->info.rx.drop_icm_addr = dmn->info.caps.nic_rx_drop_address;
 		break;
@@ -239,7 +239,7 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 			return 0;
 
 		dmn->info.supp_sw_steering = true;
-		dmn->info.tx.ste_type = DR_STE_TYPE_TX;
+		dmn->info.tx.type = DR_DOMAIN_NIC_TYPE_TX;
 		dmn->info.tx.default_icm_addr = dmn->info.caps.nic_tx_allow_address;
 		dmn->info.tx.drop_icm_addr = dmn->info.caps.nic_tx_drop_address;
 		break;
@@ -252,8 +252,8 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 		      dmn->info.caps.sw_format_ver <= MLX5_HW_CONNECTX_6DX))
 			return 0;
 
-		dmn->info.rx.ste_type = DR_STE_TYPE_RX;
-		dmn->info.tx.ste_type = DR_STE_TYPE_TX;
+		dmn->info.rx.type = DR_DOMAIN_NIC_TYPE_RX;
+		dmn->info.tx.type = DR_DOMAIN_NIC_TYPE_TX;
 		vport_cap = dr_get_vport_cap(&dmn->info.caps, 0);
 		if (!vport_cap) {
 			dr_dbg(dmn, "Failed to get eswitch manager vport\n");

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -848,6 +848,7 @@ static int dr_matcher_init_nic(struct mlx5dv_dr_matcher *matcher,
 
 	nic_matcher->e_anchor = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 						  DR_CHUNK_SIZE_1,
+						  DR_STE_HTBL_TYPE_LEGACY,
 						  DR_STE_LU_TYPE_DONT_CARE,
 						  0);
 	if (!nic_matcher->e_anchor)
@@ -855,8 +856,9 @@ static int dr_matcher_init_nic(struct mlx5dv_dr_matcher *matcher,
 
 	nic_matcher->s_htbl = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 						DR_CHUNK_SIZE_1,
-						nic_matcher->ste_builder[0].lu_type,
-						nic_matcher->ste_builder[0].byte_mask);
+						nic_matcher->ste_builder->htbl_type,
+						nic_matcher->ste_builder->lu_type,
+						nic_matcher->ste_builder->byte_mask);
 	if (!nic_matcher->s_htbl)
 		goto free_e_htbl;
 

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -425,7 +425,7 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 	int idx = 0;
 	int ret, i;
 
-	rx = nic_dmn->ste_type == DR_STE_TYPE_RX;
+	rx = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
 
 	/* Create a temporary mask to track and clear used mask fields */
 	if (matcher->match_criteria & DR_MATCHER_CRITERIA_OUTER)

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -513,6 +513,17 @@ static int dr_matcher_set_definer_builders(struct mlx5dv_dr_matcher *matcher,
 	src_ipv6 = dr_mask_is_src_addr_set(&matcher->mask.outer);
 	dst_ipv6 = dr_mask_is_dst_addr_set(&matcher->mask.outer);
 
+
+	if (caps->definer_format_sup & (1 << DR_MATCHER_DEFINER_0)) {
+		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+		ret = dr_ste_build_def0(ste_ctx, &sb[idx++], &mask, caps, false, rx);
+		if (!ret && dr_matcher_is_mask_consumed(&mask))
+			goto done;
+
+		memset(sb, 0, sizeof(*sb));
+		idx = 0;
+	}
+
 	if (caps->definer_format_sup & (1 << DR_MATCHER_DEFINER_22)) {
 		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
 		ret = dr_ste_build_def22(ste_ctx, &sb[idx++], &mask, false, rx);

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -411,6 +411,173 @@ static bool dr_mask_is_tnl_mpls_over_udp(struct dr_match_param *mask,
 	       dr_matcher_supp_tnl_mpls_over_udp(&dmn->info.caps);
 }
 
+static bool dr_matcher_is_mask_consumed(struct dr_match_param *mask)
+{
+	int i;
+
+	for (i = 0; i < sizeof(struct dr_match_param); i++)
+		if (((uint8_t *)mask)[i] != 0)
+			return false;
+
+	return true;
+}
+
+static void dr_matcher_copy_mask(struct dr_match_param *dst_mask,
+				 struct dr_match_param *src_mask,
+				 uint8_t match_criteria)
+{
+	if (match_criteria & DR_MATCHER_CRITERIA_OUTER)
+		dst_mask->outer = src_mask->outer;
+
+	if (match_criteria & DR_MATCHER_CRITERIA_MISC)
+		dst_mask->misc = src_mask->misc;
+
+	if (match_criteria & DR_MATCHER_CRITERIA_INNER)
+		dst_mask->inner = src_mask->inner;
+
+	if (match_criteria & DR_MATCHER_CRITERIA_MISC2)
+		dst_mask->misc2 = src_mask->misc2;
+
+	if (match_criteria & DR_MATCHER_CRITERIA_MISC3)
+		dst_mask->misc3 = src_mask->misc3;
+
+	if (match_criteria & DR_MATCHER_CRITERIA_MISC4)
+		dst_mask->misc4 = src_mask->misc4;
+}
+
+static void dr_matcher_destroy_definer_objs(struct dr_ste_build *sb,
+					    uint8_t idx)
+{
+	int i;
+
+	for (i = 0; i < idx; i++) {
+		mlx5dv_devx_obj_destroy(sb[i].definer_obj);
+		sb[i].lu_type = 0;
+		sb[i].htbl_type = 0;
+		sb[i].definer_obj = NULL;
+	}
+}
+
+static int dr_matcher_create_definer_objs(struct ibv_context *ctx,
+					  struct dr_ste_build *sb,
+					  uint8_t idx)
+{
+	struct mlx5dv_devx_obj *devx_obj;
+	int i;
+
+	for (i = 0; i < idx; i++) {
+		devx_obj = dr_devx_create_definer(ctx, sb[i].format_id, sb[i].match);
+		if (!devx_obj)
+			goto cleanup;
+
+		/* The lu_type combines the definer and the entry type */
+		sb[i].lu_type |= devx_obj->object_id;
+		sb[i].htbl_type = DR_STE_HTBL_TYPE_MATCH;
+		sb[i].definer_obj = devx_obj;
+	}
+
+	return 0;
+
+cleanup:
+	dr_matcher_destroy_definer_objs(sb, i);
+	return errno;
+}
+
+static void dr_matcher_clear_definers_builders(struct dr_matcher_rx_tx *nic_matcher)
+{
+	struct dr_ste_build *sb = nic_matcher->ste_builder;
+	int i;
+
+	for (i = 0; i < nic_matcher->num_of_builders; i++)
+		memset(&sb[i], 0, sizeof(*sb));
+
+	nic_matcher->num_of_builders = 0;
+}
+
+static int dr_matcher_set_definer_builders(struct mlx5dv_dr_matcher *matcher,
+					   struct dr_matcher_rx_tx *nic_matcher)
+{
+	struct dr_domain_rx_tx *nic_dmn = nic_matcher->nic_tbl->nic_dmn;
+	struct dr_ste_build *sb = nic_matcher->ste_builder;
+	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
+	bool rx = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
+	struct dr_devx_caps *caps = &dmn->info.caps;
+	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
+	struct dr_match_param mask = {};
+	uint8_t idx = 0;
+	int ret;
+
+	if (caps->definer_format_sup & (1 << DR_MATCHER_DEFINER_22)) {
+		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+		ret = dr_ste_build_def22(ste_ctx, &sb[idx++], &mask, false, rx);
+		if (!ret && dr_matcher_is_mask_consumed(&mask))
+			goto done;
+
+		memset(sb, 0, sizeof(*sb));
+		idx = 0;
+	}
+
+	if (caps->definer_format_sup & (1 << DR_MATCHER_DEFINER_24)) {
+		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+		ret = dr_ste_build_def24(ste_ctx, &sb[idx++], &mask, false, rx);
+		if (!ret && dr_matcher_is_mask_consumed(&mask))
+			goto done;
+
+		memset(sb, 0, sizeof(*sb));
+		idx = 0;
+	}
+
+	if (caps->definer_format_sup & (1 << DR_MATCHER_DEFINER_25)) {
+		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+		ret = dr_ste_build_def25(ste_ctx, &sb[idx++], &mask, false, rx);
+		if (!ret && dr_matcher_is_mask_consumed(&mask))
+			goto done;
+
+		memset(sb, 0, sizeof(*sb));
+		idx = 0;
+	}
+
+	return ENOTSUP;
+
+done:
+	nic_matcher->num_of_builders = idx;
+	return 0;
+}
+
+static int dr_matcher_set_large_ste_builders(struct mlx5dv_dr_matcher *matcher,
+					     struct dr_matcher_rx_tx *nic_matcher)
+{
+	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
+	int ret;
+
+	if (dmn->info.caps.sw_format_ver != MLX5_HW_CONNECTX_6DX ||
+	    !dmn->info.caps.definer_format_sup)
+		return ENOTSUP;
+
+	ret = dr_matcher_set_definer_builders(matcher, nic_matcher);
+	if (ret)
+		return ret;
+
+	ret = dr_matcher_create_definer_objs(dmn->ctx,
+					     nic_matcher->ste_builder,
+					     nic_matcher->num_of_builders);
+	if (ret)
+		goto clear_definers_builders;
+
+	return 0;
+
+clear_definers_builders:
+	dr_matcher_clear_definers_builders(nic_matcher);
+	return ret;
+}
+
+static void dr_matcher_clear_ste_builders(struct dr_matcher_rx_tx *nic_matcher)
+{
+	if (nic_matcher->ste_builder->htbl_type == DR_STE_HTBL_TYPE_MATCH)
+		dr_matcher_destroy_definer_objs(nic_matcher->ste_builder,
+						nic_matcher->num_of_builders);
+}
+
 static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 				       struct dr_matcher_rx_tx *nic_matcher)
 {
@@ -423,37 +590,25 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 	bool inner, rx;
 	uint8_t ipv;
 	int idx = 0;
-	int ret, i;
-
-	rx = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
-
-	/* Create a temporary mask to track and clear used mask fields */
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_OUTER)
-		mask.outer = matcher->mask.outer;
-
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_MISC)
-		mask.misc = matcher->mask.misc;
-
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_INNER)
-		mask.inner = matcher->mask.inner;
-
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_MISC2)
-		mask.misc2 = matcher->mask.misc2;
-
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_MISC3)
-		mask.misc3 = matcher->mask.misc3;
-
-	if (matcher->match_criteria & DR_MATCHER_CRITERIA_MISC4)
-		mask.misc4 = matcher->mask.misc4;
+	int ret;
 
 	ret = dr_ste_build_pre_check(dmn, matcher->match_criteria,
 				     &matcher->mask, NULL);
 	if (ret)
 		return ret;
 
+	/* Use a large definers for matching if possible */
+	ret = dr_matcher_set_large_ste_builders(matcher, nic_matcher);
+	if (!ret)
+		return 0;
+
+	/* Create a temporary mask to track and clear used mask fields */
+	dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+
 	/* Optimize RX pipe by reducing source port match, since
-	 * the FDB RX part is conneted only to the wire.
+	 * the FDB RX part is connected only to the wire.
 	 */
+	rx = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
 	if (dmn->type == MLX5DV_DR_DOMAIN_TYPE_FDB &&
 	    rx && mask.misc.source_port) {
 		mask.misc.source_port = 0;
@@ -663,16 +818,15 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 		return errno;
 	}
 
+	/* Check that all mask fields were consumed */
+	if (!dr_matcher_is_mask_consumed(&mask)) {
+		dr_dbg(dmn, "Mask contains unsupported parameters\n");
+		errno = EOPNOTSUPP;
+		return errno;
+	}
+
 	nic_matcher->num_of_builders = idx;
 
-	/* Check that all mask fields were consumed */
-	for (i = 0; i < sizeof(struct dr_match_param); i++) {
-		if (((uint8_t *)&mask)[i] != 0) {
-			dr_dbg(dmn, "Mask contains unsupported parameters\n");
-			errno = EOPNOTSUPP;
-			return errno;
-		}
-	}
 	return 0;
 }
 
@@ -796,6 +950,7 @@ static int dr_matcher_add_to_tbl(struct mlx5dv_dr_matcher *matcher)
 
 static void dr_matcher_uninit_nic(struct dr_matcher_rx_tx *nic_matcher)
 {
+	dr_matcher_clear_ste_builders(nic_matcher);
 	dr_htbl_put(nic_matcher->s_htbl);
 	dr_htbl_put(nic_matcher->e_anchor);
 }
@@ -852,7 +1007,7 @@ static int dr_matcher_init_nic(struct mlx5dv_dr_matcher *matcher,
 						  DR_STE_LU_TYPE_DONT_CARE,
 						  0);
 	if (!nic_matcher->e_anchor)
-		return errno;
+		goto clear_ste_builders;
 
 	nic_matcher->s_htbl = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 						DR_CHUNK_SIZE_1,
@@ -870,6 +1025,8 @@ static int dr_matcher_init_nic(struct mlx5dv_dr_matcher *matcher,
 
 free_e_htbl:
 	dr_ste_htbl_free(nic_matcher->e_anchor);
+clear_ste_builders:
+	dr_matcher_clear_ste_builders(nic_matcher);
 	return errno;
 }
 

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -684,19 +684,21 @@ static bool dr_rule_need_enlarge_hash(struct dr_ste_htbl *htbl,
 				      struct dr_domain_rx_tx *nic_dmn)
 {
 	struct dr_ste_htbl_ctrl *ctrl = &htbl->ctrl;
+	int threshold;
 
 	if (dmn->info.max_log_sw_icm_sz <= htbl->chunk_size)
 		return false;
 
-	if (!ctrl->may_grow)
+	if (!dr_ste_htbl_may_grow(htbl))
 		return false;
 
 	if (htbl->type == DR_STE_HTBL_TYPE_LEGACY &&
 	    dr_get_bits_per_mask(htbl->byte_mask) * CHAR_BIT <= htbl->chunk_size)
 		return false;
 
-	if (ctrl->num_of_collisions >= ctrl->increase_threshold &&
-	    (ctrl->num_of_valid_entries - ctrl->num_of_collisions) >= ctrl->increase_threshold)
+	threshold = dr_ste_htbl_increase_threshold(htbl);
+	if (ctrl->num_of_collisions >= threshold &&
+	    (ctrl->num_of_valid_entries - ctrl->num_of_collisions) >= threshold)
 		return true;
 
 	return false;

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -419,7 +419,7 @@ static struct dr_ste_htbl *dr_rule_rehash_htbl(struct mlx5dv_dr_rule *rule,
 	info.miss_icm_addr = nic_matcher->e_anchor->chunk->icm_addr;
 	dr_ste_set_formated_ste(dmn->ste_ctx,
 				dmn->info.caps.gvmi,
-				nic_dmn,
+				nic_dmn->type,
 				new_htbl,
 				formated_ste,
 				&info);
@@ -1064,17 +1064,17 @@ static int dr_rule_destroy_rule_root(struct mlx5dv_dr_rule *rule)
 }
 
 static int dr_rule_skip(enum mlx5dv_dr_domain_type domain,
-			enum dr_ste_entry_type ste_type,
+			enum dr_domain_nic_type nic_type,
 			struct dr_match_param *mask,
 			struct dr_match_param *value)
 {
 	if (domain == MLX5DV_DR_DOMAIN_TYPE_FDB) {
 		if (mask->misc.source_port) {
-			if (ste_type == DR_STE_TYPE_RX)
+			if (nic_type == DR_DOMAIN_NIC_TYPE_RX)
 				if (value->misc.source_port != WIRE_PORT)
 					return 1;
 
-			if (ste_type == DR_STE_TYPE_TX)
+			if (nic_type == DR_DOMAIN_NIC_TYPE_TX)
 				if (value->misc.source_port == WIRE_PORT)
 					return 1;
 		}
@@ -1103,7 +1103,7 @@ dr_rule_create_rule_nic(struct mlx5dv_dr_rule *rule,
 	struct dr_ste *ste = NULL; /* Fix compilation warning */
 	int ret, i;
 
-	if (dr_rule_skip(dmn->type, nic_dmn->ste_type, &matcher->mask, param))
+	if (dr_rule_skip(dmn->type, nic_dmn->type, &matcher->mask, param))
 		return 0;
 
 	/* Set the tag values inside the ste array */

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -80,6 +80,7 @@ static struct dr_ste
 	/* Create new table for miss entry */
 	new_htbl = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 				     DR_CHUNK_SIZE_1,
+				     nic_matcher->ste_builder->htbl_type,
 				     DR_STE_LU_TYPE_DONT_CARE,
 				     0);
 	if (!new_htbl) {
@@ -141,7 +142,7 @@ static int dr_rule_handle_one_ste_in_update_list(struct dr_ste_send_info *ste_in
 	if (ste_info->size == DR_STE_SIZE_CTRL)
 		memcpy(ste_info->ste->hw_ste, ste_info->data, DR_STE_SIZE_CTRL);
 	else
-		memcpy(ste_info->ste->hw_ste, ste_info->data, DR_STE_SIZE_REDUCED);
+		memcpy(ste_info->ste->hw_ste, ste_info->data, ste_info->ste->size);
 
 	ret = dr_send_postsend_ste(dmn, ste_info->ste, ste_info->data,
 				   ste_info->size, ste_info->offset);
@@ -182,13 +183,14 @@ static int dr_rule_send_update_list(struct list_head *send_ste_list,
 }
 
 static struct dr_ste *dr_rule_find_ste_in_miss_list(struct list_head *miss_list,
-						    uint8_t *hw_ste)
+						    uint8_t *hw_ste,
+						    uint8_t tag_size)
 {
 	struct dr_ste *ste;
 
 	/* Check if hw_ste is present in the list */
 	list_for_each(miss_list, ste, miss_list_node)
-		if (dr_ste_equal_tag(ste->hw_ste, hw_ste))
+		if (dr_ste_equal_tag(ste->hw_ste, hw_ste, tag_size))
 			return ste;
 
 	return NULL;
@@ -262,16 +264,18 @@ static struct dr_ste *dr_rule_rehash_copy_ste(struct mlx5dv_dr_matcher *matcher,
 	uint8_t hw_ste[DR_STE_SIZE] = {};
 	struct dr_ste_send_info *ste_info;
 	bool use_update_list = false;
+	struct dr_ste_build *sb;
 	struct dr_ste *new_ste;
 	uint8_t sb_idx;
 	int new_idx;
 
 	/* Copy STE mask from the matcher */
 	sb_idx = cur_ste->ste_chain_location - 1;
-	dr_ste_set_bit_mask(hw_ste, nic_matcher->ste_builder[sb_idx].bit_mask);
+	sb = &nic_matcher->ste_builder[sb_idx];
 
-	/* Copy STE control and tag */
-	memcpy(hw_ste, cur_ste->hw_ste, DR_STE_SIZE_REDUCED);
+	/* Copy STE control, tag and mask on legacy STE */
+	memcpy(hw_ste, cur_ste->hw_ste, cur_ste->size);
+	dr_ste_set_bit_mask(hw_ste, sb);
 	dr_ste_set_miss_addr(ste_ctx, hw_ste, nic_matcher->e_anchor->chunk->icm_addr);
 
 	new_idx = dr_ste_calc_hash_index(hw_ste, new_htbl);
@@ -295,7 +299,7 @@ static struct dr_ste *dr_rule_rehash_copy_ste(struct mlx5dv_dr_matcher *matcher,
 		use_update_list = true;
 	}
 
-	memcpy(new_ste->hw_ste, hw_ste, DR_STE_SIZE_REDUCED);
+	memcpy(new_ste->hw_ste, hw_ste, new_ste->size);
 
 	new_htbl->ctrl.num_of_valid_entries++;
 
@@ -397,6 +401,7 @@ static struct dr_ste_htbl *dr_rule_rehash_htbl(struct mlx5dv_dr_rule *rule,
 	LIST_HEAD(rehash_table_send_list);
 	struct dr_ste_htbl *new_htbl;
 	struct dr_ste *ste_to_update;
+	uint8_t *mask = NULL;
 	int err;
 
 	ste_info = calloc(1, sizeof(*ste_info));
@@ -407,6 +412,7 @@ static struct dr_ste_htbl *dr_rule_rehash_htbl(struct mlx5dv_dr_rule *rule,
 
 	new_htbl = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 				     new_size,
+				     cur_htbl->type,
 				     cur_htbl->lu_type,
 				     cur_htbl->byte_mask);
 	if (!new_htbl) {
@@ -434,8 +440,10 @@ static struct dr_ste_htbl *dr_rule_rehash_htbl(struct mlx5dv_dr_rule *rule,
 	if (err)
 		goto free_new_htbl;
 
-	if (dr_send_postsend_htbl(dmn, new_htbl, formated_ste,
-				  nic_matcher->ste_builder[ste_location - 1].bit_mask)) {
+	if (new_htbl->type == DR_STE_HTBL_TYPE_LEGACY)
+		mask = nic_matcher->ste_builder[ste_location - 1].bit_mask;
+
+	if (dr_send_postsend_htbl(dmn, new_htbl, formated_ste, mask)) {
 		dr_dbg(dmn, "Failed writing table to HW\n");
 		goto free_new_htbl;
 	}
@@ -683,7 +691,8 @@ static bool dr_rule_need_enlarge_hash(struct dr_ste_htbl *htbl,
 	if (!ctrl->may_grow)
 		return false;
 
-	if (dr_get_bits_per_mask(htbl->byte_mask) * CHAR_BIT <= htbl->chunk_size)
+	if (htbl->type == DR_STE_HTBL_TYPE_LEGACY &&
+	    dr_get_bits_per_mask(htbl->byte_mask) * CHAR_BIT <= htbl->chunk_size)
 		return false;
 
 	if (ctrl->num_of_collisions >= ctrl->increase_threshold &&
@@ -745,6 +754,9 @@ static int dr_rule_handle_action_stes(struct mlx5dv_dr_rule *rule,
 			ret = errno;
 			goto err_exit;
 		}
+
+		/* This is an always hit entry */
+		dr_ste_set_miss_addr(dmn->ste_ctx, curr_hw_ste, 0);
 
 		/* Point current ste to the new action */
 		dr_ste_set_hit_addr_by_next_htbl(dmn->ste_ctx,
@@ -853,7 +865,8 @@ again:
 			return NULL;
 	} else {
 		/* Hash table index in use, check if this ste is in the miss list */
-		matched_ste = dr_rule_find_ste_in_miss_list(miss_list, hw_ste);
+		matched_ste = dr_rule_find_ste_in_miss_list(miss_list, hw_ste,
+							    dr_ste_tag_sz(ste));
 		if (matched_ste) {
 			/*
 			 * if it is last STE in the chain, and has the same tag

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -490,21 +490,6 @@ free_table:
 	return ENOENT;
 }
 
-static void dr_ste_set_ctrl(struct dr_ste_htbl *htbl)
-{
-	struct dr_ste_htbl_ctrl *ctrl = &htbl->ctrl;
-	int num_of_entries;
-
-	htbl->ctrl.may_grow = true;
-
-	if (htbl->chunk_size == DR_CHUNK_SIZE_MAX - 1 || !htbl->byte_mask)
-		htbl->ctrl.may_grow = false;
-
-	/* Threshold is 50%, one is added to table of size 1 */
-	num_of_entries = dr_icm_pool_chunk_size_to_entries(htbl->chunk_size);
-	ctrl->increase_threshold = (num_of_entries + 1) / 2;
-}
-
 struct dr_ste_htbl *dr_ste_htbl_alloc(struct dr_icm_pool *pool,
 				      enum dr_icm_chunk_size chunk_size,
 				      enum dr_ste_htbl_type type,
@@ -551,7 +536,7 @@ struct dr_ste_htbl *dr_ste_htbl_alloc(struct dr_icm_pool *pool,
 	}
 
 	htbl->chunk_size = chunk_size;
-	dr_ste_set_ctrl(htbl);
+
 	return htbl;
 
 out_free_htbl:

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -823,6 +823,8 @@ static void dr_ste_copy_mask_spec(char *mask, struct dr_match_spec *spec)
 
 	spec->l3_ok = DEVX_GET(dr_match_spec, mask, l3_ok);
 	spec->l4_ok = DEVX_GET(dr_match_spec, mask, l4_ok);
+	spec->ipv4_checksum_ok = DEVX_GET(dr_match_spec, mask, ipv4_checksum_ok);
+	spec->l4_checksum_ok = DEVX_GET(dr_match_spec, mask, l4_checksum_ok);
 	spec->ip_ttl_hoplimit = DEVX_GET(dr_match_spec, mask, ip_ttl_hoplimit);
 
 	spec->udp_sport = DEVX_GET(dr_match_spec, mask, udp_sport);
@@ -1325,6 +1327,25 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 	sb->rx = rx;
 	sb->inner = inner;
 	ste_ctx->build_flex_parser_1_init(sb, mask);
+}
+
+int dr_ste_build_def0(struct dr_ste_ctx *ste_ctx,
+		      struct dr_ste_build *sb,
+		      struct dr_match_param *mask,
+		      struct dr_devx_caps *caps,
+		      bool inner, bool rx)
+{
+	if (!ste_ctx->build_def0_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->caps = caps;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_0;
+	ste_ctx->build_def0_init(sb, mask);
+	return 0;
 }
 
 int dr_ste_build_def6(struct dr_ste_ctx *ste_ctx,

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -1325,6 +1325,57 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 	ste_ctx->build_flex_parser_1_init(sb, mask);
 }
 
+int dr_ste_build_def22(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx)
+{
+	if (!ste_ctx->build_def22_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_22;
+	ste_ctx->build_def22_init(sb, mask);
+	return 0;
+}
+
+int dr_ste_build_def24(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx)
+{
+	if (!ste_ctx->build_def24_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_24;
+	ste_ctx->build_def24_init(sb, mask);
+	return 0;
+}
+
+int dr_ste_build_def25(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx)
+{
+	if (!ste_ctx->build_def25_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_25;
+	ste_ctx->build_def25_init(sb, mask);
+	return 0;
+}
+
 struct dr_ste_ctx *dr_ste_get_ctx(uint8_t version)
 {
 	if (version == MLX5_HW_CONNECTX_5)

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -401,14 +401,15 @@ void dr_ste_prepare_for_postsend(struct dr_ste_ctx *ste_ctx,
 /* Init one ste as a pattern for ste data array */
 void dr_ste_set_formated_ste(struct dr_ste_ctx *ste_ctx,
 			     uint16_t gvmi,
-			     struct dr_domain_rx_tx *nic_dmn,
+			     enum dr_domain_nic_type nic_type,
 			     struct dr_ste_htbl *htbl,
 			     uint8_t *formated_ste,
 			     struct dr_htbl_connect_info *connect_info)
 {
+	bool is_rx = nic_type == DR_DOMAIN_NIC_TYPE_RX;
 	struct dr_ste ste = {};
 
-	ste_ctx->ste_init(formated_ste, htbl->lu_type, nic_dmn->ste_type, gvmi);
+	ste_ctx->ste_init(formated_ste, htbl->lu_type, is_rx, gvmi);
 	ste.hw_ste = formated_ste;
 
 	if (connect_info->type == CONNECT_HIT)
@@ -427,7 +428,7 @@ int dr_ste_htbl_init_and_postsend(struct mlx5dv_dr_domain *dmn,
 
 	dr_ste_set_formated_ste(dmn->ste_ctx,
 				dmn->info.caps.gvmi,
-				nic_dmn,
+				nic_dmn->type,
 				htbl,
 				formated_ste,
 				connect_info);
@@ -692,6 +693,7 @@ int dr_ste_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			 uint8_t *ste_arr)
 {
 	struct dr_domain_rx_tx *nic_dmn = nic_matcher->nic_tbl->nic_dmn;
+	bool is_rx = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
 	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
 	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
 	struct dr_ste_build *sb;
@@ -706,7 +708,7 @@ int dr_ste_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 	for (i = 0; i < nic_matcher->num_of_builders; i++) {
 		ste_ctx->ste_init(ste_arr,
 				  sb->lu_type,
-				  nic_dmn->ste_type,
+				  is_rx,
 				  dmn->info.caps.gvmi);
 
 		dr_ste_set_bit_mask(ste_arr, sb->bit_mask);

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -821,6 +821,8 @@ static void dr_ste_copy_mask_spec(char *mask, struct dr_match_spec *spec)
 	spec->tcp_sport = DEVX_GET(dr_match_spec, mask, tcp_sport);
 	spec->tcp_dport = DEVX_GET(dr_match_spec, mask, tcp_dport);
 
+	spec->l3_ok = DEVX_GET(dr_match_spec, mask, l3_ok);
+	spec->l4_ok = DEVX_GET(dr_match_spec, mask, l4_ok);
 	spec->ip_ttl_hoplimit = DEVX_GET(dr_match_spec, mask, ip_ttl_hoplimit);
 
 	spec->udp_sport = DEVX_GET(dr_match_spec, mask, udp_sport);
@@ -1325,6 +1327,23 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 	ste_ctx->build_flex_parser_1_init(sb, mask);
 }
 
+int dr_ste_build_def6(struct dr_ste_ctx *ste_ctx,
+		      struct dr_ste_build *sb,
+		      struct dr_match_param *mask,
+		      bool inner, bool rx)
+{
+	if (!ste_ctx->build_def6_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_6;
+	ste_ctx->build_def6_init(sb, mask);
+	return 0;
+}
+
 int dr_ste_build_def22(struct dr_ste_ctx *ste_ctx,
 		       struct dr_ste_build *sb,
 		       struct dr_match_param *mask,
@@ -1373,6 +1392,23 @@ int dr_ste_build_def25(struct dr_ste_ctx *ste_ctx,
 	sb->inner = inner;
 	sb->format_id = DR_MATCHER_DEFINER_25;
 	ste_ctx->build_def25_init(sb, mask);
+	return 0;
+}
+
+int dr_ste_build_def26(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx)
+{
+	if (!ste_ctx->build_def26_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_26;
+	ste_ctx->build_def26_init(sb, mask);
 	return 0;
 }
 

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -48,9 +48,6 @@
 #define IP_PROTOCOL_UDP   0x11
 #define IP_PROTOCOL_TCP   0x06
 #define IP_PROTOCOL_IPSEC 0x33
-#define TCP_PROTOCOL      0x6
-#define UDP_PROTOCOL      0x11
-#define IPSEC_PROTOCOL    0x33
 #define HDR_LEN_L2_MACS   0xC
 #define HDR_LEN_L2_VLAN   0x4
 #define HDR_LEN_L2_ETHER  0x2

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -174,6 +174,9 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_src_gvmi_qpn_init;
 	dr_ste_builder_void_init build_flex_parser_0_init;
 	dr_ste_builder_void_init build_flex_parser_1_init;
+	dr_ste_builder_void_init build_def22_init;
+	dr_ste_builder_void_init build_def24_init;
+	dr_ste_builder_void_init build_def25_init;
 
 	/* Getters and Setters */
 	void (*ste_init)(uint8_t *hw_ste_p, uint16_t lu_type,

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -177,7 +177,7 @@ struct dr_ste_ctx {
 
 	/* Getters and Setters */
 	void (*ste_init)(uint8_t *hw_ste_p, uint16_t lu_type,
-			 uint8_t entry_type, uint16_t gvmi);
+			 bool is_rx, uint16_t gvmi);
 	void (*set_next_lu_type)(uint8_t *hw_ste_p, uint16_t lu_type);
 	uint16_t (*get_next_lu_type)(uint8_t *hw_ste_p);
 	void (*set_miss_addr)(uint8_t *hw_ste_p, uint64_t miss_addr);

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -174,9 +174,11 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_src_gvmi_qpn_init;
 	dr_ste_builder_void_init build_flex_parser_0_init;
 	dr_ste_builder_void_init build_flex_parser_1_init;
+	dr_ste_builder_void_init build_def6_init;
 	dr_ste_builder_void_init build_def22_init;
 	dr_ste_builder_void_init build_def24_init;
 	dr_ste_builder_void_init build_def25_init;
+	dr_ste_builder_void_init build_def26_init;
 
 	/* Getters and Setters */
 	void (*ste_init)(uint8_t *hw_ste_p, uint16_t lu_type,

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -185,6 +185,12 @@ struct dr_ste_ctx {
 	void (*set_hit_addr)(uint8_t *hw_ste_p, uint64_t icm_addr, uint32_t ht_size);
 	void (*set_byte_mask)(uint8_t *hw_ste_p, uint16_t byte_mask);
 	uint16_t (*get_byte_mask)(uint8_t *hw_ste_p);
+	void (*set_ctrl_always_hit_htbl)(uint8_t *hw_ste, uint16_t byte_mask,
+					 uint16_t lu_type, uint64_t icm_addr,
+					 uint32_t num_of_entries, uint16_t gvmi);
+	void (*set_ctrl_always_miss)(uint8_t *hw_ste,
+				     uint64_t miss_addr,
+				     uint16_t gvmi);
 
 	/* Actions */
 	uint32_t actions_caps;

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -174,6 +174,7 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_src_gvmi_qpn_init;
 	dr_ste_builder_void_init build_flex_parser_0_init;
 	dr_ste_builder_void_init build_flex_parser_1_init;
+	dr_ste_builder_void_init build_def0_init;
 	dr_ste_builder_void_init build_def6_init;
 	dr_ste_builder_void_init build_def22_init;
 	dr_ste_builder_void_init build_def24_init;

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -342,6 +342,25 @@ static void dr_ste_v0_init(uint8_t *hw_ste_p, uint16_t lu_type,
 	dr_ste_v0_init_full(hw_ste_p, lu_type, entry_type, gvmi);
 }
 
+static void dr_ste_v0_set_ctrl_always_hit_htbl(uint8_t *hw_ste_p,
+					       uint16_t byte_mask,
+					       uint16_t lu_type,
+					       uint64_t icm_addr,
+					       uint32_t num_of_entries,
+					       uint16_t gvmi)
+{
+	dr_ste_v0_set_next_lu_type(hw_ste_p, lu_type);
+	dr_ste_v0_set_hit_addr(hw_ste_p, icm_addr, num_of_entries);
+	dr_ste_v0_set_byte_mask(hw_ste_p, byte_mask);
+}
+
+static void dr_ste_v0_set_ctrl_always_miss(uint8_t *hw_ste_p, uint64_t miss_addr,
+					   uint16_t gvmi)
+{
+	dr_ste_v0_set_next_lu_type(hw_ste_p, DR_STE_LU_TYPE_DONT_CARE);
+	dr_ste_v0_set_miss_addr(hw_ste_p, miss_addr);
+}
+
 static void dr_ste_v0_set_rx_flow_tag(uint8_t *hw_ste_p, uint32_t flow_tag)
 {
 	DR_STE_SET(rx_steering_mult, hw_ste_p, qp_list_pointer,
@@ -1809,6 +1828,8 @@ static struct dr_ste_ctx ste_ctx_v0 = {
 	.set_hit_addr			= &dr_ste_v0_set_hit_addr,
 	.set_byte_mask			= &dr_ste_v0_set_byte_mask,
 	.get_byte_mask			= &dr_ste_v0_get_byte_mask,
+	.set_ctrl_always_hit_htbl	= &dr_ste_v0_set_ctrl_always_hit_htbl,
+	.set_ctrl_always_miss		= &dr_ste_v0_set_ctrl_always_miss,
 	/* Actions */
 	.actions_caps			= DR_STE_CTX_ACTION_CAP_NONE,
 	.set_actions_rx			= &dr_ste_v0_set_actions_rx,

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -34,6 +34,12 @@
 
 #define DR_STE_ENABLE_FLOW_TAG (1 << 31)
 
+enum dr_ste_v0_entry_type {
+	DR_STE_TYPE_TX		= 1,
+	DR_STE_TYPE_RX		= 2,
+	DR_STE_TYPE_MODIFY_PKT	= 6,
+};
+
 enum dr_ste_v0_action_tunl {
 	DR_STE_TUNL_ACTION_NONE		= 0,
 	DR_STE_TUNL_ACTION_ENABLE	= 1,
@@ -313,8 +319,9 @@ static void dr_ste_v0_set_hit_addr(uint8_t *hw_ste_p, uint64_t icm_addr, uint32_
 	DR_STE_SET(general, hw_ste_p, next_table_base_31_5_size, index);
 }
 
-static void dr_ste_v0_init(uint8_t *hw_ste_p, uint16_t lu_type,
-			   uint8_t entry_type, uint16_t gvmi)
+static void dr_ste_v0_init_full(uint8_t *hw_ste_p, uint16_t lu_type,
+				enum dr_ste_v0_entry_type entry_type,
+				uint16_t gvmi)
 {
 	dr_ste_v0_set_entry_type(hw_ste_p, entry_type);
 	dr_ste_v0_set_lu_type(hw_ste_p, lu_type);
@@ -323,6 +330,16 @@ static void dr_ste_v0_init(uint8_t *hw_ste_p, uint16_t lu_type,
 	DR_STE_SET(rx_steering_mult, hw_ste_p, gvmi, gvmi);
 	DR_STE_SET(rx_steering_mult, hw_ste_p, next_table_base_63_48, gvmi);
 	DR_STE_SET(rx_steering_mult, hw_ste_p, miss_address_63_48, gvmi);
+}
+
+static void dr_ste_v0_init(uint8_t *hw_ste_p, uint16_t lu_type,
+			   bool is_rx, uint16_t gvmi)
+{
+	enum dr_ste_v0_entry_type entry_type;
+
+	entry_type = is_rx ? DR_STE_TYPE_RX : DR_STE_TYPE_TX;
+
+	dr_ste_v0_init_full(hw_ste_p, lu_type, entry_type, gvmi);
 }
 
 static void dr_ste_v0_set_rx_flow_tag(uint8_t *hw_ste_p, uint32_t flow_tag)
@@ -398,12 +415,12 @@ static void dr_ste_v0_set_rewrite_actions(uint8_t *hw_ste_p,
 
 static inline void dr_ste_v0_arr_init_next(uint8_t **last_ste,
 					   uint32_t *added_stes,
-					   enum dr_ste_entry_type entry_type,
+					   enum dr_ste_v0_entry_type entry_type,
 					   uint16_t gvmi)
 {
 	(*added_stes)++;
 	*last_ste += DR_STE_SIZE;
-	dr_ste_v0_init(*last_ste, DR_STE_LU_TYPE_DONT_CARE, entry_type, gvmi);
+	dr_ste_v0_init_full(*last_ste, DR_STE_LU_TYPE_DONT_CARE, entry_type, gvmi);
 }
 
 static void dr_ste_v0_set_actions_tx(uint8_t *action_type_set,

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -367,7 +367,7 @@ static void dr_ste_v1_set_hit_addr(uint8_t *hw_ste_p, uint64_t icm_addr, uint32_
 }
 
 static void dr_ste_v1_init(uint8_t *hw_ste_p, uint16_t lu_type,
-			   uint8_t entry_type, uint16_t gvmi)
+			   bool is_rx, uint16_t gvmi)
 {
 	dr_ste_v1_set_lu_type(hw_ste_p, lu_type);
 	dr_ste_v1_set_next_lu_type(hw_ste_p, DR_STE_LU_TYPE_DONT_CARE);

--- a/providers/mlx5/dr_table.c
+++ b/providers/mlx5/dr_table.c
@@ -70,6 +70,7 @@ static int dr_table_init_nic(struct mlx5dv_dr_domain *dmn,
 
 	nic_tbl->s_anchor = dr_ste_htbl_alloc(dmn->ste_icm_pool,
 					      DR_CHUNK_SIZE_1,
+					      DR_STE_HTBL_TYPE_LEGACY,
 					      DR_STE_LU_TYPE_DONT_CARE,
 					      0);
 	if (!nic_tbl->s_anchor)

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -2312,6 +2312,95 @@ struct mlx5_ifc_ste_icmp_v1_bits {
 	u8         reserved_at_60[0x20];
 };
 
+struct mlx5_ifc_ste_def22_v1_bits {
+	u8         outer_ip_src_addr[0x20];
+
+	u8         outer_ip_dst_addr[0x20];
+
+	u8         outer_l4_sport[0x10];
+	u8         outer_l4_dport[0x10];
+
+	u8         reserved_at_40[0x1];
+	u8         sx_sniffer[0x1];
+	u8         functional_loopback[0x1];
+	u8         outer_ip_frag[0x1];
+	u8         qp_type[0x2];
+	u8         encapsulation_type[0x2];
+	u8         port[0x2];
+	u8         outer_l3_type[0x2];
+	u8         outer_l4_type[0x2];
+	u8         first_vlan_qualifier[0x2];
+	u8         first_priority[0x3];
+	u8         first_cfi[0x1];
+	u8         first_vlan_id[0xc];
+
+	u8         metadata_reg_c_0[0x20];
+
+	u8         outer_dmac_47_16[0x20];
+
+	u8         outer_smac_47_16[0x20];
+
+	u8         outer_smac_15_0[0x10];
+	u8         outer_dmac_15_0[0x10];
+};
+
+struct mlx5_ifc_ste_def24_v1_bits {
+	u8         metadata_reg_c_2[0x20];
+
+	u8         metadata_reg_c_3[0x20];
+
+	u8         metadata_reg_c_0[0x20];
+
+	u8         metadata_reg_c_1[0x20];
+
+	u8         outer_ip_src_addr[0x20];
+
+	u8         outer_ip_dst_addr[0x20];
+
+	u8         outer_l4_sport[0x10];
+	u8         outer_l4_dport[0x10];
+
+	u8         inner_ip_protocol[0x8];
+	u8         inner_l3_type[0x2];
+	u8         inner_l4_type[0x2];
+	u8         inner_first_vlan_type[0x2];
+	u8         inner_ip_frag[0x1];
+	u8         functional_lb[0x1];
+	u8         outer_ip_protocol[0x8];
+	u8         outer_l3_type[0x2];
+	u8         outer_l4_type[0x2];
+	u8         outer_first_vlan_type[0x2];
+	u8         outer_ip_frag[0x1];
+	u8         functional_lb_dup[0x1];
+};
+
+struct mlx5_ifc_ste_def25_v1_bits {
+	u8         inner_ip_src_addr[0x20];
+
+	u8         inner_ip_dst_addr[0x20];
+
+	u8         inner_l4_sport[0x10];
+	u8         inner_l4_dport[0x10];
+
+	u8         tunnel_header_0[0x20];
+
+	u8         tunnel_header_1[0x20];
+
+	u8         reserved_at_a0[0x20];
+
+	u8         port_number_dup[0x2];
+	u8         inner_l3_type[0x2];
+	u8         inner_l4_type[0x2];
+	u8         inner_first_vlan_type[0x2];
+	u8         port_number[0x2];
+	u8         outer_l3_type[0x2];
+	u8         outer_l4_type[0x2];
+	u8         outer_first_vlan_type[0x2];
+	u8         outer_l4_dport[0x10];
+
+	u8         reserved_at_e0[0x20];
+};
+
 struct mlx5_ifc_set_action_in_bits {
 	u8         action_type[0x4];
 	u8         field[0xc];

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -366,7 +366,8 @@ struct mlx5_ifc_dr_match_spec_bits {
 	u8         reserved_at_c0[0x14];
 	u8         l3_ok[0x1];
 	u8         l4_ok[0x1];
-	u8         reserved_at_d6[0x2];
+	u8         ipv4_checksum_ok[0x1];
+	u8         l4_checksum_ok[0x1];
 	u8         ip_ttl_hoplimit[0x8];
 
 	u8         udp_sport[0x10];
@@ -1053,6 +1054,21 @@ struct mlx5_ifc_header_modify_cap_properties_bits {
 	u8         reserved_at_300[0x100];
 };
 
+struct mlx5_ifc_flow_table_fields_supported_2_bits {
+	u8         reserved_at_0[0x17];
+	u8         inner_l3_ok[0x1];
+	u8         inner_l4_ok[0x1];
+	u8         outer_l3_ok[0x1];
+	u8         outer_l4_ok[0x1];
+	u8         psp_header[0x1];
+	u8         inner_ipv4_checksum_ok[0x1];
+	u8         inner_l4_checksum_ok[0x1];
+	u8         outer_ipv4_checksum_ok[0x1];
+	u8         outer_l4_checksum_ok[0x1];
+
+	u8         reserved_at_20[0x60];
+};
+
 struct mlx5_ifc_flow_table_nic_cap_bits {
 	u8         nic_rx_multi_path_tirs[0x1];
 	u8         nic_rx_multi_path_tirs_fts[0x1];
@@ -1086,7 +1102,31 @@ struct mlx5_ifc_flow_table_nic_cap_bits {
 
 	struct mlx5_ifc_header_modify_cap_properties_bits header_modify_nic_receive;
 
-	u8         reserved_at_1400[0x800];
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_receive;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_receive;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_receive_rdma;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_receive_rdma;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_receive_sniffer;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_receive_sniffer;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_transmit;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_transmit;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_transmit_rdma;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_transmit_rdma;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_support_2_nic_transmit_sniffer;
+
+	struct mlx5_ifc_flow_table_fields_supported_2_bits ft_field_bitmask_support_2_nic_transmit_sniffer;
+
+	u8         reserved_at_1400[0x200];
 
 	struct mlx5_ifc_header_modify_cap_properties_bits header_modify_nic_transmit;
 
@@ -2313,6 +2353,59 @@ struct mlx5_ifc_ste_icmp_v1_bits {
 	u8         reserved_at_50[0x10];
 
 	u8         reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_ste_def0_v1_bits {
+	u8         metadata_reg_c_0[0x20];
+
+	u8         metadata_reg_c_1[0x20];
+
+	u8         dmac_47_16[0x20];
+
+	u8         dmac_15_0[0x10];
+	u8         ethertype[0x10];
+
+	u8         reserved_at_60[0x1];
+	u8         sx_sniffer[0x1];
+	u8         functional_loopback[0x1];
+	u8         ip_frag[0x1];
+	u8         qp_type[0x2];
+	u8         encapsulation_type[0x2];
+	u8         port[0x2];
+	u8         outer_l3_type[0x2];
+	u8         outer_l4_type[0x2];
+	u8         first_vlan_qualifier[0x2];
+	u8         first_priority[0x3];
+	u8         first_cfi[0x1];
+	u8         first_vlan_id[0xc];
+
+	u8         reserved_at_80[0xa];
+	u8         force_loopback[0x1];
+	u8         reserved_at_8b[0x3];
+	u8         second_vlan_qualifier[0x2];
+	u8         second_priority[0x3];
+	u8         second_cfi[0x1];
+	u8         second_vlan_id[0xc];
+
+	u8         smac_47_16[0x20];
+
+	u8         smac_15_0[0x10];
+	u8         inner_ipv4_checksum_ok[0x1];
+	u8         inner_l4_checksum_ok[0x1];
+	u8         outer_ipv4_checksum_ok[0x1];
+	u8         outer_l4_checksum_ok[0x1];
+	u8         inner_l3_ok[0x1];
+	u8         inner_l4_ok[0x1];
+	u8         outer_l3_ok[0x1];
+	u8         outer_l4_ok[0x1];
+	u8         tcp_cwr[0x1];
+	u8         tcp_ece[0x1];
+	u8         tcp_urg[0x1];
+	u8         tcp_ack[0x1];
+	u8         tcp_psh[0x1];
+	u8         tcp_rst[0x1];
+	u8         tcp_syn[0x1];
+	u8         tcp_fin[0x1];
 };
 
 struct mlx5_ifc_ste_def6_v1_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1031,7 +1031,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         flex_parser_id_gtpu_first_ext_dw_0[0x4];
 	u8         reserved_at_708[0x18];
 
-	u8         reserved_at_720[0xe0];
+	u8         reserved_at_720[0xa0];
+
+	u8         match_definer_format_supported[0x40];
 };
 
 struct mlx5_ifc_header_modify_cap_properties_bits {
@@ -2475,6 +2477,7 @@ struct mlx5_ifc_alloc_flow_counter_out_bits {
 
 enum {
 	MLX5_OBJ_TYPE_FLOW_METER = 0x000a,
+	MLX5_OBJ_TYPE_MATCH_DEFINER = 0x0018,
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
 	MLX5_OBJ_TYPE_ASO_FLOW_METER = 0x0024,
 	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
@@ -2568,6 +2571,26 @@ struct mlx5_ifc_create_flow_sampler_in_bits {
 struct mlx5_ifc_query_flow_sampler_out_bits {
 	struct mlx5_ifc_general_obj_out_cmd_hdr_bits  hdr;
 	struct mlx5_ifc_flow_sampler_bits             obj;
+};
+
+struct mlx5_ifc_definer_bits {
+	u8         modify_field_select[0x40];
+
+	u8         reserved_at_40[0x40];
+
+	u8         reserved_at_80[0x10];
+	u8         format_id[0x10];
+
+	u8         reserved_at_60[0x160];
+
+	u8         ctrl[0xA0];
+	u8         match_mask_dw_11_8[0x60];
+	u8         match_mask_dw_7_0[0x100];
+};
+
+struct mlx5_ifc_create_definer_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits   hdr;
+	struct mlx5_ifc_definer_bits                  definer;
 };
 
 struct mlx5_ifc_esw_vport_context_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -363,7 +363,10 @@ struct mlx5_ifc_dr_match_spec_bits {
 	u8         tcp_sport[0x10];
 	u8         tcp_dport[0x10];
 
-	u8         reserved_at_c0[0x18];
+	u8         reserved_at_c0[0x14];
+	u8         l3_ok[0x1];
+	u8         l4_ok[0x1];
+	u8         reserved_at_d6[0x2];
 	u8         ip_ttl_hoplimit[0x8];
 
 	u8         udp_sport[0x10];
@@ -2312,6 +2315,36 @@ struct mlx5_ifc_ste_icmp_v1_bits {
 	u8         reserved_at_60[0x20];
 };
 
+struct mlx5_ifc_ste_def6_v1_bits {
+	u8         dst_ipv6_127_96[0x20];
+
+	u8         dst_ipv6_95_64[0x20];
+
+	u8         dst_ipv6_63_32[0x20];
+
+	u8         dst_ipv6_31_0[0x20];
+
+	u8         reserved_at_80[0x40];
+
+	u8         outer_l4_sport[0x10];
+	u8         outer_l4_dport[0x10];
+
+	u8         reserved_e0[0x4];
+	u8         l4_ok[0x1];
+	u8         l3_ok[0x1];
+	u8         ip_frag[0x1];
+	u8         tcp_ns[0x1];
+	u8         tcp_cwr[0x1];
+	u8         tcp_ece[0x1];
+	u8         tcp_urg[0x1];
+	u8         tcp_ack[0x1];
+	u8         tcp_psh[0x1];
+	u8         tcp_rst[0x1];
+	u8         tcp_syn[0x1];
+	u8         tcp_fin[0x1];
+	u8         reserved_f0[0x10];
+};
+
 struct mlx5_ifc_ste_def22_v1_bits {
 	u8         outer_ip_src_addr[0x20];
 
@@ -2399,6 +2432,48 @@ struct mlx5_ifc_ste_def25_v1_bits {
 	u8         outer_l4_dport[0x10];
 
 	u8         reserved_at_e0[0x20];
+};
+
+struct mlx5_ifc_ste_def26_v1_bits {
+	u8         src_ipv6_127_96[0x20];
+
+	u8         src_ipv6_95_64[0x20];
+
+	u8         src_ipv6_63_32[0x20];
+
+	u8         src_ipv6_31_0[0x20];
+
+	u8         reserved_at_80[0x3];
+	u8         ip_frag[0x1];
+	u8         reserved_at_84[0x6];
+	u8         l3_type[0x2];
+	u8         l4_type[0x2];
+	u8         first_vlan_type[0x2];
+	u8         first_priority[0x3];
+	u8         first_cfi[0x1];
+	u8         first_vlan_id[0xc];
+
+	u8         reserved_at_a0[0xb];
+	u8         l2_ok[0x1];
+	u8         l3_ok[0x1];
+	u8         l4_ok[0x1];
+	u8         second_vlan_type[0x2];
+	u8         second_priority[0x3];
+	u8         second_cfi[0x1];
+	u8         second_vlan_id[0xc];
+
+	u8         smac_47_16[0x20];
+
+	u8         smac_15_0[0x10];
+	u8         ip_porotcol[0x8];
+	u8         tcp_cwr[0x1];
+	u8         tcp_ece[0x1];
+	u8         tcp_urg[0x1];
+	u8         tcp_ack[0x1];
+	u8         tcp_psh[0x1];
+	u8         tcp_rst[0x1];
+	u8         tcp_syn[0x1];
+	u8         tcp_fin[0x1];
 };
 
 struct mlx5_ifc_set_action_in_bits {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -136,6 +136,12 @@ enum dr_matcher_criteria {
 	DR_MATCHER_CRITERIA_MAX		= 1 << 6,
 };
 
+enum dr_matcher_definer {
+	DR_MATCHER_DEFINER_22	= 22,
+	DR_MATCHER_DEFINER_24	= 24,
+	DR_MATCHER_DEFINER_25	= 25,
+};
+
 enum dr_action_type {
 	DR_ACTION_TYP_TNL_L2_TO_L2,
 	DR_ACTION_TYP_L2_TO_TNL_L2,
@@ -258,8 +264,17 @@ struct dr_ste_build {
 	struct dr_devx_caps	*caps;
 	uint16_t		lu_type;
 	enum dr_ste_htbl_type	htbl_type;
-	uint16_t		byte_mask;
-	uint8_t			bit_mask[DR_STE_SIZE_MASK];
+	union {
+		struct {
+			uint16_t	byte_mask;
+			uint8_t		bit_mask[DR_STE_SIZE_MASK];
+		};
+		struct {
+			uint16_t		format_id;
+			uint8_t			match[DR_STE_SIZE_MATCH_TAG];
+			struct mlx5dv_devx_obj	*definer_obj;
+		};
+	};
 	int (*ste_build_tag_func)(struct dr_match_param *spec,
 				  struct dr_ste_build *sb,
 				  uint8_t *tag);
@@ -539,6 +554,18 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 				struct dr_ste_build *sb,
 				struct dr_match_param *mask,
 				bool inner, bool rx);
+int dr_ste_build_def22(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx);
+int dr_ste_build_def24(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx);
+int dr_ste_build_def25(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx);
 void dr_ste_build_empty_always_hit(struct dr_ste_build *sb, bool rx);
 
 /* Actions utils */

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -750,6 +750,7 @@ struct dr_devx_caps {
 	uint32_t			num_vports;
 	struct dr_devx_vport_cap	*vports_caps;
 	struct dr_devx_roce_cap		roce_caps;
+	uint64_t			definer_format_sup;
 	bool				prio_tag_required;
 };
 
@@ -1171,6 +1172,9 @@ dr_devx_create_flow_sampler(struct ibv_context *ctx,
 			    struct dr_devx_flow_sampler_attr *sampler_attr);
 int dr_devx_query_flow_sampler(struct mlx5dv_devx_obj *obj,
 			       uint64_t *rx_icm_addr, uint64_t *tx_icm_addr);
+struct mlx5dv_devx_obj *dr_devx_create_definer(struct ibv_context *ctx,
+					       uint16_t format_id,
+					       uint8_t *match_mask);
 struct mlx5dv_devx_obj *dr_devx_create_reformat_ctx(struct ibv_context *ctx,
 						    enum reformat_type rt,
 						    size_t reformat_size,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -137,9 +137,11 @@ enum dr_matcher_criteria {
 };
 
 enum dr_matcher_definer {
+	DR_MATCHER_DEFINER_6	= 6,
 	DR_MATCHER_DEFINER_22	= 22,
 	DR_MATCHER_DEFINER_24	= 24,
 	DR_MATCHER_DEFINER_25	= 25,
+	DR_MATCHER_DEFINER_26	= 26,
 };
 
 enum dr_action_type {
@@ -554,6 +556,10 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 				struct dr_ste_build *sb,
 				struct dr_match_param *mask,
 				bool inner, bool rx);
+int dr_ste_build_def6(struct dr_ste_ctx *ste_ctx,
+		      struct dr_ste_build *sb,
+		      struct dr_match_param *mask,
+		      bool inner, bool rx);
 int dr_ste_build_def22(struct dr_ste_ctx *ste_ctx,
 		       struct dr_ste_build *sb,
 		       struct dr_match_param *mask,
@@ -563,6 +569,10 @@ int dr_ste_build_def24(struct dr_ste_ctx *ste_ctx,
 		       struct dr_match_param *mask,
 		       bool inner, bool rx);
 int dr_ste_build_def25(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx);
+int dr_ste_build_def26(struct dr_ste_ctx *ste_ctx,
 		       struct dr_ste_build *sb,
 		       struct dr_match_param *mask,
 		       bool inner, bool rx);
@@ -600,6 +610,8 @@ struct dr_match_spec {
 	uint32_t ip_protocol:8;	/* IP protocol */
 	uint32_t tcp_dport:16;	/* TCP destination port. ;tcp and udp sport/dport are mutually exclusive */
 	uint32_t tcp_sport:16;	/* TCP source port.;tcp and udp sport/dport are mutually exclusive */
+	uint32_t l3_ok:1;
+	uint32_t l4_ok:1;
 	uint32_t ip_ttl_hoplimit:8;
 	uint32_t udp_dport:16;	/* UDP destination port.;tcp and udp sport/dport are mutually exclusive */
 	uint32_t udp_sport:16;	/* UDP source port.;tcp and udp sport/dport are mutually exclusive */

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -103,12 +103,6 @@ enum dr_ste_lu_type {
 	DR_STE_LU_TYPE_DONT_CARE	= 0x0f,
 };
 
-enum dr_ste_entry_type {
-	DR_STE_TYPE_TX		= 1,
-	DR_STE_TYPE_RX		= 2,
-	DR_STE_TYPE_MODIFY_PKT	= 6,
-};
-
 enum {
 	DR_STE_SIZE		= 64,
 	DR_STE_SIZE_CTRL	= 32,
@@ -798,10 +792,15 @@ struct dr_devx_flow_sampler_attr {
 	uint32_t	sample_table_id;
 };
 
+enum dr_domain_nic_type {
+	DR_DOMAIN_NIC_TYPE_RX,
+	DR_DOMAIN_NIC_TYPE_TX,
+};
+
 struct dr_domain_rx_tx {
 	uint64_t		drop_icm_addr;
 	uint64_t		default_icm_addr;
-	enum dr_ste_entry_type	ste_type;
+	enum dr_domain_nic_type	type;
 	/* protect rx/tx domain */
 	pthread_spinlock_t	lock;
 };
@@ -1232,7 +1231,7 @@ int dr_ste_htbl_init_and_postsend(struct mlx5dv_dr_domain *dmn,
 				  bool update_hw_ste);
 void dr_ste_set_formated_ste(struct dr_ste_ctx *ste_ctx,
 			     uint16_t gvmi,
-			     struct dr_domain_rx_tx *nic_dmn,
+			     enum dr_domain_nic_type nic_type,
 			     struct dr_ste_htbl *htbl,
 			     uint8_t *formated_ste,
 			     struct dr_htbl_connect_info *connect_info);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -213,8 +213,6 @@ struct dr_ste_htbl_ctrl {
 
 	/* total number of collisions entries attached to this table */
 	int	num_of_collisions;
-	int	increase_threshold;
-	bool	may_grow;
 };
 
 enum dr_ste_htbl_type {
@@ -1112,6 +1110,26 @@ dr_icm_pool_chunk_size_to_byte(enum dr_icm_chunk_size chunk_size,
 	num_of_entries = dr_icm_pool_chunk_size_to_entries(chunk_size);
 
 	return entry_size * num_of_entries;
+}
+
+static inline int
+dr_ste_htbl_increase_threshold(struct dr_ste_htbl *htbl)
+{
+	int num_of_entries =
+		dr_icm_pool_chunk_size_to_entries(htbl->chunk_size);
+
+	/* Threshold is 50%, one is added to table of size 1 */
+	return (num_of_entries + 1) / 2;
+}
+
+static inline bool
+dr_ste_htbl_may_grow(struct dr_ste_htbl *htbl)
+{
+	if (htbl->chunk_size == DR_CHUNK_SIZE_MAX - 1 ||
+	    (htbl->type == DR_STE_HTBL_TYPE_LEGACY && !htbl->byte_mask))
+		return false;
+
+	return true;
 }
 
 static inline struct dr_devx_vport_cap

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -114,11 +114,8 @@ enum {
 	DR_STE_SIZE_CTRL	= 32,
 	DR_STE_SIZE_TAG		= 16,
 	DR_STE_SIZE_MASK	= 16,
+	DR_STE_SIZE_REDUCED	= DR_STE_SIZE - DR_STE_SIZE_MASK,
 	DR_STE_LOG_SIZE		= 6,
-};
-
-enum {
-	DR_STE_SIZE_REDUCED = DR_STE_SIZE - DR_STE_SIZE_MASK,
 };
 
 enum dr_ste_ctx_action_cap {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -137,6 +137,7 @@ enum dr_matcher_criteria {
 };
 
 enum dr_matcher_definer {
+	DR_MATCHER_DEFINER_0	= 0,
 	DR_MATCHER_DEFINER_6	= 6,
 	DR_MATCHER_DEFINER_22	= 22,
 	DR_MATCHER_DEFINER_24	= 24,
@@ -556,6 +557,11 @@ void dr_ste_build_flex_parser_1(struct dr_ste_ctx *ste_ctx,
 				struct dr_ste_build *sb,
 				struct dr_match_param *mask,
 				bool inner, bool rx);
+int dr_ste_build_def0(struct dr_ste_ctx *ste_ctx,
+		      struct dr_ste_build *sb,
+		      struct dr_match_param *mask,
+		      struct dr_devx_caps *caps,
+		      bool inner, bool rx);
 int dr_ste_build_def6(struct dr_ste_ctx *ste_ctx,
 		      struct dr_ste_build *sb,
 		      struct dr_match_param *mask,
@@ -612,6 +618,8 @@ struct dr_match_spec {
 	uint32_t tcp_sport:16;	/* TCP source port.;tcp and udp sport/dport are mutually exclusive */
 	uint32_t l3_ok:1;
 	uint32_t l4_ok:1;
+	uint32_t ipv4_checksum_ok:1;
+	uint32_t l4_checksum_ok:1;
 	uint32_t ip_ttl_hoplimit:8;
 	uint32_t udp_dport:16;	/* UDP destination port.;tcp and udp sport/dport are mutually exclusive */
 	uint32_t udp_sport:16;	/* UDP source port.;tcp and udp sport/dport are mutually exclusive */
@@ -776,6 +784,7 @@ struct dr_devx_caps {
 	uint8_t				flex_parser_id_gtpu_teid;
 	uint8_t				flex_parser_id_gtpu_dw_2;
 	uint8_t				flex_parser_id_gtpu_first_ext_dw_0;
+	uint8_t				definer_supp_checksum;
 	uint8_t				max_ft_level;
 	uint8_t				sw_format_ver;
 	bool				isolate_vl_tc;


### PR DESCRIPTION
This series adds definers support in the DR area.

Definers are FW/HW objects created over DEVX, the definer ID is used inside each steering entry based on the mask.
Definers allow to optimize PPS by matching on multiple fields compared to regular hash table entries. 
Definer creation and selection is done inside the DR code if supported without any special configuration from
the user.

Current definers cover a variety of common use cases such as ipv4 5tuple and ipvs6 5tuple as well as other customer use cases.
This feature is supported from ConnectX6-DX devices.