### PR TITLE
verbs: Introduce ibv_query_qp_data_in_order() API

### DIFF
--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -11,6 +11,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.11@IBVERBS_1.11 32
  IBVERBS_1.12@IBVERBS_1.12 34
  IBVERBS_1.13@IBVERBS_1.13 35
+ IBVERBS_1.14@IBVERBS_1.14 36
  (symver)IBVERBS_PRIVATE_34 34
  _ibv_query_gid_ex@IBVERBS_1.11 32
  _ibv_query_gid_table@IBVERBS_1.11 32
@@ -98,6 +99,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_query_port@IBVERBS_1.1 1.1.6
  ibv_query_qp@IBVERBS_1.0 1.1.6
  ibv_query_qp@IBVERBS_1.1 1.1.6
+ ibv_query_qp_data_in_order@IBVERBS_1.14 36
  ibv_query_srq@IBVERBS_1.0 1.1.6
  ibv_query_srq@IBVERBS_1.1 1.1.6
  ibv_rate_to_mbps@IBVERBS_1.1 1.1.8

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file("libibverbs.map.in"
 
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
-  1 1.13.${PACKAGE_VERSION}
+  1 1.14.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
   cmd_ah.c

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -370,6 +370,8 @@ struct verbs_context_ops {
 			  struct ibv_port_attr *port_attr);
 	int (*query_qp)(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 			int attr_mask, struct ibv_qp_init_attr *init_attr);
+	int (*query_qp_data_in_order)(struct ibv_qp *qp, enum ibv_wr_opcode op,
+				      uint32_t flags);
 	int (*query_rt_values)(struct ibv_context *context,
 			       struct ibv_values_ex *values);
 	int (*query_srq)(struct ibv_srq *srq, struct ibv_srq_attr *srq_attr);

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -397,6 +397,12 @@ static int query_ece(struct ibv_qp *qp, struct ibv_ece *ece)
 	return EOPNOTSUPP;
 }
 
