### PR TITLE
mlx5: Fix compilation on 32 bit systems with gcc 7.5

### DIFF
--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -3051,7 +3051,7 @@ static inline void mlx5_wr_memcpy(struct mlx5dv_qp_ex *mqp_ex,
 	dma_wqe = (struct mlx5_mmo_wqe *)mqp->cur_ctrl;
 	dma_wqe->mmo_meta.mmo_control_31_0 = 0;
 	dma_wqe->mmo_meta.local_key = htobe32(mpd->opaque_mr->lkey);
-	dma_wqe->mmo_meta.local_address = htobe64((uint64_t)mpd->opaque_buf);
+	dma_wqe->mmo_meta.local_address = htobe64((uint64_t)(uintptr_t)mpd->opaque_buf);
 
 	mlx5dv_set_data_seg(&dma_wqe->src, length, src_lkey, src_addr);
 	mlx5dv_set_data_seg(&dma_wqe->dest, length, dest_lkey, dest_addr);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2212,7 +2212,7 @@ static int reg_opaque_mr(struct ibv_pd *pd)
 
 	mpd->opaque_mr =
 		mlx5_reg_mr(&mpd->ibv_pd, mpd->opaque_buf, MLX5_OPAQUE_BUF_LEN,
-			    (uint64_t)mpd->opaque_buf, IBV_ACCESS_LOCAL_WRITE);
+			    (uint64_t)(uintptr_t)mpd->opaque_buf, IBV_ACCESS_LOCAL_WRITE);
 	if (!mpd->opaque_mr) {
 		ret = errno;
 		free(mpd->opaque_buf);


### PR DESCRIPTION
Fix some compilation issues as of below on 32 bit systems with gcc 7.5.
error: cast from pointer to integer of different size [-Werror=pointer-to-int-cast]