### PR TITLE
mlx5: DR, Enhance the support in few areas

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -135,6 +135,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_qp_cancel_posted_send_wrs@MLX5_1.20 36
  _mlx5dv_mkey_check@MLX5_1.20 36
  mlx5dv_dci_stream_id_reset@MLX5_1.21 37
+ mlx5dv_dr_action_create_dest_ib_port@MLX5_1.21 37
  mlx5dv_dr_matcher_set_layout@MLX5_1.21 37
  mlx5dv_get_vfio_device_list@MLX5_1.21 37
  mlx5dv_vfio_get_events_fd@MLX5_1.21 37

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -29,6 +29,7 @@ rdma_shared_provider(mlx5 libmlx5.map
   dr_ste_v1.c
   dr_table.c
   dr_send.c
+  dr_vports.c
   mlx5.c
   mlx5_vfio.c
   qp.c

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -744,7 +744,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			}
 			if (rx_rule) {
 				/* Loopback on WIRE vport is not supported */
-				if (action->vport.num == WIRE_PORT)
+				if (action->vport.caps->num == WIRE_PORT)
 					goto out_invalid_arg;
 
 				attr.final_icm_addr = action->vport.caps->icm_address_rx;
@@ -2075,7 +2075,14 @@ struct mlx5dv_dr_action
 		return NULL;
 	}
 
