### PR TITLE
mlx5: DR, Enhance support in few areas

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -135,6 +135,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_qp_cancel_posted_send_wrs@MLX5_1.20 36
  _mlx5dv_mkey_check@MLX5_1.20 36
  mlx5dv_dci_stream_id_reset@MLX5_1.21 37
+ mlx5dv_dr_matcher_set_layout@MLX5_1.21 37
  mlx5dv_get_vfio_device_list@MLX5_1.21 37
  mlx5dv_vfio_get_events_fd@MLX5_1.21 37
  mlx5dv_vfio_process_events@MLX5_1.21 37

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -752,11 +752,13 @@ int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *dmn)
 	if (!fout || !dmn)
 		return -EINVAL;
 
+	pthread_spin_lock(&dmn->debug_lock);
 	dr_domain_lock(dmn);
 
 	ret = dr_dump_domain_all(fout, dmn);
 
 	dr_domain_unlock(dmn);
+	pthread_spin_unlock(&dmn->debug_lock);
 
 	return ret;
 }
@@ -768,7 +770,9 @@ int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *tbl)
 	if (!fout || !tbl)
 		return -EINVAL;
 
+	pthread_spin_lock(&tbl->dmn->debug_lock);
 	dr_domain_lock(tbl->dmn);
+
 	ret = dr_dump_domain(fout, tbl->dmn);
 	if (ret < 0)
 		goto out;
@@ -776,6 +780,7 @@ int mlx5dv_dump_dr_table(FILE *fout, struct mlx5dv_dr_table *tbl)
 	ret = dr_dump_table_all(fout, tbl);
 out:
 	dr_domain_unlock(tbl->dmn);
+	pthread_spin_unlock(&tbl->dmn->debug_lock);
 	return ret;
 }
 
@@ -786,7 +791,9 @@ int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher)
 	if (!fout || !matcher)
 		return -EINVAL;
 
+	pthread_spin_lock(&matcher->tbl->dmn->debug_lock);
 	dr_domain_lock(matcher->tbl->dmn);
+
 	ret = dr_dump_domain(fout, matcher->tbl->dmn);
 	if (ret < 0)
 		goto out;
@@ -798,6 +805,7 @@ int mlx5dv_dump_dr_matcher(FILE *fout, struct mlx5dv_dr_matcher *matcher)
 	ret = dr_dump_matcher_all(fout, matcher);
 out:
 	dr_domain_unlock(matcher->tbl->dmn);
+	pthread_spin_unlock(&matcher->tbl->dmn->debug_lock);
 	return ret;
 }
 
@@ -808,7 +816,9 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule)
 	if (!fout || !rule)
 		return -EINVAL;
 
+	pthread_spin_lock(&rule->matcher->tbl->dmn->debug_lock);
 	dr_domain_lock(rule->matcher->tbl->dmn);
+
 	ret = dr_dump_domain(fout, rule->matcher->tbl->dmn);
 	if (ret < 0)
 		goto out;
@@ -824,6 +834,7 @@ int mlx5dv_dump_dr_rule(FILE *fout, struct mlx5dv_dr_rule *rule)
 	ret = dr_dump_rule(fout, rule);
 out:
 	dr_domain_unlock(rule->matcher->tbl->dmn);
+	pthread_spin_unlock(&rule->matcher->tbl->dmn->debug_lock);
 	return ret;
 }
 

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -699,7 +699,7 @@ static int dr_dump_domain(FILE *f, struct mlx5dv_dr_domain *dmn)
 	enum mlx5dv_dr_domain_type dmn_type = dmn->type;
 	char *dev_name = dmn->ctx->device->dev_name;
 	uint64_t domain_id;
-	int ret;
+	int ret, i;
 
 	domain_id = dr_domain_id_calc(dmn_type);
 
@@ -719,9 +719,11 @@ static int dr_dump_domain(FILE *f, struct mlx5dv_dr_domain *dmn)
 		return ret;
 
 	if (dmn->info.supp_sw_steering) {
-		ret = dr_dump_send_ring(f, dmn->send_ring, domain_id);
-		if (ret < 0)
-			return ret;
+		for (i = 0; i < DR_MAX_SEND_RINGS; i++) {
+			ret = dr_dump_send_ring(f, dmn->send_ring[i], domain_id);
+			if (ret < 0)
+				return ret;
+		}
 	}
 
 	return 0;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -281,6 +281,29 @@ static void dr_domain_caps_uninit(struct mlx5dv_dr_domain *dmn)
 		free(dmn->info.caps.vports_caps);
 }
 
