### PR TITLE
mlx5: Introduce mlx5dv_wr_memcpy builder

### DIFF
--- a/libibverbs/man/ibv_poll_cq.3
+++ b/libibverbs/man/ibv_poll_cq.3
@@ -84,7 +84,7 @@ overrun from occurrence.  In case of a CQ overrun, the async event
 will be triggered, and the CQ cannot be used.
 .PP
 IBV_WC_DRIVER1 will be reported as a response to IBV_WR_DRIVER1 opcode;
-IBV_WC_DRIVER2 will be reported on a specific driver operation.
+IBV_WC_DRIVER2/IBV_WC_DRIVER3 will be reported on specific driver operations.
 .SH "SEE ALSO"
 .BR ibv_post_send (3),
 .BR ibv_post_recv (3)

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -530,6 +530,7 @@ enum ibv_wc_opcode {
 	IBV_WC_TM_NO_TAG,
 	IBV_WC_DRIVER1,
 	IBV_WC_DRIVER2,
+	IBV_WC_DRIVER3,
 };
 
 enum {

--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -192,6 +192,7 @@ static inline void handle_good_req(struct ibv_wc *wc, struct mlx5_cqe64 *cqe, st
 	case MLX5_OPCODE_UMR:
 	case MLX5_OPCODE_SET_PSV:
 	case MLX5_OPCODE_NOP:
+	case MLX5_OPCODE_MMO:
 		wc->opcode = wq->wr_data[idx];
 		break;
 	case MLX5_OPCODE_TSO:
@@ -763,6 +764,7 @@ again:
 			case MLX5_OPCODE_UMR:
 			case MLX5_OPCODE_SET_PSV:
 			case MLX5_OPCODE_NOP:
+			case MLX5_OPCODE_MMO:
 				cq->cached_opcode = wq->wr_data[idx];
 				break;
 
@@ -1450,6 +1452,7 @@ static inline enum ibv_wc_opcode mlx5_cq_read_wc_opcode(struct ibv_cq_ex *ibcq)
 		case MLX5_OPCODE_UMR:
 		case MLX5_OPCODE_SET_PSV:
 		case MLX5_OPCODE_NOP:
+		case MLX5_OPCODE_MMO:
 			return cq->cached_opcode;
 		case MLX5_OPCODE_TSO:
 			return IBV_WC_TSO;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -118,6 +118,7 @@ rdma_alias_man_pages(
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr.3
  mlx5dv_wr_post.3 mlx5dv_wr_set_dc_addr_stream.3
  mlx5dv_wr_post.3 mlx5dv_qp_ex_from_ibv_qp_ex.3
+ mlx5dv_wr_post.3 mlx5dv_wr_memcpy.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_interleaved.3
  mlx5dv_wr_post.3 mlx5dv_wr_mr_list.3
  mlx5dv_wr_post.3 mlx5dv_wr_raw_wqe.3

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -60,6 +60,7 @@ uint32_t        flow_action_flags; /* use enum mlx5dv_flow_action_cap_flags */
 uint32_t        dc_odp_caps; /* use enum ibv_odp_transport_cap_bits */
 void		*hca_core_clock; /* points to a memory location that is mapped to the HCA's core clock */
 struct mlx5dv_sig_caps sig_caps;
+size_t max_wr_memcpy_length; /* max length that is supported by the DMA memcpy WR */
 .in -8
 };
 
@@ -98,6 +99,7 @@ MLX5DV_CONTEXT_MASK_HCA_CORE_CLOCK      = 1 << 8,
 MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9,
 MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10,
 MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11,
+MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH    = 1 << 12,
 .in -8
 };
 

--- a/providers/mlx5/man/mlx5dv_wr_post.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_post.3.md
@@ -15,6 +15,8 @@ mlx5dv_wr_set_dc_addr - Attach a DC info to the last work request
 
 mlx5dv_wr_raw_wqe - Build a raw work request
 
+mlx5dv_wr_memcpy - Build a DMA memcpy work request
+
 # SYNOPSIS
 
 ```c
@@ -52,6 +54,12 @@ static inline void mlx5dv_wr_mr_list(struct mlx5dv_qp_ex *mqp,
 				      struct ibv_sge *sge);
 
 static inline int mlx5dv_wr_raw_wqe(struct mlx5dv_qp_ex *mqp, const void *wqe);
+
+static inline void mlx5dv_wr_memcpy(struct mlx5dv_qp_ex *mqp_ex,
+				    uint32_t dest_lkey, uint64_t dest_addr,
+				    uint32_t src_lkey, uint64_t src_addr,
+				    size_t length)
+
 ```
 
 # DESCRIPTION
@@ -110,6 +118,21 @@ man for ibv_wr_post and mlx5dv_qp with its available builders and setters.
 
     In case *ibv_qp_ex->wr_flags* turns on IBV_SEND_SIGNALED, the reported WC opcode will be MLX5DV_WC_UMR.
     Unregister the *mkey* to enable other pattern registration should be done via ibv_post_send with IBV_WR_LOCAL_INV opcode.
+
+*RC* or *DCI* QPs
+:   *mlx5dv_wr_memcpy()*
+
+    Builds a DMA memcpy work request to copy data of length *length* from *src_addr* to *dest_addr*. The copy operation will be
+    done using the DMA MMO functionality of the device to copy data on PCI bus.
+
+    The MLX5DV_QP_EX_WITH_MEMCPY flag in *mlx5dv_qp_init_attr.send_ops_flags* needs to be set during QP creation.
+    If the device or QP doesn't support it then QP creation will fail.
+    The maximum memcpy length that is supported by the device is reported in *mlx5dv_context->max_wr_memcpy_length*.
+    A zero value in *mlx5dv_context->max_wr_memcpy_length* means the device doesn't support memcpy operations.
+
+    IBV_SEND_FENCE indicator should be used on a following send request which is dependent on *dest_addr* of the memcpy operation.
+
+    In case *ibv_qp_ex->wr_flags* turns on IBV_SEND_SIGNALED, the reported WC opcode will be MLX5DV_WC_MEMCPY.
 
 ## Raw WQE builders
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -920,6 +920,12 @@ static int _mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH) {
+		attrs_out->max_wr_memcpy_length =
+			mctx->dma_mmo_caps.dma_max_size;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -303,6 +303,13 @@ struct mlx5_reserved_qpns {
 
 struct mlx5_dv_context_ops;
 
+#define MLX5_DMA_MMO_MAX_SIZE	(1ULL << 31)
+struct mlx5_dma_mmo_caps {
+	uint8_t dma_mmo_sq:1; /* Indicates that RC and DCI support DMA MMO */
+	uint8_t dma_mmo_qp:1;
+	uint64_t dma_max_size;
+};
+
 struct mlx5_context {
 	struct verbs_context		ibv_ctx;
 	int				max_num_qps;
@@ -384,6 +391,7 @@ struct mlx5_context {
 	uint64_t			general_obj_types_caps;
 	uint8_t				qpc_extension_cap:1;
 	struct mlx5dv_sig_caps		sig_caps;
+	struct mlx5_dma_mmo_caps	dma_mmo_caps;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
 	uint32_t			max_num_legacy_dyn_uar_sys_page;
@@ -446,6 +454,11 @@ struct mlx5_pd {
 	uint32_t			pdn;
 	atomic_int			refcount;
 	struct mlx5_pd			*mprotection_domain;
+	struct {
+		void			*opaque_buf;
+		struct ibv_mr		*opaque_mr;
+		pthread_mutex_t		opaque_mr_mutex;
+	};
 };
 
 struct mlx5_parent_domain {
@@ -691,6 +704,8 @@ struct mlx5_qp {
 	 * write to the set_ece will clear this field.
 	 */
 	uint32_t			get_ece;
+
+	uint8_t				need_mmo_enable:1;
 };
 
 struct mlx5_ah {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -796,7 +796,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 
 	u8         reserved_at_60[0x2];
 	u8         qp_data_in_order[0x1];
-	u8         reserved_at_63[0x1d];
+	u8         reserved_at_63[0x8];
+	u8         log_dma_mmo_max_size[0x5];
+	u8         reserved_at_70[0x10];
 
 	u8         log_max_srq_sz[0x8];
 	u8         log_max_qp_sz[0x8];
@@ -857,7 +859,8 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         reserved_at_150[0x1];
 	u8         rts2rts_qp_udp_sport[0x1];
 	u8         rts2rts_lag_tx_port_affinity[0x1];
-	u8         reserved_at_153[0x7];
+	u8         dma_mmo_sq[0x1];
+	u8         reserved_at_154[0x6];
 	u8         log_max_ra_res_qp[0x6];
 
 	u8         end_pad[0x1];
@@ -1198,7 +1201,13 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         flex_parser_id_gtpu_first_ext_dw_0[0x4];
 	u8         reserved_at_708[0x18];
 
-	u8         reserved_at_720[0xa0];
+	u8         reserved_at_720[0x20];
+
+	u8         reserved_at_740[0x8];
+	u8         dma_mmo_qp[0x1];
+	u8         reserved_at_749[0x17];
+
+	u8         reserved_at_760[0x60];
 
 	u8         match_definer_format_supported[0x40];
 };
@@ -3476,8 +3485,9 @@ struct mlx5_ifc_qpc_bits {
 };
 
 struct mlx5_ifc_qpc_ext_bits {
-	u8         reserved_at_0[0x10];
-
+	u8         reserved_at_0[0x2];
+	u8         mmo[0x1];
+	u8         reserved_at_3[0xd];
 	u8	   dci_stream_channel_id[0x10];
 
 	u8         qos_queue_group_id_requester[0x20];
@@ -3569,6 +3579,7 @@ enum mlx5_qpc_opt_mask_32 {
 enum mlx5_qpc_opt_mask {
 	MLX5_QPC_OPT_MASK_INIT2INIT_DRAIN_SIGERR = 1 << 11,
 	MLX5_QPC_OPT_MASK_RTS2RTS_LAG_TX_PORT_AFFINITY = 1 << 15,
+	MLX5_QPC_OPT_MASK_INIT2INIT_MMO = 1 << 25,
 };
 
 struct mlx5_ifc_init2init_qp_out_bits {

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2962,7 +2962,7 @@ static void mlx5_send_wr_set_dc_addr_stream(struct mlx5dv_qp_ex *dv_qp,
 	mlx5_send_wr_set_dc_addr(dv_qp, ah, remote_dctn, remote_dc_key);
 }
 
-static inline void raw_wqe_init(struct ibv_qp_ex *ibqp, const void *wqe)
+static inline void raw_wqe_init(struct ibv_qp_ex *ibqp)
 {
 	struct mlx5_qp *mqp = to_mqp((struct ibv_qp *)ibqp);
 	uint32_t idx;
@@ -2996,7 +2996,7 @@ static void mlx5_wr_raw_wqe(struct mlx5dv_qp_ex *mqp_ex, const void *wqe)
 	uint8_t ds = be32toh(ctrl->qpn_ds) & 0x3f;
 	int wq_left;
 
-	raw_wqe_init(ibqp, wqe);
+	raw_wqe_init(ibqp);
 
 	wq_left = mqp->sq.qend - (void *)mqp->cur_ctrl;
 	if (likely(wq_left >= ds << 4)) {

--- a/providers/mlx5/wqe.h
+++ b/providers/mlx5/wqe.h
@@ -35,6 +35,8 @@
 
 #include <stdint.h>
 
+#include "mlx5dv.h"
+
 struct mlx5_sg_copy_ptr {
 	int	index;
 	int	offset;
@@ -200,6 +202,23 @@ struct mlx5_wqe_set_psv_seg {
 	__be16 syndrome;
 	uint8_t reserved[2];
 	__be64 transient_signature;
+};
+
+enum {
+	MLX5_OPC_MOD_MMO_DMA = 0x1,
+};
+
+struct mlx5_mmo_metadata_seg {
+	__be32 mmo_control_31_0;
+	__be32 local_key;
+	__be64 local_address;
+};
+
+struct mlx5_mmo_wqe {
+	struct mlx5_wqe_ctrl_seg ctrl;
+	struct mlx5_mmo_metadata_seg mmo_meta;
+	struct mlx5_wqe_data_seg src;
+	struct mlx5_wqe_data_seg dest;
 };
 
 #endif /* WQE_H */

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -206,6 +206,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_RECV
         IBV_WC_RECV_RDMA_WITH_IMM
         IBV_WC_DRIVER2
+        IBV_WC_DRIVER3
 
     cpdef enum ibv_create_cq_wc_flags:
         IBV_WC_EX_WITH_BYTE_LEN

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -49,6 +49,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         unsigned int            flow_action_flags
         unsigned int            dc_odp_caps
         uint8_t                 num_lag_ports
+        size_t                  max_wr_memcpy_length
 
     cdef struct mlx5dv_dci_streams:
         uint8_t       log_num_concurent
@@ -340,6 +341,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                   uint16_t num_interleaved, mlx5dv_mr_interleaved *data)
     void mlx5dv_wr_mr_list(mlx5dv_qp_ex *mqp, mlx5dv_mkey *mkey,
                            uint32_t access_flags, uint16_t num_sge, v.ibv_sge *sge)
+    void mlx5dv_wr_memcpy(mlx5dv_qp_ex *mqp, uint32_t dest_lkey, uint64_t dest_addr,
+                          uint32_t src_lkey, uint64_t src_addr, uint64_t length)
     mlx5dv_mkey *mlx5dv_create_mkey(mlx5dv_mkey_init_attr *mkey_init_attr)
     int mlx5dv_destroy_mkey(mlx5dv_mkey *mkey)
     mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(v.ibv_qp_ex *qp_ex)

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -23,6 +23,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5_OPCODE_CONFIG_CMD
         MLX5_OPCODE_UMR
         MLX5_OPCODE_TAG_MATCHING
+        MLX5_OPCODE_MMO
 
     cpdef enum:
         MLX5_WQE_CTRL_CQ_UPDATE
@@ -45,6 +46,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9
         MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10
         MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11
+        MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH    = 1 << 12
 
     cpdef enum mlx5dv_context_flags:
         MLX5DV_CONTEXT_FLAGS_CQE_V1                     = 1 << 0
@@ -153,6 +155,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_QP_EX_WITH_MR_LIST           = 1 << 1
         MLX5DV_QP_EX_WITH_MKEY_CONFIGURE    = 1 << 2
         MLX5DV_QP_EX_WITH_RAW_WQE           = 1 << 3
+        MLX5DV_QP_EX_WITH_MEMCPY            = 1 << 4
 
     cpdef enum mlx5dv_cq_init_attr_mask:
         MLX5DV_CQ_INIT_ATTR_MASK_COMPRESSED_CQE = 1 << 0
@@ -219,6 +222,11 @@ cdef extern from 'infiniband/mlx5dv.h':
 
     cpdef enum mlx5dv_vfio_context_attr_flags:
         MLX5DV_VFIO_CTX_FLAGS_INIT_LINK_DOWN
+
+    cpdef enum mlx5dv_wc_opcode:
+        MLX5DV_WC_UMR
+        MLX5DV_WC_RAW_WQE
+        MLX5DV_WC_MEMCPY
 
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -23,6 +23,7 @@ rdma_python_test(tests
   test_mlx5_dc.py
   test_mlx5_devx.py
   test_mlx5_dm_ops.py
+  test_mlx5_dma_memcpy.py
   test_mlx5_dr.py
   test_mlx5_flow.py
   test_mlx5_lag_affinity.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -241,7 +241,7 @@ class RDMATestCase(unittest.TestCase):
                     self.gid_type:
                 continue
             if not os.path.exists('/sys/class/infiniband/{}/device/net/'.format(dev)):
-                self.args.append([dev, port, idx, None])
+                self.args.append([dev, port, idx, None, None])
                 continue
             net_name = self.get_net_name(dev)
             try:

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -855,9 +855,11 @@ class Mlx5DevxTrafficBase(Mlx5RDMATestCase):
 
 
 class Mlx5RcResources(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index):
+    def __init__(self, dev_name, ib_port, gid_index, **kwargs):
+        self.dv_send_ops_flags = 0
+        self.send_ops_flags = 0
         self.create_send_ops_flags()
-        super().__init__(dev_name, ib_port, gid_index)
+        super().__init__(dev_name, ib_port, gid_index, **kwargs)
 
     def create_send_ops_flags(self):
         self.dv_send_ops_flags = 0

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -12,16 +12,18 @@ import sys
 
 from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, \
     Mlx5DVQPInitAttr, Mlx5QP, Mlx5DVDCInitAttr, Mlx5DCIStreamInitAttr, \
-    Mlx5DevxObj, Mlx5UMEM, Mlx5UAR, WqeDataSeg, WqeCtrlSeg, Wqe, Mlx5Cqe64
+    Mlx5DevxObj, Mlx5UMEM, Mlx5UAR, WqeDataSeg, WqeCtrlSeg, Wqe, Mlx5Cqe64, \
+    Mlx5DVCQInitAttr, Mlx5CQ
 from tests.base import TrafficResources, set_rnr_attributes, DCT_KEY, \
     RDMATestCase, PyverbsAPITestCase, RDMACMBaseTest, BaseResources, PATH_MTU, \
-    RNR_RETRY, RETRY_CNT, MIN_RNR_TIMER, TIMEOUT, MAX_RDMA_ATOMIC
+    RNR_RETRY, RETRY_CNT, MIN_RNR_TIMER, TIMEOUT, MAX_RDMA_ATOMIC, RCResources
 from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError, \
     PyverbsError
 from pyverbs.providers.mlx5.mlx5dv_objects import Mlx5DvObj
 from pyverbs.qp import QPCap, QPInitAttrEx, QPAttr
 import pyverbs.providers.mlx5.mlx5_enums as dve
 from pyverbs.addr import AHAttr, GlobalRoute
+from pyverbs.cq import CqInitAttrEx
 import pyverbs.mem_alloc as mem
 import pyverbs.dma_util as dma
 import pyverbs.device as d
@@ -850,3 +852,59 @@ class Mlx5DevxTrafficBase(Mlx5RDMATestCase):
             self.assertEqual(imm_inval_pkey, self.client.imm + cons_idx)
             self.server.mr.write('s' * self.server.msg_size,
                                  self.server.msg_size)
+
+
+class Mlx5RcResources(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index):
+        self.create_send_ops_flags()
+        super().__init__(dev_name, ib_port, gid_index)
+
+    def create_send_ops_flags(self):
+        self.dv_send_ops_flags = 0
+        self.send_ops_flags = e.IBV_QP_EX_WITH_SEND
+
+    def create_context(self):
+        mlx5dv_attr = Mlx5DVContextAttr()
+        try:
+            self.ctx = Mlx5Context(mlx5dv_attr, name=self.dev_name)
+        except PyverbsUserError as ex:
+            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
+        except PyverbsRDMAError:
+            raise unittest.SkipTest('Opening mlx5 context is not supported')
+
+    def create_qp_init_attr(self):
+        comp_mask = e.IBV_QP_INIT_ATTR_PD | e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+        return QPInitAttrEx(cap=self.create_qp_cap(), pd=self.pd, scq=self.cq,
+                            rcq=self.cq, qp_type=e.IBV_QPT_RC,
+                            send_ops_flags=self.send_ops_flags,
+                            comp_mask=comp_mask)
+
+    def create_qps(self):
+        try:
+            qp_init_attr = self.create_qp_init_attr()
+            comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS
+            if self.dv_send_ops_flags:
+                comp_mask |= dve.MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS
+            attr = Mlx5DVQPInitAttr(comp_mask=comp_mask,
+                                    send_ops_flags=self.dv_send_ops_flags)
+            qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+            self.qps.append(qp)
+            self.qps_num.append(qp.qp_num)
+            self.psns.append(random.getrandbits(24))
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mlx5DV QP is not supported')
+            raise ex
+
+    def create_cq(self):
+        """
+        Initializes self.cq with a dv_cq
+        :return: None
+        """
+        dvcq_init_attr = Mlx5DVCQInitAttr()
+        try:
+            self.cq = Mlx5CQ(self.ctx, CqInitAttrEx(), dvcq_init_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mlx5DV CQ is not supported')
+            raise ex

--- a/tests/test_mlx5_dma_memcpy.py
+++ b/tests/test_mlx5_dma_memcpy.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia, Inc. All rights reserved. See COPYING file
+
+from enum import Enum
+import unittest
+
+from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError
+from tests.mlx5_base import Mlx5RDMATestCase, Mlx5RcResources
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from pyverbs.pd import PD
+from pyverbs.mr import MR
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class BadFlowType(Enum):
+    DIFFERENT_PD = 1
+    MR_ILLEGAL_ACCESS = 2
+
+
+class Mlx5DmaResources(Mlx5RcResources):
+    def create_send_ops_flags(self):
+        self.dv_send_ops_flags = dve.MLX5DV_QP_EX_WITH_MEMCPY
+        self.send_ops_flags = e.IBV_QP_EX_WITH_SEND
+
+
+class DmaGgaMemcpy(Mlx5RDMATestCase):
+    def create_resources(self, bad_flow_type=0, **resource_arg):
+        """
+        Creates DmaGga test resources that include a "server" resource that
+        can be used to send the MEMCPY WR, and a destination MR to copy data to.
+        The destination MR can be created on a different PD or with insufficient
+        access permissions, according to the bad_flow_type.
+        :param bad_flow_type: (Optional) An enum of BadFlowType that indicates
+                              the bad flow type (default: 0 - good flow)
+        :param resource_arg: Dict of args that specify the resource specific
+                             attributes.
+        :return: None
+        """
+        self.server = Mlx5DmaResources(**self.dev_info, **resource_arg)
+        self.dest_pd = self.server.pd
+        dest_mr_access = e.IBV_ACCESS_LOCAL_WRITE
+        if bad_flow_type == BadFlowType.DIFFERENT_PD:
+            self.dest_pd = PD(self.server.ctx)
+        elif bad_flow_type == BadFlowType.MR_ILLEGAL_ACCESS:
+            dest_mr_access = e.IBV_ACCESS_REMOTE_READ
+        self.dest_mr = MR(self.dest_pd, self.server.msg_size, dest_mr_access)
+        # No need to connect the QPs
+        self.server.pre_run([0], [0])
+
+    def dma_memcpy(self, msg_size=1024):
+        """
+        Creates resources and posts a memcpy WR.
+        After posting the WR, the WC opcode and the data are verified.
+        :param msg_size: Size of the data to be copied (in Bytes)
+        :return: None
+        """
+        self.create_resources(msg_size=msg_size)
+        self.dest_mr.write('0' * msg_size, msg_size)
+        self.server.mr.write('s' * msg_size, msg_size)
+        self.server.qp.wr_start()
+        self.server.qp.wr_flags = e.IBV_SEND_SIGNALED
+        self.server.qp.wr_memcpy(self.dest_mr.lkey, self.dest_mr.buf, self.server.mr.lkey,
+                                 self.server.mr.buf, msg_size)
+        self.server.qp.wr_complete()
+        u.poll_cq_ex(self.server.cq)
+        wc_opcode = self.server.cq.read_opcode()
+        self.assertEqual(wc_opcode, dve.MLX5DV_WC_MEMCPY,
+                         'WC opcode validation failed')
+        self.assertEqual(self.dest_mr.read(msg_size, 0),
+                         self.server.mr.read(msg_size, 0))
+
+    def dma_memcpy_bad_protection_flow(self, bad_flow_type):
+        """
+        Creates resources with bad protection and posts a memcpy WR.
+        The bad protection is either a destination MR created on a different PD
+        or a destination MR created with insufficient access permissions.
+        :param bad_flow_type: An enum of BadFlowType that indicates the bad flow type
+        :return: None
+        """
+        self.create_resources(bad_flow_type)
+        self.server.qp.wr_start()
+        self.server.qp.wr_flags = e.IBV_SEND_SIGNALED
+        self.server.qp.wr_memcpy(self.dest_mr.lkey, self.dest_mr.buf,
+                                 self.server.mr.lkey,
+                                 self.server.mr.buf, self.server.msg_size)
+        self.server.qp.wr_complete()
+        with self.assertRaises(PyverbsRDMAError):
+            u.poll_cq_ex(self.server.cq)
+        self.assertEqual(self.server.cq.status, e.IBV_WC_LOC_PROT_ERR,
+                         'Expected CQE with Local Protection Error')
+
+    def test_dma_memcpy_data(self):
+        self.dma_memcpy()
+
+    def test_dma_memcpy_different_pd_bad_flow(self):
+        self.dma_memcpy_bad_protection_flow(BadFlowType.DIFFERENT_PD)
+
+    def test_dma_memcpy_protection_bad_flow(self):
+        self.dma_memcpy_bad_protection_flow(BadFlowType.MR_ILLEGAL_ACCESS)
+
+    def test_dma_memcpy_large_data_bad_flow(self):
+        """
+        Bad flow test, testing DMA memcpy with data larger than the maximum
+        allowed size, according to the HCA capabilities.
+        :return: None
+        """
+        try:
+            ctx = Mlx5Context(Mlx5DVContextAttr(), name=self.dev_name)
+        except PyverbsUserError as ex:
+            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
+        except PyverbsRDMAError:
+            raise unittest.SkipTest('Opening mlx5 context is not supported')
+        max_size = ctx.query_mlx5_device(
+            dve.MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH).max_wr_memcpy_length
+        max_size = max_size if max_size else 1024
+
+        with self.assertRaises(PyverbsRDMAError):
+            self.dma_memcpy(max_size + 1)

--- a/tests/test_mlx5_raw_wqe.py
+++ b/tests/test_mlx5_raw_wqe.py
@@ -1,46 +1,20 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2021 Nvidia, Inc. All rights reserved. See COPYING file
 
-import unittest
-import random
-import errno
-
-
-from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, Mlx5DVQPInitAttr, \
-    Mlx5QP, Mlx5DVCQInitAttr, Mlx5CQ, Wqe, WqeDataSeg, WqeCtrlSeg
-from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError, PyverbsError
+from pyverbs.providers.mlx5.mlx5dv import Wqe, WqeDataSeg, WqeCtrlSeg
+from pyverbs.pyverbs_error import PyverbsError
 import pyverbs.providers.mlx5.mlx5_enums as dve
-from tests.mlx5_base import Mlx5RDMATestCase
-from pyverbs.qp import QPInitAttrEx, QPCap
-from pyverbs.cq import CqInitAttrEx
-from tests.base import RCResources
+from tests.mlx5_base import Mlx5RDMATestCase, Mlx5RcResources
+from pyverbs.qp import QPCap
 from pyverbs.wr import SGE
-from pyverbs.mr import MR
 import pyverbs.enums as e
 import tests.utils as u
 
 
-class Mlx5RawWqeResources(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index):
+class Mlx5RawWqeResources(Mlx5RcResources):
+    def create_send_ops_flags(self):
         self.dv_send_ops_flags = dve.MLX5DV_QP_EX_WITH_RAW_WQE
         self.send_ops_flags = e.IBV_QP_EX_WITH_SEND
-        super().__init__(dev_name, ib_port, gid_index)
-
-    def create_context(self):
-        mlx5dv_attr = Mlx5DVContextAttr()
-        try:
-            self.ctx = Mlx5Context(mlx5dv_attr, name=self.dev_name)
-        except PyverbsUserError as ex:
-            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
-        except PyverbsRDMAError:
-            raise unittest.SkipTest('Opening mlx5 context is not supported')
-
-    def create_qp_init_attr(self):
-        comp_mask = e.IBV_QP_INIT_ATTR_PD | e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
-        return QPInitAttrEx(cap=self.create_qp_cap(), pd=self.pd, scq=self.cq,
-                            rcq=self.cq, qp_type=e.IBV_QPT_RC,
-                            send_ops_flags=self.send_ops_flags,
-                            comp_mask=comp_mask)
 
     def create_qp_cap(self):
         """
@@ -50,35 +24,6 @@ class Mlx5RawWqeResources(RCResources):
         :return:
         """
         return QPCap(max_send_wr=4, max_recv_wr=4, max_recv_sge=2, max_send_sge=2)
-
-
-    def create_qps(self):
-        try:
-            qp_init_attr = self.create_qp_init_attr()
-            comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_QP_CREATE_FLAGS | \
-                    dve.MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS
-            attr = Mlx5DVQPInitAttr(comp_mask=comp_mask, send_ops_flags=self.dv_send_ops_flags)
-            qp = Mlx5QP(self.ctx, qp_init_attr, attr)
-            self.qps.append(qp)
-            self.qps_num.append(qp.qp_num)
-            self.psns.append(random.getrandbits(24))
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create Mlx5DV QP is not supported')
-            raise ex
-
-    def create_cq(self):
-        """
-        Initializes self.cq with a dv_cq
-        :return: None
-        """
-        dvcq_init_attr = Mlx5DVCQInitAttr()
-        try:
-            self.cq = Mlx5CQ(self.ctx, CqInitAttrEx(), dvcq_init_attr)
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create Mlx5DV CQ is not supported')
-            raise ex
 
 
 class RawWqeTest(Mlx5RDMATestCase):


### PR DESCRIPTION
This series Introduces mlx5dv_wr_memcpy builder to be used for building a DMA memcpy request.

DMA memcpy is one of several Memory to Memory Offloads (MMO) available from BlueField-2 onwards.
It utilizes the GGA modules on the DPU to perform DMA memcpy, thus improving performance.

The series includes a detailed man page for the expected usage and pyverbs stuff over the new functionality.