-	vport_cap = dr_get_vport_cap(&dmn->info.caps, vport);
+	/* vport number is limited to 16 bit */
+	if (vport > WIRE_PORT) {
+		dr_dbg(dmn, "The vport number is out of range\n");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	vport_cap = dr_vports_table_get_vport_cap(&dmn->info.caps, vport);
 	if (!vport_cap) {
 		dr_dbg(dmn, "Failed to get vport %d caps\n", vport);
 		return NULL;
@@ -2086,7 +2093,6 @@ struct mlx5dv_dr_action
 		return NULL;
 
 	action->vport.dmn = dmn;
-	action->vport.num = vport;
 	action->vport.caps = vport_cap;
 
 	return action;
@@ -2115,7 +2121,7 @@ dr_action_convert_to_fte_dest(struct mlx5dv_dr_domain *dmn,
 
 		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
 		dest_info->type = MLX5_FLOW_DEST_TYPE_VPORT;
-		dest_info->vport_num = dest->vport.num;
+		dest_info->vport_num = dest->vport.caps->num;
 		break;
 	case DR_ACTION_TYP_QP:
 		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -2098,6 +2098,37 @@ struct mlx5dv_dr_action
 	return action;
 }
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_ib_port(struct mlx5dv_dr_domain *dmn,
+				     uint32_t ib_port)
+{
+	struct dr_devx_vport_cap *vport_cap;
+	struct mlx5dv_dr_action *action;
+
+	if (!dmn->info.supp_sw_steering ||
+	    dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB) {
+		dr_dbg(dmn, "Domain doesn't support ib_port actions\n");
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	vport_cap = dr_vports_table_get_ib_port_cap(&dmn->info.caps, ib_port);
+	if (!vport_cap) {
+		dr_dbg(dmn, "Failed to get ib_port %d caps\n", ib_port);
+		errno = EINVAL;
+		return NULL;
+	}
+
+	action = dr_action_create_generic(DR_ACTION_TYP_VPORT);
+	if (!action)
+		return NULL;
+
+	action->vport.dmn = dmn;
+	action->vport.caps = vport_cap;
+
+	return action;
+}
+
 static int
 dr_action_convert_to_fte_dest(struct mlx5dv_dr_domain *dmn,
 			      struct mlx5dv_dr_action *dest,

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -158,7 +158,7 @@ static int dr_domain_query_esw_mgr(struct mlx5dv_dr_domain *dmn,
 {
 	int ret;
 
-	/* Query E-Switch manager */
+	/* Query E-Switch manager PF/ECPF */
 	ret = dr_devx_query_esw_vport_context(dmn->ctx, false, 0,
 					      &esw_mngr->icm_address_rx,
 					      &esw_mngr->icm_address_tx);

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -113,21 +113,61 @@ static void dr_free_resources(struct mlx5dv_dr_domain *dmn)
 	ibv_dealloc_pd(dmn->pd);
 }
 
-static int dr_query_vport_cap(struct ibv_context *ctx, uint16_t vport_number,
-			      struct dr_devx_vport_cap *cap)
+static int dr_domain_vports_init(struct mlx5dv_dr_domain *dmn)
 {
-	bool other_vport = vport_number ? true : false;
+	struct dr_devx_vports *vports = &dmn->info.caps.vports;
 	int ret;
 
-	ret = dr_devx_query_esw_vport_context(ctx, other_vport, vport_number,
-					      &cap->icm_address_rx,
-					      &cap->icm_address_tx);
+	ret = pthread_spin_init(&vports->lock,
+				PTHREAD_PROCESS_PRIVATE);
+	if (ret) {
+		errno = ret;
+		return ret;
+	}
+
+	vports->vports = dr_vports_table_create(dmn);
+	if (!vports->vports)
+		goto free_spin_lock;
+
+	dr_vports_table_add_wire(vports);
+	return 0;
+
+free_spin_lock:
+	pthread_spin_destroy(&vports->lock);
+	return errno;
+}
+
+static void dr_domain_vports_uninit(struct mlx5dv_dr_domain *dmn)
+{
+	struct dr_devx_vports *vports = &dmn->info.caps.vports;
+
+	if (vports->vports) {
+		/* Wire port must be deleted before destroying vports table,
+		 * since it is not allocated dynamically but inserted to table
+		 * as such.
+		 */
+		dr_vports_table_del_wire(vports);
+		dr_vports_table_destroy(vports->vports);
+		vports->vports = NULL;
+	}
+	pthread_spin_destroy(&vports->lock);
+}
+
+static int dr_domain_query_esw_mgr(struct mlx5dv_dr_domain *dmn,
+				   struct dr_devx_vport_cap *esw_mngr)
+{
+	int ret;
+
+	/* Query E-Switch manager */
+	ret = dr_devx_query_esw_vport_context(dmn->ctx, false, 0,
+					      &esw_mngr->icm_address_rx,
+					      &esw_mngr->icm_address_tx);
 	if (ret)
 		return ret;
 
-	ret = dr_devx_query_gvmi(ctx, other_vport, vport_number, &cap->gvmi);
-	if (ret)
-		return ret;
+	/* E-Switch manager gvmi and vhca id are the same */
+	esw_mngr->vhca_gvmi = dmn->info.caps.gvmi;
+	esw_mngr->vport_gvmi = dmn->info.caps.gvmi;
 
 	return 0;
 }
@@ -135,56 +175,45 @@ static int dr_query_vport_cap(struct ibv_context *ctx, uint16_t vport_number,
 static int dr_domain_query_fdb_caps(struct ibv_context *ctx,
 				    struct mlx5dv_dr_domain *dmn)
 {
+	struct dr_devx_vports *vports = &dmn->info.caps.vports;
 	struct dr_esw_caps esw_caps = {};
-	uint32_t num_vports;
 	int ret;
-	int i;
 
 	if (!dmn->info.caps.eswitch_manager)
 		return 0;
 
-	num_vports = dmn->info.attr.phys_port_cnt_ex - 1;
-	dmn->info.caps.vports_caps = calloc(num_vports + 1,
-					    sizeof(struct dr_devx_vport_cap));
-	if (!dmn->info.caps.vports_caps) {
-		errno = ENOMEM;
-		return errno;
-	}
+	ret = dr_domain_query_esw_mgr(dmn, &vports->esw_mngr);
+	if (ret)
+		return ret;
 
-	/* Query vports */
-	for (i = 0; i < num_vports; i++) {
-		ret = dr_query_vport_cap(ctx, i, &dmn->info.caps.vports_caps[i]);
-		if (ret)
-			goto err;
-	}
-
-	/* Query uplink */
 	ret = dr_devx_query_esw_caps(ctx, &esw_caps);
 	if (ret)
-		goto err;
+		return ret;
 
+	vports->num_ports = dmn->info.attr.phys_port_cnt_ex;
+
+	/* Set uplink */
+	vports->wire.icm_address_rx = esw_caps.uplink_icm_address_rx;
+	vports->wire.icm_address_tx = esw_caps.uplink_icm_address_tx;
+	vports->wire.vhca_gvmi = vports->esw_mngr.vhca_gvmi;
+	vports->wire.num = WIRE_PORT;
+
+	/* Set FDB general caps */
 	dmn->info.caps.fdb_sw_owner = esw_caps.sw_owner;
 	dmn->info.caps.fdb_sw_owner_v2 = esw_caps.sw_owner_v2;
-	dmn->info.caps.vports_caps[i].icm_address_rx = esw_caps.uplink_icm_address_rx;
-	dmn->info.caps.vports_caps[i].icm_address_tx = esw_caps.uplink_icm_address_tx;
 	dmn->info.caps.esw_rx_drop_address = esw_caps.drop_icm_address_rx;
 	dmn->info.caps.esw_tx_drop_address = esw_caps.drop_icm_address_tx;
-	dmn->info.caps.num_vports = num_vports;
 
 	return 0;
-
-err:
-	free(dmn->info.caps.vports_caps);
-	dmn->info.caps.vports_caps = NULL;
-	return ret;
 }
 
 static int dr_domain_caps_init(struct ibv_context *ctx,
 			       struct mlx5dv_dr_domain *dmn)
 {
-	struct dr_devx_vport_cap *vport_cap;
 	struct ibv_port_attr port_attr = {};
 	int ret;
+
+	dmn->info.caps.dmn = dmn;
 
 	ret = ibv_query_port(ctx, 1, &port_attr);
 	if (ret) {
@@ -216,9 +245,13 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 	    !dr_send_allow_fl(&dmn->info.caps))
 		return 0;
 
-	ret = dr_domain_query_fdb_caps(ctx, dmn);
+	ret = dr_domain_vports_init(dmn);
 	if (ret)
 		return ret;
+
+	ret = dr_domain_query_fdb_caps(ctx, dmn);
+	if (ret)
+		goto uninit_vports;
 
 	switch (dmn->type) {
 	case MLX5DV_DR_DOMAIN_TYPE_NIC_RX:
@@ -254,15 +287,10 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 
 		dmn->info.rx.type = DR_DOMAIN_NIC_TYPE_RX;
 		dmn->info.tx.type = DR_DOMAIN_NIC_TYPE_TX;
-		vport_cap = dr_get_vport_cap(&dmn->info.caps, 0);
-		if (!vport_cap) {
-			dr_dbg(dmn, "Failed to get eswitch manager vport\n");
-			return errno;
-		}
 
 		dmn->info.supp_sw_steering = true;
-		dmn->info.tx.default_icm_addr = vport_cap->icm_address_tx;
-		dmn->info.rx.default_icm_addr = vport_cap->icm_address_rx;
+		dmn->info.tx.default_icm_addr = dmn->info.caps.vports.esw_mngr.icm_address_tx;
+		dmn->info.rx.default_icm_addr = dmn->info.caps.vports.esw_mngr.icm_address_rx;
 		dmn->info.rx.drop_icm_addr = dmn->info.caps.esw_rx_drop_address;
 		dmn->info.tx.drop_icm_addr = dmn->info.caps.esw_tx_drop_address;
 		break;
@@ -273,12 +301,15 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 	}
 
 	return ret;
+
+uninit_vports:
+	dr_domain_vports_uninit(dmn);
+	return ret;
 }
 
 static void dr_domain_caps_uninit(struct mlx5dv_dr_domain *dmn)
 {
-	if (dmn->info.caps.vports_caps)
-		free(dmn->info.caps.vports_caps);
+	dr_domain_vports_uninit(dmn);
 }
 
 bool dr_domain_is_support_ste_icm_size(struct mlx5dv_dr_domain *dmn,

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -375,7 +375,15 @@ static bool dr_mask_is_flex_parser_0_3_set(struct dr_match_misc4 *misc4)
 		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_2,
 			misc4->prog_sample_field_value_2) ||
 		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_3,
-			misc4->prog_sample_field_value_3));
+			misc4->prog_sample_field_value_3) ||
+		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_4,
+			misc4->prog_sample_field_value_4) ||
+		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_5,
+			misc4->prog_sample_field_value_5) ||
+		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_6,
+			misc4->prog_sample_field_value_6) ||
+		dr_mask_is_flex_parser_id_0_3_set(misc4->prog_sample_field_id_7,
+			misc4->prog_sample_field_value_7));
 }
 
 static bool dr_mask_is_flex_parser_id_4_7_set(uint32_t flex_parser_id)
