### PR TITLE
mlx5: Add DCS offload support

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -28,6 +28,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.18@MLX5_1.18 34
  MLX5_1.19@MLX5_1.19 35
  MLX5_1.20@MLX5_1.20 36
+ MLX5_1.21@MLX5_1.21 37
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -133,6 +134,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_map_ah_to_qp@MLX5_1.20 36
  mlx5dv_qp_cancel_posted_send_wrs@MLX5_1.20 36
  _mlx5dv_mkey_check@MLX5_1.20 36
+ mlx5dv_dci_stream_id_reset@MLX5_1.21 37
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/kernel-headers/rdma/mlx5-abi.h
+++ b/kernel-headers/rdma/mlx5-abi.h
@@ -50,6 +50,7 @@ enum {
 	MLX5_QP_FLAG_ALLOW_SCATTER_CQE	= 1 << 8,
 	MLX5_QP_FLAG_PACKET_BASED_CREDIT_MODE	= 1 << 9,
 	MLX5_QP_FLAG_UAR_PAGE_INDEX = 1 << 10,
+	MLX5_QP_FLAG_DCI_STREAM	= 1 << 11,
 };
 
 enum {
@@ -238,6 +239,11 @@ struct mlx5_ib_striding_rq_caps {
 	__u32 reserved;
 };
 
+struct mlx5_ib_dci_streams_caps {
+	__u8 max_log_num_concurent;
+	__u8 max_log_num_errored;
+};
+
 enum mlx5_ib_query_dev_resp_flags {
 	/* Support 128B CQE compression */
 	MLX5_IB_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP = 1 << 0,
@@ -266,7 +272,8 @@ struct mlx5_ib_query_device_resp {
 	struct mlx5_ib_sw_parsing_caps sw_parsing_caps;
 	struct mlx5_ib_striding_rq_caps striding_rq_caps;
 	__u32	tunnel_offloads_caps; /* enum mlx5_ib_tunnel_offloads */
-	__u32	reserved;
+	struct  mlx5_ib_dci_streams_caps dci_streams_caps;
+	__u16 reserved;
 };
 
 enum mlx5_ib_create_cq_flags {
@@ -313,6 +320,11 @@ struct mlx5_ib_create_srq_resp {
 	__u32	reserved;
 };
 
+struct mlx5_ib_create_qp_dci_streams {
+	__u8 log_num_concurent;
+	__u8 log_num_errored;
+};
+
 struct mlx5_ib_create_qp {
 	__aligned_u64 buf_addr;
 	__aligned_u64 db_addr;
@@ -327,7 +339,8 @@ struct mlx5_ib_create_qp {
 		__aligned_u64 access_key;
 	};
 	__u32  ece_options;
-	__u32  reserved;
+	struct  mlx5_ib_create_qp_dci_streams dci_streams;
+	__u16 reserved;
 };
 
 /* RX Hash function flags */

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.20.${PACKAGE_VERSION}
+  1 1.21.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -189,3 +189,8 @@ MLX5_1.20 {
 		mlx5dv_qp_cancel_posted_send_wrs;
 		_mlx5dv_mkey_check;
 } MLX5_1.19;
+
+MLX5_1.21 {
+	global:
+		mlx5dv_dci_stream_id_reset;
+} MLX5_1.20;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -113,6 +113,7 @@ rdma_alias_man_pages(
  mlx5dv_wr_mkey_configure.3 mlx5dv_wr_set_mkey_layout_interleaved.3
  mlx5dv_wr_mkey_configure.3 mlx5dv_wr_set_mkey_layout_list.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
+ mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr_stream.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_interleaved.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_list.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -8,6 +8,7 @@ rdma_man_pages(
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_mkey.3.md
   mlx5dv_create_qp.3.md
+  mlx5dv_dci_stream_id_reset.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_create_cmd_comp.3.md
   mlx5dv_devx_create_event_channel.3.md

--- a/providers/mlx5/man/mlx5dv_create_qp.3.md
+++ b/providers/mlx5/man/mlx5dv_create_qp.3.md
@@ -95,9 +95,18 @@ struct mlx5dv_qp_init_attr {
 ## *dc_init_attr*
 
 ```c
+
+struct mlx5dv_dci_streams {
+	uint8_t log_num_concurent;
+	uint8_t log_num_errored;
+};
+
 struct mlx5dv_dc_init_attr {
 	enum mlx5dv_dc_type	dc_type;
-	uint64_t dct_access_key;
+	union {
+	    uint64_t dct_access_key;
+	    struct mlx5dv_dci_streams dci_streams;
+	};
 };
 ```
 
@@ -110,6 +119,16 @@ struct mlx5dv_dc_init_attr {
 *dct_access_key*
 :	used to create a DCT QP.
 
+*dci_streams*
+:	dci_streams used to define DCI QP with multiple concurrent streams.
+	Valid when comp_mask includes MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS.
+
+	log_num_concurent
+		Defines the number of parallel different streams that could be handled by HW.
+		All work request of a specific stream_id are handled in order.
+
+	log_num_errored
+		Defines the number of dci error stream channels before moving DCI to an error state.
 
 *send_ops_flags*
 :	A bitwise OR of the various values described below.

--- a/providers/mlx5/man/mlx5dv_dci_stream_id_reset.3.md
+++ b/providers/mlx5/man/mlx5dv_dci_stream_id_reset.3.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: mlx5dv_dci_stream_id_reset
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_dci_stream_id_reset - Reset stream_id of a given DCI QP
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_dci_stream_id_reset(struct ibv_qp *qp, uint16_t stream_id);
+```
+
+# DESCRIPTION
+
+Used by SW to reset an errored *stream_id* in the HW DCI context.
+
+On work completion with error, the application should call ibv_query_qp() to check if the QP was moved to an error state,
+or it's still operational (in RTS state), which means that the specific *stream_id* that caused the completion with error is in error state.
+
+Errors which are stream related will cause only that *stream_id's* work request to be flushed as they are handled in order in the send queue.
+Once all *stream_id* WR's are flushed, application should reset the errored *stream_id* by calling mlx5dv_dci_stream_id_reset().
+Work requested for other *stream_id's* will continue to be processed by the QP.
+The DCI QP will move to an error state and stop operating once the number of unique *stream_id* in error reaches the DCI QP's 'log_num_errored' streams defined by SW.
+
+Application should use the 'wr_id' in the ibv_wc to find the *stream_id* from it’s private context.
+
+# ARGUMENTS
+
+*qp*
+:	The ibv_qp object to issue the action on.
+
+*stream_id*
+:	The DCI stream channel id that need to be reset.
+
+# RETURN VALUE
+
+Returns 0 on success, or the value of errno on failure (which indicates the failure reason).
+
+# AUTHOR
+
+Lior Nahmanson <liorna@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -40,6 +40,12 @@ uint32_t supported_qpts;
 };
 .PP
 .nf
+struct mlx5dv_dci_streams_caps {
+uint8_t max_log_num_concurent; /* max log number of parallel different streams that could be handled by HW */
+uint8_t max_log_num_errored; /* max DCI error stream channels supported per DCI before a DCI move to an error state */
+};
+.PP
+.nf
 struct mlx5dv_context {
 .in +8
 uint8_t         version;
@@ -91,6 +97,7 @@ MLX5DV_CONTEXT_MASK_DC_ODP_CAPS         = 1 << 7,
 MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK      = 1 << 8,
 MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9,
 MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10,
+MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11,
 .in -8
 };
 

--- a/providers/mlx5/man/mlx5dv_wr_post.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_post.3.md
@@ -25,6 +25,12 @@ static inline void mlx5dv_wr_set_dc_addr(struct mlx5dv_qp_ex *mqp,
                                          uint32_t remote_dctn,
                                          uint64_t remote_dc_key);
 
+static inline void mlx5dv_wr_set_dc_addr_stream(struct mlx5dv_qp_ex *mqp,
+						struct ibv_ah *ah,
+						uint32_t remote_dctn,
+						uint64_t remote_dc_key,
+						uint16_t stream_id);
+
 struct mlx5dv_mr_interleaved {
 	uint64_t        addr;
 	uint32_t        bytes_count;
@@ -126,6 +132,10 @@ man for ibv_wr_post and mlx5dv_qp with its available builders and setters.
     This setter is available when the QP transport is DCI and send_ops_flags
     in struct ibv_qp_init_attr_ex is set.
     The available builders and setters for DCI QP are the same as RC QP.
+    DCI QP created with MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS can call
+    *mlx5dv_wr_set_dc_addr_stream()* to define the *stream_id* of the operation
+    to allow HW to choose one of the multiple concurrent DCI resources.
+    Calls to *mlx5dv_wr_set_dc_addr()* are equivalent to using *stream_id*=0
 
 # EXAMPLE
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -873,6 +873,11 @@ int mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_TUNNEL_OFFLOADS;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_DCI_STREAMS) {
+		attrs_out->dci_streams_caps = mctx->dci_streams_caps;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_DCI_STREAMS;
+	}
+
 	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_DYN_BFREGS) {
 		attrs_out->max_dynamic_bfregs = mctx->num_dyn_bfregs;
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_DYN_BFREGS;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -371,6 +371,7 @@ struct mlx5_context {
 	struct mlx5dv_ctx_allocators	extern_alloc;
 	struct mlx5dv_sw_parsing_caps	sw_parsing_caps;
 	struct mlx5dv_striding_rq_caps	striding_rq_caps;
+	struct mlx5dv_dci_streams_caps  dci_streams_caps;
 	uint32_t			tunnel_offloads_caps;
 	struct mlx5_packet_pacing_caps	packet_pacing_caps;
 	struct mlx5_entropy_caps	entropy_caps;

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -3314,7 +3314,7 @@ struct mlx5_ifc_qpc_ext_bits {
 
 	u8         qos_queue_group_id_responder[0x20];
 
-	u8         reserved_at_60[0x7a0];
+	u8         reserved_at_60[0x5a0];
 };
 
 struct mlx5_ifc_create_tir_out_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -3308,7 +3308,9 @@ struct mlx5_ifc_qpc_bits {
 };
 
 struct mlx5_ifc_qpc_ext_bits {
-	u8         reserved_at_0[0x20];
+	u8         reserved_at_0[0x10];
+
+	u8	   dci_stream_channel_id[0x10];
 
 	u8         qos_queue_group_id_requester[0x20];
 
@@ -3367,6 +3369,7 @@ struct mlx5_ifc_create_qp_in_bits {
 };
 
 enum mlx5_qpc_opt_mask_32 {
+	MLX5_QPC_OPT_MASK_32_DCI_STREAM_CHANNEL_ID = 1 << 0,
 	MLX5_QPC_OPT_MASK_32_QOS_QUEUE_GROUP_ID = 1 << 1,
 	MLX5_QPC_OPT_MASK_32_UDP_SPORT = 1 << 2,
 };

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -270,6 +270,7 @@ enum mlx5dv_qp_init_attr_mask {
 	MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS	= 1 << 0,
 	MLX5DV_QP_INIT_ATTR_MASK_DC			= 1 << 1,
 	MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS		= 1 << 2,
+	MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS            = 1 << 3,
 };
 
 enum mlx5dv_dc_type {
@@ -277,9 +278,17 @@ enum mlx5dv_dc_type {
 	MLX5DV_DCTYPE_DCI,
 };
 
+struct mlx5dv_dci_streams {
+	uint8_t log_num_concurent;
+	uint8_t log_num_errored;
+};
+
 struct mlx5dv_dc_init_attr {
 	enum mlx5dv_dc_type	dc_type;
-	uint64_t dct_access_key;
+	union {
+		uint64_t dct_access_key;
+		struct mlx5dv_dci_streams dci_streams;
+	};
 };
 
 enum mlx5dv_qp_create_send_ops_flags {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -83,6 +83,7 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK	= 1 << 8,
 	MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS	= 1 << 9,
 	MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD	= 1 << 10,
+	MLX5DV_CONTEXT_MASK_DCI_STREAMS		= 1 << 11,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -101,6 +102,11 @@ struct mlx5dv_striding_rq_caps {
 	uint32_t min_single_wqe_log_num_of_strides;
 	uint32_t max_single_wqe_log_num_of_strides;
 	uint32_t supported_qpts;
+};
+
+struct mlx5dv_dci_streams_caps {
+	uint8_t max_log_num_concurent;
+	uint8_t max_log_num_errored;
 };
 
 enum mlx5dv_tunnel_offloads {
@@ -192,6 +198,7 @@ struct mlx5dv_context {
 	void		*hca_core_clock;
 	uint8_t		num_lag_ports;
 	struct mlx5dv_sig_caps sig_caps;
+	struct mlx5dv_dci_streams_caps dci_streams_caps;
 };
 
 enum mlx5dv_context_flags {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1892,6 +1892,8 @@ int mlx5dv_modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num);
 
 int mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport);
 
+int mlx5dv_dci_stream_id_reset(struct ibv_qp *qp, uint16_t stream_id);
+
 enum mlx5dv_sched_elem_attr_flags {
 	MLX5DV_SCHED_ELEM_ATTR_FLAGS_BW_SHARE	= 1 << 0,
 	MLX5DV_SCHED_ELEM_ATTR_FLAGS_MAX_AVG_BW	= 1 << 1,

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -417,6 +417,11 @@ struct mlx5dv_qp_ex {
 	void (*wr_set_mkey_sig_block)(struct mlx5dv_qp_ex *mqp,
 				      const struct mlx5dv_sig_block_attr *attr);
 	void (*wr_raw_wqe)(struct mlx5dv_qp_ex *mqp, const void *wqe);
+	void (*wr_set_dc_addr_stream)(struct mlx5dv_qp_ex *mqp,
+				      struct ibv_ah *ah,
+				      uint32_t remote_dctn,
+				      uint64_t remote_dc_key,
+				      uint16_t stream_id);
 };
 
 struct mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex *qp);
@@ -427,6 +432,16 @@ static inline void mlx5dv_wr_set_dc_addr(struct mlx5dv_qp_ex *mqp,
 					 uint64_t remote_dc_key)
 {
 	mqp->wr_set_dc_addr(mqp, ah, remote_dctn, remote_dc_key);
+}
+
+static inline void mlx5dv_wr_set_dc_addr_stream(struct mlx5dv_qp_ex *mqp,
+						struct ibv_ah *ah,
+						uint32_t remote_dctn,
+						uint64_t remote_dc_key,
+						uint16_t stream_id)
+{
+	mqp->wr_set_dc_addr_stream(mqp, ah, remote_dctn,
+				   remote_dc_key, stream_id);
 }
 
 static inline void mlx5dv_wr_mr_interleaved(struct mlx5dv_qp_ex *mqp,
@@ -1052,10 +1067,10 @@ struct mlx5_wqe_ctrl_seg {
 	__be32		opmod_idx_opcode;
 	__be32		qpn_ds;
 	uint8_t		signature;
-	uint8_t		rsvd[2];
+	__be16		dci_stream_channel_id;
 	uint8_t		fm_ce_se;
 	__be32		imm;
-};
+} __attribute__((__packed__)) __attribute__((__aligned__(4)));
 
 struct mlx5_mprq_wqe {
 	struct mlx5_wqe_srq_next_seg	nseg;

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2950,6 +2950,18 @@ static void mlx5_send_wr_set_dc_addr(struct mlx5dv_qp_ex *dv_qp,
 		mqp->cur_setters_cnt++;
 }
 
+static void mlx5_send_wr_set_dc_addr_stream(struct mlx5dv_qp_ex *dv_qp,
+					    struct ibv_ah *ah,
+					    uint32_t remote_dctn,
+					    uint64_t remote_dc_key,
+					    uint16_t stream_id)
+{
+	struct mlx5_qp *mqp = mqp_from_mlx5dv_qp_ex(dv_qp);
+
+	mqp->cur_ctrl->dci_stream_channel_id = htobe16(stream_id);
+	mlx5_send_wr_set_dc_addr(dv_qp, ah, remote_dctn, remote_dc_key);
+}
+
 static inline void raw_wqe_init(struct ibv_qp_ex *ibqp, const void *wqe)
 {
 	struct mlx5_qp *mqp = to_mqp((struct ibv_qp *)ibqp);
@@ -3207,6 +3219,7 @@ int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
 		fill_wr_builders_rc_xrc_dc(ibqp);
 		fill_wr_setters_ud_xrc_dc(ibqp);
 		dv_qp->wr_set_dc_addr = mlx5_send_wr_set_dc_addr;
+		dv_qp->wr_set_dc_addr_stream = mlx5_send_wr_set_dc_addr_stream;
 		break;
 
 	default:

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3815,6 +3815,10 @@ void mlx5_query_device_ctx(struct mlx5_context *mctx)
 		resp.striding_rq_caps.supported_qpts;
 	mctx->tunnel_offloads_caps = resp.tunnel_offloads_caps;
 	mctx->packet_pacing_caps = resp.packet_pacing_caps;
+	mctx->dci_streams_caps.max_log_num_concurent =
+		resp.dci_streams_caps.max_log_num_concurent;
+	mctx->dci_streams_caps.max_log_num_errored =
+		resp.dci_streams_caps.max_log_num_errored;
 
 	if (resp.flags & MLX5_IB_QUERY_DEV_RESP_FLAGS_CQE_128B_COMP)
 		mctx->vendor_cap_flags |= MLX5_VENDOR_CAP_FLAGS_CQE_128B_COMP;

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -251,6 +251,9 @@ cdef extern from 'infiniband/mlx5dv.h':
     void mlx5dv_pp_free(mlx5dv_pp *pp)
     void mlx5dv_wr_set_dc_addr(mlx5dv_qp_ex *mqp, v.ibv_ah *ah,
                                uint32_t remote_dctn, uint64_t remote_dc_key)
+    void mlx5dv_wr_set_dc_addr_stream(mlx5dv_qp_ex *mqp, v.ibv_ah *ah,
+                                      uint32_t remote_dctn, uint64_t remote_dc_key,
+                                      uint16_t stream_id)
     void mlx5dv_wr_mr_interleaved(mlx5dv_qp_ex *mqp, mlx5dv_mkey *mkey,
                                   uint32_t access_flags, uint32_t repeat_count,
                                   uint16_t num_interleaved, mlx5dv_mr_interleaved *data)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -49,9 +49,14 @@ cdef extern from 'infiniband/mlx5dv.h':
         unsigned int            dc_odp_caps
         uint8_t                 num_lag_ports
 
+    cdef struct mlx5dv_dci_streams:
+        uint8_t       log_num_concurent
+        uint8_t       log_num_errored
+
     cdef struct mlx5dv_dc_init_attr:
         mlx5dv_dc_type      dc_type
         unsigned long       dct_access_key
+        mlx5dv_dci_streams  dci_streams
 
     cdef struct mlx5dv_qp_init_attr:
         unsigned long       comp_mask

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -239,6 +239,7 @@ cdef extern from 'infiniband/mlx5dv.h':
                                  uint8_t *active_port_num)
     int mlx5dv_modify_qp_lag_port(v.ibv_qp *qp, uint8_t port_num)
     int mlx5dv_modify_qp_udp_sport(v.ibv_qp *qp, uint16_t udp_sport)
+    int mlx5dv_dci_stream_id_reset(v.ibv_qp *qp, uint16_t stream_id)
     v.ibv_cq_ex *mlx5dv_create_cq(v.ibv_context *context,
                                   v.ibv_cq_init_attr_ex *cq_attr,
                                   mlx5dv_cq_init_attr *mlx5_cq_attr)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -30,6 +30,10 @@ cdef extern from 'infiniband/mlx5dv.h':
         unsigned int    max_single_wqe_log_num_of_strides
         unsigned int    supported_qpts
 
+    cdef struct mlx5dv_dci_streams_caps:
+        uint8_t    max_log_num_concurent
+        uint8_t    max_log_num_errored
+
     cdef struct mlx5dv_context:
         unsigned char           version
         unsigned long           flags
@@ -37,6 +41,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         mlx5dv_cqe_comp_caps    cqe_comp_caps
         mlx5dv_sw_parsing_caps  sw_parsing_caps
         mlx5dv_striding_rq_caps striding_rq_caps
+        mlx5dv_dci_streams_caps dci_streams_caps
         unsigned int            tunnel_offloads_caps
         unsigned int            max_dynamic_bfregs
         unsigned long           max_clock_info_update_nsec

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -22,6 +22,9 @@ cdef class Mlx5DVContext(PyverbsObject):
 cdef class Mlx5DVPortAttr(PyverbsObject):
     cdef dv.mlx5dv_port attr
 
+cdef class Mlx5DCIStreamInitAttr(PyverbsObject):
+    cdef dv.mlx5dv_dci_streams dci_streams
+
 cdef class Mlx5DVDCInitAttr(PyverbsObject):
     cdef dv.mlx5dv_dc_init_attr attr
 

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -742,6 +742,18 @@ cdef class Mlx5QP(QPEx):
             raise PyverbsRDMAError(f'Failed to cancel send WRs', -rc)
         return rc
 
+    def wr_set_dc_addr_stream(self, AH ah, remote_dctn, remote_dc_key, stream_id):
+        """
+        Attach a DC info to the last work request.
+        :param ah: Address Handle to the requested DCT.
+        :param remote_dctn: The remote DCT number.
+        :param remote_dc_key: The remote DC key.
+        :param stream_id: DCI stream channel_id
+        """
+        dv.mlx5dv_wr_set_dc_addr_stream(dv.mlx5dv_qp_ex_from_ibv_qp_ex(self.qp_ex),
+                                        ah.ah, remote_dctn, remote_dc_key,
+                                        stream_id)
+
     @staticmethod
     def query_lag_port(QP qp):
         """

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -808,6 +808,18 @@ cdef class Mlx5QP(QPEx):
         if rc != 0:
             raise PyverbsRDMAError(f'Failed to map AH to QP #{qp_num}', rc)
 
+    @staticmethod
+    def modify_dci_stream_channel_id(QP qp, uint16_t stream_id):
+        """
+        Reset an errored stream_id in the HW DCI context.
+        :param qp: A DCI QP in RTS state.
+        :param stream_id: The desired stream_id that need to be reset.
+        """
+        rc = dv.mlx5dv_dci_stream_id_reset(qp.qp, stream_id)
+        if rc != 0:
+            raise PyverbsRDMAError(f'Failed to reset stream_id #{stream_id} for DCI QP'
+                                   f'#{qp.qp.qp_num}', rc)
+
 
 cdef class Mlx5DVCQInitAttr(PyverbsObject):
     """

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -175,7 +175,8 @@ cdef class Mlx5Context(Context):
                 dve.MLX5DV_CONTEXT_MASK_DYN_BFREGS |\
                 dve.MLX5DV_CONTEXT_MASK_CLOCK_INFO_UPDATE |\
                 dve.MLX5DV_CONTEXT_MASK_DC_ODP_CAPS |\
-                dve.MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS
+                dve.MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS |\
+                dve.MLX5DV_CONTEXT_MASK_DCI_STREAMS
         else:
             dv_attr.comp_mask = comp_mask
         rc = dv.mlx5dv_query_device(self.context, &dv_attr.dv)
@@ -324,6 +325,10 @@ cdef class Mlx5DVContext(PyverbsObject):
     def num_lag_ports(self):
         return self.dv.num_lag_ports
 
+    @property
+    def dci_streams_caps(self):
+        return self.dv.dci_streams_caps
+
     def __str__(self):
         print_format = '{:20}: {:<20}\n'
         ident_format = '  {:20}: {:<20}\n'
@@ -348,12 +353,17 @@ cdef class Mlx5DVContext(PyverbsObject):
                                    self.dv.striding_rq_caps.max_single_wqe_log_num_of_strides) +\
                ident_format.format('supported QP types',
                                    qpts_to_str(self.dv.striding_rq_caps.supported_qpts))
+        stream = 'DCI stream caps:\n' +\
+                  ident_format.format('max log num concurent streams',
+                                      self.dv.dci_streams_caps.max_log_num_concurent) +\
+                  ident_format.format('max log num errored streams',
+                                      self.dv.dci_streams_caps.max_log_num_errored)
         return print_format.format('Version', self.dv.version) +\
                print_format.format('Flags',
                                    context_flags_to_str(self.dv.flags)) +\
                print_format.format('comp mask',
                                    context_comp_mask_to_str(self.dv.comp_mask)) +\
-               cqe + swp + strd +\
+               cqe + swp + strd + stream +\
                print_format.format('Tunnel offloads caps',
                                    tunnel_offloads_to_str(self.dv.tunnel_offloads_caps)) +\
                print_format.format('Max dynamic BF registers',

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -87,6 +87,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS    = 1 << 0
         MLX5DV_QP_INIT_ATTR_MASK_DC                 = 1 << 1
         MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS     = 1 << 2
+        MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS        = 1 << 3
 
     cpdef enum mlx5dv_qp_create_flags:
         MLX5DV_QP_CREATE_TUNNEL_OFFLOADS            = 1 << 0

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -44,6 +44,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_MASK_DC_ODP_CAPS         = 1 << 7
         MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9
         MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10
+        MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11
 
     cpdef enum mlx5dv_context_flags:
         MLX5DV_CONTEXT_FLAGS_CQE_V1                     = 1 << 0

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -6,17 +6,18 @@ import random
 import errno
 
 from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, \
-    Mlx5DVQPInitAttr, Mlx5QP, Mlx5DVDCInitAttr
+    Mlx5DVQPInitAttr, Mlx5QP, Mlx5DVDCInitAttr, Mlx5DCIStreamInitAttr
 from tests.base import TrafficResources, set_rnr_attributes, DCT_KEY, \
     RDMATestCase, PyverbsAPITestCase, RDMACMBaseTest
-from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError, \
+    PyverbsError
 from pyverbs.qp import QPCap, QPInitAttrEx, QPAttr
 import pyverbs.providers.mlx5.mlx5_enums as dve
 from pyverbs.addr import AHAttr, GlobalRoute
 import pyverbs.device as d
+from pyverbs.pd import PD
 import pyverbs.enums as e
 from pyverbs.mr import MR
-
 
 MELLANOX_VENDOR_ID = 0x02c9
 MLX5_DEVS = {
@@ -41,6 +42,10 @@ MLX5_DEVS = {
 	0xa2d6, # BlueField-2 integrated ConnectX-6 Dx network controller
 	0xa2dc, # BlueField-3 integrated ConnectX-7 network controller
 }
+
+DCI_TEST_GOOD_FLOW = 0
+DCI_TEST_BAD_FLOW_WITH_RESET = 1
+DCI_TEST_BAD_FLOW_WITHOUT_RESET = 2
 
 
 def is_mlx5_dev(ctx):
@@ -155,3 +160,237 @@ class Mlx5DcResources(TrafficResources):
             if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest(f'Create DC QP is not supported')
             raise ex
+
+
+class Mlx5DcStreamsRes(Mlx5DcResources):
+    def __init__(self, dev_name, ib_port, gid_index, send_ops_flags,
+                 qp_count=1, create_flags=0):
+        self.bad_flow = 0
+        self.mr_bad_flow = False
+        self.stream_check = False
+        super().__init__(dev_name, ib_port, gid_index, send_ops_flags,
+                         qp_count, create_flags)
+
+    def reset_qp(self, qp_idx):
+        qp_attr = QPAttr(qp_state=e.IBV_QPS_RESET)
+        self.qps[qp_idx].modify(qp_attr, e.IBV_QP_STATE)
+        self.qps[qp_idx].to_rts(qp_attr)
+        err_mask = self.qp_stream_errors[qp_idx][0]
+        index = 0
+        # Clear all set dci
+        while err_mask != 0:
+            if (err_mask & 0x1) == 0x1:
+                Mlx5QP.modify_dci_stream_channel_id(self.qps[qp_idx], index)
+            index += 1
+            err_mask >>= 1
+        self.qp_stream_errors[qp_idx][0] = 0
+
+    def get_stream_id(self, qp_idx):
+        return self.current_qp_stream_id[qp_idx]
+
+    def generate_stream_id(self, qp_idx):
+        self.current_qp_stream_id[qp_idx] += 1
+        # Reset stream id to check double-usage
+        if self.current_qp_stream_id[qp_idx] > self.dcis[qp_idx]['stream']+2:
+            self.current_qp_stream_id[qp_idx] = 1
+        return self.current_qp_stream_id[qp_idx]
+
+    def dci_reset_stream_id(self, qp_idx):
+        stream_id = self.get_stream_id(qp_idx)
+        Mlx5QP.modify_dci_stream_channel_id(self.qps[qp_idx], stream_id)
+        # Check once if error raised when reset wrong stream id
+        if self.stream_check:
+            try:
+                Mlx5QP.modify_dci_stream_channel_id(self.qps[qp_idx],
+                                                    stream_id+1)
+            except PyverbsRDMAError as ex:
+                self.stream_check = False
+
+    def bad_flow_handler_qp(self, qp_idx, ex, reset=False):
+        str_id = self.get_stream_id(qp_idx)
+        bt_stream = (1 << str_id)
+        if isinstance(ex, PyverbsRDMAError):
+            if ex.error_code == e.IBV_WC_LOC_PROT_ERR:
+                self.qp_stream_errors[qp_idx][1] += 1
+                if (self.qp_stream_errors[qp_idx][0] & bt_stream) != 0:
+                    raise PyverbsError(f'Dublicate error from stream id {str_id}')
+                self.qp_stream_errors[qp_idx][0] |= bt_stream
+            if ex.error_code == e.IBV_WC_WR_FLUSH_ERR:
+                qp_attr, _ = self.qps[qp_idx].query(e.IBV_QP_STATE)
+                if qp_attr.cur_qp_state == e.IBV_QPS_ERR and reset:
+                    if self.qp_stream_errors[qp_idx][1] != self.dcis[qp_idx]['errored']:
+                        msg = f'QP {qp_idx} in ERR state with wrong number of counter'
+                        raise PyverbsError(msg)
+                    self.reset_qp(qp_idx)
+                    self.qp_stream_errors[qp_idx][2] = True
+                if qp_attr.cur_qp_state == e.IBV_QPS_RTS:
+                    if (self.qp_stream_errors[qp_idx][0] & bt_stream) == 0:
+                        msg = f'WQE flushed for wrong stream id {str_id}'
+                        raise PyverbsError(msg)
+        return True
+
+    def bad_flow_handling(self, qp_idx, ex, reset=False):
+        if self.bad_flow == DCI_TEST_GOOD_FLOW:
+            return False
+        if self.bad_flow == DCI_TEST_BAD_FLOW_WITH_RESET:
+            self.qp_stream_errors[qp_idx][1] += 1
+            if reset:
+                self.dci_reset_stream_id(qp_idx)
+            return True
+        if self.bad_flow == DCI_TEST_BAD_FLOW_WITHOUT_RESET:
+            return self.bad_flow_handler_qp(qp_idx, ex, reset)
+        return False
+
+    def set_bad_flow(self, bad_flow):
+        self.bad_flow = bad_flow
+        if self.bad_flow:
+            self.pd_bad = PD(self.ctx)
+            self.mr_bad_flow = False
+        if bad_flow == DCI_TEST_BAD_FLOW_WITH_RESET:
+            self.stream_check = True
+
+    def is_bad_flow(self, qp_idx):
+        cnt = self.get_stream_id(qp_idx)
+        if self.bad_flow == DCI_TEST_GOOD_FLOW:
+            return False
+        if self.bad_flow == DCI_TEST_BAD_FLOW_WITH_RESET:
+            if (cnt % 3) != 0:
+                return False
+            self.qp_stream_errors[qp_idx][0] += 1
+        if self.bad_flow == DCI_TEST_BAD_FLOW_WITHOUT_RESET:
+            if self.qp_stream_errors[qp_idx][2]:
+                return False
+        return True
+
+    def check_bad_flow(self, qp_idx):
+        change_mr = False
+        if self.is_bad_flow(qp_idx):
+            if not self.mr_bad_flow:
+                self.mr_bad_flow = True
+                pd = self.pd_bad
+                change_mr = True
+        else:
+            if self.mr_bad_flow:
+                self.mr_bad_flow = False
+                pd = self.pd
+                change_mr = True
+        if change_mr:
+            self.mr.rereg(flags=e.IBV_REREG_MR_CHANGE_PD, pd=pd,
+                          addr=0, length=0, access=0)
+
+    def check_after_traffic(self):
+        if self.bad_flow == DCI_TEST_BAD_FLOW_WITH_RESET:
+            for errs in self.qp_stream_errors:
+                if errs[0] != errs[1]:
+                    msg = f'Number of qp_stream_errors {errs[0]} not same '\
+                          f'as number of catches {errs[1]}'
+                    raise PyverbsError(msg)
+            if self.stream_check:
+                msg = 'Reset of good stream id does not create exception'
+                raise PyverbsError(msg)
+
+    def generate_dci_attr(self, qpn):
+        # This array contains current number of log_dci_streams
+        # and log_dci_errored values per qp. For 1-st qp number
+        # of streams greater than number of errored and vice-versa
+        # for the 2nd qp.
+        qp_arr = {0: [3, 2], 1: [2, 3]}
+        try:
+            dci_caps = self.ctx.query_mlx5_device().dci_streams_caps
+        except PyverbsRDMAError as ex:
+            if ex.error_code in [errno.EOPNOTSUPP, errno.EPROTONOSUPPORT]:
+                raise unittest.SkipTest('Get DCI caps is not supported')
+            raise ex
+        if not dci_caps or dci_caps['max_log_num_concurent'] == 0:
+            raise unittest.SkipTest('DCI caps is not supported by HW')
+        self.log_dci_streams = min(qp_arr.get(qpn, [1,1])[0],
+                                   dci_caps['max_log_num_concurent'])
+        self.log_dci_errored = min(qp_arr.get(qpn, [1,1])[1],
+                                   dci_caps['max_log_num_errored'])
+
+    def create_qps(self):
+        # Create the DCI QPs.
+        qp_init_attr = self.create_qp_init_attr(self.send_ops_flags)
+        self.dcis = {}
+        # This array contains current stream id
+        self.current_qp_stream_id = {}
+        # This array counts different errors in bad_flow
+        self.qp_stream_errors = []
+        comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_DC | \
+                    dve.MLX5DV_QP_INIT_ATTR_MASK_DCI_STREAMS
+        try:
+            for qpn in range(self.qp_count):
+                if self.create_flags:
+                    comp_mask |= dve.MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS
+                self.generate_dci_attr(qpn)
+                stream_ctx = Mlx5DCIStreamInitAttr(self.log_dci_streams,
+                                                   self.log_dci_errored)
+                self.dcis[qpn] = {'stream': 1 << self.log_dci_streams,
+                                  'errored': 1 << self.log_dci_errored}
+                attr = Mlx5DVQPInitAttr(comp_mask=comp_mask,
+                                        create_flags=self.create_flags,
+                                        dc_init_attr=Mlx5DVDCInitAttr(dci_streams=stream_ctx))
+                qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+                self.qps.append(qp)
+                # Different values for start point of stream id per qp
+                self.current_qp_stream_id[qpn] = qpn
+                # Array of errors for bad_flow
+                # For DCI_TEST_BAD_FLOW_WITH_RESET
+                #  First element - number of injected bad flows
+                #  Second element - number of exceptions from bad flows
+                # For DCI_TEST_BAD_FLOW_WITHOUT_RESET
+                #  First element - bitmap of bad flow streams
+                #  Second element - number of exceptions from bad flows
+                #  Third element - flag if reset of qp been executed
+                self.qp_stream_errors.append([0, 0, False])
+                self.qps_num.append(qp.qp_num)
+                self.psns.append(random.getrandbits(24))
+            # Create the DCT QP.
+            qp_init_attr = self.create_qp_init_attr()
+            dc_attr = Mlx5DVDCInitAttr(dc_type=dve.MLX5DV_DCTYPE_DCT,
+                                       dct_access_key=DCT_KEY)
+            attr = Mlx5DVQPInitAttr(comp_mask=dve.MLX5DV_QP_INIT_ATTR_MASK_DC,
+                                    dc_init_attr=dc_attr)
+            self.dct_qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code in [errno.EOPNOTSUPP, errno.EPROTONOSUPPORT]:
+                raise unittest.SkipTest('Create DC QP is not supported')
+            raise ex
+
+    @staticmethod
+    def traffic_with_bad_flow(client, server, iters, gid_idx, port):
+        """
+        Runs basic traffic with bad flow between two sides
+        :param client: client side, clients base class is BaseTraffic
+        :param server: server side, servers base class is BaseTraffic
+        :param iters: number of traffic iterations
+        :param gid_idx: local gid index
+        :param port: IB port
+        :return: None
+        """
+        import tests.utils as u
+        send_op = e.IBV_QP_EX_WITH_SEND
+        ah_client = u.get_global_ah(client, gid_idx, port)
+        s_recv_wr = u.get_recv_wr(server)
+        c_recv_wr = u.get_recv_wr(client)
+        for qp_idx in range(server.qp_count):
+            # Prepare the receive queue with RecvWR
+            u.post_recv(client, c_recv_wr, qp_idx=qp_idx)
+            u.post_recv(server, s_recv_wr, qp_idx=qp_idx)
+        read_offset = 0
+        for _ in range(iters):
+            for qp_idx in range(server.qp_count):
+                _, c_send_object = u.get_send_elements(client, False)
+                u.send(client, c_send_object, send_op, True, qp_idx,
+                       ah_client, False)
+                try:
+                    u.poll_cq(client.cq)
+                except PyverbsError as ex:
+                    if client.bad_flow_handling(qp_idx, ex, True):
+                        continue
+                    raise ex
+                u.poll_cq(server.cq)
+                u.post_recv(server, s_recv_wr, qp_idx=qp_idx)
+                msg_received = server.mr.read(server.msg_size, read_offset)
+                u.validate(msg_received, True, server.msg_size)
+        client.check_after_traffic()

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -4,7 +4,10 @@
 import unittest
 import errno
 
-from tests.mlx5_base import Mlx5DcResources, Mlx5RDMATestCase
+import pyverbs.providers.mlx5.mlx5_enums as me
+from tests.mlx5_base import Mlx5DcResources, Mlx5RDMATestCase, Mlx5DcStreamsRes,\
+    DCI_TEST_GOOD_FLOW, DCI_TEST_BAD_FLOW_WITH_RESET,\
+    DCI_TEST_BAD_FLOW_WITHOUT_RESET
 from pyverbs.pyverbs_error import PyverbsRDMAError
 from pyverbs.providers.mlx5.mlx5dv import Mlx5QP
 import pyverbs.enums as e
@@ -40,16 +43,19 @@ class DCTest(Mlx5RDMATestCase):
         self.client.remote_dct_num = self.server.dct_qp.qp_num
         self.server.remote_dct_num = self.client.dct_qp.qp_num
 
-    def create_players(self, resource, **resource_arg):
+    def create_players(self, resource, bad_flow=DCI_TEST_GOOD_FLOW, **resource_arg):
         """
         Init DC tests resources.
         :param resource: The RDMA resources to use.
+        :param bad_flow: Test bad flows (relevant for DCS tests only)
         :param resource_arg: Dict of args that specify the resource specific
         attributes.
         :return: None
         """
         self.client = resource(**self.dev_info, **resource_arg)
         self.server = resource(**self.dev_info, **resource_arg)
+        if bad_flow:
+            self.client.set_bad_flow(bad_flow)
         self.client.pre_run(self.server.psns, self.server.qps_num)
         self.server.pre_run(self.client.psns, self.client.qps_num)
         self.sync_remote_attr()
@@ -98,3 +104,43 @@ class DCTest(Mlx5RDMATestCase):
         self.check_odp_dc_support()
         u.traffic(**self.traffic_args, new_send=True,
                   send_op=e.IBV_QP_EX_WITH_SEND)
+
+    def test_dc_rdma_write_stream(self):
+        """
+        Check good flow of DCS.
+        Calculate stream_id for DCS test by setting same stream id
+        twice for WR and after increase it. Setting goes by loop
+        and after stream_id is more than number of concurrent
+        streams + 1 then stream_id returns to 1.
+        :raises SkipTest: In case DCI is not supported with HW
+        """
+        self.create_players(Mlx5DcStreamsRes, qp_count=2,
+                            send_ops_flags=e.IBV_QP_EX_WITH_RDMA_WRITE)
+        u.rdma_traffic(**self.traffic_args, new_send=True,
+                       send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+
+    def test_dc_send_stream_bad_flow(self):
+        """
+        Check bad flow of DCS with reset stream id.
+        Create error in dci stream by setting invalid PD so dci stream goes to error.
+        In the end, the test verifies that the number of errors is as expected.
+        :raises SkipTest: In case DCI is not supported with HW
+        """
+        self.create_players(Mlx5DcStreamsRes, bad_flow=DCI_TEST_BAD_FLOW_WITH_RESET,
+                            qp_count=1, send_ops_flags=e.IBV_QP_EX_WITH_SEND)
+        self.client.traffic_with_bad_flow(**self.traffic_args)
+
+    def test_dc_send_stream_bad_flow_qp(self):
+        """
+        Check bad flow of DCS with reset qp.
+        Checked if resetting of wrong dci stream id produces an exception.
+        This bad flow creates enough errors without resetting the streams,
+        enforcing the QP to get into ERR state. Then the checking is stopped.
+        Also has feature that after QP goes in ERR state test will
+        reset QP to RTS state.
+        :raises SkipTest: In case DCI is not supported with HW
+        """
+        self.iters = 20
+        self.create_players(Mlx5DcStreamsRes, bad_flow=DCI_TEST_BAD_FLOW_WITHOUT_RESET,
+                            qp_count=1, send_ops_flags=e.IBV_QP_EX_WITH_SEND)
+        self.client.traffic_with_bad_flow(**self.traffic_args)


### PR DESCRIPTION
This series adds DCS offload support by exposing some DV API stuff.

DCS is an offload to SW load balancing of DC initiator work requests.

A single DCI can be connected to only one target at the time and can't start a new connection until the previous work request is completed. This limitation will cause a delay when the initiator process needs to transfer data to multiple targets at the same time.

The SW solution is to use a process that handling and spreading the work request on many DCIs according to destinations.
This feature is an offload to this process and coming to reduce the load from the CPU and improve the performance.

Detailed man pages were added, the series includes also some pyverbs stuff which tests the functionality.