### PR TITLE
RXE Memory Window Support

### DIFF
--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -99,7 +99,16 @@ struct rxe_send_wr {
 			__u32	remote_qkey;
 			__u16	pkey_index;
 		} ud;
+		struct {
+			__aligned_u64	addr;
+			__aligned_u64	length;
+			__u32		mr_lkey;
+			__u32		mw_rkey;
+			__u32		rkey;
+			__u32		access;
+		} mw;
 		/* reg is only used by the kernel and is not part of the uapi */
+#ifdef __KERNEL__
 		struct {
 			union {
 				struct ib_mr *mr;
@@ -108,6 +117,7 @@ struct rxe_send_wr {
 			__u32	     key;
 			__u32	     access;
 		} reg;
+#endif
 	} wr;
 };
 


### PR DESCRIPTION
Subject: [PATCH v2 0/2] Implement memory windows support for rxe

These patches makes the required changes to the rxe provider and the
rxe ABI to support the kernel memory windows patches to the rxe driver.

Signed-off-by: Bob Pearson <rpearsonhpe@gmail.com>
---

Bob Pearson (2):
  Update kernel headers
  Providers/rxe: Implement memory windows

 kernel-headers/rdma/rdma_user_rxe.h |  10 ++
 providers/rxe/rxe.c                 | 157 +++++++++++++++++++++++++++-
 2 files changed, 165 insertions(+), 2 deletions(-)