@@ -389,7 +397,11 @@ static bool dr_mask_is_flex_parser_4_7_set(struct dr_match_misc4 *misc4)
 	return (dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_0) ||
 		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_1) ||
 		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_2) ||
-		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_3));
+		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_3) ||
+		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_4) ||
+		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_5) ||
+		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_6) ||
+		dr_mask_is_flex_parser_id_4_7_set(misc4->prog_sample_field_id_7));
 }
 
 static bool dr_mask_is_tunnel_header_0_1_set(struct dr_match_misc5 *misc5)

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -949,6 +949,22 @@ static void dr_ste_copy_mask_misc4(char *mask, struct dr_match_misc4 *spec)
 		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_id_3);
 	spec->prog_sample_field_value_3 =
 		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_value_3);
+	spec->prog_sample_field_id_4 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_id_4);
+	spec->prog_sample_field_value_4 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_value_4);
+	spec->prog_sample_field_id_5 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_id_5);
+	spec->prog_sample_field_value_5 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_value_5);
+	spec->prog_sample_field_id_6 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_id_6);
+	spec->prog_sample_field_value_6 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_value_6);
+	spec->prog_sample_field_id_7 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_id_7);
+	spec->prog_sample_field_value_7 =
+		DEVX_GET(dr_match_set_misc4, mask, prog_sample_field_value_7);
 }
 
 static void dr_ste_copy_mask_misc5(char *mask, struct dr_match_misc5 *spec)

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -1732,15 +1732,24 @@ static void dr_ste_v0_build_src_gvmi_qpn_init(struct dr_ste_build *sb,
 	sb->ste_build_tag_func = &dr_ste_v0_build_src_gvmi_qpn_tag;
 }
 
