### PR TITLE
man page: Fix return value for ibv_advise_mr()

### DIFF
--- a/libibverbs/man/ibv_advise_mr.3.md
+++ b/libibverbs/man/ibv_advise_mr.3.md
@@ -95,7 +95,19 @@ application performance.
 :	In one of the following:
 	o The PD is invalid.
 	o The flags are invalid.
+	o The requested address doesn't belong to a MR, but a MW or something.
 
+*EPERM*
+:	In one of the following:
+	o Referencing a valid lkey outside the caller's security scope.
+	o The advice is IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE but the specified
+	  MR in the scatter gather list is not registered as writable access.
+
+*ENOENT*
+:	The providing lkeys aren't consistent with the MR's.
+
+*ENOMEM*
+:	Not enough memory.
 # NOTES
 
 An application may pre-fetch any address range within an ODP MR when using the


### PR DESCRIPTION
According to the linux kernel implementation by mlx5[1], EINVAL will be
returned in the case the avdice is IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE but
the specified MR in the scatter gather list is not registered as writable
access.

[1]: https://elixir.bootlin.com/linux/v5.13.11/source/drivers/infiniband/hw/mlx5/odp.c#L1719

Signed-off-by: Li Zhijian <lizhijian@cn.fujitsu.com>