+static int query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
+				  uint32_t flags)
+{
+	return 0;
+}
+
 static int query_port(struct ibv_context *context, uint8_t port_num,
 		      struct ibv_port_attr *port_attr)
 {
@@ -559,6 +565,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	query_ece,
 	query_port,
 	query_qp,
+	query_qp_data_in_order,
 	query_rt_values,
 	query_srq,
 	read_counters,
@@ -683,6 +690,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_PRIV_OP_IC(vctx, query_ece);
 	SET_PRIV_OP_IC(ctx, query_port);
 	SET_PRIV_OP(ctx, query_qp);
+	SET_PRIV_OP_IC(ctx, query_qp_data_in_order);
 	SET_OP(vctx, query_rt_values);
 	SET_OP(vctx, read_counters);
 	SET_PRIV_OP(ctx, query_srq);

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -160,6 +160,11 @@ IBVERBS_1.13 {
 		ibv_unimport_dm;
 } IBVERBS_1.12;
 
+IBVERBS_1.14 {
+	global:
+		ibv_query_qp_data_in_order;
+} IBVERBS_1.13;
+
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
    version. See the top level CMakeLists.txt for this setting. */
 

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -64,6 +64,7 @@ rdma_man_pages(
   ibv_query_pkey.3.md
   ibv_query_port.3
   ibv_query_qp.3
+  ibv_query_qp_data_in_order.3.md
   ibv_query_rt_values_ex.3
   ibv_query_srq.3
   ibv_rate_to_mbps.3.md

--- a/libibverbs/man/ibv_query_qp_data_in_order.3.md
+++ b/libibverbs/man/ibv_query_qp_data_in_order.3.md
@@ -1,0 +1,62 @@
+---
+date: 2020-3-3
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: ibv_query_qp_data_in_order
+---
+
+# NAME
+
+ibv_query_qp_data_in_order - check if qp data is guaranteed to be in order.
+
+# SYNOPSIS
+
+```c
+#include <infiniband/verbs.h>
+
+int ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op, uint32_t flags);
+
+```
+
+
+# DESCRIPTION
+
+**ibv_query_qp_data_in_order()** Checks whether WQE data is guaranteed to be
+written in-order, and thus reader may poll for data instead of poll for completion.
+This function indicates data is written in-order within each WQE, but cannot be used to determine ordering between separate WQEs.
+This function describes ordering at the receiving side of the QP, not the sending side.
+
+# ARGUMENTS
+*qp*
+:       The local queue pair (QP) to query.
+
+*op*
+:       The operation type to query about. Different operation types may write data in a different order.
+	For RDMA read operations: describes ordering of RDMA reads posted on this local QP.
+	For RDMA write operations: describes ordering of remote RDMA writes being done into this local QP.
+	For RDMA send operations: describes ordering of remote RDMA sends being done into this local QP.
+	This function should not be used to determine ordering of other operation types.
+
+*flags*
+:	Extra field for future input. For now must be 0.
+
+# RETURN VALUE
+
+**ibv_query_qp_data_in_order()** Returns 1 if the data is guaranteed to be written in-order, 0 otherwise.
+
+# NOTES
+
+Return value is valid only when the data is read by the CPU and relaxed ordering MR is not the target of the transfer.
+
+# SEE ALSO
+
+**ibv_query_qp**(3)
+
+# AUTHOR
+
+Patrisious Haddad <phaddad@nvidia.com>
+
+Yochai Cohen <yochai@nvidia.com>

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -684,6 +684,19 @@ LATEST_SYMVER_FUNC(ibv_query_qp, 1_1, "IBVERBS_1.1",
 	return 0;
 }
 
+int ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
+			       uint32_t flags)
+{
+#if !defined(__i386__) && !defined(__x86_64__)
+	/* Currently this API is only supported for x86 architectures since most
+	 * non-x86 platforms are known to be OOO and need to do a per-platform study.
+	 */
+	return 0;
+#else
+	return get_ops(qp->context)->query_qp_data_in_order(qp, op, flags);
+#endif
+}
+
 LATEST_SYMVER_FUNC(ibv_modify_qp, 1_1, "IBVERBS_1.1",
 		   int,
 		   struct ibv_qp *qp, struct ibv_qp_attr *attr,

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -3148,6 +3148,20 @@ ibv_modify_qp_rate_limit(struct ibv_qp *qp,
 }
 
 /**
+ * ibv_query_qp_data_in_order - Checks whether the data is guaranteed to be
+ *   written in-order.
+ * @qp: The QP to query.
+ * @op: Operation type.
+ * @flags: Extra field for future input. For now must be 0.
+ *
+ * Return Value
+ * ibv_query_qp_data_in_order() returns 1 if the data is guaranteed to be
+ *   written in-order, 0 otherwise.
+ */
+int ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
+			       uint32_t flags);
+
+/**
  * ibv_query_qp - Returns the attribute list and current values for the
  *   specified QP.
  * @qp: The QP to query.

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -167,6 +167,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.unimport_dm = mlx5_unimport_dm,
 	.unimport_mr = mlx5_unimport_mr,
 	.unimport_pd = mlx5_unimport_pd,
+	.query_qp_data_in_order = mlx5_query_qp_data_in_order,
 };
 
 static const struct verbs_context_ops mlx5_ctx_cqev1_ops = {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -398,6 +398,7 @@ struct mlx5_context {
 	struct mlx5_bf			*nc_uar;
 	void				*cq_uar_reg;
 	struct mlx5_reserved_qpns	reserved_qpns;
+	uint8_t				qp_data_in_order_cap:1;
 };
 
 struct mlx5_bitmap {
@@ -1088,6 +1089,8 @@ struct ibv_qp *mlx5_create_qp(struct ibv_pd *pd, struct ibv_qp_init_attr *attr);
 int mlx5_query_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		  int attr_mask,
 		  struct ibv_qp_init_attr *init_attr);
+int mlx5_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
+				uint32_t flags);
 int mlx5_modify_qp(struct ibv_qp *qp, struct ibv_qp_attr *attr,
 		   int attr_mask);
 int mlx5_modify_qp_rate_limit(struct ibv_qp *qp,

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -51,6 +51,7 @@ enum {
 	MLX5_CMD_OP_INIT2INIT_QP = 0x50e,
 	MLX5_CMD_OP_CREATE_PSV = 0x600,
 	MLX5_CMD_OP_DESTROY_PSV = 0x601,
+	MLX5_CMD_OP_QUERY_DCT = 0x713,
 	MLX5_CMD_OP_QUERY_ESW_VPORT_CONTEXT = 0x752,
 	MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT = 0x754,
 	MLX5_CMD_OP_QUERY_ROCE_ADDRESS = 0x760,
@@ -641,7 +642,11 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         reserved_at_21[0xf];
 	u8         vhca_id[0x10];
 
-	u8         reserved_at_40[0x40];
+	u8         reserved_at_40[0x20];
+
+	u8         reserved_at_60[0x2];
+	u8         qp_data_in_order[0x1];
+	u8         reserved_at_63[0x1d];
 
 	u8         log_max_srq_sz[0x8];
 	u8         log_max_qp_sz[0x8];
@@ -2654,6 +2659,12 @@ enum {
 	MLX5_ACTION_IN_FIELD_OUT_GTPU_TEID     = 0x6E,
 };
 
+struct mlx5_ifc_dctc_bits {
+	u8         reserved_at_0[0x1d];
+	u8         data_in_order[0x1];
+	u8         reserved_at_1e[0x362];
+};
+
 struct mlx5_ifc_packet_reformat_context_in_bits {
 	u8	reserved_at_0[0x5];
 	u8	reformat_type[0x3];
@@ -3040,7 +3051,7 @@ struct mlx5_ifc_qpc_bits {
 	u8         log_sq_size[0x4];
 	u8         reserved_at_55[0x3];
 	u8         ts_format[0x2];
-	u8         reserved_at_5a[0x1];
+	u8         data_in_order[0x1];
 	u8         rlky[0x1];
 	u8         ulp_stateless_offload_mode[0x4];
 
@@ -3405,6 +3416,30 @@ struct mlx5_ifc_query_qp_in_bits {
 
 	u8         reserved_at_40[0x8];
 	u8         qpn[0x18];
+
+	u8         reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_query_dct_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+
+	struct mlx5_ifc_dctc_bits dctc;
+};
+
+struct mlx5_ifc_query_dct_in_bits {
+	u8         opcode[0x10];
+	u8         reserved_at_10[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x8];
+	u8         dctn[0x18];
 
 	u8         reserved_at_60[0x20];
 };

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -723,6 +723,7 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_query_rt_values_ex(ibv_context *context, ibv_values_ex *values)
     int ibv_get_async_event(ibv_context *context, ibv_async_event *event)
     void ibv_ack_async_event(ibv_async_event *event)
+    int ibv_query_qp_data_in_order(ibv_qp *qp, ibv_wr_opcode op, uint32_t flags)
 
 
 cdef extern from 'infiniband/driver.h':

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -1229,6 +1229,15 @@ cdef class QP(PyverbsCM):
         if rc != 0:
             raise PyverbsRDMAError('Failed to Bind MW', rc)
 
+    def query_data_in_order(self, op, flags=0):
+        """
+        Query if QP data is guaranteed to be in order.
+        :param op: Operation type.
+        :param flags: Extra field for future input. For now must be 0.
+        :return: 1 in case the data is guaranteed to be in order, 0 otherwise.
+        """
+        return v.ibv_query_qp_data_in_order(self.qp, op, flags)
+
     @property
     def qp_type(self):
         return self.qp.qp_type

--- a/tests/test_qp.py
+++ b/tests/test_qp.py
@@ -228,6 +228,19 @@ class QPTest(PyverbsAPITestCase):
         """
         self.query_qp_common_test(e.IBV_QPT_RAW_PACKET)
 
+    def test_query_data_in_order(self):
+        """
+        Queries an UD QP data in order after moving it to RTS state.
+        Verifies that the result from the query is valid.
+        """
+        with PD(self.ctx) as pd:
+            with CQ(self.ctx, 100, None, None, 0) as cq:
+                qia = u.get_qp_init_attr(cq, self.attr)
+                qia.qp_type = e.IBV_QPT_UD
+                qp = self.create_qp(pd, qia, False, True, self.ib_port)
+                is_data_in_order = qp.query_data_in_order(e.IBV_WR_SEND)
+                self.assertIn(is_data_in_order, [0, 1], 'Data in order result is not valid')
+
     def test_modify_ud_qp(self):
         """
         Queries a UD QP after calling modify(). Verifies that its properties are


### PR DESCRIPTION
This series Introduces ibv_query_qp_data_in_order() API.

This enables an application to check whether WQE data is guaranteed to be written in-order on the given QP and thus reader may poll for data instead of poll for completion.

The API was implemented by mlx5 driver over DEVX.
A detailed man page and some pyverbs stuff were added as well.