-static void dr_ste_set_flex_parser(uint32_t *misc4_field_id,
+static void dr_ste_set_flex_parser(uint16_t lu_type,
+				   uint32_t *misc4_field_id,
 				   uint32_t *misc4_field_value,
 				   bool *parser_is_used,
 				   uint8_t *tag)
 {
 	uint32_t id = *misc4_field_id;
 	uint8_t *parser_ptr;
+	bool skip_parser;
 
-	if (parser_is_used[id])
+	/* Since this is a shared function to set flex parsers,
+	 * we need to skip it if lookup type and parser ID doesn't match
+	 */
+	skip_parser = id <= DR_STE_MAX_FLEX_0_ID ?
+		      lu_type != DR_STE_V0_LU_TYPE_FLEX_PARSER_0 :
+		      lu_type != DR_STE_V0_LU_TYPE_FLEX_PARSER_1;
+
+	if (skip_parser || parser_is_used[id])
 		return;
 
 	parser_is_used[id] = true;
@@ -1758,22 +1767,45 @@ static int dr_ste_v0_build_flex_parser_tag(struct dr_match_param *value,
 	struct dr_match_misc4 *misc_4_mask = &value->misc4;
 	bool parser_is_used[NUM_OF_FLEX_PARSERS] = {};
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_0,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_0,
 			       &misc_4_mask->prog_sample_field_value_0,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_1,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_1,
 			       &misc_4_mask->prog_sample_field_value_1,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_2,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_2,
 			       &misc_4_mask->prog_sample_field_value_2,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_3,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_3,
 			       &misc_4_mask->prog_sample_field_value_3,
 			       parser_is_used, tag);
 
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_4,
+			       &misc_4_mask->prog_sample_field_value_4,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_5,
+			       &misc_4_mask->prog_sample_field_value_5,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_6,
+			       &misc_4_mask->prog_sample_field_value_6,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_7,
+			       &misc_4_mask->prog_sample_field_value_7,
+			       parser_is_used, tag);
 	return 0;
 }
 

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -1708,12 +1708,13 @@ static int dr_ste_v0_build_src_gvmi_qpn_tag(struct dr_match_param *value,
 
 	source_gvmi_set = DR_STE_GET(src_gvmi_qp, bit_mask, source_gvmi);
 	if (source_gvmi_set) {
-		vport_cap = dr_get_vport_cap(sb->caps, misc->source_port);
+		vport_cap = dr_vports_table_get_vport_cap(sb->caps,
+							  misc->source_port);
 		if (!vport_cap)
 			return errno;
 
-		if (vport_cap->gvmi)
-			DR_STE_SET(src_gvmi_qp, tag, source_gvmi, vport_cap->gvmi);
+		if (vport_cap->vport_gvmi)
+			DR_STE_SET(src_gvmi_qp, tag, source_gvmi, vport_cap->vport_gvmi);
 
 		misc->source_port = 0;
 	}

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2143,15 +2143,24 @@ static void dr_ste_v1_build_src_gvmi_qpn_init(struct dr_ste_build *sb,
 	sb->ste_build_tag_func = &dr_ste_v1_build_src_gvmi_qpn_tag;
 }
 
-static void dr_ste_set_flex_parser(uint32_t *misc4_field_id,
+static void dr_ste_set_flex_parser(uint16_t lu_type,
+				   uint32_t *misc4_field_id,
 				   uint32_t *misc4_field_value,
 				   bool *parser_is_used,
 				   uint8_t *tag)
 {
 	uint32_t id = *misc4_field_id;
 	uint8_t *parser_ptr;
+	bool skip_parser;
 
-	if (parser_is_used[id])
+	/* Since this is a shared function to set flex parsers,
+	 * we need to skip it if lookup type and parser ID doesn't match
+	 */
+	skip_parser = id <= DR_STE_MAX_FLEX_0_ID ?
+		      lu_type != DR_STE_V1_LU_TYPE_FLEX_PARSER_0 :
+		      lu_type != DR_STE_V1_LU_TYPE_FLEX_PARSER_1;
+
+	if (skip_parser || parser_is_used[id])
 		return;
 
 	parser_is_used[id] = true;
@@ -2169,22 +2178,45 @@ static int dr_ste_v1_build_felx_parser_tag(struct dr_match_param *value,
 	struct dr_match_misc4 *misc_4_mask = &value->misc4;
 	bool parser_is_used[NUM_OF_FLEX_PARSERS] = {};
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_0,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_0,
 			       &misc_4_mask->prog_sample_field_value_0,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_1,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_1,
 			       &misc_4_mask->prog_sample_field_value_1,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_2,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_2,
 			       &misc_4_mask->prog_sample_field_value_2,
 			       parser_is_used, tag);
 
-	dr_ste_set_flex_parser(&misc_4_mask->prog_sample_field_id_3,
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_3,
 			       &misc_4_mask->prog_sample_field_value_3,
 			       parser_is_used, tag);
 
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_4,
+			       &misc_4_mask->prog_sample_field_value_4,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_5,
+			       &misc_4_mask->prog_sample_field_value_5,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_6,
+			       &misc_4_mask->prog_sample_field_value_6,
+			       parser_is_used, tag);
+
+	dr_ste_set_flex_parser(sb->lu_type,
+			       &misc_4_mask->prog_sample_field_id_7,
+			       &misc_4_mask->prog_sample_field_value_7,
+			       parser_is_used, tag);
 	return 0;
 }
 

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2119,12 +2119,13 @@ static int dr_ste_v1_build_src_gvmi_qpn_tag(struct dr_match_param *value,
 
 	source_gvmi_set = DR_STE_GET(src_gvmi_qp_v1, bit_mask, source_gvmi);
 	if (source_gvmi_set) {
-		vport_cap = dr_get_vport_cap(sb->caps, misc->source_port);
+		vport_cap = dr_vports_table_get_vport_cap(sb->caps,
+							  misc->source_port);
 		if (!vport_cap)
 			return errno;
 
-		if (vport_cap->gvmi)
-			DR_STE_SET(src_gvmi_qp_v1, tag, source_gvmi, vport_cap->gvmi);
+		if (vport_cap->vport_gvmi)
+			DR_STE_SET(src_gvmi_qp_v1, tag, source_gvmi, vport_cap->vport_gvmi);
 
 		misc->source_port = 0;
 	}
@@ -2428,12 +2429,13 @@ static int dr_ste_v1_build_def16_tag(struct dr_match_param *value,
 
 	source_gvmi_set = DR_STE_GET(def16_v1, sb->match, source_gvmi);
 	if (source_gvmi_set) {
-		vport_cap = dr_get_vport_cap(sb->caps, misc->source_port);
+		vport_cap = dr_vports_table_get_vport_cap(sb->caps,
+							  misc->source_port);
 		if (!vport_cap)
 			return errno;
 
-		if (vport_cap->gvmi)
-			DR_STE_SET(def16_v1, tag, source_gvmi, vport_cap->gvmi);
+		if (vport_cap->vport_gvmi)
+			DR_STE_SET(def16_v1, tag, source_gvmi, vport_cap->vport_gvmi);
 
 		misc->source_port = 0;
 	}

--- a/providers/mlx5/dr_vports.c
+++ b/providers/mlx5/dr_vports.c
@@ -102,8 +102,11 @@ struct dr_devx_vport_cap *
 dr_vports_table_get_vport_cap(struct dr_devx_caps *caps, uint16_t vport)
 {
 	struct dr_devx_vports *vports = &caps->vports;
+	bool other_vport = !!vport || caps->is_ecpf;
 	struct dr_devx_vport_cap *vport_cap;
-	bool other_vport = !!vport;
+
+	if (vport == ECPF_PORT && caps->is_ecpf)
+		return &vports->esw_mngr;
 
 	/* no lock on vport_find since table is updated atomically */
 	vport_cap = dr_vports_table_find_vport_num(vports->vports,

--- a/providers/mlx5/dr_vports.c
+++ b/providers/mlx5/dr_vports.c
@@ -15,6 +15,28 @@ static int dr_vports_calc_bucket_idx(uint32_t vport_key)
 	return vport_key % DR_VPORTS_BUCKETS;
 }
 
+static struct dr_devx_vport_cap *
+dr_vports_table_find_vport_num(struct dr_vports_table *h, uint16_t vhca_gvmi,
+			       uint16_t vport_num)
+{
+	struct dr_devx_vport_cap *vport_cap;
+	uint32_t vport_key;
+	uint32_t idx;
+
+	vport_key = dr_vports_gen_vport_key(vhca_gvmi, vport_num);
+	idx = dr_vports_calc_bucket_idx(vport_key);
+
+	vport_cap = h->buckets[idx];
+	while (vport_cap) {
+		if (vport_cap->vhca_gvmi == vhca_gvmi &&
+		    vport_cap->num == vport_num)
+			return vport_cap;
+		vport_cap = vport_cap->next;
+	}
+
+	return NULL;
+}
+
 static void dr_vports_table_add_vport(struct dr_vports_table *h,
 				      struct dr_devx_vport_cap *vport)
 {
@@ -26,6 +48,111 @@ static void dr_vports_table_add_vport(struct dr_vports_table *h,
 
 	vport->next = h->buckets[idx];
 	h->buckets[idx] = vport;
+}
+
+static struct dr_devx_vport_cap *
+dr_vports_table_query_and_add_vport(struct ibv_context *ctx,
+				    struct dr_devx_vports *vports,
+				    bool other_vport,
+				    uint16_t vport_number)
+{
+	struct dr_devx_vport_cap *new_vport;
+	int ret = 0;
+
+	pthread_spin_lock(&vports->lock);
+	new_vport = dr_vports_table_find_vport_num(vports->vports,
+						   vports->esw_mngr.vhca_gvmi,
+						   vport_number);
+	if (new_vport)
+		goto unlock_ret;
+
+	new_vport = calloc(1, sizeof(*new_vport));
+	if (!new_vport) {
+		errno = ENOMEM;
+		goto unlock_ret;
+	}
+
+	ret = dr_devx_query_esw_vport_context(ctx, other_vport,
+					      vport_number,
+					      &new_vport->icm_address_rx,
+					      &new_vport->icm_address_tx);
+	if (ret)
+		goto unlock_free;
+
+	ret = dr_devx_query_gvmi(ctx, other_vport, vport_number, &new_vport->vport_gvmi);
+	if (ret)
+		goto unlock_free;
+
+	new_vport->num = vport_number;
+	new_vport->vhca_gvmi = vports->esw_mngr.vhca_gvmi;
+	dr_vports_table_add_vport(vports->vports, new_vport);
+
+	pthread_spin_unlock(&vports->lock);
+	return new_vport;
+
+unlock_free:
+	free(new_vport);
+	new_vport = NULL;
+unlock_ret:
+	pthread_spin_unlock(&vports->lock);
+	return new_vport;
+}
+
+struct dr_devx_vport_cap *
+dr_vports_table_get_vport_cap(struct dr_devx_caps *caps, uint16_t vport)
+{
+	struct dr_devx_vports *vports = &caps->vports;
+	struct dr_devx_vport_cap *vport_cap;
+	bool other_vport = !!vport;
+
+	/* no lock on vport_find since table is updated atomically */
+	vport_cap = dr_vports_table_find_vport_num(vports->vports,
+						   vports->esw_mngr.vhca_gvmi,
+						   vport);
+	if (vport_cap)
+		return vport_cap;
+
+	return dr_vports_table_query_and_add_vport(caps->dmn->ctx, vports,
+						   other_vport, vport);
+}
+
+void dr_vports_table_add_wire(struct dr_devx_vports *vports)
+{
+	pthread_spin_lock(&vports->lock);
+	vports->wire.num = WIRE_PORT;
+	dr_vports_table_add_vport(vports->vports, &vports->wire);
+	pthread_spin_unlock(&vports->lock);
+}
+
+void dr_vports_table_del_wire(struct dr_devx_vports *vports)
+{
+	struct dr_devx_vport_cap *wire = &vports->wire;
+	struct dr_vports_table *h = vports->vports;
+	struct dr_devx_vport_cap *vport, *prev;
+	uint32_t vport_key;
+	uint32_t idx;
+
+	vport_key = dr_vports_gen_vport_key(wire->vhca_gvmi, wire->num);
+	idx = dr_vports_calc_bucket_idx(vport_key);
+
+	pthread_spin_lock(&vports->lock);
+	if (h->buckets[idx] == wire) {
+		h->buckets[idx] = wire->next;
+		goto out_unlock;
+	}
+
+	vport = h->buckets[idx];
+	while (vport) {
+		if (vport == wire) {
+			prev->next = vport->next;
+			break;
+		}
+		prev = vport;
+		vport = vport->next;
+	}
+
+out_unlock:
+	pthread_spin_unlock(&vports->lock);
 }
 
 struct dr_vports_table *dr_vports_table_create(struct mlx5dv_dr_domain *dmn)

--- a/providers/mlx5/dr_vports.c
+++ b/providers/mlx5/dr_vports.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved
+ */
+
+#include <stdlib.h>
+#include "mlx5dv_dr.h"
+
+static uint32_t dr_vports_gen_vport_key(uint16_t vhca_gvmi, uint16_t vport_num)
+{
+	return (((uint32_t)vhca_gvmi) << 16) | vport_num;
+}
+
+static int dr_vports_calc_bucket_idx(uint32_t vport_key)
+{
+	return vport_key % DR_VPORTS_BUCKETS;
+}
+
+static void dr_vports_table_add_vport(struct dr_vports_table *h,
+				      struct dr_devx_vport_cap *vport)
+{
+	uint32_t vport_key;
+	uint32_t idx;
+
+	vport_key = dr_vports_gen_vport_key(vport->vhca_gvmi, vport->num);
+	idx = dr_vports_calc_bucket_idx(vport_key);
+
+	vport->next = h->buckets[idx];
+	h->buckets[idx] = vport;
+}
+
+struct dr_vports_table *dr_vports_table_create(struct mlx5dv_dr_domain *dmn)
+{
+	struct dr_vports_table *h;
+
+	h = calloc(1, sizeof(*h));
+	if (!h) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	return h;
+}
+
+void dr_vports_table_destroy(struct dr_vports_table *h)
+{
+	struct dr_devx_vport_cap *vport_cap, *next;
+	uint32_t idx;
+
+	for (idx = 0; idx < DR_VPORTS_BUCKETS; ++idx) {
+		vport_cap = h->buckets[idx];
+		while (vport_cap) {
+			next = vport_cap->next;
+			free(vport_cap);
+			vport_cap = next;
+		}
+	}
+
+	free(h);
+}

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -193,6 +193,7 @@ MLX5_1.20 {
 MLX5_1.21 {
 	global:
 		mlx5dv_dci_stream_id_reset;
+		mlx5dv_dr_action_create_dest_ib_port;
 		mlx5dv_dr_matcher_set_layout;
 		mlx5dv_get_vfio_device_list;
 		mlx5dv_vfio_get_events_fd;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -73,6 +73,7 @@ rdma_alias_man_pages(
  mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_reg_ex.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_table.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ib_port.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ibv_qp.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_devx_tir.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_vport.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -24,7 +24,15 @@ mlx5dv_dr_action_create_default_miss - Create default miss action
 
 mlx5dv_dr_action_create_tag - Create tag actions
 
-mlx5dv_dr_action_create_dest_ibv_qp, mlx5dv_dr_action_create_dest_table, mlx5dv_dr_action_create_dest_vport, mlx5dv_dr_action_create_dest_devx_tir - Create packet destination actions
+mlx5dv_dr_action_create_dest_ibv_qp - Create packet destination QP action
+
+mlx5dv_dr_action_create_dest_table  - Create packet destination dr table action
+
+mlx5dv_dr_action_create_dest_vport - Create packet destination vport action
+
+mlx5dv_dr_action_create_dest_ib_port - Create packet destination IB port action
+
+mlx5dv_dr_action_create_dest_devx_tir - Create packet destination TIR action
 
 mlx5dv_dr_action_create_dest_array - Create destination array action
 
@@ -108,6 +116,10 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_table(
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_vport(
 		struct mlx5dv_dr_domain *domain,
 		uint32_t vport);
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ib_port(
+		struct mlx5dv_dr_domain *domain,
+		uint32_t ib_port);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_devx_tir(
 		struct mlx5dv_devx_obj *devx_obj);
@@ -241,6 +253,7 @@ Action: Destination
 *mlx5dv_dr_action_create_dest_ibv_qp* creates a terminating action delivering the packet to a QP, defined by **ibqp**. Valid only on domain type NIC_RX.
 *mlx5dv_dr_action_create_dest_table* creates a forwarding action to another flow table, defined by **table**. The destination **table** must be from the same domain with a level higher than zero.
 *mlx5dv_dr_action_create_dest_vport* creates a forwarding action to a **vport** on the same **domain**. Valid only on domain type FDB.
+*mlx5dv_dr_action_create_dest_ib_port* creates a forwarding action to a **ib_port** on the same **domain**. The valid range of ports is a based on the capability phys_port_cnt_ex provided by ibq_query_device_ex and it is possible to query the ports details using mlx5dv_query_port. Action is supported only on domain type FDB.
 *mlx5dv_dr_action_create_dest_devx_tir* creates a terminating action delivering the packet to a TIR, defined by **devx_obj**. Valid only on domain type NIC_RX.
 
 Action: Array

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -75,6 +75,7 @@ enum {
 	MLX5_CMD_OP_QUERY_DCT = 0x713,
 	MLX5_CMD_OP_CREATE_XRQ = 0x717,
 	MLX5_CMD_OP_DESTROY_XRQ = 0x718,
+	MLX5_CMD_OP_QUERY_ESW_FUNCTIONS = 0x740,
 	MLX5_CMD_OP_QUERY_ESW_VPORT_CONTEXT = 0x752,
 	MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT = 0x754,
 	MLX5_CMD_OP_MODIFY_NIC_VPORT_CONTEXT = 0x755,
@@ -1185,8 +1186,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         trusted_vnic_vhca[0x1];
 	u8         sw_owner_id[0x1];
 	u8         reserve_not_to_use[0x1];
-	u8         reserved_at_620[0xa0];
-	u8         reserved_at_6c0[0x4];
+	u8         reserved_at_620[0x60];
+	u8         sf[0x1];
+	u8         reserved_at_682[0x43];
 	u8         flex_parser_id_geneve_opt_0[0x4];
 	u8         flex_parser_id_icmp_dw1[0x4];
 	u8         flex_parser_id_icmp_dw0[0x4];
@@ -1363,6 +1365,13 @@ struct mlx5_ifc_odp_cap_bits {
 	u8         reserved_at_120[0x6e0];
 };
 
+struct mlx5_ifc_e_switch_cap_bits {
+	u8         reserved_at_0[0x4b];
+	u8         log_max_esw_sf[0x5];
+	u8         esw_sf_base_id[0x10];
+	u8         reserved_at_60[0x7a0];
+};
+
 enum {
 	ELEMENT_TYPE_CAP_MASK_TASR = 1 << 0,
 	ELEMENT_TYPE_CAP_MASK_QUEUE_GROUP = 1 << 4,
@@ -1406,6 +1415,7 @@ union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_cmd_hca_cap_bits cmd_hca_cap;
 	struct mlx5_ifc_flow_table_nic_cap_bits flow_table_nic_cap;
 	struct mlx5_ifc_flow_table_eswitch_cap_bits flow_table_eswitch_cap;
+	struct mlx5_ifc_e_switch_cap_bits e_switch_cap;
 	struct mlx5_ifc_device_mem_cap_bits device_mem_cap;
 	struct mlx5_ifc_odp_cap_bits odp_cap;
 	struct mlx5_ifc_roce_cap_bits roce_caps;
@@ -1453,6 +1463,7 @@ enum {
 	MLX5_SET_HCA_CAP_OP_MOD_NIC_FLOW_TABLE        = 0x7 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_ESW_FLOW_TABLE        = 0x8 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_QOS                   = 0xc << 1,
+	MLX5_SET_HCA_CAP_OP_MOD_ESW                   = 0x9 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY         = 0xf << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2  = 0x20 << 1,
 };
@@ -4005,6 +4016,49 @@ struct mlx5_ifc_dr_action_hw_copy_bits {
 	u8         reserved_at_30[0x2];
 	u8         source_left_shifter[0x6];
 	u8         reserved_at_38[0x8];
+};
+
+struct mlx5_ifc_host_params_context_bits {
+	u8         host_number[0x8];
+	u8         reserved_at_8[0x6];
+	u8         host_pf_vhca_id_valid[0x1];
+	u8         host_pf_disabled[0x1];
+	u8         host_num_of_vfs[0x10];
+
+	u8         host_total_vfs[0x10];
+	u8         host_pci_bus[0x10];
+
+	u8         host_pf_vhca_id[0x10];
+	u8         host_pci_device[0x10];
+
+	u8         reserved_at_60[0x10];
+	u8         host_pci_function[0x10];
+
+	u8         reserved_at_80[0x180];
+};
+
+struct mlx5_ifc_query_esw_functions_in_bits {
+	u8         opcode[0x10];
+	u8         reserved_at_10[0x10];
+
+	u8         reserved_at_20[0x10];
+	u8         op_mod[0x10];
+
+	u8         reserved_at_40[0x40];
+};
+
+struct mlx5_ifc_query_esw_functions_out_bits {
+	u8         status[0x8];
+	u8         reserved_at_8[0x18];
+
+	u8         syndrome[0x20];
+
+	u8         reserved_at_40[0x40];
+
+	struct mlx5_ifc_host_params_context_bits host_params_context;
+
+	u8         reserved_at_280[0x180];
+	u8         host_sf_enable[0][0x40];
 };
 
 struct mlx5_ifc_create_flow_group_in_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -674,7 +674,21 @@ struct mlx5_ifc_dr_match_set_misc4_bits {
 
 	u8         prog_sample_field_id_3[0x20];
 
-	u8         reserved[0x100];
+	u8         prog_sample_field_value_4[0x20];
+
+	u8         prog_sample_field_id_4[0x20];
+
+	u8         prog_sample_field_value_5[0x20];
+
+	u8         prog_sample_field_id_5[0x20];
+
+	u8         prog_sample_field_value_6[0x20];
+
+	u8         prog_sample_field_id_6[0x20];
+
+	u8         prog_sample_field_value_7[0x20];
+
+	u8         prog_sample_field_id_7[0x20];
 };
 
 struct mlx5_ifc_dr_match_set_misc5_bits {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1844,6 +1844,10 @@ mlx5dv_dr_action_create_dest_vport(struct mlx5dv_dr_domain *domain,
 				   uint32_t vport);
 
 struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_ib_port(struct mlx5dv_dr_domain *domain,
+				     uint32_t ib_port);
+
+struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_dest_devx_tir(struct mlx5dv_devx_obj *devx_obj);
 
 enum mlx5dv_dr_action_dest_type {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -54,6 +54,7 @@
 #define NUM_OF_FLEX_PARSERS	8
 #define DR_STE_MAX_FLEX_0_ID	3
 #define DR_STE_MAX_FLEX_1_ID	7
+#define DR_VPORTS_BUCKETS	256
 
 #define dr_dbg(dmn, arg...) dr_dbg_ctx((dmn)->ctx, ##arg)
 
@@ -790,8 +791,12 @@ struct dr_esw_caps {
 
 struct dr_devx_vport_cap {
 	uint16_t gvmi;
+	uint16_t vhca_gvmi;
 	uint64_t icm_address_rx;
 	uint64_t icm_address_tx;
+	uint16_t num;
+	/* locate vports table */
+	struct dr_devx_vport_cap *next;
 };
 
 struct dr_devx_roce_cap {
@@ -799,6 +804,10 @@ struct dr_devx_roce_cap {
 	bool fl_rc_qp_when_roce_disabled;
 	bool fl_rc_qp_when_roce_enabled;
 	uint8_t qp_ts_format;
+};
+
+struct dr_vports_table {
+	struct dr_devx_vport_cap *buckets[DR_VPORTS_BUCKETS];
 };
 
 struct dr_devx_caps {
@@ -1560,4 +1569,8 @@ int dr_buddy_init(struct dr_icm_buddy_mem *buddy, uint32_t max_order);
 void dr_buddy_cleanup(struct dr_icm_buddy_mem *buddy);
 int dr_buddy_alloc_mem(struct dr_icm_buddy_mem *buddy, int order);
 void dr_buddy_free_mem(struct dr_icm_buddy_mem *buddy, uint32_t seg, int order);
+
+struct dr_vports_table *dr_vports_table_create(struct mlx5dv_dr_domain *dmn);
+void dr_vports_table_destroy(struct dr_vports_table *vports_tbl);
+
 #endif

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -47,6 +47,7 @@
 #define DR_MAX_SEND_RINGS	14
 #define NUM_OF_LOCKS		DR_MAX_SEND_RINGS
 #define WIRE_PORT		0xFFFF
+#define ECPF_PORT		0xFFFE
 #define DR_STE_SVLAN		0x1
 #define DR_STE_CVLAN		0x2
 #define CVLAN_ETHERTYPE	0x8100
@@ -861,6 +862,7 @@ struct dr_devx_caps {
 	struct dr_devx_roce_cap		roce_caps;
 	uint64_t			definer_format_sup;
 	bool				prio_tag_required;
+	bool				is_ecpf;
 	struct dr_devx_vports		vports;
 };
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -796,6 +796,8 @@ struct dr_devx_vport_cap {
 	uint64_t icm_address_rx;
 	uint64_t icm_address_tx;
 	uint16_t num;
+	uint32_t metadata_c;
+	uint32_t metadata_c_mask;
 	/* locate vports table */
 	struct dr_devx_vport_cap *next;
 };
@@ -818,6 +820,8 @@ struct dr_devx_vports {
 	struct dr_devx_vport_cap	wire;
 	/* PF + VFS + SF */
 	struct dr_vports_table		*vports;
+	/* IB ports to vport + other_vports */
+	struct dr_devx_vport_cap	**ib_ports;
 	/* Number of vports PF + VFS + SFS + WIRE */
 	uint32_t			num_ports;
 	/* Protect vport query and add*/
@@ -1576,6 +1580,8 @@ void dr_vports_table_add_wire(struct dr_devx_vports *vports);
 void dr_vports_table_del_wire(struct dr_devx_vports *vports);
 struct dr_devx_vport_cap *dr_vports_table_get_vport_cap(struct dr_devx_caps *caps,
 							uint16_t vport);
+struct dr_devx_vport_cap *dr_vports_table_get_ib_port_cap(struct dr_devx_caps *caps,
+							  uint32_t ib_port);
 struct dr_vports_table *dr_vports_table_create(struct mlx5dv_dr_domain *dmn);
 void dr_vports_table_destroy(struct dr_vports_table *vports_tbl);
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -753,6 +753,14 @@ struct dr_match_misc4 {
 	uint32_t prog_sample_field_id_2;
 	uint32_t prog_sample_field_value_3;
 	uint32_t prog_sample_field_id_3;
+	uint32_t prog_sample_field_value_4;
+	uint32_t prog_sample_field_id_4;
+	uint32_t prog_sample_field_value_5;
+	uint32_t prog_sample_field_id_5;
+	uint32_t prog_sample_field_value_6;
+	uint32_t prog_sample_field_id_6;
+	uint32_t prog_sample_field_value_7;
+	uint32_t prog_sample_field_id_7;
 };
 
 struct dr_match_misc5 {


### PR DESCRIPTION
This series enhances the DR support in few areas as of below. 
- Query vports dynamically to support SFs.
- Support ECPF vport.
- Add destination IB port action.
- Extend misc4 flex parsers support.