### PR TITLE
rdma_getaddrinfo: correct the return value

### DIFF
--- a/librdmacm/addrinfo.c
+++ b/librdmacm/addrinfo.c
@@ -285,7 +285,7 @@ int rdma_getaddrinfo(const char *node, const char *service,
 
 err:
 	rdma_freeaddrinfo(rai);
-	return ret;
+	return ERR(ret);
 }
 
 void rdma_freeaddrinfo(struct rdma_addrinfo *res)


### PR DESCRIPTION
Per man page, errno should indicate the failure reason:
RETURN VALUE
       Returns 0 on success, or -1 on error (errno will be set to indicate the failure reason), or one of the following nonzero error codes:

Previously, if it calls ucma_getaddrinfo() with errors, ret will not be set
correctly.
rdma_getaddrinfo
  -> ucma_getaddrinfo()
    -> getaddrinfo() # error occurs
then, in this case, errno will not be updated correctly as well:
Jul 13 15:14:02.393944 [58856] *ERROR* info.c:  56: rpma_info_new: rdma_getaddrinfo(node=r92.168.1.11, service=(null), ai_flags=active, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP) failed: Success

After:
Jul 13 15:20:27.244103 [60610] *ERROR* info.c:  56: rpma_info_new: rdma_getaddrinfo(node=r92.168.1.11, service=(null), ai_flags=active, ai_qp_type=IBV_QPT_RC, ai_port_space=RDMA_PS_TCP) failed: No such file or directory

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>