### PR TITLE
mlx5: DR, Support ability to allow/prevent duplicate rules

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -129,6 +129,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_umem_reg_ex@MLX5_1.19 35
  mlx5dv_dm_map_op_addr@MLX5_1.19 35
  _mlx5dv_query_port@MLX5_1.19 35
+ mlx5dv_dr_domain_allow_duplicate_rules@MLX5_1.20 36
  mlx5dv_map_ah_to_qp@MLX5_1.20 36
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -438,6 +438,17 @@ void mlx5dv_dr_domain_set_reclaim_device_memory(struct mlx5dv_dr_domain *dmn,
 	dr_domain_unlock(dmn);
 }
 
+void mlx5dv_dr_domain_allow_duplicate_rules(struct mlx5dv_dr_domain *dmn,
+					    bool allow)
+{
+	dr_domain_lock(dmn);
+	if (allow)
+		dmn->flags &= ~DR_DOMAIN_FLAG_DISABLE_DUPLICATE_RULES;
+	else
+		dmn->flags |= DR_DOMAIN_FLAG_DISABLE_DUPLICATE_RULES;
+	dr_domain_unlock(dmn);
+}
+
 int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *dmn)
 {
 	if (atomic_load(&dmn->refcount) > 1)

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -863,6 +863,11 @@ again:
 			if (!dr_ste_is_last_in_rule(nic_matcher, ste_location))
 				return matched_ste;
 
+			if (dmn->flags & DR_DOMAIN_FLAG_DISABLE_DUPLICATE_RULES) {
+				dr_dbg(dmn, "Duplicate rules are not supported\n");
+				errno = EEXIST;
+				return NULL;
+			}
 			dr_dbg(dmn, "Duplicate rule inserted\n");
 		}
 

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -184,5 +184,6 @@ MLX5_1.19 {
 
 MLX5_1.20 {
 	global:
+		mlx5dv_dr_domain_allow_duplicate_rules;
 		mlx5dv_map_ah_to_qp;
 } MLX5_1.19;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -82,6 +82,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_domain_allow_duplicate_rules.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_sync.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -10,7 +10,7 @@ footer: mlx5
 
 # NAME
 
-mlx5dv_dr_domain_create, mlx5dv_dr_domain_sync, mlx5dv_dr_domain_destroy, mlx5dv_dr_domain_set_reclaim_device_memory - Manage flow domains
+mlx5dv_dr_domain_create, mlx5dv_dr_domain_sync, mlx5dv_dr_domain_destroy, mlx5dv_dr_domain_set_reclaim_device_memory, mlx5dv_dr_domain_allow_duplicate_rules - Manage flow domains
 
 mlx5dv_dr_table_create, mlx5dv_dr_table_destroy - Manage flow tables
 
@@ -64,6 +64,8 @@ int mlx5dv_dr_domain_destroy(struct mlx5dv_dr_domain *domain);
 void mlx5dv_dr_domain_set_reclaim_device_memory(
 		struct mlx5dv_dr_domain *dmn,
 		bool enable);
+
+void mlx5dv_dr_domain_allow_duplicate_rules(struct mlx5dv_dr_domain *dmn, bool allow);
 
 struct mlx5dv_dr_table *mlx5dv_dr_table_create(
 		struct mlx5dv_dr_domain *domain,
@@ -196,6 +198,8 @@ Default behavior: Forward packet to eSwitch manager vport.
 
 
 *mlx5dv_dr_domain_set_reclaim_device_memory()* is used to enable the reclaiming of device memory back to the system when not in use, by default this feature is disabled.
+
+*mlx5dv_dr_domain_allow_duplicate_rules()* is used to allow or prevent insertion of rules matching on same fields(duplicates) on non root tables, by default this feature is allowed.
 
 ## Table
 *mlx5dv_dr_table_create()* creates a DR table in the **domain**, at the appropriate **level**, and can be used with *mlx5dv_dr_matcher_create()* and *mlx5dv_dr_action_create_dest_table()*.

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1499,6 +1499,9 @@ int mlx5dv_dr_domain_sync(struct mlx5dv_dr_domain *domain, uint32_t flags);
 void mlx5dv_dr_domain_set_reclaim_device_memory(struct mlx5dv_dr_domain *dmn,
 						bool enable);
 
+void mlx5dv_dr_domain_allow_duplicate_rules(struct mlx5dv_dr_domain *domain,
+					    bool allow);
+
 struct mlx5dv_dr_table *
 mlx5dv_dr_table_create(struct mlx5dv_dr_domain *domain, uint32_t level);
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -823,6 +823,7 @@ struct dr_domain_info {
 
 enum dr_domain_flags {
 	 DR_DOMAIN_FLAG_MEMORY_RECLAIM = 1 << 0,
+	 DR_DOMAIN_FLAG_DISABLE_DUPLICATE_RULES = 1 << 1,
 };
 
 struct mlx5dv_dr_domain {


### PR DESCRIPTION
Add support to allow or prevent insertion of duplicate rules, this enables user to choose one behavior from:
- Detect already existing rule and fail.
- Allow it, which enables to update the rule's action, but this will take affect once the previous rule will be deleted.

By default duplicate rules are allowed.