### PR TITLE
man page: Document EINVAL meaning for ibv_fork_init()

### DIFF
--- a/libibverbs/man/ibv_fork_init.3.md
+++ b/libibverbs/man/ibv_fork_init.3.md
@@ -33,7 +33,9 @@ always blocked until all child processes end or change address spaces via an
 # RETURN VALUE
 
 **ibv_fork_init()** returns 0 on success, or the value of errno on failure
-(which indicates the failure reason).
+(which indicates the failure reason). An error value of EINVAL indicates that
+there had been RDMA memory registration already and it is therefore not
+safe anymore to fork.
 
 # NOTES
 


### PR DESCRIPTION
It was not clear to me from the man page that ibv_fork_init actually
has a detection if memory was already registered before calling this
function. I guess EINVAL might be most likely reason why
ibv_fork_init might fail and it also can be used to give a program
failure reason to the end user.

Signed-off-by: Bernd Schubert <bschubert@ddn.com>