### PR TITLE
Verbs logging API

### DIFF
--- a/Documentation/libibverbs.md
+++ b/Documentation/libibverbs.md
@@ -56,3 +56,21 @@ need to increase this limit.  This is usually done for ordinary users
 via the file /etc/security/limits.conf.  More configuration may be
 necessary if you are logging in via OpenSSH and your sshd is
 configured to use privilege separation.
+
+# Debugging
+
+### Enabling debug prints
+
+Library and providers debug prints can be enabled using the `VERBS_LOG_LEVEL`
+environment variable, the output shall be written to the file provided in the
+`VERBS_LOG_FILE` environment variable. When the library is compiled in debug
+mode and no file is provided the output will be written to stderr.
+
+Note: some of the debug prints are only available when the library is compiled
+in debug mode.
+
+The following table describes the expected behavior when VERBS_LOG_LEVEL is set:
+|                 | Release                         | Debug                                          |
+|-----------------|---------------------------------|------------------------------------------------|
+| Regular prints  | Output to VERBS_LOG_FILE if set | Output to VERBS_LOG_FILE, or stderr if not set |
+| Datapath prints | Compiled out, no output         | Output to VERBS_LOG_FILE, or stderr if not set |

--- a/buildlib/RDMA_BuildType.cmake
+++ b/buildlib/RDMA_BuildType.cmake
@@ -39,4 +39,8 @@ function(RDMA_BuildType)
 	    CACHE STRING "Default flags for RelWithDebInfo configuration" FORCE)
     endif()
   endforeach()
+
+  if (CMAKE_BUILD_TYPE STREQUAL Debug OR CMAKE_BUILD_TYPE STREQUAL RelWithDebInfo)
+    add_definitions("-DVERBS_DEBUG")
+  endif()
 endfunction()

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -49,6 +49,56 @@
 
 struct verbs_device;
 
+enum {
+	VERBS_LOG_LEVEL_NONE,
+	VERBS_LOG_ERR,
+	VERBS_LOG_WARN,
+	VERBS_LOG_INFO,
+	VERBS_LOG_DEBUG,
+};
+
+void __verbs_log(struct verbs_context *ctx, uint32_t level,
+		 const char *fmt, ...);
+
+#define verbs_log(ctx, level, format, arg...)                                  \
+do {                                                                           \
+	int tmp = errno;                                                       \
+	__verbs_log(ctx, level, "%s: %s:%d: " format,                          \
+		    (ctx)->context.device->name, __func__, __LINE__, ##arg);   \
+	errno = tmp;                                                           \
+} while (0)
+
+#define verbs_debug(ctx, format, arg...) \
+	verbs_log(ctx, VERBS_LOG_DEBUG, format, ##arg)
+
+#define verbs_info(ctx, format, arg...) \
+	verbs_log(ctx, VERBS_LOG_INFO, format, ##arg)
+
+#define verbs_warn(ctx, format, arg...) \
+	verbs_log(ctx, VERBS_LOG_WARN, format, ##arg)
+
+#define verbs_err(ctx, format, arg...) \
+	verbs_log(ctx, VERBS_LOG_ERR, format, ##arg)
+
+#ifdef VERBS_DEBUG
+#define verbs_log_datapath(ctx, level, format, arg...) \
+	verbs_log(ctx, level, format, ##arg)
+#else
+#define verbs_log_datapath(ctx, level, format, arg...) {}
+#endif
+
+#define verbs_debug_datapath(ctx, format, arg...) \
+	verbs_log_datapath(ctx, VERBS_LOG_DEBUG, format, ##arg)
+
+#define verbs_info_datapath(ctx, format, arg...) \
+	verbs_log_datapath(ctx, VERBS_LOG_INFO, format, ##arg)
+
+#define verbs_warn_datapath(ctx, format, arg...) \
+	verbs_log_datapath(ctx, VERBS_LOG_WARN, format, ##arg)
+
+#define verbs_err_datapath(ctx, format, arg...) \
+	verbs_log_datapath(ctx, VERBS_LOG_ERR, format, ##arg)
+
 enum verbs_xrcd_mask {
 	VERBS_XRCD_HANDLE	= 1 << 0,
 	VERBS_XRCD_RESERVED	= 1 << 1

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -172,6 +172,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 	global:
 		/* These historical symbols are now private to libibverbs */
 		__ioctl_final_num_attrs;
+		__verbs_log;
 		_verbs_init_and_alloc_context;
 		execute_ioctl;
 		ibv_cmd_advise_mr;

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -610,8 +610,8 @@ static int hns_roce_v2_poll_one(struct hns_roce_cq *cq,
 
 		ret = hns_roce_handle_recv_inl_wqe(cqe, cur_qp, wc, opcode);
 		if (ret) {
-			fprintf(stderr,
-				PFX "failed to handle recv inline wqe!\n");
+			verbs_err(verbs_get_ctx(cq->ibv_cq.context),
+				  PFX "failed to handle recv inline wqe!\n");
 			return ret;
 		}
 

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -164,12 +164,14 @@ struct ibv_mr *hns_roce_u_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	struct ib_uverbs_reg_mr_resp resp;
 
 	if (!addr) {
-		fprintf(stderr, "2nd parm addr is NULL!\n");
+		verbs_err(verbs_get_ctx(pd->context),
+			  "2nd parm addr is NULL!\n");
 		return NULL;
 	}
 
 	if (!length) {
-		fprintf(stderr, "3st parm length is 0!\n");
+		verbs_err(verbs_get_ctx(pd->context),
+			  "3st parm length is 0!\n");
 		return NULL;
 	}
 


### PR DESCRIPTION
This PR adds a generic logging API to libibverbs and its providers controlled by a new environment variable VERBS_LOG_LEVEL.

This PR demonstrates the API usage by the EFA provider, other providers (mlx5, hns for ex.) can be converted to make use of it as well.