### PR TITLE
Rxe Implement Memory Windows

### DIFF
--- a/kernel-headers/rdma/rdma_user_rxe.h
+++ b/kernel-headers/rdma/rdma_user_rxe.h
@@ -99,7 +99,16 @@ struct rxe_send_wr {
 			__u32	remote_qkey;
 			__u16	pkey_index;
 		} ud;
+		struct {
+			__aligned_u64	addr;
+			__aligned_u64	length;
+			__u32		mr_lkey;
+			__u32		mw_rkey;
+			__u32		rkey;
+			__u32		access;
+		} mw;
 		/* reg is only used by the kernel and is not part of the uapi */
+#ifdef __KERNEL__
 		struct {
 			union {
 				struct ib_mr *mr;
@@ -108,6 +117,7 @@ struct rxe_send_wr {
 			__u32	     key;
 			__u32	     access;
 		} reg;
+#endif
 	} wr;
 };
 


### PR DESCRIPTION
From 7a6feeb37a9816497b8c59905d7d46979262cc57 Mon Sep 17 00:00:00 2001
From: Bob Pearson <rpearsonhpe@gmail.com>
Date: Thu, 17 Jun 2021 23:16:51 -0500
Subject: [PATCH v3 0/2] Implement memory windows support for rxe

These patches makes the required changes to the rxe provider and the
rxe ABI to support the kernel memory windows patches to the rxe driver.

The kernel patches are accepted upstream in linux-rdma for-next.

Signed-off-by: Bob Pearson <rpearsonhpe@gmail.com>
---

Bob Pearson (2):
  Update kernel headers
  Providers/rxe: Implement memory windows

 kernel-headers/rdma/rdma_user_rxe.h |  10 ++
 providers/rxe/rxe.c                 | 199 +++++++++++++++++++++++-----
 2 files changed, 175 insertions(+), 34 deletions(-)