### PR TITLE
Link util static library to pyverbs

### DIFF
--- a/buildlib/pyverbs_functions.cmake
+++ b/buildlib/pyverbs_functions.cmake
@@ -2,6 +2,8 @@
 # Copyright (c) 2018, Mellanox Technologies. All rights reserved.  See COPYING file
 # Copyright (c) 2020, Intel Corporation. All rights reserved.  See COPYING file
 
+set(COMMON_LIBS_PIC ccan_pic rdma_util_pic)
+
 function(build_module_from_cfiles PY_MODULE MODULE_NAME ALL_CFILES LINKER_FLAGS)
   string(REGEX REPLACE "\\.so$" "" SONAME "${MODULE_NAME}${CMAKE_PYTHON_SO_SUFFIX}")
   add_library(${SONAME} SHARED ${ALL_CFILES})
@@ -9,7 +11,7 @@ function(build_module_from_cfiles PY_MODULE MODULE_NAME ALL_CFILES LINKER_FLAGS)
     COMPILE_FLAGS "${CMAKE_C_FLAGS} -fPIC -fno-strict-aliasing -Wno-unused-function -Wno-redundant-decls -Wno-shadow -Wno-cast-function-type -Wno-implicit-fallthrough -Wno-unknown-warning -Wno-unknown-warning-option -Wno-deprecated-declarations ${NO_VAR_TRACKING_FLAGS}"
     LIBRARY_OUTPUT_DIRECTORY "${BUILD_PYTHON}/${PY_MODULE}"
     PREFIX "")
-  target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs rdmacm ${LINKER_FLAGS})
+  target_link_libraries(${SONAME} LINK_PRIVATE ${PYTHON_LIBRARIES} ibverbs rdmacm ${LINKER_FLAGS} ${COMMON_LIBS_PIC} ${CMAKE_THREAD_LIBS_INIT})
   install(TARGETS ${SONAME}
     DESTINATION ${CMAKE_INSTALL_PYTHON_ARCH_LIB}/${PY_MODULE})
 endfunction()


### PR DESCRIPTION
Some internal util functions are needed by pyverbs, thus the static
rdma_util library should be linked in order to expose the required
internal headers and symbols.