+bool dr_domain_is_support_ste_icm_size(struct mlx5dv_dr_domain *dmn,
+				       uint32_t req_log_icm_sz)
+{
+	if (dmn->info.caps.log_icm_size < req_log_icm_sz + DR_STE_LOG_SIZE)
+		return false;
+
+	return true;
+}
+
+bool dr_domain_set_max_ste_icm_size(struct mlx5dv_dr_domain *dmn,
+				    uint32_t req_log_icm_sz)
+{
+	if (!dr_domain_is_support_ste_icm_size(dmn, req_log_icm_sz))
+		return false;
+
+	if (dmn->info.max_log_sw_icm_sz < req_log_icm_sz) {
+		dmn->info.max_log_sw_icm_sz = req_log_icm_sz;
+		dr_icm_pool_set_pool_max_log_chunk_sz(dmn->ste_icm_pool,
+						      dmn->info.max_log_sw_icm_sz);
+	}
+	return true;
+}
+
 static int dr_domain_check_icm_memory_caps(struct mlx5dv_dr_domain *dmn)
 {
 	uint32_t max_req_bytes_log, max_req_chunks_log;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -106,7 +106,7 @@ clean_pd:
 
 static void dr_free_resources(struct mlx5dv_dr_domain *dmn)
 {
-	dr_send_ring_free(dmn->send_ring);
+	dr_send_ring_free(dmn);
 	dr_icm_pool_destroy(dmn->action_icm_pool);
 	dr_icm_pool_destroy(dmn->ste_icm_pool);
 	mlx5dv_devx_free_uar(dmn->uar);

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -348,6 +348,9 @@ static int dr_icm_pool_sync_pool_buddies(struct dr_icm_pool *pool)
 
 	pthread_spin_unlock(&pool->lock);
 
+	/* Avoid race between delete resource to its reuse on other QP */
+	dr_send_ring_force_drain(pool->dmn);
+
 	if (pool->dmn->flags & DR_DOMAIN_FLAG_MEMORY_RECLAIM)
 		need_reclaim = true;
 

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -470,7 +470,7 @@ void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 	struct dr_icm_pool *pool = buddy->pool;
 
 	/* move the memory to the waiting list AKA "hot" */
-	pthread_spin_lock(&buddy->pool->lock);
+	pthread_spin_lock(&pool->lock);
 	list_del_init(&chunk->chunk_list);
 	list_add_tail(&buddy->hot_list, &chunk->chunk_list);
 	buddy->pool->hot_memory_size += chunk->byte_size;
@@ -479,7 +479,7 @@ void dr_icm_free_chunk(struct dr_icm_chunk *chunk)
 	if (dr_icm_pool_is_sync_required(pool) && !pool->syncing)
 		dr_icm_pool_sync_pool_buddies(buddy->pool);
 
-	pthread_spin_unlock(&buddy->pool->lock);
+	pthread_spin_unlock(&pool->lock);
 }
 
 struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -1096,9 +1096,9 @@ static int dr_rule_destroy_rule(struct mlx5dv_dr_rule *rule)
 {
 	struct mlx5dv_dr_domain *dmn = rule->matcher->tbl->dmn;
 
-	dr_domain_lock(dmn);
+	pthread_spin_lock(&dmn->debug_lock);
 	list_del(&rule->rule_list);
-	dr_domain_unlock(dmn);
+	pthread_spin_unlock(&dmn->debug_lock);
 
 	switch (dmn->type) {
 	case MLX5DV_DR_DOMAIN_TYPE_NIC_RX:
@@ -1337,9 +1337,9 @@ dr_rule_create_rule(struct mlx5dv_dr_matcher *matcher,
 	if (ret)
 		goto remove_action_members;
 
-	dr_domain_lock(dmn);
+	pthread_spin_lock(&dmn->debug_lock);
 	list_add_tail(&matcher->rule_list, &rule->rule_list);
-	dr_domain_unlock(dmn);
+	pthread_spin_unlock(&dmn->debug_lock);
 
 	return rule;
 

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -1079,9 +1079,9 @@ static bool dr_rule_verify(struct mlx5dv_dr_matcher *matcher,
 static int dr_rule_destroy_rule_nic(struct mlx5dv_dr_rule *rule,
 				    struct dr_rule_rx_tx *nic_rule)
 {
-	dr_domain_nic_lock(nic_rule->nic_matcher->nic_tbl->nic_dmn);
+	dr_rule_lock(nic_rule, NULL);
 	dr_rule_clean_rule_members(rule, nic_rule);
-	dr_domain_nic_unlock(nic_rule->nic_matcher->nic_tbl->nic_dmn);
+	dr_rule_unlock(nic_rule);
 	return 0;
 }
 
@@ -1190,7 +1190,7 @@ dr_rule_create_rule_nic(struct mlx5dv_dr_rule *rule,
 	if (ret)
 		return ret;
 
-	dr_domain_nic_lock(nic_rule->nic_matcher->nic_tbl->nic_dmn);
+	dr_rule_lock(nic_rule, hw_ste_arr);
 
 	cur_htbl = nic_matcher->s_htbl;
 
@@ -1247,7 +1247,7 @@ free_rule:
 		free(ste_info);
 	}
 out_unlock:
-	dr_domain_nic_unlock(nic_rule->nic_matcher->nic_tbl->nic_dmn);
+	dr_rule_unlock(nic_rule);
 	return ret;
 }
 

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -308,7 +308,8 @@ static struct dr_ste *dr_rule_rehash_copy_ste(struct mlx5dv_dr_matcher *matcher,
 		if (!ste_info) {
 			dr_dbg(matcher->tbl->dmn, "Failed allocating ste_info\n");
 			errno = ENOMEM;
-			goto err_exit;
+			dr_htbl_put(new_ste->htbl);
+			return NULL;
 		}
 		dr_send_fill_and_append_ste_send_info(new_ste, DR_STE_SIZE, 0,
 						      hw_ste, ste_info,
@@ -318,10 +319,6 @@ static struct dr_ste *dr_rule_rehash_copy_ste(struct mlx5dv_dr_matcher *matcher,
 	dr_rule_rehash_copy_ste_ctrl(matcher, nic_matcher, cur_ste, new_ste);
 
 	return new_ste;
-
-err_exit:
-	dr_ste_free(new_ste, matcher, nic_matcher);
-	return NULL;
 }
 
 static int dr_rule_rehash_copy_miss_list(struct mlx5dv_dr_matcher *matcher,

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -569,7 +569,7 @@ static int dr_handle_pending_wc(struct mlx5dv_dr_domain *dmn,
 
 	if (send_ring->pending_wqe >= send_ring->signal_th) {
 		/* Queue is full start drain it */
-		if (send_ring->pending_wqe >= dmn->send_ring->signal_th * TH_NUMS_TO_DRAIN)
+		if (send_ring->pending_wqe >= send_ring->signal_th * TH_NUMS_TO_DRAIN)
 			is_drain = true;
 
 		do {
@@ -623,9 +623,11 @@ static void dr_fill_data_segs(struct dr_send_ring *send_ring,
 }
 
 static int dr_postsend_icm_data(struct mlx5dv_dr_domain *dmn,
-				struct postsend_info *send_info)
+				struct postsend_info *send_info,
+				int ring_idx)
 {
-	struct dr_send_ring *send_ring = dmn->send_ring;
+	struct dr_send_ring *send_ring =
+		dmn->send_ring[ring_idx % DR_MAX_SEND_RINGS];
 	uint32_t buff_offset;
 	int ret;
 
@@ -635,8 +637,8 @@ static int dr_postsend_icm_data(struct mlx5dv_dr_domain *dmn,
 		goto out_unlock;
 
 	if (send_info->write.length > dmn->info.max_inline_size) {
-		buff_offset = (send_ring->tx_head & (dmn->send_ring->signal_th - 1)) *
-			send_ring->max_post_send_size;
+		buff_offset = (send_ring->tx_head & (send_ring->signal_th - 1)) *
+			dmn->info.max_send_size;
 		/* Copy to ring mr */
 		memcpy(send_ring->buf + buff_offset,
 		       (void *) (uintptr_t)send_info->write.addr,
@@ -663,9 +665,9 @@ static int dr_get_tbl_copy_details(struct mlx5dv_dr_domain *dmn,
 {
 	int alloc_size;
 
-	if (htbl->chunk->byte_size > dmn->send_ring->max_post_send_size) {
-		*iterations = htbl->chunk->byte_size / dmn->send_ring->max_post_send_size;
-		*byte_size = dmn->send_ring->max_post_send_size;
+	if (htbl->chunk->byte_size > dmn->info.max_send_size) {
+		*iterations = htbl->chunk->byte_size / dmn->info.max_send_size;
+		*byte_size = dmn->info.max_send_size;
 		alloc_size = *byte_size;
 		*num_stes = *byte_size / DR_STE_SIZE;
 	} else {
@@ -709,7 +711,7 @@ int dr_send_postsend_ste(struct mlx5dv_dr_domain *dmn, struct dr_ste *ste,
 	send_info.remote_addr   = dr_ste_get_mr_addr(ste) + offset;
 	send_info.rkey          = ste->htbl->chunk->rkey;
 
-	return dr_postsend_icm_data(dmn, &send_info);
+	return dr_postsend_icm_data(dmn, &send_info, 0);
 }
 
 int dr_send_postsend_htbl(struct mlx5dv_dr_domain *dmn, struct dr_ste_htbl *htbl,
@@ -762,7 +764,7 @@ int dr_send_postsend_htbl(struct mlx5dv_dr_domain *dmn, struct dr_ste_htbl *htbl
 		send_info.remote_addr	= dr_ste_get_mr_addr(htbl->ste_arr + ste_index);
 		send_info.rkey		= htbl->chunk->rkey;
 
-		ret = dr_postsend_icm_data(dmn, &send_info);
+		ret = dr_postsend_icm_data(dmn, &send_info, 0);
 		if (ret)
 			goto out_free;
 	}
@@ -815,7 +817,7 @@ int dr_send_postsend_formated_htbl(struct mlx5dv_dr_domain *dmn,
 		send_info.remote_addr	= dr_ste_get_mr_addr(htbl->ste_arr + ste_index);
 		send_info.rkey		= htbl->chunk->rkey;
 
-		ret = dr_postsend_icm_data(dmn, &send_info);
+		ret = dr_postsend_icm_data(dmn, &send_info, 0);
 		if (ret)
 			goto out_free;
 	}
@@ -837,7 +839,7 @@ int dr_send_postsend_action(struct mlx5dv_dr_domain *dmn,
 	send_info.remote_addr	= action->rewrite.chunk->mr_addr;
 	send_info.rkey		= action->rewrite.chunk->rkey;
 
-	return dr_postsend_icm_data(dmn, &send_info);
+	return dr_postsend_icm_data(dmn, &send_info, 0);
 }
 
 bool dr_send_allow_fl(struct dr_devx_caps *caps)
@@ -856,11 +858,11 @@ static int dr_send_get_qp_ts_format(struct dr_devx_caps *caps)
 		MLX5_QPC_TIMESTAMP_FORMAT_DEFAULT;
 }
 
-static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn)
+static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn,
+				struct dr_qp *dr_qp)
 {
 	struct dr_devx_qp_rts_attr rts_attr = {};
 	struct dr_devx_qp_rtr_attr rtr_attr = {};
-	struct dr_qp *dr_qp = dmn->send_ring->qp;
 	enum ibv_mtu mtu = IBV_MTU_1024;
 	uint16_t gid_index = 0;
 	int port = 1;
@@ -911,10 +913,31 @@ static int dr_prepare_qp_to_rts(struct mlx5dv_dr_domain *dmn)
 	return 0;
 }
 
+static void dr_send_ring_free_one(struct dr_send_ring *send_ring)
+{
+	dr_destroy_qp(send_ring->qp);
+	ibv_destroy_cq(send_ring->cq.ibv_cq);
+	ibv_dereg_mr(send_ring->sync_mr);
+	ibv_dereg_mr(send_ring->mr);
+	free(send_ring->buf);
+	free(send_ring->sync_buff);
+	free(send_ring);
+}
+
+void dr_send_ring_free(struct mlx5dv_dr_domain *dmn)
+{
+	int i;
+
+	for (i = 0; i < DR_MAX_SEND_RINGS; i++)
+		dr_send_ring_free_one(dmn->send_ring[i]);
+}
+
 /* Each domain has its own ib resources */
-int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn)
+static int dr_send_ring_alloc_one(struct mlx5dv_dr_domain *dmn,
+				  struct dr_send_ring **curr_send_ring)
 {
 	struct dr_qp_init_attr init_attr = {};
+	struct dr_send_ring *send_ring;
 	struct mlx5dv_pd mlx5_pd = {};
 	struct mlx5dv_cq mlx5_cq = {};
 	int cq_size, page_size;
@@ -924,43 +947,39 @@ int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn)
 			   IBV_ACCESS_REMOTE_READ;
 	int ret;
 
-	dmn->info.max_send_size =
-		dr_icm_pool_chunk_size_to_byte(DR_CHUNK_SIZE_1K,
-					       DR_ICM_TYPE_STE);
-
-	dmn->send_ring = calloc(1, sizeof(*dmn->send_ring));
-	if (!dmn->send_ring) {
+	send_ring = calloc(1, sizeof(*send_ring));
+	if (!send_ring) {
 		dr_dbg(dmn, "Couldn't allocate send-ring\n");
 		errno = ENOMEM;
 		return errno;
 	}
 
-	ret = pthread_spin_init(&dmn->send_ring->lock, PTHREAD_PROCESS_PRIVATE);
+	ret = pthread_spin_init(&send_ring->lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret) {
 		errno = ret;
 		goto free_send_ring;
 	}
 
 	cq_size = QUEUE_SIZE + 1;
-	dmn->send_ring->cq.ibv_cq = ibv_create_cq(dmn->ctx, cq_size, NULL, NULL, 0);
-	if (!dmn->send_ring->cq.ibv_cq) {
+	send_ring->cq.ibv_cq = ibv_create_cq(dmn->ctx, cq_size, NULL, NULL, 0);
+	if (!send_ring->cq.ibv_cq) {
 		dr_dbg(dmn, "Failed to create CQ with %u entries\n", cq_size);
 		ret = ENODEV;
 		errno = ENODEV;
 		goto free_send_ring;
 	}
 
-	obj.cq.in = dmn->send_ring->cq.ibv_cq;
+	obj.cq.in = send_ring->cq.ibv_cq;
 	obj.cq.out = &mlx5_cq;
 
 	ret = mlx5dv_init_obj(&obj, MLX5DV_OBJ_CQ);
 	if (ret)
 		goto clean_cq;
 
-	dmn->send_ring->cq.buf = mlx5_cq.buf;
-	dmn->send_ring->cq.db = mlx5_cq.dbrec;
-	dmn->send_ring->cq.ncqe = mlx5_cq.cqe_cnt;
-	dmn->send_ring->cq.cqe_sz = mlx5_cq.cqe_size;
+	send_ring->cq.buf = mlx5_cq.buf;
+	send_ring->cq.db = mlx5_cq.dbrec;
+	send_ring->cq.ncqe = mlx5_cq.cqe_cnt;
+	send_ring->cq.cqe_sz = mlx5_cq.cqe_size;
 
 	obj.pd.in = dmn->pd;
 	obj.pd.out = &mlx5_pd;
@@ -983,52 +1002,45 @@ int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn)
 	if (dr_send_allow_fl(&dmn->info.caps))
 		init_attr.isolate_vl_tc = dmn->info.caps.isolate_vl_tc;
 
-	dmn->send_ring->qp = dr_create_rc_qp(dmn->ctx, &init_attr);
-	if (!dmn->send_ring->qp)  {
+	send_ring->qp = dr_create_rc_qp(dmn->ctx, &init_attr);
+	if (!send_ring->qp)  {
 		dr_dbg(dmn, "Couldn't create QP\n");
 		ret = errno;
 		goto clean_cq;
 	}
-	dmn->send_ring->cq.qp = dmn->send_ring->qp;
 
-	dmn->info.max_send_wr = QUEUE_SIZE;
-	dmn->info.max_inline_size = min(dmn->send_ring->qp->max_inline_data,
-					DR_STE_SIZE);
-
-	dmn->send_ring->signal_th = dmn->info.max_send_wr / SIGNAL_PER_DIV_QUEUE;
+	send_ring->cq.qp = send_ring->qp;
+	send_ring->max_inline_size = min(send_ring->qp->max_inline_data, DR_STE_SIZE);
+	send_ring->signal_th = QUEUE_SIZE / SIGNAL_PER_DIV_QUEUE;
 
 	/* Prepare qp to be used */
-	ret = dr_prepare_qp_to_rts(dmn);
+	ret = dr_prepare_qp_to_rts(dmn, send_ring->qp);
 	if (ret) {
 		dr_dbg(dmn, "Couldn't prepare QP\n");
 		goto clean_qp;
 	}
 
-	dmn->send_ring->max_post_send_size =
-		dr_icm_pool_chunk_size_to_byte(DR_CHUNK_SIZE_1K, DR_ICM_TYPE_STE);
-
 	/* Allocating the max size as a buffer for writing */
-	size = dmn->send_ring->signal_th * dmn->send_ring->max_post_send_size;
+	size = send_ring->signal_th * dmn->info.max_send_size;
 	page_size = sysconf(_SC_PAGESIZE);
-	ret = posix_memalign(&dmn->send_ring->buf, page_size, size);
+	ret = posix_memalign(&send_ring->buf, page_size, size);
 	if (ret) {
 		dr_dbg(dmn, "Couldn't allocate send-ring buf.\n");
 		errno = ret;
 		goto clean_qp;
 	}
 
-	memset(dmn->send_ring->buf, 0, size);
-	dmn->send_ring->buf_size = size;
+	memset(send_ring->buf, 0, size);
+	send_ring->buf_size = size;
 
-	dmn->send_ring->mr = ibv_reg_mr(dmn->pd, dmn->send_ring->buf, size,
-					access_flags);
-	if (!dmn->send_ring->mr) {
+	send_ring->mr = ibv_reg_mr(dmn->pd, send_ring->buf, size, access_flags);
+	if (!send_ring->mr) {
 		dr_dbg(dmn, "Couldn't register send-ring MR\n");
 		ret = errno;
 		goto free_mem;
 	}
 
-	ret = posix_memalign(&dmn->send_ring->sync_buff, page_size,
+	ret = posix_memalign(&send_ring->sync_buff, page_size,
 			     dmn->info.max_send_size);
 	if (ret) {
 		dr_dbg(dmn, "Couldn't allocate send-ring sync_buf.\n");
@@ -1036,53 +1048,72 @@ int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn)
 		goto clean_mr;
 	}
 
-	dmn->send_ring->sync_mr = ibv_reg_mr(dmn->pd, dmn->send_ring->sync_buff,
-					     dmn->info.max_send_size,
-					     IBV_ACCESS_LOCAL_WRITE |
-					     IBV_ACCESS_REMOTE_READ |
-					     IBV_ACCESS_REMOTE_WRITE);
-	if (!dmn->send_ring->sync_mr) {
+	send_ring->sync_mr = ibv_reg_mr(dmn->pd, send_ring->sync_buff,
+					dmn->info.max_send_size,
+					IBV_ACCESS_LOCAL_WRITE |
+					IBV_ACCESS_REMOTE_READ |
+					IBV_ACCESS_REMOTE_WRITE);
+	if (!send_ring->sync_mr) {
 		dr_dbg(dmn, "Couldn't register sync mr\n");
 		ret = errno;
 		goto clean_sync_buf;
 	}
 
+	*curr_send_ring = send_ring;
+
 	return 0;
 
 clean_sync_buf:
-	free(dmn->send_ring->sync_buff);
+	free(send_ring->sync_buff);
 clean_mr:
-	ibv_dereg_mr(dmn->send_ring->mr);
+	ibv_dereg_mr(send_ring->mr);
 free_mem:
-	free(dmn->send_ring->buf);
+	free(send_ring->buf);
 clean_qp:
-	dr_destroy_qp(dmn->send_ring->qp);
+	dr_destroy_qp(send_ring->qp);
 clean_cq:
-	ibv_destroy_cq(dmn->send_ring->cq.ibv_cq);
+	ibv_destroy_cq(send_ring->cq.ibv_cq);
 free_send_ring:
-	free(dmn->send_ring);
+	free(send_ring);
 
 	return ret;
 }
 
-void dr_send_ring_free(struct dr_send_ring *send_ring)
+int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn)
 {
-	dr_destroy_qp(send_ring->qp);
-	ibv_destroy_cq(send_ring->cq.ibv_cq);
-	ibv_dereg_mr(send_ring->sync_mr);
-	ibv_dereg_mr(send_ring->mr);
-	free(send_ring->sync_buff);
-	free(send_ring->buf);
-	free(send_ring);
+	int i, ret;
+
+	dmn->info.max_send_size =
+		dr_icm_pool_chunk_size_to_byte(DR_CHUNK_SIZE_1K,
+					       DR_ICM_TYPE_STE);
+
+	for (i = 0; i < DR_MAX_SEND_RINGS; i++) {
+		ret = dr_send_ring_alloc_one(dmn, &dmn->send_ring[i]);
+		if (ret) {
+			dr_dbg(dmn, "Couldn't allocate send-rings id[%d]\n", i);
+			goto free_send_ring;
+		}
+	}
+
+	return 0;
+
+free_send_ring:
+	for (; i > 0; i--)
+		dr_send_ring_free_one(dmn->send_ring[i - 1]);
+
+	return ret;
 }
 
 int dr_send_ring_force_drain(struct mlx5dv_dr_domain *dmn)
 {
-	struct dr_send_ring *send_ring = dmn->send_ring;
+	struct dr_send_ring *send_ring = dmn->send_ring[0];
 	struct postsend_info send_info = {};
+	int i, j, num_of_sends_req;
 	uint8_t data[DR_STE_SIZE];
-	int i, num_of_sends_req;
+	int num_qps;
 	int ret;
+
+	num_qps = dr_domain_is_mq_enable(dmn) ? DR_MAX_SEND_RINGS : 1;
 
 	/* Sending this amount of requests makes sure we will get drain */
 	num_of_sends_req = send_ring->signal_th * TH_NUMS_TO_DRAIN / 2;
@@ -1095,14 +1126,13 @@ int dr_send_ring_force_drain(struct mlx5dv_dr_domain *dmn)
 	send_info.remote_addr	= (uintptr_t) send_ring->sync_mr->addr;
 	send_info.rkey		= send_ring->sync_mr->rkey;
 
-
 	for (i = 0; i < num_of_sends_req; i++) {
-		ret = dr_postsend_icm_data(dmn, &send_info);
-		if (ret)
-			return ret;
+		for (j = 0; j < num_qps; j++) {
+			ret = dr_postsend_icm_data(dmn, &send_info, j);
+			if (ret)
+				return ret;
+		}
 	}
-	pthread_spin_lock(&send_ring->lock);
-	ret = dr_handle_pending_wc(dmn, send_ring);
-	pthread_spin_unlock(&send_ring->lock);
-	return ret;
+
+	return 0;
 }

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -341,10 +341,12 @@ static void dr_ste_remove_middle_ste(struct dr_ste_ctx *ste_ctx,
 }
 
 void dr_ste_free(struct dr_ste *ste,
-		 struct mlx5dv_dr_matcher *matcher,
-		 struct dr_matcher_rx_tx *nic_matcher)
+		 struct mlx5dv_dr_rule *rule,
+		 struct dr_rule_rx_tx *nic_rule)
 {
+	struct dr_matcher_rx_tx *nic_matcher = nic_rule->nic_matcher;
 	struct dr_ste_send_info *cur_ste_info, *tmp_ste_info;
+	struct mlx5dv_dr_matcher *matcher = rule->matcher;
 	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
 	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
 	struct dr_ste_send_info ste_info_head;
@@ -387,8 +389,10 @@ void dr_ste_free(struct dr_ste *ste,
 	list_for_each_safe(&send_ste_list, cur_ste_info, tmp_ste_info, send_list) {
 		list_del(&cur_ste_info->send_list);
 		dr_send_postsend_ste(dmn, cur_ste_info->ste,
-				     cur_ste_info->data, cur_ste_info->size,
-				     cur_ste_info->offset);
+				     cur_ste_info->data,
+				     cur_ste_info->size,
+				     cur_ste_info->offset,
+				     nic_rule->lock_index);
 	}
 
 	if (put_on_origin_table)
@@ -443,7 +447,8 @@ int dr_ste_htbl_init_and_postsend(struct mlx5dv_dr_domain *dmn,
 				  struct dr_domain_rx_tx *nic_dmn,
 				  struct dr_ste_htbl *htbl,
 				  struct dr_htbl_connect_info *connect_info,
-				  bool update_hw_ste)
+				  bool update_hw_ste,
+				  uint8_t send_ring_idx)
 {
 	uint8_t formated_ste[DR_STE_SIZE] = {};
 
@@ -454,14 +459,16 @@ int dr_ste_htbl_init_and_postsend(struct mlx5dv_dr_domain *dmn,
 				formated_ste,
 				connect_info);
 
-	return dr_send_postsend_formated_htbl(dmn, htbl, formated_ste, update_hw_ste);
+	return dr_send_postsend_formated_htbl(dmn, htbl, formated_ste,
+					      update_hw_ste, send_ring_idx);
 }
 
 int dr_ste_create_next_htbl(struct mlx5dv_dr_matcher *matcher,
 			    struct dr_matcher_rx_tx *nic_matcher,
 			    struct dr_ste *ste,
 			    uint8_t *cur_hw_ste,
-			    enum dr_icm_chunk_size log_table_size)
+			    enum dr_icm_chunk_size log_table_size,
+			    uint8_t send_ring_idx)
 {
 	struct dr_domain_rx_tx *nic_dmn = nic_matcher->nic_tbl->nic_dmn;
 	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
@@ -490,7 +497,7 @@ int dr_ste_create_next_htbl(struct mlx5dv_dr_matcher *matcher,
 		info.type = CONNECT_MISS;
 		info.miss_icm_addr = nic_matcher->e_anchor->chunk->icm_addr;
 		if (dr_ste_htbl_init_and_postsend(dmn, nic_dmn, next_htbl,
-						  &info, false)) {
+						  &info, false, send_ring_idx)) {
 			dr_dbg(dmn, "Failed writing table to HW\n");
 			goto free_table;
 		}

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -389,6 +389,7 @@ static void dr_ste_v0_set_rx_decap(uint8_t *hw_ste_p)
 {
 	DR_STE_SET(rx_steering_mult, hw_ste_p, tunneling_action,
 		   DR_STE_TUNL_ACTION_DECAP);
+	DR_STE_SET(rx_steering_mult, hw_ste_p, fail_on_error, 1);
 }
 
 static void dr_ste_v0_set_go_back_bit(uint8_t *hw_ste_p)
@@ -421,6 +422,7 @@ static void dr_ste_v0_set_rx_decap_l3(uint8_t *hw_ste_p, bool vlan)
 	DR_STE_SET(rx_steering_mult, hw_ste_p, tunneling_action,
 		   DR_STE_TUNL_ACTION_L3_DECAP);
 	DR_STE_SET(modify_packet, hw_ste_p, action_description, vlan ? 1 : 0);
+	DR_STE_SET(rx_steering_mult, hw_ste_p, fail_on_error, 1);
 }
 
 static void dr_ste_v0_set_rewrite_actions(uint8_t *hw_ste_p,

--- a/providers/mlx5/dr_table.c
+++ b/providers/mlx5/dr_table.c
@@ -79,7 +79,7 @@ static int dr_table_init_nic(struct mlx5dv_dr_domain *dmn,
 	info.type = CONNECT_MISS;
 	info.miss_icm_addr = nic_dmn->default_icm_addr;
 	ret = dr_ste_htbl_init_and_postsend(dmn, nic_dmn, nic_tbl->s_anchor,
-					    &info, true);
+					    &info, true, 0);
 	if (ret)
 		goto free_s_anchor;
 

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -193,6 +193,7 @@ MLX5_1.20 {
 MLX5_1.21 {
 	global:
 		mlx5dv_dci_stream_id_reset;
+		mlx5dv_dr_matcher_set_layout;
 		mlx5dv_get_vfio_device_list;
 		mlx5dv_vfio_get_events_fd;
 		mlx5dv_vfio_process_events;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -97,6 +97,7 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_set_reclaim_device_memory.3
  mlx5dv_dr_flow.3 mlx5dv_dr_matcher_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_matcher_destroy.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_matcher_set_layout.3
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_rule_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_table_create.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -14,7 +14,7 @@ mlx5dv_dr_domain_create, mlx5dv_dr_domain_sync, mlx5dv_dr_domain_destroy, mlx5dv
 
 mlx5dv_dr_table_create, mlx5dv_dr_table_destroy - Manage flow tables
 
-mlx5dv_dr_matcher_create, mlx5dv_dr_matcher_destroy - Manage flow matchers
+mlx5dv_dr_matcher_create, mlx5dv_dr_matcher_destroy, mlx5dv_dr_matcher_set_layout - Manage flow matchers
 
 mlx5dv_dr_rule_create, mlx5dv_dr_rule_destroy - Manage flow rules
 
@@ -80,6 +80,9 @@ struct mlx5dv_dr_matcher *mlx5dv_dr_matcher_create(
 		struct mlx5dv_flow_match_parameters *mask);
 
 int mlx5dv_dr_matcher_destroy(struct mlx5dv_dr_matcher *matcher);
+
+
+int mlx5dv_dr_matcher_set_layout(struct mlx5dv_dr_matcher *matcher, struct mlx5dv_dr_matcher_layout *matcher_layout);
 
 struct mlx5dv_dr_rule *mlx5dv_dr_rule_create(
 		struct mlx5dv_dr_matcher *matcher,
@@ -212,6 +215,12 @@ A table should be destroyed by calling *mlx5dv_dr_table_destroy()* once all depe
 *mlx5dv_dr_matcher_create()* create a matcher object in **table**, at sorted **priority** (lower value is check first). A matcher can hold multiple rules, all with identical **mask** of type *struct mlx5dv_flow_match_parameters* which represents the exact attributes to be compared by HW steering. The **match_criteria_enable** and **mask** are defined in a device spec format. Only the fields that where masked in the *matcher* should be filled by the rule in *mlx5dv_dr_rule_create()*.
 
 A matcher should be destroyed by calling *mlx5dv_dr_matcher_destroy()* once all depended resources are released.
+
+*mlx5dv_dr_matcher_set_layout()* is used to set specific layout parameters of a matcher, on some conditions setting some attributes might not be supported, in such cases ENOTSUP will be returned. **flags** should be a set of type *enum mlx5dv_dr_matcher_layout_flags*:
+
+**MLX5DV_DR_MATCHER_LAYOUT_RESIZABLE**: The matcher can resize its scale and resources according to the rules that are inserted or removed.
+
+**MLX5DV_DR_MATCHER_LAYOUT_NUM_RULE**: Indicates a hint from the application about the number of the rules the matcher is expected to handle. This allows preallocation of matcher resources for faster rule updates when using with non-resizable layout mode.
 
 ## Actions
 A set of action create API are defined by *mlx5dv_dr_action_create_\*()*. All action are created as *struct mlx5dv_dr_action*.

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1791,6 +1791,19 @@ mlx5dv_dr_matcher_create(struct mlx5dv_dr_table *table,
 
 int mlx5dv_dr_matcher_destroy(struct mlx5dv_dr_matcher *matcher);
 
+enum mlx5dv_dr_matcher_layout_flags {
+	MLX5DV_DR_MATCHER_LAYOUT_RESIZABLE = 1 << 0,
+	MLX5DV_DR_MATCHER_LAYOUT_NUM_RULE = 1 << 1,
+};
+
+struct mlx5dv_dr_matcher_layout {
+	uint32_t flags; /* use enum mlx5dv_dr_matcher_layout_flags */
+	uint32_t log_num_of_rules_hint;
+};
+
+int mlx5dv_dr_matcher_set_layout(struct mlx5dv_dr_matcher *matcher,
+				 struct mlx5dv_dr_matcher_layout *layout);
+
 struct mlx5dv_dr_rule *
 mlx5dv_dr_rule_create(struct mlx5dv_dr_matcher *matcher,
 		      struct mlx5dv_flow_match_parameters *value,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -912,6 +912,7 @@ struct dr_domain_info {
 	uint32_t		max_send_wr;
 	uint32_t		max_log_sw_icm_sz;
 	uint32_t		max_log_action_icm_sz;
+	uint32_t		max_send_size;
 	struct dr_domain_rx_tx	rx;
 	struct dr_domain_rx_tx	tx;
 	struct ibv_device_attr_ex attr;
@@ -1426,7 +1427,7 @@ struct dr_send_ring {
 	pthread_spinlock_t	lock;
 	void			*buf;
 	uint32_t		buf_size;
-	uint8_t			sync_buff[MIN_READ_SYNC];
+	void			*sync_buff;
 	struct ibv_mr		*sync_mr;
 };
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -917,6 +917,7 @@ struct dr_domain_info {
 	struct dr_domain_rx_tx	tx;
 	struct ibv_device_attr_ex attr;
 	struct dr_devx_caps	caps;
+	bool			use_mqs;
 };
 
 enum dr_domain_flags {
@@ -985,6 +986,7 @@ struct dr_matcher_rx_tx {
 	uint8_t				num_of_builders;
 	uint64_t			default_icm_addr;
 	struct dr_table_rx_tx		*nic_tbl;
+	bool				fixed_size;
 };
 
 struct mlx5dv_dr_matcher {
@@ -1200,6 +1202,9 @@ dr_icm_pool_chunk_size_to_byte(enum dr_icm_chunk_size chunk_size,
 	return entry_size * num_of_entries;
 }
 
+void dr_icm_pool_set_pool_max_log_chunk_sz(struct dr_icm_pool *pool,
+					   enum dr_icm_chunk_size max_log_chunk_sz);
+
 static inline int
 dr_ste_htbl_increase_threshold(struct dr_ste_htbl *htbl)
 {
@@ -1340,6 +1345,14 @@ static inline bool dr_is_root_table(struct mlx5dv_dr_table *tbl)
 {
 	return tbl->level == 0;
 }
+
+bool dr_domain_is_support_ste_icm_size(struct mlx5dv_dr_domain *dmn,
+				       uint32_t req_log_icm_sz);
+bool dr_domain_set_max_ste_icm_size(struct mlx5dv_dr_domain *dmn,
+				    uint32_t req_log_icm_sz);
+int dr_rule_rehash_matcher_s_anchor(struct mlx5dv_dr_matcher *matcher,
+				    struct dr_matcher_rx_tx *nic_matcher,
+				    enum dr_icm_chunk_size new_size);
 
 struct dr_icm_pool *dr_icm_pool_create(struct mlx5dv_dr_domain *dmn,
 				       enum dr_icm_type icm_type);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -1426,7 +1426,6 @@ struct dr_send_ring {
 	pthread_spinlock_t	lock;
 	void			*buf;
 	uint32_t		buf_size;
-	struct ibv_wc		wc[MAX_SEND_CQE];
 	uint8_t			sync_buff[MIN_READ_SYNC];
 	struct ibv_mr		*sync_mr;
 };

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -912,7 +912,6 @@ struct dr_domain_rx_tx {
 struct dr_domain_info {
 	bool			supp_sw_steering;
 	uint32_t		max_inline_size;
-	uint32_t		max_send_wr;
 	uint32_t		max_log_sw_icm_sz;
 	uint32_t		max_log_action_icm_sz;
 	uint32_t		max_send_size;
@@ -937,7 +936,7 @@ struct mlx5dv_dr_domain {
 	atomic_int			refcount;
 	struct dr_icm_pool		*ste_icm_pool;
 	struct dr_icm_pool		*action_icm_pool;
-	struct dr_send_ring		*send_ring;
+	struct dr_send_ring		*send_ring[DR_MAX_SEND_RINGS];
 	struct dr_domain_info		info;
 	struct list_head		tbl_list;
 	uint32_t			flags;
@@ -1493,7 +1492,6 @@ struct dr_cq {
 };
 
 #define MAX_SEND_CQE		64
-#define MIN_READ_SYNC		64
 
 struct dr_send_ring {
 	struct dr_cq		cq;
@@ -1503,8 +1501,7 @@ struct dr_send_ring {
 	uint32_t		pending_wqe;
 	/* Signal request per this trash hold value */
 	uint16_t		signal_th;
-	/* Each post_send_size less than max_post_send_size */
-	uint32_t		max_post_send_size;
+	uint32_t                max_inline_size;
 	/* manage the send queue */
 	uint32_t		tx_head;
 	/* protect QP/CQ operations */
@@ -1516,7 +1513,7 @@ struct dr_send_ring {
 };
 
 int dr_send_ring_alloc(struct mlx5dv_dr_domain *dmn);
-void dr_send_ring_free(struct dr_send_ring *send_ring);
+void dr_send_ring_free(struct mlx5dv_dr_domain *dmn);
 int dr_send_ring_force_drain(struct mlx5dv_dr_domain *dmn);
 bool dr_send_allow_fl(struct dr_devx_caps *caps);
 int dr_send_postsend_ste(struct mlx5dv_dr_domain *dmn, struct dr_ste *ste,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -412,14 +412,14 @@ dr_ste_conv_modify_hdr_sw_field(struct dr_ste_ctx *ste_ctx,
 
 struct dr_ste_ctx *dr_ste_get_ctx(uint8_t version);
 void dr_ste_free(struct dr_ste *ste,
-		 struct mlx5dv_dr_matcher *matcher,
-		 struct dr_matcher_rx_tx *nic_matcher);
+		 struct mlx5dv_dr_rule *rule,
+		 struct dr_rule_rx_tx *nic_rule);
 static inline void dr_ste_put(struct dr_ste *ste,
-			      struct mlx5dv_dr_matcher *matcher,
-			      struct dr_matcher_rx_tx *nic_matcher)
+			      struct mlx5dv_dr_rule *rule,
+			      struct dr_rule_rx_tx *nic_rule)
 {
 	if (atomic_fetch_sub(&ste->refcount, 1) == 1)
-		dr_ste_free(ste, matcher, nic_matcher);
+		dr_ste_free(ste, rule, nic_rule);
 }
 
 /* initial as 0, increased only when ste appears in a new rule */
@@ -438,7 +438,8 @@ int dr_ste_create_next_htbl(struct mlx5dv_dr_matcher *matcher,
 			    struct dr_matcher_rx_tx *nic_matcher,
 			    struct dr_ste *ste,
 			    uint8_t *cur_hw_ste,
-			    enum dr_icm_chunk_size log_table_size);
+			    enum dr_icm_chunk_size log_table_size,
+			    uint8_t send_ring_idx);
 
 /* STE build functions */
 int dr_ste_build_pre_check(struct mlx5dv_dr_domain *dmn,
@@ -1438,7 +1439,8 @@ int dr_ste_htbl_init_and_postsend(struct mlx5dv_dr_domain *dmn,
 				  struct dr_domain_rx_tx *nic_dmn,
 				  struct dr_ste_htbl *htbl,
 				  struct dr_htbl_connect_info *connect_info,
-				  bool update_hw_ste);
+				  bool update_hw_ste,
+				  uint8_t send_ring_idx);
 void dr_ste_set_formated_ste(struct dr_ste_ctx *ste_ctx,
 			     uint16_t gvmi,
 			     enum dr_domain_nic_type nic_type,
@@ -1517,13 +1519,16 @@ void dr_send_ring_free(struct mlx5dv_dr_domain *dmn);
 int dr_send_ring_force_drain(struct mlx5dv_dr_domain *dmn);
 bool dr_send_allow_fl(struct dr_devx_caps *caps);
 int dr_send_postsend_ste(struct mlx5dv_dr_domain *dmn, struct dr_ste *ste,
-			 uint8_t *data, uint16_t size, uint16_t offset);
+			 uint8_t *data, uint16_t size, uint16_t offset,
+			 uint8_t ring_idx);
 int dr_send_postsend_htbl(struct mlx5dv_dr_domain *dmn, struct dr_ste_htbl *htbl,
-			  uint8_t *formated_ste, uint8_t *mask);
+			  uint8_t *formated_ste, uint8_t *mask,
+			  uint8_t send_ring_idx);
 int dr_send_postsend_formated_htbl(struct mlx5dv_dr_domain *dmn,
 				   struct dr_ste_htbl *htbl,
 				   uint8_t *ste_init_data,
-				   bool update_hw_ste);
+				   bool update_hw_ste,
+				   uint8_t send_ring_idx);
 int dr_send_postsend_action(struct mlx5dv_dr_domain *dmn,
 			    struct mlx5dv_dr_action *action);
 /* buddy functions & structure */

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -938,6 +938,8 @@ struct mlx5dv_dr_domain {
 	struct dr_domain_info		info;
 	struct list_head		tbl_list;
 	uint32_t			flags;
+	/* protect debug lists of all tracked objects */
+	pthread_spinlock_t		debug_lock;
 };
 
 static inline void dr_domain_nic_lock(struct dr_domain_rx_tx *nic_dmn)


### PR DESCRIPTION
This series enhanced the DR support in few area as of below.
- It includes some bug fixes and cleanups.
- Introduce a new DV API to control the DR matcher layout.
- Add multi-queues support for post sending rules, this is applicable when matcher layout is set to non-resizable.
- Improve locking scheme in few places to enable adding rules in parallel.