### PR TITLE
tests: Fix exception handling in QpExTestCase

### DIFF
--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -177,8 +177,9 @@ class QpExTestCase(RDMATestCase):
             server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
                                            self.gid_index)
         except PyverbsRDMAError as ex:
-           if ex.error_code == errno.EOPNOTSUPP:
+            if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Create player with {} is not supported'.format(qp_type))
+            raise ex
         client.pre_run(server.psns, server.qps_num)
         server.pre_run(client.psns, client.qps_num)
         return client, server


### PR DESCRIPTION
The exception must be raised again to avoid the fall-through to the
rest of the test.

Additionally, the "if" statement checking for EOPNOTSUPP was not
properly aligned.

Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>


# Background
We had a case where `ibv_reg_mr(3)` was failing, but the error reported by the test suite was confusing as the test ignored the exception being thrown:
```console
$ ./build/bin/run_tests.py -v -k test_qp_ex
[...]
======================================================================
ERROR: test_qp_ex_rc_atomic_cmp_swp (tests.test_qpex.QpExTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/rdma-core/tests/test_qpex.py", line 243, in test_qp_ex_rc_atomic_cmp_swp
    client, server = self.create_players('rc_cmp_swp')
  File "/workspace/rdma-core/tests/test_qpex.py", line 182, in create_players
    client.pre_run(server.psns, server.qps_num)
UnboundLocalError: local variable 'client' referenced before assignment
```

With this commit, the error message is now propagated correctly:
```console
======================================================================
ERROR: test_qp_ex_rc_atomic_cmp_swp (tests.test_qpex.QpExTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/workspace/rdma-core/tests/test_qpex.py", line 249, in test_qp_ex_rc_atomic_cmp_swp
    client, server = self.create_players('rc_cmp_swp')
  File "/workspace/rdma-core/tests/test_qpex.py", line 176, in create_players
    client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
  File "/workspace/rdma-core/tests/base.py", line 499, in __init__
    self.init_resources()
  File "/workspace/rdma-core/tests/base.py", line 514, in init_resources
    self.create_mr()
  File "/workspace/rdma-core/tests/base.py", line 531, in create_mr
    self.mr = MR(self.pd, self.msg_size, e.IBV_ACCESS_LOCAL_WRITE)
  File "mr.pyx", line 115, in pyverbs.mr.MR.__init__
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to register a MR. length: 1024, access flags: 1. Errno: 14, Bad address
```