### PR TITLE
kernel-boot: Exclude loading rdma-core modules for s390x

### DIFF
--- a/kernel-boot/rdma-load-modules@.service.in
+++ b/kernel-boot/rdma-load-modules@.service.in
@@ -16,6 +16,8 @@ Before=network-pre.target
 # Orders all kernel module startup before rdma-hw.target can become ready
 Before=rdma-hw.target
 
+# Exclude loading rdma modules for s390x: https://bugzilla.redhat.com/show_bug.cgi?id=1782876
+ConditionArchitecture=!s390x
 ConditionCapability=CAP_SYS_MODULE
 
 [Service]


### PR DESCRIPTION
When booting a system with RoCE cards on s390x, the rdma load modules was failing along with infiniband (https://bugzilla.redhat.com/show_bug.cgi?id=1782876). These modules are not needed for Melanox RoCE cards and infiniband is not supported by s390x at all.