### PR TITLE
tests: Add atomic traffic tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ rdma_python_test(tests
   mlx5_prm_structs.py
   rdmacm_utils.py
   test_addr.py
+  test_atomic.py
   test_cq.py
   test_cq_events.py
   test_cqex.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -506,6 +506,11 @@ class TrafficResources(BaseResources):
     def qp(self):
         return self.qps[0]
 
+    @property
+    def mr_lkey(self):
+        if self.mr:
+            return self.mr.lkey
+
     def init_resources(self):
         """
         Initializes a CQ, MR and an RC QP.

--- a/tests/base.py
+++ b/tests/base.py
@@ -691,8 +691,10 @@ class XRCResources(TrafficResources):
             attr_ex = QPInitAttrEx(qp_type=e.IBV_QPT_XRC_RECV,
                                    comp_mask=e.IBV_QP_INIT_ATTR_XRCD,
                                    xrcd=self.xrcd)
-            qp_attr.qp_access_flags = e.IBV_ACCESS_REMOTE_WRITE | \
-                                      e.IBV_ACCESS_REMOTE_READ
+            qp_attr.qp_access_flags = e.IBV_ACCESS_LOCAL_WRITE | \
+                                      e.IBV_ACCESS_REMOTE_READ | \
+                                      e.IBV_ACCESS_REMOTE_WRITE | \
+                                      e.IBV_ACCESS_REMOTE_ATOMIC
             recv_qp = QP(self.ctx, attr_ex, qp_attr)
             self.rqp_lst.append(recv_qp)
 
@@ -745,6 +747,8 @@ class XRCResources(TrafficResources):
         ah_attr = AHAttr(port_num=self.ib_port, is_global=True,
                          gr=gr, dlid=self.port_attr.lid)
         qp_attr = QPAttr()
+        qp_attr.max_rd_atomic = MAX_RD_ATOMIC
+        qp_attr.max_dest_rd_atomic = MAX_DEST_RD_ATOMIC
         qp_attr.path_mtu = PATH_MTU
         set_rnr_attributes(qp_attr)
         qp_attr.ah_attr = ah_attr

--- a/tests/base_rdmacm.py
+++ b/tests/base_rdmacm.py
@@ -137,6 +137,10 @@ class CMResources(abc.ABC):
     def create_child_id(self, cm_event=None):
         pass
 
+    @property
+    def mr_lkey(self):
+        return self.mr.lkey
+
 
 class AsyncCMResources(CMResources):
     """

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -1,0 +1,161 @@
+import unittest
+import errno
+
+from tests.base import RCResources, RDMATestCase, XRCResources
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.qp import QPAttr, QPInitAttr
+import pyverbs.device as d
+import pyverbs.enums as e
+from pyverbs.mr import MR
+import tests.utils as u
+
+
+class RCAtomic(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index, msg_size=8, qp_access=None,
+                 mr_access=None):
+        """
+        Initialize an RCAtomic Resource object.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param msg_size: Message size for all resources memory actions
+        :param qp_access: The QP access to use when modifying the resource's QP
+        :param mr_access: The MR access to use when registering the resource's MR
+        """
+        atomic_access = e.IBV_ACCESS_LOCAL_WRITE | \
+            e.IBV_ACCESS_REMOTE_ATOMIC
+        self.qp_access = qp_access if qp_access else atomic_access
+        self.mr_access = mr_access if mr_access else atomic_access
+        super().__init__(dev_name=dev_name, ib_port=ib_port,
+                         gid_index=gid_index)
+        self.msg_size = msg_size
+        self.new_mr_lkey = None
+
+    def create_mr(self):
+        try:
+            self.mr = MR(self.pd, self.msg_size, self.mr_access)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Reg MR with access ({self.mr_access}) is not supported')
+            raise ex
+
+    def create_qp_init_attr(self):
+        return QPInitAttr(qp_type=e.IBV_QPT_RC, scq=self.cq, sq_sig_all=0,
+                          rcq=self.cq, srq=self.srq, cap=self.create_qp_cap())
+
+    def create_qp_attr(self):
+        qp_attr = QPAttr(port_num=self.ib_port)
+        qp_attr.qp_access_flags = self.qp_access
+        return qp_attr
+
+    @property
+    def mr_lkey(self):
+        return self.new_mr_lkey if self.new_mr_lkey is not None else self.mr.lkey
+
+
+class XRCAtomic(XRCResources):
+    def create_mr(self):
+        try:
+            atomic_access = e.IBV_ACCESS_LOCAL_WRITE | \
+                e.IBV_ACCESS_REMOTE_ATOMIC
+            self.mr = MR(self.pd, self.msg_size, atomic_access)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Reg MR with access ({atomic_access}) is not supported')
+            raise ex
+
+
+class AtomicTest(RDMATestCase):
+    """
+    Test various functionalities of the DM class.
+    """
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.server = None
+        self.client = None
+        self.traffic_args = None
+        ctx = d.Context(name=self.dev_name)
+        if ctx.query_device().atomic_caps == e.IBV_ATOMIC_NONE:
+            raise unittest.SkipTest('Atomic operations are not supported')
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init Atomic tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.sync_remote_attr()
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
+
+    def sync_remote_attr(self):
+        """
+        Sync the MR remote attributes between the server and the client.
+        """
+        self.server.rkey = self.client.mr.rkey
+        self.server.raddr = self.client.mr.buf
+        self.client.rkey = self.server.mr.rkey
+        self.client.raddr = self.server.mr.buf
+
+    def test_atomic_cmp_and_swap(self):
+        self.create_players(RCAtomic)
+        u.atomic_traffic(**self.traffic_args, send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
+        u.atomic_traffic(**self.traffic_args, send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP,
+                         receiver_val=1, sender_val=1)
+
+    def test_atomic_fetch_and_add(self):
+        self.create_players(RCAtomic)
+        u.atomic_traffic(**self.traffic_args,
+                         send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_xrc_atomic_fetch_and_add(self):
+        self.create_players(XRCAtomic)
+        u.atomic_traffic(**self.traffic_args,
+                         send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_xrc_atomic_cmp_and_swap(self):
+        self.create_players(XRCAtomic)
+        u.atomic_traffic(**self.traffic_args, send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
+        u.atomic_traffic(**self.traffic_args, send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP,
+                         receiver_val=1, sender_val=1)
+
+    def test_atomic_invalid_qp_access(self):
+        self.create_players(RCAtomic, qp_access=e.IBV_ACCESS_LOCAL_WRITE)
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            u.atomic_traffic(**self.traffic_args,
+                             send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_atomic_invalid_mr_access(self):
+        self.create_players(RCAtomic, mr_access=e.IBV_ACCESS_LOCAL_WRITE)
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            u.atomic_traffic(**self.traffic_args,
+                             send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_atomic_non_aligned_addr(self):
+        self.create_players(RCAtomic, msg_size=9)
+        self.client.raddr += 1
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            u.atomic_traffic(**self.traffic_args,
+                             send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_atomic_invalid_lkey(self):
+        self.create_players(RCAtomic)
+        self.client.new_mr_lkey = self.client.mr.lkey + 1
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            u.atomic_traffic(**self.traffic_args,
+                             send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
+
+    def test_atomic_invalid_rkey(self):
+        self.create_players(RCAtomic)
+        self.client.rkey += 1
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            u.atomic_traffic(**self.traffic_args,
+                             send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -248,8 +248,9 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         server.mr.write('s' * 8, 8)
-        u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP)
+        u.atomic_traffic(client, server, self.iters, self.gid_index,
+                         self.ib_port, new_send=True,
+                         send_op=e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP)
 
     def test_qp_ex_rc_atomic_fetch_add(self):
         client, server = self.create_players('rc_fetch_add')
@@ -260,8 +261,9 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         server.mr.write('s' * 8, 8)
-        u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
+        u.atomic_traffic(client, server, self.iters, self.gid_index,
+                         self.ib_port, new_send=True,
+                         send_op=e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
 
     def test_qp_ex_rc_bind_mw(self):
         """

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -454,11 +454,11 @@ def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
     elif send_op == e.IBV_QP_EX_WITH_RDMA_READ:
         qp.wr_rdma_read(agr_obj.rkey, agr_obj.raddr)
     elif send_op == e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP:
-        # We're checking the returned value (remote's content), so cmp/swp
-        # values are of no importance.
-        qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr, 42, 43)
+        qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr,
+                             int8b_from_int(2), int8b_from_int(0))
     elif send_op == e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD:
-        qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr, 1)
+        qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr,
+                               int8b_from_int(2))
     elif send_op == e.IBV_QP_EX_WITH_BIND_MW:
         bind_info = MWBindInfo(agr_obj.mr, agr_obj.mr.buf, agr_obj.mr.rkey,
                                e.IBV_ACCESS_REMOTE_WRITE)
@@ -893,6 +893,110 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
                  client.msg_size)
         if same_side_check:
             server.mr.write('s' * server.msg_size, server.msg_size)
+
+
+def atomic_traffic(client, server, iters, gid_idx, port, new_send=False,
+                   send_op=None, receiver_val=1, sender_val=2):
+    """
+    Runs atomic traffic between two sides.
+    :param client: Client side, clients base class is BaseTraffic
+    :param server: Server side, servers base class is BaseTraffic
+    :param iters: Number of traffic iterations
+    :param gid_idx: Local gid index
+    :param port: IB port
+    :param new_send: If True use new post send API.
+    :param send_op: The send_wr opcode.
+    :param receiver_val: The requested value on the reciver MR.
+    :param sender_val: The requested value on the sender SendWR.
+    """
+    send_element_idx = 1 if new_send else 0
+    for _ in range(iters):
+        client.mr.write(int.to_bytes(sender_val, 1, byteorder='big') * 8, 8)
+        server.mr.write(int.to_bytes(receiver_val, 1, byteorder='big') * 8, 8)
+        c_send_wr = get_atomic_send_elements(client, send_op,
+                                             cmp_add=sender_val,
+                                             swap=0)[send_element_idx]
+        if isinstance(server, XRCResources):
+            c_send_wr.set_qp_type_xrc(server.srq.get_srq_num())
+        send(client, c_send_wr, send_op, new_send)
+        poll_cq(client.cq)
+        validate_atomic(send_op, server, client, receiver_val=receiver_val,
+                        send_cmp_add=sender_val, send_swp=0)
+        server.mr.write(int.to_bytes(sender_val, 1, byteorder='big') * 8, 8)
+        client.mr.write(int.to_bytes(receiver_val, 1, byteorder='big') * 8, 8)
+        s_send_wr = get_atomic_send_elements(server, send_op,
+                                             cmp_add=sender_val,
+                                             swap=0)[send_element_idx]
+        if isinstance(client, XRCResources):
+            s_send_wr.set_qp_type_xrc(client.srq.get_srq_num())
+        send(server, s_send_wr, send_op, new_send)
+        poll_cq(server.cq)
+        validate_atomic(send_op, client, server, receiver_val=receiver_val,
+                        send_cmp_add=sender_val, send_swp=0)
+
+
+def validate_atomic(opcode, recv_player, send_player, receiver_val,
+                    send_cmp_add, send_swp):
+    """
+    Validate the data after atomic operations. The expected data in each side of
+    traffic depends on the atomic type and the sender SendWR values.
+    :param opcode: The atomic opcode.
+    :param recv_player: The receiver player.
+    :param send_player: The sender player.
+    :param receiver_val: The value on the receiver MR before the atomic action.
+    :param send_cmp_add: The send WR compare/add value depende on the atomic
+                         type.
+    :param send_swp: The send WR swap value, used only in atomic compare and
+                     swap.
+    """
+    send_expected = receiver_val
+    if opcode in [e.IBV_WR_ATOMIC_CMP_AND_SWP,
+                  e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP]:
+        recv_expected = send_swp if receiver_val == send_cmp_add \
+            else receiver_val
+    if opcode in [e.IBV_WR_ATOMIC_FETCH_AND_ADD,
+                  e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD]:
+        recv_expected = receiver_val + send_cmp_add
+    send_actual = int.from_bytes(send_player.mr.read(length=8, offset=0),
+                                 byteorder='big')
+    recv_actual = int.from_bytes(recv_player.mr.read(length=8, offset=0),
+                                 byteorder='big')
+    if send_actual != int8b_from_int(send_expected):
+        raise PyverbsError(
+            'Atomic sender data validation failed: expected {exp}, received {rcv}'.
+                format(exp=int8b_from_int(send_expected), rcv=send_actual))
+    if recv_actual != int8b_from_int(recv_expected):
+        raise PyverbsError(
+            'Atomic reciver data validation failed: expected {exp}, received {rcv}'.
+                format(exp=int8b_from_int(recv_expected), rcv=recv_actual))
+
+
+def int8b_from_int(num):
+    """
+    Duplicate one-byte value int to 8 bytes.
+    e.g. 1 => b'\x01\x01\x01\x01\x01\x01\x01\x01' == 72340172838076673
+    :param num: One byte int number (0 <= num < 256).
+    :return: The new number in int format.
+    """
+    num_multi_8_str = int.to_bytes(num, 1, byteorder='big') * 8
+    return int.from_bytes(num_multi_8_str, byteorder='big')
+
+
+def get_atomic_send_elements(agr_obj, opcode, cmp_add=0, swap=0):
+    """
+    Creates a single SGE and a single Send WR for atomic operations.
+    :param agr_obj: Aggregation object which contains all resources necessary
+    :param opcode: The send opcode
+    :param cmp_add: The compare or add value (depends on the opcode).
+    :param swap: The swap value.
+    :return: Send WR and its SGE
+    """
+    sge = SGE(agr_obj.mr.buf, 8, agr_obj.mr_lkey)
+    send_wr = SendWR(opcode=opcode, num_sge=1, sg=[sge])
+    send_wr.set_wr_atomic(rkey=int(agr_obj.rkey), addr=int(agr_obj.raddr),
+                          compare_add=int8b_from_int(cmp_add),
+                          swap=int8b_from_int(swap))
+    return send_wr, sge
 
 
 def xrc_traffic(client, server, is_cq_ex=False, send_op=None):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -383,7 +383,7 @@ def get_send_elements(agr_obj, is_server, opcode=e.IBV_WR_SEND):
     offset = GRH_SIZE if qp_type == e.IBV_QPT_UD else 0
     msg = (agr_obj.msg_size + offset) * ('s' if is_server else 'c')
     mr.write(msg, agr_obj.msg_size + offset)
-    sge = SGE(mr.buf + offset, agr_obj.msg_size, mr.lkey)
+    sge = SGE(mr.buf + offset, agr_obj.msg_size, agr_obj.mr_lkey)
     send_wr = SendWR(opcode=opcode, num_sge=1, sg=[sge])
     if opcode in [e.IBV_WR_RDMA_WRITE, e.IBV_WR_RDMA_READ]:
         send_wr.set_wr_rdma(int(agr_obj.rkey), int(agr_obj.remote_addr))
@@ -616,6 +616,8 @@ def validate(received_str, is_server, msg_size):
 
 
 def send(agr_obj, send_object, send_op=None, new_send=False, qp_idx=0, ah=None, is_imm=False):
+    if isinstance(agr_obj, XRCResources):
+        agr_obj.qps = agr_obj.sqp_lst
     if new_send:
         return post_send_ex(agr_obj, send_object, send_op, qp_idx, ah)
     return post_send(agr_obj, send_object, qp_idx, ah, is_imm)


### PR DESCRIPTION
Add new atomic traffic tests to cover multiple atomic flows.
The tests cover both FETCH_AND_ADD and CMP_AND_SWP opcodes including
data validation and some bad flows.