### PR TITLE
mlx5: Introduce mlx5dv_wr_raw_wqe builder

### DIFF
--- a/libibverbs/man/ibv_poll_cq.3
+++ b/libibverbs/man/ibv_poll_cq.3
@@ -83,7 +83,8 @@ overrun from occurrence.  In case of a CQ overrun, the async event
 .B IBV_EVENT_CQ_ERR
 will be triggered, and the CQ cannot be used.
 .PP
-IBV_WC_DRIVER1 will be reported as a response to IBV_WR_DRIVER1 opcode.
+IBV_WC_DRIVER1 will be reported as a response to IBV_WR_DRIVER1 opcode;
+IBV_WC_DRIVER2 will be reported on a specific driver operation.
 .SH "SEE ALSO"
 .BR ibv_post_send (3),
 .BR ibv_post_recv (3)

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -529,6 +529,7 @@ enum ibv_wc_opcode {
 	IBV_WC_TM_RECV,
 	IBV_WC_TM_NO_TAG,
 	IBV_WC_DRIVER1,
+	IBV_WC_DRIVER2,
 };
 
 enum {

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -115,4 +115,5 @@ rdma_alias_man_pages(
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_interleaved.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_list.3
+ mlx5dv_wr_post.3 mlx5dv_wr_raw_wqe.3
 )

--- a/providers/mlx5/man/mlx5dv_wr_post.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_post.3.md
@@ -13,6 +13,8 @@ title: MLX5DV_WR
 
 mlx5dv_wr_set_dc_addr - Attach a DC info to the last work request
 
+mlx5dv_wr_raw_wqe - Build a raw work request
+
 # SYNOPSIS
 
 ```c
@@ -42,6 +44,8 @@ static inline void mlx5dv_wr_mr_list(struct mlx5dv_qp_ex *mqp,
 				      uint32_t access_flags, /* use enum ibv_access_flags */
 				      uint16_t num_sges,
 				      struct ibv_sge *sge);
+
+static inline int mlx5dv_wr_raw_wqe(struct mlx5dv_qp_ex *mqp, const void *wqe);
 ```
 
 # DESCRIPTION
@@ -101,6 +105,17 @@ man for ibv_wr_post and mlx5dv_qp with its available builders and setters.
     In case *ibv_qp_ex->wr_flags* turns on IBV_SEND_SIGNALED, the reported WC opcode will be MLX5DV_WC_UMR.
     Unregister the *mkey* to enable other pattern registration should be done via ibv_post_send with IBV_WR_LOCAL_INV opcode.
 
+## Raw WQE builders
+
+*mlx5dv_wr_raw_wqe()*
+:   It is used to build a custom work request (WQE) and post it on a normal QP. The caller needs to set all details
+    of the WQE (except the "ctrl.wqe_index" and "ctrl.signature" fields, which is the driver's responsibility to set).
+    The MLX5DV_QP_EX_WITH_RAW_WQE flag in mlx5_qp_attr.send_ops_flags needs to be set.
+
+    The wr_flags are ignored as it's the caller's responsibility to set flags in WQE.
+
+    No matter what the send opcode is, the work completion opcode for a raw WQE is IBV_WC_DRIVER2.
+
 ## QP Specific setters
 
 *DCI* QPs
@@ -148,3 +163,5 @@ ret = ibv_wr_complete(qpx);
 # AUTHOR
 
 Guy Levi <guyle@mellanox.com>
+
+Mark Zhang <markzhang@nvidia.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -465,6 +465,7 @@ enum {
 	MLX5_CQ_FLAGS_SINGLE_THREADED = 1 << 4,
 	MLX5_CQ_FLAGS_DV_OWNED = 1 << 5,
 	MLX5_CQ_FLAGS_TM_SYNC_REQ = 1 << 6,
+	MLX5_CQ_FLAGS_RAW_WQE = 1 << 7,
 };
 
 struct mlx5_cq {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -279,6 +279,7 @@ enum mlx5dv_qp_create_send_ops_flags {
 	MLX5DV_QP_EX_WITH_MR_INTERLEAVED	= 1 << 0,
 	MLX5DV_QP_EX_WITH_MR_LIST		= 1 << 1,
 	MLX5DV_QP_EX_WITH_MKEY_CONFIGURE	= 1 << 2,
+	MLX5DV_QP_EX_WITH_RAW_WQE		= 1 << 3,
 };
 
 struct mlx5dv_qp_init_attr {
@@ -361,6 +362,7 @@ struct mlx5dv_mkey_conf_attr {
 
 enum mlx5dv_wc_opcode {
 	MLX5DV_WC_UMR = IBV_WC_DRIVER1,
+	MLX5DV_WC_RAW_WQE = IBV_WC_DRIVER2,
 };
 
 struct mlx5dv_qp_ex {
@@ -398,6 +400,7 @@ struct mlx5dv_qp_ex {
 				const struct mlx5dv_mr_interleaved *data);
 	void (*wr_set_mkey_sig_block)(struct mlx5dv_qp_ex *mqp,
 				      const struct mlx5dv_sig_block_attr *attr);
+	void (*wr_raw_wqe)(struct mlx5dv_qp_ex *mqp, const void *wqe);
 };
 
 struct mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex *qp);
@@ -497,6 +500,11 @@ static inline int mlx5dv_mkey_check(struct mlx5dv_mkey *mkey,
 }
 
 int mlx5dv_qp_cancel_posted_send_wrs(struct mlx5dv_qp_ex *mqp, uint64_t wr_id);
+
+static inline void mlx5dv_wr_raw_wqe(struct mlx5dv_qp_ex *mqp, const void *wqe)
+{
+	mqp->wr_raw_wqe(mqp, wqe);
+}
 
 enum mlx5dv_flow_action_esp_mask {
 	MLX5DV_FLOW_ACTION_ESP_MASK_FLAGS	= 1 << 0,

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -205,6 +205,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_TSO
         IBV_WC_RECV
         IBV_WC_RECV_RDMA_WITH_IMM
+        IBV_WC_DRIVER2
 
     cpdef enum ibv_create_cq_wc_flags:
         IBV_WC_EX_WITH_BYTE_LEN

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -3,7 +3,7 @@
 
 include 'mlx5dv_enums.pxd'
 
-from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
+from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 from libcpp cimport bool
 
 cimport pyverbs.libibverbs as v
@@ -200,6 +200,23 @@ cdef extern from 'infiniband/mlx5dv.h':
         mlx5dv_mkey_err_type err_type
         err err
 
+    cdef struct mlx5_wqe_data_seg:
+        uint32_t    byte_count
+        uint32_t    lkey
+        uint64_t    addr
+
+    cdef struct mlx5_wqe_ctrl_seg:
+        uint32_t    opmod_idx_opcode
+        uint32_t    qpn_ds
+        uint8_t     signature
+        uint8_t     fm_ce_se
+        uint32_t    imm
+
+    void mlx5dv_set_ctrl_seg(mlx5_wqe_ctrl_seg *seg, uint16_t pi, uint8_t opcode,
+                             uint8_t opmod, uint32_t qp_num, uint8_t fm_ce_se,
+                             uint8_t ds, uint8_t signature, uint32_t imm)
+    void mlx5dv_set_data_seg(mlx5_wqe_data_seg *seg, uint32_t length,
+                             uint32_t lkey, uintptr_t address)
     bool mlx5dv_is_supported(v.ibv_device *device)
     v.ibv_context* mlx5dv_open_device(v.ibv_device *device,
                                       mlx5dv_context_attr *attr)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -232,7 +232,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     v.ibv_cq_ex *mlx5dv_create_cq(v.ibv_context *context,
                                   v.ibv_cq_init_attr_ex *cq_attr,
                                   mlx5dv_cq_init_attr *mlx5_cq_attr)
-
+    void mlx5dv_wr_raw_wqe(mlx5dv_qp_ex *mqp_ex, const void *wqe)
     mlx5dv_var *mlx5dv_alloc_var(v.ibv_context *context, uint32_t flags)
     void mlx5dv_free_var(mlx5dv_var *dv_var)
     mlx5dv_pp *mlx5dv_pp_alloc(v.ibv_context *context, size_t pp_context_sz,

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -54,3 +54,18 @@ cdef class Mlx5UAR(PyverbsObject):
 
 cdef class Mlx5DmOpAddr(PyverbsCM):
     cdef void *addr
+
+cdef class WqeSeg(PyverbsCM):
+    cdef void *segment
+    cpdef _copy_to_buffer(self, addr)
+
+cdef class WqeCtrlSeg(WqeSeg):
+    pass
+
+cdef class WqeDataSeg(WqeSeg):
+    pass
+
+cdef class Wqe(PyverbsCM):
+    cdef void *addr
+    cdef int is_user_addr
+    cdef object segments

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -550,6 +550,14 @@ cdef class Mlx5QP(QPEx):
         dv.mlx5dv_wr_set_dc_addr(dv.mlx5dv_qp_ex_from_ibv_qp_ex(self.qp_ex),
                                  ah.ah, remote_dctn, remote_dc_key)
 
+    def wr_raw_wqe(self, wqe):
+        """
+        Build a raw work request
+        :param wqe: A Wqe object
+        """
+        cdef void *wqe_ptr = <void *> <uintptr_t> wqe.address
+        dv.mlx5dv_wr_raw_wqe(dv.mlx5dv_qp_ex_from_ibv_qp_ex(self.qp_ex), wqe_ptr)
+
     def wr_mr_interleaved(self, Mlx5Mkey mkey, access_flags, repeat_count,
                           mr_interleaved_lst):
         """

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -5,6 +5,31 @@
 
 cdef extern from 'infiniband/mlx5dv.h':
 
+    cpdef enum:
+        MLX5_OPCODE_NOP
+        MLX5_OPCODE_SEND_INVAL
+        MLX5_OPCODE_RDMA_WRITE
+        MLX5_OPCODE_RDMA_WRITE_IMM
+        MLX5_OPCODE_SEND
+        MLX5_OPCODE_SEND_IMM
+        MLX5_OPCODE_TSO
+        MLX5_OPCODE_RDMA_READ
+        MLX5_OPCODE_ATOMIC_CS
+        MLX5_OPCODE_ATOMIC_FA
+        MLX5_OPCODE_ATOMIC_MASKED_CS
+        MLX5_OPCODE_ATOMIC_MASKED_FA
+        MLX5_OPCODE_FMR
+        MLX5_OPCODE_LOCAL_INVAL
+        MLX5_OPCODE_CONFIG_CMD
+        MLX5_OPCODE_UMR
+        MLX5_OPCODE_TAG_MATCHING
+
+    cpdef enum:
+        MLX5_WQE_CTRL_CQ_UPDATE
+        MLX5_WQE_CTRL_SOLICITED
+        MLX5_WQE_CTRL_FENCE
+        MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE
+
     cpdef enum  mlx5dv_context_attr_flags:
         MLX5DV_CONTEXT_FLAGS_DEVX
 
@@ -125,6 +150,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_QP_EX_WITH_MR_INTERLEAVED    = 1 << 0
         MLX5DV_QP_EX_WITH_MR_LIST           = 1 << 1
         MLX5DV_QP_EX_WITH_MKEY_CONFIGURE    = 1 << 2
+        MLX5DV_QP_EX_WITH_RAW_WQE           = 1 << 3
 
     cpdef enum mlx5dv_cq_init_attr_mask:
         MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE = 1 << 0

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,7 @@ rdma_python_test(tests
   test_mlx5_mkey.py
   test_mlx5_pp.py
   test_mlx5_query_port.py
+  test_mlx5_raw_wqe.py
   test_mlx5_rdmacm.py
   test_mlx5_sched.py
   test_mlx5_timestamp.py

--- a/tests/test_mlx5_raw_wqe.py
+++ b/tests/test_mlx5_raw_wqe.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia, Inc. All rights reserved. See COPYING file
+
+import unittest
+import random
+import errno
+
+
+from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, Mlx5DVQPInitAttr, \
+    Mlx5QP, Mlx5DVCQInitAttr, Mlx5CQ, Wqe, WqeDataSeg, WqeCtrlSeg
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError, PyverbsError
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from tests.mlx5_base import Mlx5RDMATestCase
+from pyverbs.qp import QPInitAttrEx, QPCap
+from pyverbs.cq import CqInitAttrEx
+from tests.base import RCResources
+from pyverbs.wr import SGE
+from pyverbs.mr import MR
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class Mlx5RawWqeResources(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index):
+        self.dv_send_ops_flags = dve.MLX5DV_QP_EX_WITH_RAW_WQE
+        self.send_ops_flags = e.IBV_QP_EX_WITH_SEND
+        super().__init__(dev_name, ib_port, gid_index)
+
+    def create_context(self):
+        mlx5dv_attr = Mlx5DVContextAttr()
+        try:
+            self.ctx = Mlx5Context(mlx5dv_attr, name=self.dev_name)
+        except PyverbsUserError as ex:
+            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
+        except PyverbsRDMAError:
+            raise unittest.SkipTest('Opening mlx5 context is not supported')
+
+    def create_qp_init_attr(self):
+        comp_mask = e.IBV_QP_INIT_ATTR_PD | e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+        return QPInitAttrEx(cap=self.create_qp_cap(), pd=self.pd, scq=self.cq,
+                            rcq=self.cq, qp_type=e.IBV_QPT_RC,
+                            send_ops_flags=self.send_ops_flags,
+                            comp_mask=comp_mask)
+
+    def create_qp_cap(self):
+        """
+        Create QPCap such that work queue elements will wrap around the send
+        work queue, this happens due to the iteration count being higher
+        than the max_send_wr.
+        :return:
+        """
+        return QPCap(max_send_wr=4, max_recv_wr=4, max_recv_sge=2, max_send_sge=2)
+
+
+    def create_qps(self):
+        try:
+            qp_init_attr = self.create_qp_init_attr()
+            comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS | \
+                    dve.MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS
+            attr = Mlx5DVQPInitAttr(comp_mask=comp_mask, send_ops_flags=self.dv_send_ops_flags)
+            qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+            self.qps.append(qp)
+            self.qps_num.append(qp.qp_num)
+            self.psns.append(random.getrandbits(24))
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mlx5DV QP is not supported')
+            raise ex
+
+    def create_cq(self):
+        """
+        Initializes self.cq with a dv_cq
+        :return: None
+        """
+        dvcq_init_attr = Mlx5DVCQInitAttr()
+        try:
+            self.cq = Mlx5CQ(self.ctx, CqInitAttrEx(), dvcq_init_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mlx5DV CQ is not supported')
+            raise ex
+
+
+class RawWqeTest(Mlx5RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init RawWqe test resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+                             attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+
+    def prepare_send_elements(self):
+        mr = self.client.mr
+        sge_count = 2
+        unit_size = mr.length / 2
+        data_segs = [WqeDataSeg(unit_size, mr.lkey, mr.buf + i * unit_size) for
+                     i in range(sge_count)]
+        ctrl_seg = WqeCtrlSeg()
+        ctrl_seg.fm_ce_se = dve.MLX5_WQE_CTRL_CQ_UPDATE
+        segment_num = 1 + len(data_segs)
+        ctrl_seg.opmod_idx_opcode = dve.MLX5_OPCODE_SEND
+        ctrl_seg.qpn_ds = segment_num | int(self.client.qp.qp_num) << 8
+        self.raw_send_wqe = Wqe([ctrl_seg] + data_segs)
+        self.regular_send_sge = SGE(mr.buf, mr.length, mr.lkey)
+
+    def mixed_traffic(self):
+        s_recv_wr = u.get_recv_wr(self.server)
+        u.post_recv(self.server, s_recv_wr)
+        self.prepare_send_elements()
+
+        for i in range(self.iters):
+            self.client.qp.wr_start()
+            if i % 2:
+                self.client.mr.write('c' * self.client.mr.length, self.client.mr.length)
+                self.client.qp.wr_flags = e.IBV_SEND_SIGNALED
+                self.client.qp.wr_send()
+                self.client.qp.wr_set_sge(self.regular_send_sge)
+            else:
+                self.client.mr.write('s' * self.client.mr.length, self.client.mr.length)
+                self.client.qp.wr_raw_wqe(self.raw_send_wqe)
+            self.client.qp.wr_complete()
+            u.poll_cq_ex(self.client.cq)
+            u.poll_cq_ex(self.server.cq)
+            u.post_recv(self.server, s_recv_wr)
+
+            if not i % 2 and self.client.cq.read_opcode() != e.IBV_WC_DRIVER2:
+                raise PyverbsError('Opcode validation failed: expected '
+                                   f'{e.IBV_WC_DRIVER2}, received {self.client.cq.read_opcode()}')
+
+            act_buffer = self.server.mr.read(self.server.mr.length, 0)
+            u.validate(act_buffer, i % 2, self.server.mr.length)
+
+    def test_mixed_raw_wqe_traffic(self):
+        """
+        Runs traffic with a mix of SEND opcode regular WQEs and SEND opcode RAW
+        WQEs.
+        """
+        self.create_players(Mlx5RawWqeResources)
+        self.mixed_traffic()


### PR DESCRIPTION
Introduce mlx5dv_wr_raw_wqe builder to be used for building a raw work request.

The user needs to set the raw WQE according to mlx5 device specification, the driver internally may override some fields which are state related. 

The work completion opcode for a raw WQE will be IBV_WC_DRIVER2 that was added for a specific driver operation. 

Man pages were updated with the expected usage accordingly.

The series includes also some pyverbs stuff to test this functionality. 