### PR TITLE
tests: Add missing MAC element to args list

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -241,7 +241,7 @@ class RDMATestCase(unittest.TestCase):
                     self.gid_type:
                 continue
             if not os.path.exists('/sys/class/infiniband/{}/device/net/'.format(dev)):
-                self.args.append([dev, port, idx, None])
+                self.args.append([dev, port, idx, None, None])
                 continue
             net_name = self.get_net_name(dev)
             try:


### PR DESCRIPTION
The args list is missing the fifth MAC element which results in an
IndexError exception.

======================================================================
ERROR: test_qp_ex_srd_old_send (tests.test_efa_srd.QPSRDTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ec2-user/rdma-core/tests/test_efa_srd.py", line 18, in setUp
    super().setUp()
  File "/home/ec2-user/rdma-core/tests/efa_base.py", line 42, in setUp
    super().setUp()
  File "/home/ec2-user/rdma-core/tests/base.py", line 216, in setUp
    self._select_config()
  File "/home/ec2-user/rdma-core/tests/base.py", line 269, in _select_config
    self.mac_addr = args[4]
IndexError: list index out of range

Fixes: db19c366f123 ("tests: Add MAC address to the tests' args")
Signed-off-by: Gal Pressman <galpress@amazon.com>