### PR TITLE
Pyverbs fork tests

### DIFF
--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -23,6 +23,7 @@ rdma_cython_module(pyverbs ""
   ${DMABUF_ALLOC}
   enums.pyx
   flow.pyx
+  fork.pyx
   mem_alloc.pyx
   mr.pyx
   pd.pyx

--- a/pyverbs/fork.pyx
+++ b/pyverbs/fork.pyx
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+
+#cython: language_level=3
+
+from pyverbs.base import PyverbsRDMAError
+cimport pyverbs.libibverbs as v
+
+
+def fork_init():
+    ret = v.ibv_fork_init()
+    if ret:
+        raise PyverbsRDMAError('Failed to init fork support', ret)
+
+
+def is_fork_initialized():
+    return v.ibv_is_fork_initialized()

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -5,7 +5,6 @@ include 'libibverbs_enums.pxd'
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 from posix.time cimport timespec
 
-
 cdef extern from 'infiniband/verbs.h':
 
     cdef struct anon:
@@ -724,6 +723,8 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_get_async_event(ibv_context *context, ibv_async_event *event)
     void ibv_ack_async_event(ibv_async_event *event)
     int ibv_query_qp_data_in_order(ibv_qp *qp, ibv_wr_opcode op, uint32_t flags)
+    int ibv_fork_init()
+    ibv_fork_status ibv_is_fork_initialized()
 
 
 cdef extern from 'infiniband/driver.h':

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -447,6 +447,11 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_GID_TYPE_ROCE_V1
         IBV_GID_TYPE_ROCE_V2
 
+    cpdef enum ibv_fork_status:
+        IBV_FORK_DISABLED
+        IBV_FORK_ENABLED
+        IBV_FORK_UNNEEDED
+
 
 cdef extern from "<infiniband/verbs_api.h>":
     cdef unsigned long long IBV_ADVISE_MR_ADVICE_PREFETCH

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ rdma_python_test(tests
   test_efa_srd.py
   test_efadv.py
   test_flow.py
+  test_fork.py
   test_mlx5_cq.py
   test_mlx5_dc.py
   test_mlx5_dm_ops.py

--- a/tests/test_fork.py
+++ b/tests/test_fork.py
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright 2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+
+import errno
+import pyverbs.enums as e
+from pyverbs.fork import fork_init, is_fork_initialized
+from pyverbs.pyverbs_error import PyverbsRDMAError
+
+from tests.base import PyverbsAPITestCase
+
+
+class ForkAPITest(PyverbsAPITestCase):
+    """
+    Test the API of the fork functions.
+    """
+
+    def test_is_fork_initialized(self):
+        try:
+            fork_init()
+            expected_ret = [e.IBV_FORK_ENABLED, e.IBV_FORK_UNNEEDED]
+        except PyverbsRDMAError as ex:
+            # Depends on the order of the tests EINVAL could be returned if
+            # fork_init() is called after an MR has already been registered.
+            self.assertEqual(ex.error_code, errno.EINVAL)
+            expected_ret = [e.IBV_FORK_DISABLED, e.IBV_FORK_UNNEEDED]
+
+        ret = is_fork_initialized()
+        if self.config['verbosity']:
+            print(f'is_fork_initialized() = {ret}')
+        self.assertIn(ret, expected_ret)


### PR DESCRIPTION
This PR adds basic fork unit testing by calling ibv_fork_init() and ibv_is_fork_initialized().
The fork tests are impacted by the order of tests execution, for example, if a previous test has registered an MR then ibv_fork_init() is expected to fail. If only the fork tests are run, it should succeed.
