### PR TITLE
mlx5: Add DV APIs to support MKEY with crypto offloads

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -138,6 +138,9 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_crypto_login_query_state@MLX5_1.21 37
  mlx5dv_crypto_logout@MLX5_1.21 37
  mlx5dv_dci_stream_id_reset@MLX5_1.21 37
+ mlx5dv_dek_create@MLX5_1.21 37
+ mlx5dv_dek_destroy@MLX5_1.21 37
+ mlx5dv_dek_query@MLX5_1.21 37
  mlx5dv_dr_action_create_dest_ib_port@MLX5_1.21 37
  mlx5dv_dr_matcher_set_layout@MLX5_1.21 37
  mlx5dv_get_vfio_device_list@MLX5_1.21 37

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -134,6 +134,9 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_map_ah_to_qp@MLX5_1.20 36
  mlx5dv_qp_cancel_posted_send_wrs@MLX5_1.20 36
  _mlx5dv_mkey_check@MLX5_1.20 36
+ mlx5dv_crypto_login@MLX5_1.21 37
+ mlx5dv_crypto_login_query_state@MLX5_1.21 37
+ mlx5dv_crypto_logout@MLX5_1.21 37
  mlx5dv_dci_stream_id_reset@MLX5_1.21 37
  mlx5dv_dr_action_create_dest_ib_port@MLX5_1.21 37
  mlx5dv_dr_matcher_set_layout@MLX5_1.21 37

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -192,6 +192,9 @@ MLX5_1.20 {
 
 MLX5_1.21 {
 	global:
+		mlx5dv_crypto_login;
+		mlx5dv_crypto_login_query_state;
+		mlx5dv_crypto_logout;
 		mlx5dv_dci_stream_id_reset;
 		mlx5dv_dr_action_create_dest_ib_port;
 		mlx5dv_dr_matcher_set_layout;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -196,6 +196,9 @@ MLX5_1.21 {
 		mlx5dv_crypto_login_query_state;
 		mlx5dv_crypto_logout;
 		mlx5dv_dci_stream_id_reset;
+		mlx5dv_dek_create;
+		mlx5dv_dek_destroy;
+		mlx5dv_dek_query;
 		mlx5dv_dr_action_create_dest_ib_port;
 		mlx5dv_dr_matcher_set_layout;
 		mlx5dv_get_vfio_device_list;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -8,6 +8,7 @@ rdma_man_pages(
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_mkey.3.md
   mlx5dv_create_qp.3.md
+  mlx5dv_crypto_login.3.md
   mlx5dv_dci_stream_id_reset.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_create_cmd_comp.3.md
@@ -50,6 +51,8 @@ rdma_man_pages(
 rdma_alias_man_pages(
  mlx5dv_alloc_var.3 mlx5dv_free_var.3
  mlx5dv_create_mkey.3 mlx5dv_destroy_mkey.3
+ mlx5dv_crypto_login.3 mlx5dv_crypto_login_query_state.3
+ mlx5dv_crypto_login.3 mlx5dv_crypto_logout.3
  mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_destroy_cmd_comp.3
  mlx5dv_devx_create_event_channel.3 mlx5dv_devx_destroy_event_channel.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -46,6 +46,7 @@ rdma_man_pages(
   mlx5dv_vfio_get_events_fd.3.md
   mlx5dv_vfio_process_events.3.md
   mlx5dv_wr_post.3.md
+  mlx5dv_wr_set_mkey_crypto.3.md
   mlx5dv_wr_set_mkey_sig_block.3.md
   mlx5dv.7
 )

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -10,6 +10,7 @@ rdma_man_pages(
   mlx5dv_create_qp.3.md
   mlx5dv_crypto_login.3.md
   mlx5dv_dci_stream_id_reset.3.md
+  mlx5dv_dek_create.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_create_cmd_comp.3.md
   mlx5dv_devx_create_event_channel.3.md
@@ -53,6 +54,8 @@ rdma_alias_man_pages(
  mlx5dv_create_mkey.3 mlx5dv_destroy_mkey.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_login_query_state.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_logout.3
+ mlx5dv_dek_create.3 mlx5dv_dek_query.3
+ mlx5dv_dek_create.3 mlx5dv_dek_destroy.3
  mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_destroy_cmd_comp.3
  mlx5dv_devx_create_event_channel.3 mlx5dv_devx_destroy_event_channel.3

--- a/providers/mlx5/man/mlx5dv_create_mkey.3.md
+++ b/providers/mlx5/man/mlx5dv_create_mkey.3.md
@@ -52,6 +52,13 @@ Create an indirect mkey to enable application uses its specific device functiona
 		Indirect mkey is being created.
 	MLX5DV_MKEY_INIT_ATTR_FLAGS_BLOCK_SIGNATURE:
 		Enable block signature offload support for mkey.
+	MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO:
+		Enable crypto offload support for mkey.
+		Setting this flag means that crypto operations will be done and
+		hence, must be configured. I.e. if this flag is set and the MKey
+		was not configured for crypto properties using
+		**mlx5dv_wr_set_mkey_crypto()**, then running traffic with the
+		MKey will fail, generating a CQE with error.
 
 *max_entries*
 :	Requested max number of pointed entries by this indirect mkey.

--- a/providers/mlx5/man/mlx5dv_crypto_login.3.md
+++ b/providers/mlx5/man/mlx5dv_crypto_login.3.md
@@ -1,0 +1,132 @@
+---
+layout: page
+title: mlx5dv_crypto_login / mlx5dv_crypto_login_query_state / mlx5dv_crypto_logout
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_crypto_login - Creates a crypto login session
+
+mlx5dv_crypto_login_query_state - Queries the state of the current crypto login session
+
+mlx5dv_crypto_logout - Logs out from the current crypto login session
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_crypto_login(struct ibv_context *context,
+			struct mlx5dv_crypto_login_attr *login_attr);
+
+int mlx5dv_crypto_login_query_state(struct ibv_context *context,
+				    enum mlx5dv_crypto_login_state *state);
+
+int mlx5dv_crypto_logout(struct ibv_context *context);
+```
+
+# DESCRIPTION
+
+When using a crypto engine that is in wrapped import method, an active crypto
+login session must be present in order to create and query Data Encryption Keys
+(DEKs).
+
+**mlx5dv_crypto_login()** Creates a crypto login session with the credential
+given in *login_attr* and associates it with *context*. Only one active crypto
+login session can be associated per device context.
+
+**mlx5dv_crypto_login_query_state()** queries the state of the crypto login
+session associated with *context* and returns the state in *state*, which
+indicates whether it is valid, invalid or doesn't exist.
+A valid crypto login session can become invalid if the credential or the import
+KEK used in the crypto login session were deleted during the login session
+(for example by a crypto officer).
+In this case, **mlx5dv_crypto_logout()** should be called to destroy the current
+invalid crypto login session and if still necessary, **mlx5dv_crypto_login()**
+should be called to create a new crypto login session with valid credential and
+import KEK.
+
+**mlx5dv_crypto_logout()** logs out from the current crypto login session
+associated with *context*.
+
+Existing DEKs that were previously loaded to the device during a crypto login
+session don't need an active crypto login session in order to be used (in MKey
+or during traffic).
+
+# ARGUMENTS
+
+## context
+
+The device context to associate the crypto login session with.
+
+## login_attr
+
+Crypto login attributes specify the credential to login with and the import KEK
+to be used for secured communications during the crypto login session.
+
+```c
+struct mlx5dv_crypto_login_attr {
+	uint32_t credential_id;
+	uint32_t import_kek_id;
+	char credential[48];
+	uint64_t comp_mask;
+};
+```
+
+*credential_id*
+
+:	An ID of a credential, from the credentials stored on the device,
+	that indicates the credential that should be validated against the
+	credential provided in *credential*.
+
+*import_kek_id*
+
+:	An ID of an import KEK, from the import KEKs stored on the device,
+	that indicates the import KEK that will be used for unwrapping the
+	credential provided in *credential* and also for all other secured
+	communications during the crypto login session.
+
+*credential*
+
+:	The credential to login with. Must be provided wrapped by the AES key
+	wrap algorithm using the import KEK indicated by *import_kek_id*.
+
+*comp_mask*
+
+:	Reserved For future extension, must be 0 now.
+
+## state
+
+Indicates the state of the current crypto login session. can be one of
+MLX5DV_CRYPTO_LOGIN_STATE_VALID, MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN and
+MLX5DV_CRYPTO_LOGIN_STATE_INVALID.
+
+# RETURN VALUE
+
+**mlx5dv_crypto_login()** returns 0 on success and errno value on error.
+
+**mlx5dv_crypto_login_query_state()** returns 0 on success and updates *state*
+with the queried state. On error, errno value is returned.
+
+**mlx5dv_crypto_logout()** returns 0 on success and errno value on error.
+
+# ERRORS
+
+EEXIST
+
+:	A crypto login session already exists.
+
+EINVAL
+
+:	Invalid attributes were provided, or one or more of *credential*,
+	*credential_id* and *import_kek_id* are invalid.
+
+ENOENT
+
+:	No crypto login session exists.
+
+# AUTHORS
+
+Avihai Horon <avihaih@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_dek_create.3.md
+++ b/providers/mlx5/man/mlx5dv_dek_create.3.md
@@ -1,0 +1,220 @@
+---
+layout: page
+title: mlx5dv_dek_create / mlx5dv_dek_query / mlx5dv_dek_destroy
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_dek_create - Creates a DEK
+
+mlx5dv_dek_query - Queries a DEK's attributes
+
+mlx5dv_dek_destroy - Destroys a DEK
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_dek *mlx5dv_dek_create(struct ibv_context *context,
+				     struct mlx5dv_dek_init_attr *init_attr);
+
+int mlx5dv_dek_query(struct mlx5dv_dek *dek, struct mlx5dv_dek_attr *attr);
+
+int mlx5dv_dek_destroy(struct mlx5dv_dek *dek);
+```
+
+# DESCRIPTION
+
+Data Encryption Keys (DEKs) are used to encrypt and decrypt transmitted data.
+After a DEK is created, it can be configured in MKeys for crypto offload
+operations.
+DEKs are not persistent and are destroyed upon process exit. Therefore,
+software process needs to re-create all needed DEKs on startup.
+
+**mlx5dv_dek_create()** creates a new DEK with the attributes specified in
+*init_attr*. A pointer to the newly created dek is returned, which can be used
+for DEK query, DEK destruction and when configuring a MKey for crypto offload
+operations. An active crypto login session must be present in order to create
+a DEK.
+
+To use the created DEK in a MKey, a valid or active crypto login session is not
+needed. Revoking the import KEK or credential that were used during the login
+(and therefore rendering the login session invalid) does not prevent using a
+created DEK.
+
+**mlx5dv_dek_query()** queries the DEK specified by *dek* and returns the
+queried attributes in *attr*. An active crypto login session must be present
+in order to query a DEK.
+
+**mlx5dv_dek_destroy()** destroys the DEK specified by *dek*.
+
+# ARGUMENTS
+
+## context
+
+The device context to create the DEK with. *context* must have an active crypto
+login session associated with in order to create the DEK.
+
+## init_attr
+
+```c
+struct mlx5dv_dek_init_attr {
+	enum mlx5dv_crypto_key_size key_size;
+	bool has_keytag;
+	enum mlx5dv_crypto_key_purpose key_purpose;
+	struct ibv_pd *pd;
+	char opaque[8];
+	char key[128];
+	uint64_t comp_mask;
+};
+```
+
+*key_size*
+
+:	The size of the key, can be one of the following
+
+	**MLX5DV_CRYPTO_KEY_SIZE_128**
+
+	:	Key size is 128 bit.
+
+	**MLX5DV_CRYPTO_KEY_SIZE_256**
+
+	:	Key size is 256 bit.
+
+*has_keytag*
+
+:	Whether the DEK has a keytag or not. If set, the key should include a
+	8 Bytes keytag.
+	Keytag is used to verify that the DEK being used by a MKey is the
+	expected DEK. This is done by comparing the keytag that was defined
+	during DEK creation with the keytag provided in the MKey crypto
+	configuration, and failing the operation if they are different.
+
+*key_purpose*
+
+:	The purpose of the key, currently can only be the following value
+
+	**MLX5DV_CRYPTO_KEY_PURPOSE_AES_XTS**
+
+	:	The key will be used for AES-XTS crypto engine.
+
+*pd*
+
+:	The protection domain to be associated with the DEK.
+
+*opaque*
+
+:	Plaintext metadata to describe the key.
+
+*key*
+
+:	The key that will be used for encryption and decryption of transmitted
+	data. Must be provided wrapped by the import KEK that was specified
+	for the crypto login session.
+	Actual size and layout of this field depend on the provided *key_size*
+	and *has_keytag* fields.
+	*key* should be constructed according to the following table.
+
+	Table: DEK *key* Field Construction.
+
+	|   Key size   |  Has Keytag  |                      Key Layout                    |
+	| ------------ | ------------ | -------------------------------------------------- |
+	|    128 Bit   |      No      |         ENC(iv_64b + key1_128b + key2_128b)        |
+	|              |              |                                                    |
+	|    256 Bit   |      No      |         ENC(iv_64b + key1_256b + key2_256b)        |
+	|              |              |                                                    |
+	|    128 Bit   |     Yes      |  ENC(iv_64b + key1_128b + key2_128b + 64b_keytag)  |
+	|              |              |                                                    |
+	|    256 Bit   |     Yes      |  ENC(iv_64b + key1_256b + key2_256b + 64b_keytag)  |
+
+	Where ENC() is AES key wrap algorithm and iv_64b is 0xA6A6A6A6A6A6A6A6
+	as per the AES key wrap spec.
+
+	The following example shows how to wrap a 128 bit key that has keytag
+	using a 128 bit import KEK in OpenSSL:
+
+	```c
+	unsigned char import_kek[16]; /* 128 bit import KEK in plaintext for wrapping */
+	unsigned char iv[8] = {0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6, 0xA6};
+
+	/*
+	 * Indexes 0-15 are key1 in plaintext, indexes 16-31 are key2 in plaintext,
+	 * and indexes 32-39 are key_tag in plaintext.
+	 */
+	unsigned char key[40];
+
+	unsigned char wrapped_key[48];
+	EVP_CIPHER_CTX *ctx;
+	int len;
+
+	ctx = EVP_CIPHER_CTX_new();
+	EVP_CIPHER_CTX_set_flags(ctx, EVP_CIPHER_CTX_FLAG_WRAP_ALLOW);
+	EVP_EncryptInit_ex(ctx, EVP_aes_128_wrap(), NULL, import_kek, iv);
+	EVP_EncryptUpdate(ctx, wrapped_key, &len, key, sizeof(key));
+	EVP_EncryptFinal_ex(ctx, wrapped_key + len, &len);
+	EVP_CIPHER_CTX_free(ctx);
+	```
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+## dek
+
+	Pointer to an existing DEK to query or to destroy.
+
+## attr
+
+	DEK attributes to be populated when querying a DEK.
+
+```c
+struct mlx5dv_dek_attr {
+	enum mlx5dv_dek_state state;
+	char opaque[8];
+	uint64_t comp_mask;
+};
+```
+
+*state*
+
+:	The state of the DEK, can be one of the following
+
+	**MLX5DV_DEK_STATE_READY**
+
+	:	The key is ready for use. This is the state of the key when it
+		is first created.
+
+	**MLX5DV_DEK_STATE_ERROR**
+
+	:	The key is unusable. The key needs to be destroyed and
+		re-created in order to be used. This can happen, for example,
+		due to DEK memory corruption.
+
+*opaque*
+
+:	Plaintext metadata to describe the key.
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+# RETURN VALUE
+
+**mlx5dv_dek_create()** returns a pointer to a new *struct mlx5dv_dek* on
+success. On error NULL is returned and errno is set.
+
+**mlx5dv_dek_query()** returns 0 on success and updates *attr* with the queried
+DEK attributes. On error errno value is returned.
+
+**mlx5dv_dek_destroy()** returns 0 on success and errno value on error.
+
+# SEE ALSO
+
+**mlx5dv_crypto_login**(3)
+
+# AUTHORS
+
+Avihai Horon <avihaih@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -61,6 +61,7 @@ uint32_t        dc_odp_caps; /* use enum ibv_odp_transport_cap_bits */
 void		*hca_core_clock; /* points to a memory location that is mapped to the HCA's core clock */
 struct mlx5dv_sig_caps sig_caps;
 size_t max_wr_memcpy_length; /* max length that is supported by the DMA memcpy WR */
+struct mlx5dv_crypto_caps crypto_caps;
 .in -8
 };
 
@@ -100,6 +101,7 @@ MLX5DV_CONTEXT_MASK_NUM_LAG_PORTS       = 1 << 9,
 MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10,
 MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11,
 MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH    = 1 << 12,
+MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD      = 1 << 13,
 .in -8
 };
 
@@ -175,6 +177,52 @@ MLX5DV_BLOCK_SIZE_CAP_520 = 1 << MLX5DV_BLOCK_SIZE_520,
 MLX5DV_BLOCK_SIZE_CAP_4048 = 1 << MLX5DV_BLOCK_SIZE_4048,
 MLX5DV_BLOCK_SIZE_CAP_4096 = 1 << MLX5DV_BLOCK_SIZE_4096,
 MLX5DV_BLOCK_SIZE_CAP_4160 = 1 << MLX5DV_BLOCK_SIZE_4160,
+.in -8
+};
+
+.PP
+.nf
+struct mlx5dv_crypto_caps {
+.in +8
+/*
+ * if failed_selftests != 0 it means there are some self tests errors
+ * that may render specific crypto engines unusable. Exact code meaning
+ * should be consulted with NVIDIA.
+ */
+uint16_t failed_selftests;
+uint8_t crypto_engines; /* use enum mlx5dv_crypto_engines_caps */
+uint8_t wrapped_import_method; /* use enum mlx5dv_crypto_wrapped_import_method_caps */
+uint8_t log_max_num_deks;
+uint32_t flags; /* use enum mlx5dv_crypto_caps_flags */
+.in -8
+};
+
+enum mlx5dv_crypto_engines_caps {
+.in +8
+	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS = 1 << 0,
+.in -8
+};
+
+enum mlx5dv_crypto_wrapped_import_method_caps {
+.in +8
+	MLX5DV_CRYPTO_WRAPPED_IMPORT_METHOD_CAP_AES_XTS = 1 << 0,
+.in -8
+};
+
+enum mlx5dv_crypto_caps_flags {
+.in +8
+	/* Indicates whether crypto capabilities are enabled on the device. */
+	MLX5DV_CRYPTO_CAPS_CRYPTO = 1 << 0,
+
+	/* Indicates whether crypto engines that are in wrapped import method are operational. */
+	MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL = 1 << 1,
+
+	/*
+	 * If set, indicates that after the next FW reset the device will go back to
+	 * commissioning mode, meaning that MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL
+	 * will be set to 0.
+	 */
+	MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_GOING_TO_COMMISSIONING = 1 << 2,
 .in -8
 };
 

--- a/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
@@ -280,6 +280,21 @@ reset the signature attributes without invalidating the MKEY, use the
 	See dedicated man page for **mlx5dv_wr_set_mkey_sig_block**(3).
 
 
+## Crypto setter
+
+The crypto attributes of the MKey allow encryption and decryption of transmitted
+data from memory to network and when receiving data from network to memory.
+
+Use the crypto setter to set/update the crypto attributes of the MKey. When
+the MKey is created with **MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO** it must be
+configured with crypto attributes before the MKey can be used.
+
+**mlx5dv_wr_set_mkey_crypto()**
+
+:	Set MKey crypto attributes. If the MKey is already configured with
+	crypto attributes, the setter overrides the previous value.
+	see dedicated man page for **mlx5dv_wr_set_mkey_crypto**(3).
+
 # EXAMPLES
 
 ## Create QP and MKEY

--- a/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
@@ -1,0 +1,296 @@
+---
+layout: page
+title: mlx5dv_wr_set_mkey_crypto
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_wr_set_mkey_crypto - Configure a MKey for crypto operation.
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+static inline void
+mlx5dv_wr_set_mkey_crypto(struct mlx5dv_qp_ex *mqp,
+			  const struct mlx5dv_crypto_attr *attr);
+```
+# DESCRIPTION
+
+Configure a MKey with crypto properties. With this, the device will
+encrypt/decrypt data when transmitting data from memory to network and when
+receiving data from network to memory.
+
+In order to configure MKey with crypto properties, the MKey should be created
+with **MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO**. MKey that was created with
+**MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO** must have crypto properties
+configured to it before it can be used, i.e. this setter must be called before
+the MKey can be used or else traffic will fail, generating a CQE with error.
+A call to this setter on a MKey that already has crypto properties configured
+to it will override existing crypto properties.
+
+Configuring crypto properties to a MKey is done by specifying the crypto
+standard that should be used and its attributes, and also by providing the Data
+Encryption Key (DEK) to be used for the encryption/decryption itself.
+
+The MKey represents a virtually contiguous memory, by configuring a layout to
+it. The crypto properties of the MKey describe whether data in this virtually
+contiguous memory is encrypted or in plaintext, and whether it should be
+encrypted/decrypted before transmitting it or after receiving it. Depending on
+the actual operation that happens (TX or RX), the device will do the "right
+thing" based on the crypto properties configured in the MKey.
+
+MKeys can be configured with both crypto and signature properties at the same
+time by calling both **mlx5dv_wr_set_mkey_crypto()**(3) and
+**mlx5dv_wr_set_mkey_sig_block()**(3). In this case, both crypto and signature
+operations will be performed according to the crypto and signature properties
+configured in the MKey, and the order of operations will be determined by the
+*signature_crypto_order* property.
+
+## Example 1 (corresponds to row F in the table below):
+
+Memory signature domain is not configured, and memory data is encrypted.
+
+Wire signature domain is not configured, and wire data is in plaintext.
+
+*encrypt_on_tx* is set to false, and because signature is not configured,
+*signature_crypto_order* value doesn't matter.
+
+A SEND is issued using the MKey as a local key.
+
+Result: device will gather the encrypted data from the MKey (using whatever
+layout configured to the MKey to locate the actual memory), decrypt it using
+the supplied DEK and transmit the decrypted data to the wire.
+
+## Example 1.1:
+
+Same as above, but a RECV is issued with the same MKey, and RX happens.
+
+Result: device will receive the data from the wire, encrypt it using the
+supplied DEK and scatter it to the MKey (using whatever layout configured to
+the MKey to locate the actual memory).
+
+## Example 2 (corresponds to row C in the table below):
+
+Memory signature domain is configured for no signature, and memory data is in
+plaintext.
+
+Wire signature domain is configured for T10DIF every 512 Bytes block, and wire
+data (including the T10DIF) is encrypted.
+
+*encrypt_on_tx* is set to true and *signature_crypto_order* is set to be
+**MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX**.
+*data_unit_size* is set to **MLX5DV_BLOCK_SIZE_520**.
+
+The MKey is sent to a remote node that issues a RDMA_READ to this MKey.
+
+Result: device will gather the data from the MKey (using whatever layout
+configured to the MKey to locate the actual memory), generate an additional
+T10DIF field every 512B of data, encrypt the data and the newly generated
+T10DIF field using the supplied DEK, and transmit it to the wire.
+
+## Example 2.1:
+
+Same as above, but remote node issues a RDMA_WRITE to this MKey.
+
+Result: device will receive the data from the wire, decrypt the data using the
+supplied DEK, validate each T10DIF field against the previous 512B of data,
+strip the T10DIF field, and scatter the data alone to the MKey (using whatever
+layout configured to the MKey to locate the actual memory).
+
+# ARGUMENTS
+
+*mqp*
+:	The QP where an MKey configuration work request was created by
+	**mlx5dv_wr_mkey_configure()**.
+
+*attr*
+:	Crypto attributes to set for the MKey.
+
+## Crypto Attributes
+
+Crypto attributes describe the format (encrypted or plaintext) and layout of
+the input and output data in memory and wire domains, the crypto standard
+that should be used and its attributes.
+
+```c
+struct mlx5dv_crypto_attr {
+	enum mlx5dv_crypto_standard crypto_standard;
+	bool encrypt_on_tx;
+	enum mlx5dv_signature_crypto_order signature_crypto_order;
+	enum mlx5dv_block_size data_unit_size;
+	char initial_tweak[16];
+	struct mlx5dv_dek *dek;
+	char keytag[8];
+	uint64_t comp_mask;
+};
+```
+
+*crypto_standard*
+
+:	The encryption standard that should be used, currently can only be the
+	following value
+
+	**MLX5DV_CRYPTO_STANDARD_AES_XTS**
+
+	:	The AES-XTS encryption standard defined in IEEE Std 1619-2007.
+
+*encrypt_on_tx*
+
+:	If set, memory data will be encrypted during TX and wire data will be
+	decrypted during RX.
+	If not set, memory data will be decrypted during TX and wire data will
+	be encrypted during RX.
+
+*signature_crypto_order*
+
+:	Controls the order between crypto and signature operations (Please see
+	detailed table below). Relevant only if signature is configured.
+	Can be one of the following values
+
+	**MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX**
+
+	:	During TX, first perform crypto operation (encrypt/decrypt based
+		on *encrypt_on_tx*) and then signature operation on memory data.
+		During RX, first perform signature operation and then crypto
+		operation (encrypt/decrypt based on *encrypt_on_tx*) on wire
+		data.
+
+	**MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX**
+
+	:	During TX, first perform signature operation and then crypto
+		operation (encrypt/decrypt based on *encrypt_on_tx*) on memory
+		data.
+		During RX, first perform crypto operation (encrypt/decrypt based
+		on *encrypt_on_tx*) and then signature operation on wire data.
+
+	Table: *signature_crypto_order* and *encrypt_on_tx* Meaning.
+
+	The table describes the possible data layouts in memory and wire
+	domains, and the order in which crypto and signature operations are
+	performed according to *signature_crypto_order*, *encrypt_on_tx*
+	and signature configuration.
+
+	Memory column represents the data layout in the memory domain.
+
+	Wire column represents the data layout in the wire domain.
+
+	There are three possible operations that can be performed by the device
+	on the data when processing it from memory to wire and from wire to
+	memory:
+
+	1. Crypto operation.
+	2. Signature operation in memory domain.
+	3. Signature operation in wire domain.
+
+	Op1, Op2 and Op3 columns represent these operations. On TX, Op1, Op2
+	and Op3 are performed on memory data to produce the data layout that is
+	specified in Wire column. On RX, Op3, Op2 and Op1 are performed on wire
+	data to produce the data layout specified in Memory column. "SIG.mem"
+	and "SIG.wire" represent the signature operation that is performed in
+	memory and wire domains respectively. None means no operation is
+	performed. The exact signature operations are determined by the
+	signature attributes configured by **mlx5dv_wr_set_mkey_sig_block()**.
+
+	encrypt_on_tx and signature_crypto_order columns represent the values
+	that *encrypt_on_tx* and *signature_crypto_order* should have in order
+	to achieve such behavior.
+
+	|     |      Memory      |        Op1       |        Op2       |        Op3       |       Wire       | encrypt_on_tx |     signature_crypto_order     |
+	|-----| ---------------- | ---------------- | ---------------- | ---------------- | ---------------- |---------------|--------------------------------|
+	|  A  | data             | Encrypt on TX    | SIG.mem = none   | SIG.wire = none  | enc(data)        |     True      | Doesn't matter                 |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  B  | data             | Encrypt On TX    | SIG.mem = none   | SIG.wire = SIG   | enc(data)+SIG    |     True      | SIGNATURE_AFTER_CRYPTO_ON_TX   |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  C  | data             | SIG.mem = none   | SIG.wire = SIG   | Encrypt on TX    | enc(data+SIG)    |     True      | SIGNATURE_BEFORE_CRYPTO_ON_TX  |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  D  | data+SIG         | SIG.mem = SIG    | SIG.wire = none  | Encrypt on TX    | enc(data)        |     True      | SIGNATURE_BEFORE_CRYPTO_ON_TX  |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  E  | data+SIG1        | SIG.mem = SIG1   | SIG.wire = SIG2  | Encrypt on TX    | enc(data+SIG2)   |     True      | SIGNATURE_BEFORE_CRYPTO_ON_TX  |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  F  | enc(data)        | Decrypt on TX    | SIG.mem = none   | SIG.wire = none  | data             |     False     | Doesn't matter                 |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  G  | enc(data)        | Decrypt on TX    | SIG.mem = none   | SIG.wire = SIG   | data+SIG         |     False     | SIGNATURE_AFTER_CRYPTO_ON_TX   |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  H  | enc(data+SIG)    | Decrypt on TX    | SIG.mem = SIG    | SIG.wire = none  | data             |     False     | SIGNATURE_AFTER_CRYPTO_ON_TX   |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  I  | enc(data+SIG1)   | Decrypt on TX    | SIG.mem = SIG1   | SIG.wire = SIG2  | data+SIG2        |     False     | SIGNATURE_AFTER_CRYPTO_ON_TX   |
+	|     |                  |                  |                  |                  |                  |               |                                |
+	|  J  | enc(data)+SIG    | SIG.mem = SIG    | SIG.wire = none  | Decrypt on TX    | data             |     False     | SIGNATURE_BEFORE_CRYPTO_ON_TX  |
+
+	Notes:
+
+	- "Encrypt on TX" also means "Decrypt on RX", and "Decrypt on TX"
+	  also means "Encrypt on RX".
+
+	- When signature properties are not configured in the MKey, only crypto
+	  operations will be performed. Thus, *signature_crypto_order* has no
+	  meaning in this case (rows A and F), and it can be set to either one
+	  of its values.
+
+*data_unit_size*
+
+:	For storage, this will normally be the storage block size. The tweak is
+	incremented after each *data_unit_size* during the encryption. can be
+	one of **enum mlx5dv_block_size**.
+
+*initial_tweak*
+
+:	A value to be used during encryption of each data unit. This value is
+	incremented by the device for every data unit in the message. For
+	storage encryption, this will normally be the LBA of the first block
+	in the message, so that the increments represent the LBAs of the rest
+	of the blocks in the message.
+
+*dek*
+
+:	The DEK to be used for the crypto operations. This DEK must be
+	pre-loaded to the device using **mlx5dv_dek_create()**.
+
+*key_tag*
+
+:	A tag that verifies that the correct DEK is being used. *key_tag* is
+	optional and is valid only if the DEK was created with **has_keytag**
+	set to true. If so, it must match the key tag that was provided when
+	the DEK was created. Supllied in plaintext.
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+# RETURN VALUE
+
+This function does not return a value.
+
+In case of error, user will be notified later when completing the DV WRs chain.
+
+# NOTES
+
+MKey must be created with **MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO** flag.
+
+The last operation posted on the supplied QP should be
+**mlx5dv_wr_mkey_configure**(3), or one of its related setters, and the
+operation must still be open (no doorbell issued).
+
+In case of **ibv_wr_complete()** failure or calling to **ibv_wr_abort()**, the
+MKey may be left in an unknown state. The next configuration of it should not
+assume any previous state of the MKey, i.e. signature/crypto should be
+re-configured or reset, as required. For example, assuming
+**mlx5dv_wr_set_mkey_sig_block()** and then **ibv_wr_abort()** were called,
+then on the next configuration of the MKey, if signature is not needed, it
+should be reset using **MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR**.
+
+# SEE ALSO
+
+**mlx5dv_wr_mkey_configure**(3), **mlx5dv_wr_set_mkey_sig_block**(3),
+**mlx5dv_create_mkey**(3), **mlx5dv_destroy_mkey**(3),
+**mlx5dv_crypto_login**(3), **mlx5dv_dek_create**(3)
+
+# AUTHORS
+
+Oren Duer  <oren@nvidia.com>
+
+Avihai Horon <avihaih@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_wr_set_mkey_sig_block.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_set_mkey_sig_block.3.md
@@ -343,6 +343,14 @@ The last operation posted on the supplied QP should be
 **mlx5dv_wr_mkey_configure**(3), or one of its related setters, and the
 operation must still be open (no doorbell issued).
 
+In case of **ibv_wr_complete()** failure or calling to **ibv_wr_abort()**, the
+MKey may be left in an unknown state. The next configuration of it should not
+assume any previous state of the MKey, i.e. signature/crypto should be
+re-configured or reset, as required. For example, assuming
+**mlx5dv_wr_set_mkey_sig_block()** and then **ibv_wr_abort()** were called,
+then on the next configuration of the MKey, if signature is not needed, it
+should be reset using **MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR**.
+
 # SEE ALSO
 
 **mlx5dv_wr_mkey_configure**(3), **mlx5dv_create_mkey**(3),

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -926,6 +926,11 @@ static int _mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD) {
+		attrs_out->crypto_caps = mctx->crypto_caps;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -2377,6 +2377,7 @@ static int mlx5_set_context(struct mlx5_context *context,
 	pthread_mutex_init(&context->uidx_table_mutex, NULL);
 	pthread_mutex_init(&context->mkey_table_mutex, NULL);
 	pthread_mutex_init(&context->dyn_bfregs_mutex, NULL);
+	pthread_mutex_init(&context->crypto_login_mutex, NULL);
 	for (i = 0; i < MLX5_QP_TABLE_SIZE; ++i)
 		context->qp_table[i].refcnt = 0;
 

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -392,6 +392,7 @@ struct mlx5_context {
 	uint8_t				qpc_extension_cap:1;
 	struct mlx5dv_sig_caps		sig_caps;
 	struct mlx5_dma_mmo_caps	dma_mmo_caps;
+	struct mlx5dv_crypto_caps	crypto_caps;
 	pthread_mutex_t			dyn_bfregs_mutex; /* protects the dynamic bfregs allocation */
 	uint32_t			num_dyn_bfregs;
 	uint32_t			max_num_legacy_dyn_uar_sys_page;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -860,6 +860,10 @@ struct mlx5_mkey {
 	struct mlx5_sig_ctx *sig;
 };
 
+struct mlx5dv_dek {
+	struct mlx5dv_devx_obj *devx_obj;
+};
+
 struct mlx5_devx_event_channel {
 	struct ibv_context *context;
 	struct mlx5dv_devx_event_channel dv_event_channel;
@@ -1447,6 +1451,12 @@ struct mlx5_dv_context_ops {
 	int (*crypto_login_query_state)(struct ibv_context *context,
 					enum mlx5dv_crypto_login_state *state);
 	int (*crypto_logout)(struct ibv_context *context);
+
+	struct mlx5dv_dek *(*dek_create)(struct ibv_context *context,
+					 struct mlx5dv_dek_init_attr *init_attr);
+	int (*dek_query)(struct mlx5dv_dek *dek,
+			 struct mlx5dv_dek_attr *dek_attr);
+	int (*dek_destroy)(struct mlx5dv_dek *dek);
 
 	struct mlx5dv_var *(*alloc_var)(struct ibv_context *context, uint32_t flags);
 	void (*free_var)(struct mlx5dv_var *dv_var);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -801,6 +801,25 @@ struct mlx5_devx_umem {
 	size_t size;
 };
 
+/*
+ * The BSF state is used in signature and crypto attributes. It indicates the
+ * state the attributes are in, and helps constructing the signature and crypto
+ * BSFs during MKey configuration.
+ *
+ * INIT state indicates that the attributes are not configured.
+ * RESET state indicates that the attributes should be reset in current MKey
+ * configuration.
+ * SET state indicates that the attributes have been set before.
+ * UPDATED state indicates that the attributes have been updated in current
+ * MKey configuration.
+ */
+enum mlx5_mkey_bsf_state {
+	MLX5_MKEY_BSF_STATE_INIT,
+	MLX5_MKEY_BSF_STATE_RESET,
+	MLX5_MKEY_BSF_STATE_SET,
+	MLX5_MKEY_BSF_STATE_UPDATED,
+};
+
 struct mlx5_psv {
 	uint32_t index;
 	struct mlx5dv_devx_obj *devx_obj;
@@ -833,7 +852,7 @@ struct mlx5_sig_block {
 	struct mlx5_psv *mem_psv;
 	struct mlx5_psv *wire_psv;
 	struct mlx5_sig_block_attr attr;
-	bool updated;
+	enum mlx5_mkey_bsf_state state;
 };
 
 struct mlx5_sig_err {
@@ -852,12 +871,24 @@ struct mlx5_sig_ctx {
 	bool err_exists;
 };
 
+struct mlx5_crypto_attr {
+	enum mlx5dv_crypto_standard crypto_standard;
+	bool encrypt_on_tx;
+	enum mlx5dv_signature_crypto_order signature_crypto_order;
+	enum mlx5dv_block_size data_unit_size;
+	char initial_tweak[16];
+	struct mlx5dv_dek *dek;
+	char keytag[8];
+	enum mlx5_mkey_bsf_state state;
+};
+
 struct mlx5_mkey {
 	struct mlx5dv_mkey dv_mkey;
 	struct mlx5dv_devx_obj *devx_obj;
 	uint16_t num_desc;
 	uint64_t length;
 	struct mlx5_sig_ctx *sig;
+	struct mlx5_crypto_attr *crypto;
 };
 
 struct mlx5dv_dek {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -414,6 +414,8 @@ struct mlx5_context {
 	struct mlx5_reserved_qpns	reserved_qpns;
 	uint8_t				qp_data_in_order_cap:1;
 	struct mlx5_dv_context_ops	*dv_ctx_ops;
+	struct mlx5dv_devx_obj		*crypto_login;
+	pthread_mutex_t			crypto_login_mutex;
 };
 
 struct mlx5_bitmap {
@@ -1439,6 +1441,12 @@ struct mlx5_dv_context_ops {
 
 	struct mlx5dv_mkey *(*create_mkey)(struct mlx5dv_mkey_init_attr *mkey_init_attr);
 	int (*destroy_mkey)(struct mlx5dv_mkey *dv_mkey);
+
+	int (*crypto_login)(struct ibv_context *context,
+			    struct mlx5dv_crypto_login_attr *login_attr);
+	int (*crypto_login_query_state)(struct ibv_context *context,
+					enum mlx5dv_crypto_login_state *state);
+	int (*crypto_logout)(struct ibv_context *context);
 
 	struct mlx5dv_var *(*alloc_var)(struct ibv_context *context, uint32_t flags);
 	void (*free_var)(struct mlx5dv_var *dv_var);

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -3103,6 +3103,7 @@ struct mlx5_ifc_dealloc_flow_counter_in_bits {
 enum {
 	MLX5_OBJ_TYPE_FLOW_METER = 0x000a,
 	MLX5_OBJ_TYPE_MATCH_DEFINER = 0x0018,
+	MLX5_OBJ_TYPE_CRYPTO_LOGIN = 0x001F,
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
 	MLX5_OBJ_TYPE_ASO_FLOW_METER = 0x0024,
 	MLX5_OBJ_TYPE_ASO_FIRST_HIT = 0x0025,
@@ -5369,4 +5370,39 @@ struct mlx5_ifc_dealloc_xrcd_in_bits {
 
 	u8         reserved_at_60[0x20];
 };
+
+enum {
+	MLX5_CRYPTO_LOGIN_OBJ_STATE_VALID    = 0x0,
+	MLX5_CRYPTO_LOGIN_OBJ_STATE_INVALID  = 0x1,
+};
+
+struct mlx5_ifc_crypto_login_obj_bits {
+	u8         modify_field_select[0x40];
+
+	u8         reserved_at_40[0x40];
+
+	u8         reserved_at_80[0x4];
+	u8         state[0x4];
+	u8         credential_pointer[0x18];
+
+	u8         reserved_at_a0[0x8];
+	u8         session_import_kek_ptr[0x18];
+
+	u8         reserved_at_c0[0x140];
+
+	u8         credential[12][0x20];
+
+	u8         reserved_at_380[0x480];
+};
+
+struct mlx5_ifc_create_crypto_login_obj_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits     hdr;
+	struct mlx5_ifc_crypto_login_obj_bits           login_obj;
+};
+
+struct mlx5_ifc_query_crypto_login_obj_out_bits {
+	struct mlx5_ifc_general_obj_out_cmd_hdr_bits    hdr;
+	struct mlx5_ifc_crypto_login_obj_bits           obj;
+};
+
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1534,7 +1534,9 @@ struct mlx5_ifc_mkc_bits {
 	u8         reserved_at_1d9[0x1];
 	u8         log_page_size[0x5];
 
-	u8         reserved_at_1e0[0x20];
+	u8         reserved_at_1e0[0x3];
+	u8         crypto_en[0x2];
+	u8         reserved_at_1e5[0x1b];
 };
 
 struct mlx5_ifc_create_mkey_out_bits {
@@ -5452,6 +5454,17 @@ struct mlx5_ifc_create_encryption_key_obj_in_bits {
 struct mlx5_ifc_query_encryption_key_obj_out_bits {
 	struct mlx5_ifc_general_obj_out_cmd_hdr_bits    hdr;
 	struct mlx5_ifc_encryption_key_obj_bits         obj;
+};
+
+enum {
+	MLX5_ENCRYPTION_ORDER_ENCRYPTED_WIRE_SIGNATURE    = 0x0,
+	MLX5_ENCRYPTION_ORDER_ENCRYPTED_MEMORY_SIGNATURE  = 0x1,
+	MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_WIRE          = 0x2,
+	MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_MEMORY        = 0x3,
+};
+
+enum {
+	MLX5_ENCRYPTION_STANDARD_AES_XTS  = 0x0,
 };
 
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1136,7 +1136,10 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         steering_format_version[0x4];
 	u8         create_qp_start_hint[0x18];
 
-	u8         reserved_at_460[0x10];
+	u8         reserved_at_460[0x8];
+	u8         aes_xts[0x1];
+	u8         crypto[0x1];
+	u8         reserved_at_46a[0x6];
 	u8         max_num_eqs[0x10];
 
 	u8         sigerr_domain_and_sig_type[0x1];
@@ -1424,6 +1427,30 @@ struct mlx5_ifc_cmd_hca_cap_2_bits {
 	u8         reserved_at_a0[0x760];
 };
 
+enum {
+	MLX5_CRYPTO_CAPS_WRAPPED_IMPORT_METHOD_AES = 0x4,
+};
+
+struct mlx5_ifc_crypto_caps_bits {
+	u8         wrapped_crypto_operational[0x1];
+	u8         wrapped_crypto_going_to_commissioning[0x1];
+	u8         reserved_at_2[0x16];
+	u8         wrapped_import_method[0x8];
+
+	u8         reserved_at_20[0xb];
+	u8         log_max_num_deks[0x5];
+	u8         reserved_at_30[0x3];
+	u8         log_max_num_import_keks[0x5];
+	u8         reserved_at_38[0x3];
+	u8         log_max_num_creds[0x5];
+
+	u8         failed_selftests[0x10];
+	u8         num_nv_import_keks[0x8];
+	u8         num_nv_credentials[0x8];
+
+	u8         reserved_at_60[0x7a0];
+};
+
 union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_atomic_caps_bits atomic_caps;
 	struct mlx5_ifc_cmd_hca_cap_bits cmd_hca_cap;
@@ -1435,6 +1462,7 @@ union mlx5_ifc_hca_cap_union_bits {
 	struct mlx5_ifc_roce_cap_bits roce_caps;
 	struct mlx5_ifc_qos_cap_bits qos_caps;
 	struct mlx5_ifc_cmd_hca_cap_2_bits cmd_hca_cap_2;
+	struct mlx5_ifc_crypto_caps_bits crypto_caps;
 	u8         reserved_at_0[0x8000];
 };
 
@@ -1479,6 +1507,7 @@ enum {
 	MLX5_SET_HCA_CAP_OP_MOD_QOS                   = 0xc << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_ESW                   = 0x9 << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_DEVICE_MEMORY         = 0xf << 1,
+	MLX5_SET_HCA_CAP_OP_MOD_CRYPTO                = 0x1a << 1,
 	MLX5_SET_HCA_CAP_OP_MOD_GENERAL_DEVICE_CAP_2  = 0x20 << 1,
 };
 

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -3102,6 +3102,7 @@ struct mlx5_ifc_dealloc_flow_counter_in_bits {
 
 enum {
 	MLX5_OBJ_TYPE_FLOW_METER = 0x000a,
+	MLX5_OBJ_TYPE_DEK = 0x000C,
 	MLX5_OBJ_TYPE_MATCH_DEFINER = 0x0018,
 	MLX5_OBJ_TYPE_CRYPTO_LOGIN = 0x001F,
 	MLX5_OBJ_TYPE_FLOW_SAMPLER = 0x0020,
@@ -5403,6 +5404,54 @@ struct mlx5_ifc_create_crypto_login_obj_in_bits {
 struct mlx5_ifc_query_crypto_login_obj_out_bits {
 	struct mlx5_ifc_general_obj_out_cmd_hdr_bits    hdr;
 	struct mlx5_ifc_crypto_login_obj_bits           obj;
+};
+
+enum {
+	MLX5_ENCRYPTION_KEY_OBJ_STATE_READY  = 0x0,
+	MLX5_ENCRYPTION_KEY_OBJ_STATE_ERROR  = 0x1,
+};
+
+enum {
+	MLX5_ENCRYPTION_KEY_OBJ_KEY_SIZE_SIZE_128  = 0x0,
+	MLX5_ENCRYPTION_KEY_OBJ_KEY_SIZE_SIZE_256  = 0x1,
+};
+
+enum {
+	MLX5_ENCRYPTION_KEY_OBJ_KEY_PURPOSE_AES_XTS  = 0x3,
+};
+
+struct mlx5_ifc_encryption_key_obj_bits {
+	u8         modify_field_select[0x40];
+
+	u8         state[0x8];
+	u8         reserved_at_48[0xc];
+	u8         key_size[0x4];
+	u8         has_keytag[0x1];
+	u8         reserved_at_59[0x3];
+	u8         key_purpose[0x4];
+
+	u8         reserved_at_60[0x8];
+	u8         pd[0x18];
+
+	u8         reserved_at_80[0x100];
+
+	u8         opaque[0x40];
+
+	u8         reserved_at_1c0[0x40];
+
+	u8         key[32][0x20];
+
+	u8         reserved_at_600[0x200];
+};
+
+struct mlx5_ifc_create_encryption_key_obj_in_bits {
+	struct mlx5_ifc_general_obj_in_cmd_hdr_bits     hdr;
+	struct mlx5_ifc_encryption_key_obj_bits         key_obj;
+};
+
+struct mlx5_ifc_query_encryption_key_obj_out_bits {
+	struct mlx5_ifc_general_obj_out_cmd_hdr_bits    hdr;
+	struct mlx5_ifc_encryption_key_obj_bits         obj;
 };
 
 #endif /* MLX5_IFC_H */

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -574,6 +574,45 @@ int mlx5dv_crypto_login_query_state(struct ibv_context *context,
 
 int mlx5dv_crypto_logout(struct ibv_context *context);
 
+enum mlx5dv_crypto_key_size {
+	MLX5DV_CRYPTO_KEY_SIZE_128,
+	MLX5DV_CRYPTO_KEY_SIZE_256,
+};
+
+enum mlx5dv_crypto_key_purpose {
+	MLX5DV_CRYPTO_KEY_PURPOSE_AES_XTS,
+};
+
+enum mlx5dv_dek_state {
+	MLX5DV_DEK_STATE_READY,
+	MLX5DV_DEK_STATE_ERROR,
+};
+
+struct mlx5dv_dek_init_attr {
+	enum mlx5dv_crypto_key_size key_size;
+	bool has_keytag;
+	enum mlx5dv_crypto_key_purpose key_purpose;
+	struct ibv_pd *pd;
+	char opaque[8];
+	char key[128];
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_dek_attr {
+	enum mlx5dv_dek_state state;
+	char opaque[8];
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_dek;
+
+struct mlx5dv_dek *mlx5dv_dek_create(struct ibv_context *context,
+				     struct mlx5dv_dek_init_attr *init_attr);
+
+int mlx5dv_dek_query(struct mlx5dv_dek *dek, struct mlx5dv_dek_attr *attr);
+
+int mlx5dv_dek_destroy(struct mlx5dv_dek *dek);
+
 enum mlx5dv_flow_action_esp_mask {
 	MLX5DV_FLOW_ACTION_ESP_MASK_FLAGS	= 1 << 0,
 };

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -553,6 +553,27 @@ static inline void mlx5dv_wr_raw_wqe(struct mlx5dv_qp_ex *mqp, const void *wqe)
 	mqp->wr_raw_wqe(mqp, wqe);
 }
 
+struct mlx5dv_crypto_login_attr {
+	uint32_t credential_id;
+	uint32_t import_kek_id;
+	char credential[48];
+	uint64_t comp_mask;
+};
+
+enum mlx5dv_crypto_login_state {
+	MLX5DV_CRYPTO_LOGIN_STATE_VALID,
+	MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN,
+	MLX5DV_CRYPTO_LOGIN_STATE_INVALID,
+};
+
+int mlx5dv_crypto_login(struct ibv_context *context,
+			struct mlx5dv_crypto_login_attr *login_attr);
+
+int mlx5dv_crypto_login_query_state(struct ibv_context *context,
+				    enum mlx5dv_crypto_login_state *state);
+
+int mlx5dv_crypto_logout(struct ibv_context *context);
+
 enum mlx5dv_flow_action_esp_mask {
 	MLX5DV_FLOW_ACTION_ESP_MASK_FLAGS	= 1 << 0,
 };

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -85,6 +85,7 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD	= 1 << 10,
 	MLX5DV_CONTEXT_MASK_DCI_STREAMS		= 1 << 11,
 	MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH	= 1 << 12,
+	MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD	= 1 << 13,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -181,6 +182,33 @@ struct mlx5dv_sig_caps {
 	uint16_t crc_type; /* use enum mlx5dv_sig_crc_type_caps */
 };
 
+enum mlx5dv_crypto_engines_caps {
+	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS = 1 << 0,
+};
+
+enum mlx5dv_crypto_wrapped_import_method_caps {
+	MLX5DV_CRYPTO_WRAPPED_IMPORT_METHOD_CAP_AES_XTS = 1 << 0,
+};
+
+enum mlx5dv_crypto_caps_flags {
+	MLX5DV_CRYPTO_CAPS_CRYPTO = 1 << 0,
+	MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL = 1 << 1,
+	MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_GOING_TO_COMMISSIONING = 1 << 2,
+};
+
+struct mlx5dv_crypto_caps {
+	/*
+	 * if failed_selftests != 0 it means there are some self tests errors
+	 * that may render specific crypto engines unusable. Exact code meaning
+	 * should be consulted with NVIDIA.
+	 */
+	uint16_t failed_selftests;
+	uint8_t crypto_engines; /* use enum mlx5dv_crypto_engines_caps */
+	uint8_t wrapped_import_method; /* use enum mlx5dv_crypto_wrapped_import_method_caps */
+	uint8_t log_max_num_deks;
+	uint32_t flags; /* use enum mlx5dv_crypto_caps_flags */
+};
+
 /*
  * Direct verbs device-specific attributes
  */
@@ -201,6 +229,7 @@ struct mlx5dv_context {
 	struct mlx5dv_sig_caps sig_caps;
 	struct mlx5dv_dci_streams_caps dci_streams_caps;
 	size_t max_wr_memcpy_length;
+	struct mlx5dv_crypto_caps crypto_caps;
 };
 
 enum mlx5dv_context_flags {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -252,6 +252,7 @@ enum mlx5dv_qp_create_flags {
 enum mlx5dv_mkey_init_attr_flags {
 	MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT = 1 << 0,
 	MLX5DV_MKEY_INIT_ATTR_FLAGS_BLOCK_SIGNATURE = 1 << 1,
+	MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO = 1 << 2,
 };
 
 struct mlx5dv_mkey_init_attr {
@@ -370,6 +371,26 @@ struct mlx5dv_sig_block_attr {
 	uint64_t comp_mask;
 };
 
+enum mlx5dv_crypto_standard {
+	MLX5DV_CRYPTO_STANDARD_AES_XTS,
+};
+
+enum mlx5dv_signature_crypto_order {
+	MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX,
+	MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX,
+};
+
+struct mlx5dv_crypto_attr {
+	enum mlx5dv_crypto_standard crypto_standard;
+	bool encrypt_on_tx;
+	enum mlx5dv_signature_crypto_order signature_crypto_order;
+	enum mlx5dv_block_size data_unit_size;
+	char initial_tweak[16];
+	struct mlx5dv_dek *dek;
+	char keytag[8];
+	uint64_t comp_mask;
+};
+
 enum mlx5dv_mkey_conf_flags {
 	MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR = 1 << 0,
 };
@@ -430,6 +451,8 @@ struct mlx5dv_qp_ex {
 			  uint32_t dest_lkey, uint64_t dest_addr,
 			  uint32_t src_lkey, uint64_t src_addr,
 			  size_t length);
+	void (*wr_set_mkey_crypto)(struct mlx5dv_qp_ex *mqp,
+				   const struct mlx5dv_crypto_attr *attr);
 };
 
 struct mlx5dv_qp_ex *mlx5dv_qp_ex_from_ibv_qp_ex(struct ibv_qp_ex *qp);
@@ -506,6 +529,13 @@ static inline void mlx5dv_wr_set_mkey_sig_block(struct mlx5dv_qp_ex *mqp,
 						const struct mlx5dv_sig_block_attr *attr)
 {
 	mqp->wr_set_mkey_sig_block(mqp, attr);
+}
+
+static inline void
+mlx5dv_wr_set_mkey_crypto(struct mlx5dv_qp_ex *mqp,
+			  const struct mlx5dv_crypto_attr *attr)
+{
+	mqp->wr_set_mkey_crypto(mqp, attr);
 }
 
 static inline void mlx5dv_wr_memcpy(struct mlx5dv_qp_ex *mqp,

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2287,8 +2287,9 @@ static bool mlx5_umr_block_t10dif_sbs(struct mlx5_sig_block_domain *block_mem,
 	return true;
 }
 
-static int mlx5_umr_fill_bsf(struct mlx5_bsf *bsf,
-			     struct mlx5_sig_block *block)
+static int mlx5_umr_fill_sig_bsf(struct mlx5_bsf *bsf,
+				 struct mlx5_sig_block *block,
+				 bool have_crypto_bsf)
 {
 	struct mlx5_bsf_basic *basic = &bsf->basic;
 	struct mlx5_sig_block_domain *block_mem = &block->attr.mem;
@@ -2300,7 +2301,9 @@ static int mlx5_umr_fill_bsf(struct mlx5_bsf *bsf,
 
 	memset(bsf, 0, sizeof(*bsf));
 
-	basic->bsf_size_sbs |= MLX5_BSF_SIZE_WITH_INLINE << MLX5_BSF_SIZE_SHIFT;
+	basic->bsf_size_sbs |= (have_crypto_bsf ? MLX5_BSF_SIZE_SIG_AND_CRYPTO :
+						  MLX5_BSF_SIZE_WITH_INLINE)
+			       << MLX5_BSF_SIZE_SHIFT;
 	basic->raw_data_size = htobe32(UINT32_MAX);
 	if (block_wire->sig_type != MLX5_SIG_TYPE_NONE ||
 	    block_mem->sig_type != MLX5_SIG_TYPE_NONE)
@@ -2354,6 +2357,68 @@ static int mlx5_umr_fill_bsf(struct mlx5_bsf *bsf,
 				bs_to_bs_selector(block_wire->block_size);
 		}
 	}
+
+	return 0;
+}
+
+static int get_crypto_order(bool encrypt_on_tx,
+			    enum mlx5dv_signature_crypto_order sig_crypto_order,
+			    struct mlx5_sig_block *block)
+{
+	int order = -1;
+
+	if (encrypt_on_tx) {
+		if (sig_crypto_order ==
+		    MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX)
+			order = MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_WIRE;
+		else
+			order = MLX5_ENCRYPTION_ORDER_ENCRYPTED_WIRE_SIGNATURE;
+	} else {
+		if (sig_crypto_order ==
+		    MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX)
+			order = MLX5_ENCRYPTION_ORDER_ENCRYPTED_MEMORY_SIGNATURE;
+		else
+			order = MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_MEMORY;
+	}
+
+	/*
+	 * The combination of RAW_WIRE or RAW_MEMORY with signature configured
+	 * in both memory and wire domains is not yet supported by the device.
+	 * Return error if the user has mistakenly configured it.
+	 */
+	if (order == MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_WIRE ||
+	    order == MLX5_ENCRYPTION_ORDER_ENCRYPTED_RAW_MEMORY)
+		if (block && block->attr.mem.sig_type != MLX5_SIG_TYPE_NONE &&
+		    block->attr.wire.sig_type != MLX5_SIG_TYPE_NONE)
+			return -1;
+
+	return order;
+}
+
+static int mlx5_umr_fill_crypto_bsf(struct mlx5_crypto_bsf *crypto_bsf,
+				    struct mlx5_crypto_attr *attr,
+				    struct mlx5_sig_block *block)
+{
+	int order;
+
+	memset(crypto_bsf, 0, sizeof(*crypto_bsf));
+
+	crypto_bsf->bsf_size_type |= MLX5_BSF_SIZE_WITH_INLINE
+				     << MLX5_BSF_SIZE_SHIFT;
+	crypto_bsf->bsf_size_type |= MLX5_BSF_TYPE_CRYPTO;
+	order = get_crypto_order(attr->encrypt_on_tx,
+				 attr->signature_crypto_order, block);
+	if (order < 0)
+		return EINVAL;
+	crypto_bsf->enc_order = order;
+	crypto_bsf->enc_standard = MLX5_ENCRYPTION_STANDARD_AES_XTS;
+	crypto_bsf->raw_data_size = htobe32(UINT32_MAX);
+	crypto_bsf->bs_pointer = bs_to_bs_selector(attr->data_unit_size);
+	memcpy(crypto_bsf->xts_init_tweak, attr->initial_tweak,
+	       sizeof(crypto_bsf->xts_init_tweak));
+	crypto_bsf->rsvd_dek_ptr =
+		htobe32(attr->dek->devx_obj->object_id & 0x00FFFFFF);
+	memcpy(crypto_bsf->keytag, attr->keytag, sizeof(crypto_bsf->keytag));
 
 	return 0;
 }
@@ -2426,84 +2491,54 @@ static uint64_t psv_transient_signature(enum mlx5_sig_type type,
 	return ts;
 }
 
-static void umr_wqe_finalize(struct mlx5_qp *mqp)
+static inline void set_mkc_sig_err_cnt(struct mlx5_mkey *mkey,
+				       struct mlx5_wqe_umr_ctrl_seg *umr_ctrl,
+				       struct mlx5_wqe_mkey_context_seg *mk)
 {
-	struct mlx5_mkey *mkey = mqp->cur_mkey;
-	struct mlx5_sig_block *block;
-	void *seg;
-	void *qend = mqp->sq.qend;
-	struct mlx5_wqe_umr_ctrl_seg *umr_ctrl;
-	struct mlx5_wqe_mkey_context_seg *mk;
-	size_t cur_data_size;
-	size_t max_data_size;
-	size_t bsf_size = sizeof(struct mlx5_bsf);
-	struct mlx5_wqe_ctrl_seg *wqe_ctrl;
-	bool mem_sig;
-	bool wire_sig;
-	uint64_t ts;
-	int ret;
-
-	if (!mkey->sig)
-		goto umr_finalize;
-
-	seg = (void *)mqp->cur_ctrl + sizeof(struct mlx5_wqe_ctrl_seg);
-	umr_ctrl = seg;
-	seg += sizeof(struct mlx5_wqe_umr_ctrl_seg);
-	if (unlikely(seg == qend))
-		seg = mlx5_get_send_wqe(mqp, 0);
-	mk = seg;
-
 	umr_ctrl->mkey_mask |= htobe64(MLX5_WQE_UMR_CTRL_MKEY_MASK_SIG_ERR);
 	mk->flags_pd |= htobe32(
 		(mkey->sig->err_count & MLX5_WQE_MKEY_CONTEXT_SIG_ERR_CNT_MASK)
 		<< MLX5_WQE_MKEY_CONTEXT_SIG_ERR_CNT_SHIFT);
+}
 
-	block = &mkey->sig->block;
-	if (!(block->updated))
-		goto umr_finalize;
+static inline void suppress_umr_completion(struct mlx5_qp *mqp)
+{
+	struct mlx5_wqe_ctrl_seg *wqe_ctrl;
 
-	cur_data_size = be16toh(umr_ctrl->klm_octowords) * 16;
-	max_data_size = mqp->max_inline_data + sizeof(struct mlx5_wqe_inl_data_seg);
-	if (unlikely((cur_data_size + bsf_size) > max_data_size)) {
-		mqp->err = ENOMEM;
-		return;
-	}
+	/*
+	 * Up to 3 WQEs can be posted to configure an MKEY with the signature
+	 * attributes: 1 UMR + 1 or 2 SET_PSV. The MKEY is ready to use when the
+	 * last WQE is completed. There is no reason to report 3 completions.
+	 * One completion for the last SET_PSV WQE is enough. Reset the signal
+	 * flag to suppress a completion for UMR WQE.
+	 */
+	wqe_ctrl = (void *)mqp->cur_ctrl;
+	wqe_ctrl->fm_ce_se &= ~MLX5_WQE_CTRL_CQ_UPDATE;
+}
 
-	/* The length must fit the raw_data_size of the BSF. */
-	if (unlikely(mkey->length > UINT32_MAX)) {
-		mqp->err = EINVAL;
-		return;
-	}
-
-	seg = mqp->cur_data + cur_data_size;
-	if (unlikely(seg >= qend))
-		seg = qend - seg + mlx5_get_send_wqe(mqp, 0);
-
-	ret = mlx5_umr_fill_bsf(seg, block);
-	if (ret) {
-		mqp->err = ret;
-		return;
-	}
+static inline void
+sig_crypto_umr_wqe_finalize(struct mlx5_qp *mqp, size_t bsf_size,
+			    struct mlx5_wqe_umr_ctrl_seg *umr_ctrl,
+			    struct mlx5_wqe_mkey_context_seg *mk)
+{
 	mqp->cur_size += bsf_size / 16;
 
 	umr_ctrl->bsf_octowords = htobe16(bsf_size / 16);
 	umr_ctrl->mkey_mask |= htobe64(MLX5_WQE_UMR_CTRL_MKEY_MASK_BSF_ENABLE);
 	mk->flags_pd |= htobe32(MLX5_WQE_MKEY_CONTEXT_FLAGS_BSF_ENABLE);
 
-	/*
-	 * Up to 3 WQEs can be posted to configure an MKEY with the signature
-	 * attributes: 1 UMR + 1 or 2 SET_PSV. The MKEY is ready to use when
-	 * the last WQE is completed. There is no reason to report 3
-	 * completions. One completion for the last SET_PSV WQE is enough.
-	 * Reset the signal flag to suppress a completion for UMR WQE.
-	 */
-	wqe_ctrl = (void *)mqp->cur_ctrl;
-	wqe_ctrl->fm_ce_se &= ~MLX5_WQE_CTRL_CQ_UPDATE;
-
 	mqp->nreq++;
 	mqp->fm_cache = MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE;
 	_common_wqe_finalize(mqp);
 	mqp->cur_mkey = NULL;
+}
+
+static inline void mlx5_umr_set_psvs(struct mlx5_qp *mqp,
+				     struct mlx5_sig_block *block)
+{
+	uint64_t ts;
+	bool mem_sig;
+	bool wire_sig;
 
 	mem_sig = block->attr.mem.sig_type != MLX5_SIG_TYPE_NONE;
 	wire_sig = block->attr.wire.sig_type != MLX5_SIG_TYPE_NONE;
@@ -2519,6 +2554,171 @@ static void umr_wqe_finalize(struct mlx5_qp *mqp)
 					     &block->attr.wire.sig);
 		mlx5_umr_set_psv(mqp, block->wire_psv->index, ts, false);
 	}
+}
+
+static void crypto_umr_wqe_finalize(struct mlx5_qp *mqp)
+{
+	struct mlx5_mkey *mkey = mqp->cur_mkey;
+	void *seg;
+	void *qend = mqp->sq.qend;
+	struct mlx5_wqe_umr_ctrl_seg *umr_ctrl;
+	struct mlx5_wqe_mkey_context_seg *mk;
+	size_t cur_data_size;
+	size_t max_data_size;
+	size_t bsf_size = 0;
+	bool set_crypto_bsf = false;
+	bool set_psv = false;
+	int ret;
+
+	seg = (void *)mqp->cur_ctrl + sizeof(struct mlx5_wqe_ctrl_seg);
+	umr_ctrl = seg;
+	seg += sizeof(struct mlx5_wqe_umr_ctrl_seg);
+	if (unlikely(seg == qend))
+		seg = mlx5_get_send_wqe(mqp, 0);
+	mk = seg;
+
+	if (mkey->sig)
+		set_mkc_sig_err_cnt(mkey, umr_ctrl, mk);
+
+	if (!(mkey->sig &&
+	      mkey->sig->block.state == MLX5_MKEY_BSF_STATE_UPDATED) &&
+	    !(mkey->crypto->state == MLX5_MKEY_BSF_STATE_UPDATED) &&
+	    !(mkey->sig && mkey->sig->block.state == MLX5_MKEY_BSF_STATE_RESET))
+		goto umr_finalize;
+
+	if (mkey->sig) {
+		bsf_size += sizeof(struct mlx5_bsf);
+
+		if (mkey->sig->block.state == MLX5_MKEY_BSF_STATE_UPDATED ||
+		    mkey->sig->block.state == MLX5_MKEY_BSF_STATE_SET)
+			set_psv = true;
+	}
+
+	if (mkey->crypto->state == MLX5_MKEY_BSF_STATE_UPDATED ||
+	    mkey->crypto->state == MLX5_MKEY_BSF_STATE_SET) {
+		bsf_size += sizeof(struct mlx5_crypto_bsf);
+		set_crypto_bsf = true;
+	}
+
+	cur_data_size = be16toh(umr_ctrl->klm_octowords) * 16;
+	max_data_size =
+		mqp->max_inline_data + sizeof(struct mlx5_wqe_inl_data_seg);
+	if (unlikely((cur_data_size + bsf_size) > max_data_size)) {
+		mqp->err = ENOMEM;
+		return;
+	}
+
+	/* The length must fit the raw_data_size of the BSF. */
+	if (unlikely(mkey->length > UINT32_MAX)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	seg = mqp->cur_data + cur_data_size;
+	if (unlikely(seg >= qend))
+		seg = qend - seg + mlx5_get_send_wqe(mqp, 0);
+
+	if (mkey->sig) {
+		/* If sig and crypto are enabled, sig BSF must be set */
+		ret = mlx5_umr_fill_sig_bsf(seg, &mkey->sig->block,
+					    set_crypto_bsf);
+		if (ret) {
+			mqp->err = ret;
+			return;
+		}
+
+		if (set_psv)
+			suppress_umr_completion(mqp);
+
+		seg += sizeof(struct mlx5_bsf);
+		if (unlikely(seg == qend))
+			seg = mlx5_get_send_wqe(mqp, 0);
+	}
+
+	if (set_crypto_bsf) {
+		ret = mlx5_umr_fill_crypto_bsf(seg, mkey->crypto,
+					       mkey->sig ? &mkey->sig->block :
+							   NULL);
+		if (ret) {
+			mqp->err = ret;
+			return;
+		}
+	}
+
+	sig_crypto_umr_wqe_finalize(mqp, bsf_size, umr_ctrl, mk);
+
+	if (set_psv)
+		mlx5_umr_set_psvs(mqp, &mkey->sig->block);
+
+	return;
+
+umr_finalize:
+	mqp->nreq++;
+	_common_wqe_finalize(mqp);
+	mqp->cur_mkey = NULL;
+}
+
+static void umr_wqe_finalize(struct mlx5_qp *mqp)
+{
+	struct mlx5_mkey *mkey = mqp->cur_mkey;
+	struct mlx5_sig_block *block;
+	void *seg;
+	void *qend = mqp->sq.qend;
+	struct mlx5_wqe_umr_ctrl_seg *umr_ctrl;
+	struct mlx5_wqe_mkey_context_seg *mk;
+	size_t cur_data_size;
+	size_t max_data_size;
+	size_t bsf_size = sizeof(struct mlx5_bsf);
+	int ret;
+
+	if (!mkey->sig && !mkey->crypto)
+		goto umr_finalize;
+
+	if (mkey->crypto) {
+		crypto_umr_wqe_finalize(mqp);
+		return;
+	}
+
+	seg = (void *)mqp->cur_ctrl + sizeof(struct mlx5_wqe_ctrl_seg);
+	umr_ctrl = seg;
+	seg += sizeof(struct mlx5_wqe_umr_ctrl_seg);
+	if (unlikely(seg == qend))
+		seg = mlx5_get_send_wqe(mqp, 0);
+	mk = seg;
+
+	set_mkc_sig_err_cnt(mkey, umr_ctrl, mk);
+
+	block = &mkey->sig->block;
+	if (block->state != MLX5_MKEY_BSF_STATE_UPDATED)
+		goto umr_finalize;
+
+	cur_data_size = be16toh(umr_ctrl->klm_octowords) * 16;
+	max_data_size =
+		mqp->max_inline_data + sizeof(struct mlx5_wqe_inl_data_seg);
+	if (unlikely((cur_data_size + bsf_size) > max_data_size)) {
+		mqp->err = ENOMEM;
+		return;
+	}
+
+	/* The length must fit the raw_data_size of the BSF. */
+	if (unlikely(mkey->length > UINT32_MAX)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	seg = mqp->cur_data + cur_data_size;
+	if (unlikely(seg >= qend))
+		seg = qend - seg + mlx5_get_send_wqe(mqp, 0);
+
+	ret = mlx5_umr_fill_sig_bsf(seg, &mkey->sig->block, false);
+	if (ret) {
+		mqp->err = ret;
+		return;
+	}
+
+	suppress_umr_completion(mqp);
+	sig_crypto_umr_wqe_finalize(mqp, bsf_size, umr_ctrl, mk);
+	mlx5_umr_set_psvs(mqp, block);
 
 	return;
 umr_finalize:
@@ -2586,19 +2786,35 @@ static void mlx5_send_wr_mkey_configure(struct mlx5dv_qp_ex *dv_qp,
 	mqp->cur_data = seg;
 	umr_ctrl->flags = MLX5_WQE_UMR_CTRL_FLAG_INLINE;
 
-	if (attr->conf_flags & MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR)
-		/*
-		 * Set bsf_enable bit in the mask to update the corresponding
-		 * bit in the MKEY context. The new value is 0(BSF is disabled)
-		 * because the MKEY context segment (*mk) was zeroed in few
-		 * lines above.
-		 */
-		mkey_mask |= MLX5_WQE_UMR_CTRL_MKEY_MASK_BSF_ENABLE;
+	if (mkey->sig) {
+		if (attr->conf_flags & MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR) {
+			mkey->sig->block.attr.mem.sig_type = MLX5_SIG_TYPE_NONE;
+			mkey->sig->block.attr.wire.sig_type =
+				MLX5_SIG_TYPE_NONE;
+			mkey->sig->block.state = MLX5_MKEY_BSF_STATE_RESET;
+			/*
+			 * Set bsf_enable bit in the mask to update the
+			 * corresponding bit in the MKEY context. The new value
+			 * is 0 (BSF is disabled) because the MKEY context
+			 * segment (*mk) was zeroed in few lines above.
+			 */
+			mkey_mask |= MLX5_WQE_UMR_CTRL_MKEY_MASK_BSF_ENABLE;
+		} else {
+			if (mkey->sig->block.state ==
+			    MLX5_MKEY_BSF_STATE_UPDATED)
+				mkey->sig->block.state =
+					MLX5_MKEY_BSF_STATE_SET;
+			else if (mkey->sig->block.state ==
+				 MLX5_MKEY_BSF_STATE_RESET)
+				mkey->sig->block.state =
+					MLX5_MKEY_BSF_STATE_INIT;
+		}
+	}
+
+	if (mkey->crypto && mkey->crypto->state == MLX5_MKEY_BSF_STATE_UPDATED)
+		mkey->crypto->state = MLX5_MKEY_BSF_STATE_SET;
 
 	umr_ctrl->mkey_mask = htobe64(mkey_mask);
-
-	if (mkey->sig)
-		mkey->sig->block.updated = false;
 
 	mqp->fm_cache = MLX5_WQE_CTRL_INITIATOR_SMALL_FENCE;
 	mqp->inl_wqe = 1;
@@ -2883,7 +3099,7 @@ static void mlx5_send_wr_set_mkey_sig_block(struct mlx5dv_qp_ex *dv_qp,
 
 	/* Check whether the setter is already called for the current UMR WQE. */
 	sig_block = &mkey->sig->block;
-	if (unlikely(sig_block->updated)) {
+	if (unlikely(sig_block->state == MLX5_MKEY_BSF_STATE_UPDATED)) {
 		mqp->err = EINVAL;
 		return;
 	}
@@ -2925,7 +3141,78 @@ static void mlx5_send_wr_set_mkey_sig_block(struct mlx5dv_qp_ex *dv_qp,
 	sig_block->attr.check_mask = dv_attr->check_mask;
 	sig_block->attr.copy_mask = dv_attr->copy_mask;
 
-	sig_block->updated = true;
+	sig_block->state = MLX5_MKEY_BSF_STATE_UPDATED;
+
+	mqp->cur_setters_cnt++;
+	if (mqp->cur_setters_cnt == mqp->num_mkey_setters)
+		umr_wqe_finalize(mqp);
+}
+
+static void
+mlx5_send_wr_set_mkey_crypto(struct mlx5dv_qp_ex *dv_qp,
+			     const struct mlx5dv_crypto_attr *dv_attr)
+{
+	struct mlx5_qp *mqp = mqp_from_mlx5dv_qp_ex(dv_qp);
+	struct mlx5_mkey *mkey = mqp->cur_mkey;
+	struct mlx5_crypto_attr *crypto_attr;
+
+	if (unlikely(mqp->err))
+		return;
+
+	if (unlikely(!mkey)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	if (unlikely(!mkey->crypto)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	/* Check whether the setter is already called for the current UMR WQE */
+	crypto_attr = mkey->crypto;
+	if (unlikely(crypto_attr->state == MLX5_MKEY_BSF_STATE_UPDATED)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	if (unlikely(dv_attr->comp_mask)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	if (unlikely(dv_attr->crypto_standard !=
+		     MLX5DV_CRYPTO_STANDARD_AES_XTS)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	if (unlikely(
+		    dv_attr->signature_crypto_order !=
+			    MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX &&
+		    dv_attr->signature_crypto_order !=
+			    MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	if (unlikely(dv_attr->data_unit_size < MLX5DV_BLOCK_SIZE_512 ||
+		     dv_attr->data_unit_size > MLX5DV_BLOCK_SIZE_4160)) {
+		mqp->err = EINVAL;
+		return;
+	}
+
+	crypto_attr->crypto_standard = dv_attr->crypto_standard;
+	crypto_attr->encrypt_on_tx = dv_attr->encrypt_on_tx;
+	crypto_attr->signature_crypto_order = dv_attr->signature_crypto_order;
+	crypto_attr->data_unit_size = dv_attr->data_unit_size;
+	crypto_attr->dek = dv_attr->dek;
+	memcpy(crypto_attr->initial_tweak, dv_attr->initial_tweak,
+	       sizeof(crypto_attr->initial_tweak));
+	memcpy(crypto_attr->keytag, dv_attr->keytag,
+	       sizeof(crypto_attr->keytag));
+
+	crypto_attr->state = MLX5_MKEY_BSF_STATE_UPDATED;
 
 	mqp->cur_setters_cnt++;
 	if (mqp->cur_setters_cnt == mqp->num_mkey_setters)
@@ -3209,6 +3496,8 @@ int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
 				mlx5_send_wr_set_mkey_layout_interleaved;
 			dv_qp->wr_set_mkey_sig_block =
 				mlx5_send_wr_set_mkey_sig_block;
+			dv_qp->wr_set_mkey_crypto =
+				mlx5_send_wr_set_mkey_crypto;
 			dv_qp->wr_memcpy = mlx5_wr_memcpy;
 		}
 

--- a/providers/mlx5/wqe.h
+++ b/providers/mlx5/wqe.h
@@ -134,6 +134,8 @@ enum {
 	MLX5_BSF_SIZE_BASIC = 0,
 	MLX5_BSF_SIZE_EXTENDED = 1,
 	MLX5_BSF_SIZE_WITH_INLINE = 2,
+	MLX5_BSF_SIZE_SIG_AND_CRYPTO = 3,
+	MLX5_BSF_TYPE_CRYPTO = 1,
 	MLX5_BSF_SIZE_SHIFT = 6,
 	MLX5_BSF_SBS_SHIFT = 4,
 
@@ -168,6 +170,21 @@ struct mlx5_bsf_inl {
 	uint8_t rsvd[3];
 	uint8_t dif_inc_ref_guard_check;
 	__be16 dif_app_bitmask_check;
+};
+
+struct mlx5_crypto_bsf {
+	uint8_t bsf_size_type;
+	uint8_t enc_order;
+	uint8_t rsvd0;
+	uint8_t enc_standard;
+	__be32 raw_data_size;
+	uint8_t bs_pointer;
+	uint8_t rsvd1[7];
+	__be32 xts_init_tweak[4];
+	__be32 rsvd_dek_ptr;
+	uint8_t rsvd2[4];
+	uint8_t keytag[8];
+	uint8_t rsvd3[16];
 };
 
 struct mlx5_bsf {

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -21,6 +21,7 @@ cdef class PD(PyverbsCM):
     cdef object qps
     cdef object parent_domains
     cdef object mkeys
+    cdef object deks
     cdef object _is_imported
 
 cdef class ParentDomainInitAttr(PyverbsObject):

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -63,6 +63,7 @@ cdef class PD(PyverbsCM):
         self.qps = weakref.WeakSet()
         self.parent_domains = weakref.WeakSet()
         self.mkeys = weakref.WeakSet()
+        self.deks = weakref.WeakSet()
 
     def advise_mr(self, advise, uint32_t flags, sg_list not None):
         """
@@ -104,8 +105,8 @@ cdef class PD(PyverbsCM):
         """
         if self.pd != NULL:
             self.logger.debug('Closing PD')
-            close_weakrefs([self.mkeys, self.parent_domains, self.qps, self.ahs,
-                            self.mws, self.mrs, self.srqs])
+            close_weakrefs([self.deks, self.mkeys, self.parent_domains, self.qps,
+                            self.ahs, self.mws, self.mrs, self.srqs])
             if not self._is_imported:
                 rc = v.ibv_dealloc_pd(self.pd)
                 if rc != 0:

--- a/pyverbs/providers/mlx5/CMakeLists.txt
+++ b/pyverbs/providers/mlx5/CMakeLists.txt
@@ -10,6 +10,7 @@ rdma_cython_module(pyverbs/providers/mlx5 mlx5
   mlx5_enums.pyx
   mlx5_vfio.pyx
   mlx5dv.pyx
+  mlx5dv_crypto.pyx
   mlx5dv_flow.pyx
   mlx5dv_mkey.pyx
   mlx5dv_objects.pyx

--- a/pyverbs/providers/mlx5/mlx5dv_crypto.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_crypto.pxd
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia, Inc. All rights reserved. See COPYING file
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.pd cimport PD
+
+
+cdef class Mlx5CryptoLoginAttr(PyverbsObject):
+    cdef dv.mlx5dv_crypto_login_attr mlx5dv_crypto_login_attr
+
+cdef class Mlx5DEKInitAttr(PyverbsObject):
+    cdef dv.mlx5dv_dek_init_attr mlx5dv_dek_init_attr
+    cdef PD pd
+
+cdef class Mlx5DEKAttr(PyverbsObject):
+    cdef dv.mlx5dv_dek_attr mlx5dv_dek_attr
+
+cdef class Mlx5CryptoAttr(PyverbsObject):
+    cdef dv.mlx5dv_crypto_attr mlx5dv_crypto_attr
+
+cdef class Mlx5DEK(PyverbsCM):
+    cdef dv.mlx5dv_dek *mlx5dv_dek
+    cdef PD pd

--- a/pyverbs/providers/mlx5/mlx5dv_crypto.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_crypto.pyx
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia, Inc. All rights reserved. See COPYING file
+
+from libc.string cimport memcpy
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.device cimport Context
+from pyverbs.pd cimport PD
+
+
+cdef class Mlx5CryptoLoginAttr(PyverbsObject):
+    def __init__(self, credential, credential_id=0, import_kek_id=0):
+        """
+        Initializes a Mlx5CryptoLoginAttr object representing
+        mlx5dv_crypto_login_attr C struct.
+        :param credential: The credential to login with. Must be provided
+                           wrapped by the AES key wrap algorithm using the
+                           import KEK indicated by *import_kek_id*.
+        :param credential_id: The index of credential that stored on the device.
+        :param import_kek_id: The index of import_kek that stored on the device.
+        """
+        cdef char *credential_c = credential
+        self.mlx5dv_crypto_login_attr.credential_id = credential_id
+        self.mlx5dv_crypto_login_attr.import_kek_id = import_kek_id
+        memcpy(self.mlx5dv_crypto_login_attr.credential, credential_c, 48)
+
+    @property
+    def credential_id(self):
+        return self.mlx5dv_crypto_login_attr.credential_id
+
+    @property
+    def import_kek_id(self):
+        return self.mlx5dv_crypto_login_attr.import_kek_id
+
+    @property
+    def credential(self):
+        return self.mlx5dv_crypto_login_attr.credential
+
+    @property
+    def comp_mask(self):
+        return self.mlx5dv_crypto_login_attr.comp_mask
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return 'Mlx5CryptoLoginAttr:\n' +\
+               print_format.format('Credential id', self.credential_id) +\
+               print_format.format('Import KEK id', self.import_kek_id) +\
+               print_format.format('Credential', self.credential) +\
+               print_format.format('Comp mask', self.comp_mask)
+
+
+cdef class Mlx5DEKInitAttr(PyverbsObject):
+    def __init__(self, PD pd, key_size, has_keytag=False, key_purpose=0, opaque=bytes(),
+                 key=bytes(), comp_mask=0):
+        """
+        Initializes a Mlx5DEKInitAttr object representing mlx5dv_dek_init_attr
+        C struct.
+        :param pd: The protection domain to be associated with the DEK.
+        :param credential_id: The size of the key,
+                              can be MLX5DV_CRYPTO_KEY_SIZE_128/256
+        :param has_keytag: Whether the DEK has a keytag or not. If set, the key
+                           should include a 8 Bytes keytag.
+        :param key_purpose: The crypto purpose of the key.
+        :param opaque: Plaintext metadata to describe the key.
+        :param key: The key itself, wrapped by the crypto login session's
+                    import KEK.
+        :param comp_mask: Reserved for future extension.
+        """
+        cdef char *opaque_c = opaque
+        cdef char *key_c = key
+        self.pd = pd
+        self.mlx5dv_dek_init_attr.pd = pd.pd
+        self.mlx5dv_dek_init_attr.key_size = key_size
+        self.mlx5dv_dek_init_attr.has_keytag = has_keytag
+        self.mlx5dv_dek_init_attr.key_purpose = key_purpose
+        memcpy(self.mlx5dv_dek_init_attr.opaque, opaque_c, 8)
+        memcpy(self.mlx5dv_dek_init_attr.key, key_c, 128)
+        self.mlx5dv_dek_init_attr.comp_mask = comp_mask
+
+    @property
+    def key_size(self):
+        return self.mlx5dv_dek_init_attr.key_size
+
+    @property
+    def has_keytag(self):
+        return self.mlx5dv_dek_init_attr.has_keytag
+
+    @property
+    def key_purpose(self):
+        return self.mlx5dv_dek_init_attr.key_purpose
+
+    @property
+    def opaque(self):
+        return self.mlx5dv_dek_init_attr.opaque.decode()
+
+    @property
+    def key(self):
+        return self.mlx5dv_dek_init_attr.key.hex()
+
+    @property
+    def comp_mask(self):
+        return self.mlx5dv_dek_init_attr.comp_mask
+
+    def __str__(self):
+        print_format = '{:20}: {:<20}\n'
+        return 'Mlx5DEKInitAttr:\n' +\
+            print_format.format('key_size', self.key_size) +\
+            print_format.format('Has keytag', self.has_keytag) +\
+            print_format.format('Key purpose', self.key_purpose) +\
+            print_format.format('Opaque', self.opaque) +\
+            print_format.format('Key (in hex format)', self.key) +\
+            print_format.format('Comp mask', self.comp_mask)
+
+
+cdef class Mlx5DEKAttr(PyverbsObject):
+    """
+    Initializes a Mlx5DEKAttr object representing mlx5dv_dek_attr
+    C struct.
+    """
+    @property
+    def state(self):
+        return self.mlx5dv_dek_attr.state
+
+    @property
+    def opaque(self):
+        return self.mlx5dv_dek_attr.opaque
+
+    @property
+    def comp_mask(self):
+        return self.mlx5dv_dek_attr.comp_mask
+
+
+cdef class Mlx5CryptoAttr(PyverbsObject):
+    def __init__(self, crypto_standard=0, encrypt_on_tx=False, signature_crypto_order=0,
+                 data_unit_size=0, initial_tweak=bytes(), Mlx5DEK dek=None,
+                 keytag=bytes(), comp_mask=0):
+        """
+        Initializes a Mlx5CryptoAttr object representing mlx5dv_crypto_attr
+        C struct.
+        :param crypto_standard: The encryption standard that should be used.
+        :param encrypt_on_tx: If set, memory data will be encrypted during TX
+                              and wire data will be decrypted during RX.
+        :param signature_crypto_order: Controls the order between crypto and
+                                       signature operations. Relevant only if
+                                       signature is configured.
+        :param data_unit_size: The tweak is	incremented after each
+                               *data_unit_size* during the encryption.
+        :param initial_tweak: A value to be used during encryption of each data
+                              unit. This value is incremented by the device for
+                              every data unit in the message
+        :param dek: The DEK to be used for the crypto operations.
+        :param keytag: A tag that verifies that the correct DEK is being used.
+        :param comp_mask: Reserved for future extension.
+        """
+        cdef char *initial_tweak_c = initial_tweak
+        cdef char *keytag_c = keytag
+        self.mlx5dv_crypto_attr.crypto_standard = crypto_standard
+        self.mlx5dv_crypto_attr.encrypt_on_tx = encrypt_on_tx
+        self.mlx5dv_crypto_attr.signature_crypto_order = signature_crypto_order
+        self.mlx5dv_crypto_attr.data_unit_size = data_unit_size
+        memcpy(self.mlx5dv_crypto_attr.initial_tweak, initial_tweak_c, 16)
+        self.mlx5dv_crypto_attr.dek = dek.mlx5dv_dek
+        memcpy(self.mlx5dv_crypto_attr.keytag, keytag_c, 8)
+        self.mlx5dv_crypto_attr.comp_mask = comp_mask
+
+    @property
+    def crypto_standard(self):
+        return self.mlx5dv_crypto_attr.crypto_standard
+
+    @property
+    def encrypt_on_tx(self):
+        return self.mlx5dv_crypto_attr.encrypt_on_tx
+
+    @property
+    def signature_crypto_order(self):
+        return self.mlx5dv_crypto_attr.signature_crypto_order
+
+    @property
+    def data_unit_size(self):
+        return self.mlx5dv_crypto_attr.data_unit_size
+
+    @property
+    def initial_tweak(self):
+        return self.mlx5dv_crypto_attr.initial_tweak.hex()
+
+    @property
+    def keytag(self):
+        print('@keytag')
+        return self.mlx5dv_crypto_attr.keytag.hex()
+
+    @property
+    def comp_mask(self):
+        return self.mlx5dv_crypto_attr.comp_mask
+
+    def __str__(self):
+        print_format = '{:30}: {:<20}\n'
+        return 'Mlx5CryptoAttr:\n' +\
+            print_format.format('Crypto standard', self.crypto_standard) +\
+            print_format.format('Encrypt on TX', self.encrypt_on_tx) +\
+            print_format.format('Signature crypto order', self.signature_crypto_order) +\
+            print_format.format('Data unit size', self.data_unit_size) +\
+            print_format.format('Initial tweak (in hex format)', self.initial_tweak) +\
+            print_format.format('keytag (in hex format)', self.keytag) +\
+            print_format.format('Comp mask', self.comp_mask)
+
+
+cdef class Mlx5DEK(PyverbsCM):
+    def __init__(self, Context ctx, Mlx5DEKInitAttr dek_init_attr):
+        """
+        Create a Mlx5DEK object.
+        :param context: Context to create the schedule resources on.
+        :param dek_init_attr: Mlx5DEKInitAttr, containing the DEK attributes.
+        """
+        self.mlx5dv_dek = dv.mlx5dv_dek_create(ctx.context,
+                                               &dek_init_attr.mlx5dv_dek_init_attr)
+        if self.mlx5dv_dek == NULL:
+            raise PyverbsRDMAErrno('Failed to create DEK')
+        self.pd = dek_init_attr.pd
+        self.pd.deks.add(self)
+
+    def query(self):
+        """
+        Query the dek state.
+        :return: Mlx5DEKAttr which contains the dek state and opaque.
+        """
+        dek_attr = Mlx5DEKAttr()
+        rc = dv.mlx5dv_dek_query(self.mlx5dv_dek, &dek_attr.mlx5dv_dek_attr)
+        if rc:
+            raise PyverbsRDMAError('Failed to query the dek', rc)
+        return dek_attr
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.mlx5dv_dek != NULL:
+            rc = dv.mlx5dv_dek_destroy(self.mlx5dv_dek)
+            if rc:
+                raise PyverbsRDMAError('Failed to destroy a DEK', rc)
+            self.mlx5dv_dek = NULL
+            self.pd = None

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -47,6 +47,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_MASK_SIGNATURE_OFFLOAD   = 1 << 10
         MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11
         MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH    = 1 << 12
+        MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD      = 1 << 13
 
     cpdef enum mlx5dv_context_flags:
         MLX5DV_CONTEXT_FLAGS_CQE_V1                     = 1 << 0
@@ -107,6 +108,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     cpdef enum mlx5dv_mkey_init_attr_flags:
         MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT
         MLX5DV_MKEY_INIT_ATTR_FLAGS_BLOCK_SIGNATURE
+        MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO
 
     cpdef enum mlx5dv_mkey_err_type:
         MLX5DV_MKEY_NO_ERR
@@ -227,6 +229,40 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_WC_UMR
         MLX5DV_WC_RAW_WQE
         MLX5DV_WC_MEMCPY
+
+    cpdef enum mlx5dv_crypto_standard:
+        MLX5DV_CRYPTO_STANDARD_AES_XTS
+
+    cpdef enum mlx5dv_signature_crypto_order:
+        MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_AFTER_CRYPTO_ON_TX
+        MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX
+
+    cpdef enum mlx5dv_crypto_login_state:
+        MLX5DV_CRYPTO_LOGIN_STATE_VALID
+        MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN
+        MLX5DV_CRYPTO_LOGIN_STATE_INVALID
+
+    cpdef enum mlx5dv_crypto_key_size:
+        MLX5DV_CRYPTO_KEY_SIZE_128
+        MLX5DV_CRYPTO_KEY_SIZE_256
+
+    cpdef enum mlx5dv_crypto_key_purpose:
+        MLX5DV_CRYPTO_KEY_PURPOSE_AES_XTS
+
+    cpdef enum mlx5dv_dek_state:
+        MLX5DV_DEK_STATE_READY
+        MLX5DV_DEK_STATE_ERROR
+
+    cpdef enum mlx5dv_crypto_engines_caps:
+        MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS
+
+    cpdef enum mlx5dv_crypto_wrapped_import_method_caps:
+        MLX5DV_CRYPTO_WRAPPED_IMPORT_METHOD_CAP_AES_XTS
+
+    cpdef enum mlx5dv_crypto_caps_flags:
+        MLX5DV_CRYPTO_CAPS_CRYPTO
+        MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL
+        MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_GOING_TO_COMMISSIONING
 
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -20,6 +20,7 @@ rdma_python_test(tests
   test_flow.py
   test_fork.py
   test_mlx5_cq.py
+  test_mlx5_crypto.py
   test_mlx5_dc.py
   test_mlx5_devx.py
   test_mlx5_dm_ops.py

--- a/tests/test_mlx5_crypto.py
+++ b/tests/test_mlx5_crypto.py
@@ -1,0 +1,371 @@
+import unittest
+import struct
+import errno
+import json
+import os
+
+from pyverbs.providers.mlx5.mlx5dv_mkey import Mlx5Mkey, Mlx5MrInterleaved, \
+    Mlx5MkeyConfAttr, Mlx5SigCrc, Mlx5SigBlockDomain, Mlx5SigBlockAttr
+from pyverbs.providers.mlx5.mlx5dv_crypto import Mlx5CryptoLoginAttr, Mlx5DEK, \
+    Mlx5DEKInitAttr, Mlx5CryptoAttr
+from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, \
+    Mlx5DVQPInitAttr, Mlx5QP
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError
+from tests.mlx5_base import Mlx5RDMATestCase, Mlx5PyverbsAPITestCase
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from pyverbs.wr import SGE, SendWR, RecvWR
+from pyverbs.qp import QPInitAttrEx, QPCap
+from tests.base import RCResources
+from pyverbs.pd import PD
+import pyverbs.enums as e
+import tests.utils as u
+
+DEK_OPAQUE = b'dek'
+
+"""
+Crytpo operation requires specific input from the user, e.g. the wrapped credential that the
+device is configured with. The input should be provided in JSON format in a file in this path:
+"/tmp/mlx5_crypto_test.txt".
+User can also set this environment variable with his file path: MLX5_CRYPTO_TEST_INFO
+
+This doc describes the input option with examples to the format:
+Mandatory:
+Wrapped credential: The credential that was configured in the device wrapped.
+Wrapped key: Wrapped key for the DEK creation. The key should be encrypted using the KEK
+             (Key Encrypted Key).
+Optional:
+Wrapped 256 bits key: Wrapped key for the DEK creation when the key size of 256 bits is required.
+                      If not provided, that test will only use the key in size of 128 bits.
+Encrypted data for 512 of 'c': If a user wants to have data validation, he needs to provide
+                               expected encrypted data for a plain text of 512 bytes of the
+                               character 'c'. If not provided, data validation will be skipped.
+
+Example of content of such file:
+[{"credential": [8704278040424473809, 4403447855848063568, 13892768337045135232,
+5942481448427925932, 171338997253969038, 5703425261028721211],
+"wrapped_key": [contains 5 integers of 64bits each],
+"encrypted_data_for_512_c": [contains 64 integers of 64bits each],
+"wrapped_256_bits_key": [contains 9 integers of 64bits each]}]
+"""
+
+
+def check_crypto_caps(dev_name):
+    """
+    Check that this device support crypto actions.
+    :param dev_name: The device name.
+    """
+    mlx5dv_attr = Mlx5DVContextAttr()
+    ctx = Mlx5Context(mlx5dv_attr, name=dev_name)
+    crypto_caps = ctx.query_mlx5_device().crypto_caps
+    failed_selftests = crypto_caps['failed_selftests']
+    if failed_selftests:
+        raise unittest.SkipTest(f'The device crypto selftest failed ({failed_selftests})')
+    if not dve.MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS & crypto_caps['crypto_engines']:
+        raise unittest.SkipTest('The device crypto engines does not support AES')
+
+
+def require_crypto_login_details(instance):
+    """
+    Parse the crypto login session details from this file:
+        '/tmp/mlx5_crypto_test.txt'
+    If the file doesn't exists or the content is not in Json format, skip the test.
+    :param instance: The test instance.
+    """
+    crypto_file = '/tmp/mlx5_crypto_test.txt'
+    if 'MLX5_CRYPTO_TEST_INFO' in os.environ:
+        crypto_file = os.environ['MLX5_CRYPTO_TEST_INFO']
+    try:
+        with open(crypto_file, 'r') as f:
+            test_details = f.read()
+            setattr(instance, 'crypto_details', test_details)
+            json.loads(test_details)
+            instance.crypto_details = json.loads(test_details)[0]
+    except json.JSONDecodeError:
+        raise unittest.SkipTest(f'The crypto data in {crypto_file} must be in Json format')
+    except FileNotFoundError:
+        raise unittest.SkipTest(f'Crypto login details must be supplied in {crypto_file}')
+
+
+def requires_crypto_support():
+    def outer(func):
+        def inner(instance):
+            require_crypto_login_details(instance)
+            check_crypto_caps(instance.dev_name)
+            return func(instance)
+        return inner
+    return outer
+
+
+class Mlx5CryptoResources(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index, dv_send_ops_flags=0,
+                 mkey_create_flags=dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT):
+        self.dv_send_ops_flags = dv_send_ops_flags
+        self.mkey_create_flags = mkey_create_flags
+        self.max_inline_data = 512
+        self.send_ops_flags = e.IBV_QP_EX_WITH_SEND
+        super().__init__(dev_name, ib_port, gid_index)
+        self.create_mkeys()
+
+    def create_mkeys(self):
+        try:
+            self.wire_enc_mkey = Mlx5Mkey(self.pd, self.mkey_create_flags, max_entries=1)
+            self.mem_enc_mkey = Mlx5Mkey(self.pd, self.mkey_create_flags, max_entries=1)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mkey is not supported')
+            raise ex
+
+    def create_qp_cap(self):
+        return QPCap(max_send_wr=self.num_msgs, max_recv_wr=self.num_msgs,
+                     max_inline_data=self.max_inline_data)
+
+    def create_qp_init_attr(self):
+        comp_mask = e.IBV_QP_INIT_ATTR_PD | e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS
+        return QPInitAttrEx(cap=self.create_qp_cap(), pd=self.pd, scq=self.cq,
+                            rcq=self.cq, qp_type=e.IBV_QPT_RC,
+                            send_ops_flags=self.send_ops_flags,
+                            comp_mask=comp_mask)
+
+    def create_qps(self):
+        try:
+            qp_init_attr = self.create_qp_init_attr()
+            comp_mask = dve.MLX5DV_QP_INIT_ATTR_MASK_SEND_OPS_FLAGS
+            attr = Mlx5DVQPInitAttr(comp_mask=comp_mask,
+                                    send_ops_flags=self.dv_send_ops_flags)
+            qp = Mlx5QP(self.ctx, qp_init_attr, attr)
+            self.qps.append(qp)
+            self.qps_num.append(qp.qp_num)
+            self.psns.append(0)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create Mlx5DV QP is not supported')
+            raise ex
+
+
+class Mlx5CryptoAPITest(Mlx5PyverbsAPITestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+        self.crypto_details = None
+
+    def verify_create_dek_out_of_login_session(self):
+        """
+        Verify that create DEK out of crypto login session is not permited.
+        """
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            Mlx5DEK(self.ctx, self.dek_init_attr)
+        self.assertEqual(ex.exception.error_code, errno.EINVAL)
+
+    def verify_login_state(self, expected_state):
+        """
+        Query the session login state and verify that it's as expected.
+        """
+        state = Mlx5Context.query_login_state(self.ctx)
+        self.assertEqual(state, expected_state)
+
+    def verify_login_twice(self):
+        """
+        Verify that when there is already a login session alive the second login
+        fails.
+        """
+        with self.assertRaises(PyverbsRDMAError) as ex:
+            Mlx5Context.crypto_login(self.ctx, self.login_attr)
+        self.assertEqual(ex.exception.error_code, errno.EEXIST)
+
+    def verify_dek_opaque(self):
+        """
+        Query the DEK and verify that its opaque is as expected.
+        """
+        dek_attr = self.dek.query()
+        self.assertEqual(dek_attr.opaque, DEK_OPAQUE)
+
+    @requires_crypto_support()
+    def test_mlx5_dek_management(self):
+        """
+        Test crypto login and DEK management APIs.
+        The test checks also that invalid actions are not permited, e.g, create
+        DEK not in login session.
+        """
+        try:
+            self.pd = PD(self.ctx)
+            cred_bytes = struct.pack('!6Q', *self.crypto_details['credential'])
+            key = struct.pack('!5Q', *self.crypto_details['wrapped_key'])
+            self.dek_init_attr = \
+                Mlx5DEKInitAttr(self.pd, key=key,
+                                key_size=dve.MLX5DV_CRYPTO_KEY_SIZE_128,
+                                key_purpose=dve.MLX5DV_CRYPTO_KEY_PURPOSE_AES_XTS,
+                                opaque=DEK_OPAQUE)
+            self.verify_create_dek_out_of_login_session()
+            self.verify_login_state(dve.MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN)
+
+            # Login to crypto session
+            self.login_attr = Mlx5CryptoLoginAttr(cred_bytes)
+            Mlx5Context.crypto_login(self.ctx, self.login_attr)
+            self.verify_login_state(dve.MLX5DV_CRYPTO_LOGIN_STATE_VALID)
+            self.verify_login_twice()
+            self.dek = Mlx5DEK(self.ctx, self.dek_init_attr)
+            self.verify_dek_opaque()
+            self.dek.close()
+
+            # Logout from crypto session
+            Mlx5Context.crypto_logout(self.ctx)
+            self.verify_login_state(dve.MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN)
+        except PyverbsRDMAError as ex:
+            print(ex)
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create crypto elements is not supported')
+            raise ex
+
+
+class Mlx5CryptoTrafficTest(Mlx5RDMATestCase):
+    """
+    Test the mlx5 cryto APIs.
+    """
+    def setUp(self):
+        super().setUp()
+        self.iters = 10
+        self.crypto_details = None
+        self.validate_data = False
+        self.key_size = dve.MLX5DV_CRYPTO_KEY_SIZE_128
+
+    def create_players(self, resource, **resource_arg):
+        """
+        Init Mlx5CryptoTest test resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+                             attributes.
+        :return: None
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+
+    def create_client_dek(self):
+        """
+        Create DEK using the client resources.
+        """
+        cred_bytes = struct.pack('!6Q', *self.crypto_details['credential'])
+        log_attr = Mlx5CryptoLoginAttr(cred_bytes)
+        Mlx5Context.crypto_login(self.client.ctx, log_attr)
+        key = struct.pack('!5Q', *self.crypto_details['wrapped_key'])
+        if self.key_size == dve.MLX5DV_CRYPTO_KEY_SIZE_256:
+            key = struct.pack('!9Q', *self.crypto_details['wrapped_256_bits_key'])
+        self.dek_attr = Mlx5DEKInitAttr(self.client.pd, key=key,
+                                        key_size=self.key_size,
+                                        key_purpose=dve.MLX5DV_CRYPTO_KEY_PURPOSE_AES_XTS)
+        self.dek = Mlx5DEK(self.client.ctx, self.dek_attr)
+
+    def reg_client_mkey(self, signature=False):
+        """
+        Configure an mkey with crypto attributes.
+        :param signature: True if signature configuration requested.
+        """
+        num_of_configuration = 4 if signature else 3
+        for mkey in [self.client.wire_enc_mkey, self.client.mem_enc_mkey]:
+            self.client.qp.wr_start()
+            self.client.qp.wr_flags = e.IBV_SEND_SIGNALED | e.IBV_SEND_INLINE
+            offset = 0 if mkey == self.client.wire_enc_mkey else self.client.msg_size/2
+            sge = SGE(self.client.mr.buf + offset, self.client.msg_size/2, self.client.mr.lkey)
+            self.client.qp.wr_mkey_configure(mkey, num_of_configuration, Mlx5MkeyConfAttr())
+            self.client.qp.wr_set_mkey_access_flags(e.IBV_ACCESS_LOCAL_WRITE)
+            self.client.qp.wr_set_mkey_layout_list([sge])
+            if signature:
+                self.configure_mkey_signature()
+            initial_tweak = struct.pack('!2Q', int(0), int(0))
+            encrypt_on_tx = mkey == self.client.wire_enc_mkey
+            sign_crypto_order = dve.MLX5DV_SIGNATURE_CRYPTO_ORDER_SIGNATURE_BEFORE_CRYPTO_ON_TX
+            crypto_attr = Mlx5CryptoAttr(crypto_standard=dve.MLX5DV_CRYPTO_STANDARD_AES_XTS,
+                                         encrypt_on_tx=encrypt_on_tx,
+                                         signature_crypto_order=sign_crypto_order,
+                                         data_unit_size=dve.MLX5DV_BLOCK_SIZE_512,
+                                         dek=self.dek, initial_tweak=initial_tweak)
+            self.client.qp.wr_set_mkey_crypto(crypto_attr)
+            self.client.qp.wr_complete()
+            u.poll_cq(self.client.cq)
+
+    def configure_mkey_signature(self):
+        """
+        Configure an mkey with signature attributes.
+        """
+        sig_crc = Mlx5SigCrc(crc_type=dve.MLX5DV_SIG_CRC_TYPE_CRC32, seed=0xFFFFFFFF)
+        sig_block_domain = Mlx5SigBlockDomain(sig_type=dve.MLX5DV_SIG_TYPE_CRC, crc=sig_crc,
+                                              block_size=dve.MLX5DV_BLOCK_SIZE_512)
+        sig_attr = Mlx5SigBlockAttr(wire=sig_block_domain,
+                                    check_mask=dve.MLX5DV_SIG_MASK_CRC32)
+        self.client.qp.wr_set_mkey_sig_block(sig_attr)
+
+    def get_send_wr(self, player, wire_encryption):
+        mkey = player.wire_enc_mkey if wire_encryption else player.mem_enc_mkey
+        sge = SGE(0, player.msg_size/2, mkey.lkey)
+        return SendWR(opcode=e.IBV_WR_SEND, num_sge=1, sg=[sge])
+
+    def get_recv_wr(self, player, wire_encryption):
+        offset = 0 if wire_encryption else player.msg_size/2
+        sge = SGE(player.mr.buf + offset, player.msg_size/2, player.mr.lkey)
+        return RecvWR(sg=[sge], num_sge=1)
+
+    def prepare_validate_data(self):
+        self.client.mr.write('c' * 512, 512)
+        encrypted_data = struct.pack('!64Q', *self.crypto_details['encrypted_data_for_512_c'])
+        self.client.mr.write(encrypted_data, 512, offset=512)
+
+    def validate_crypto_data(self):
+        """
+        Validate the server MR data. Verify that the encryption/decryption works well.
+        """
+        send_msg = self.client.mr.read(1024, 0)
+        recv_msg = self.server.mr.read(1024, 0)
+        self.assertEqual(send_msg[0:512], recv_msg[512:1024])
+        self.assertEqual(send_msg[512:1024], recv_msg[0:512])
+
+    def traffic(self):
+        """
+        Perform RC traffic using the configured mkeys.
+        """
+        if self.validate_data:
+            self.prepare_validate_data()
+        for _ in range(self.iters):
+            self.server.qp.post_recv(self.get_recv_wr(self.server, wire_encryption=True))
+            self.server.qp.post_recv(self.get_recv_wr(self.server, wire_encryption=False))
+            self.client.qp.post_send(self.get_send_wr(self.client, wire_encryption=True))
+            self.client.qp.post_send(self.get_send_wr(self.client, wire_encryption=False))
+            u.poll_cq(self.client.cq, count=2)
+            u.poll_cq(self.server.cq, count=2)
+            if self.validate_data:
+                self.validate_crypto_data()
+
+    @requires_crypto_support()
+    def test_mlx5_crypto_mkey(self):
+        """
+        Create Mkeys, register a memory layout using the mkeys, configure
+        crypto attributes on it and then perform traffic.
+        """
+        if 'encrypted_data_for_512_c' in self.crypto_details:
+            self.validate_data = True
+        mkey_flags = dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO | \
+            dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT
+        self.create_players(Mlx5CryptoResources,
+                            dv_send_ops_flags=dve.MLX5DV_QP_EX_WITH_MKEY_CONFIGURE,
+                            mkey_create_flags=mkey_flags)
+        self.create_client_dek()
+        self.reg_client_mkey()
+        self.traffic()
+
+    @requires_crypto_support()
+    def test_mlx5_crypto_signature_mkey(self):
+        """
+        Create Mkeys, register a memory layout using this mkey, configure
+        crypto and signature attributes on it and then perform traffic using
+        this mkey.
+        """
+        if 'wrapped_256_bits_key' in self.crypto_details:
+            self.key_size = dve.MLX5DV_CRYPTO_KEY_SIZE_256
+        mkey_flags = dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_CRYPTO | \
+                     dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_INDIRECT | \
+                     dve.MLX5DV_MKEY_INIT_ATTR_FLAGS_BLOCK_SIGNATURE
+        self.create_players(Mlx5CryptoResources,
+                            dv_send_ops_flags=dve.MLX5DV_QP_EX_WITH_MKEY_CONFIGURE,
+                            mkey_create_flags=mkey_flags)
+        self.create_client_dek()
+        self.reg_client_mkey(signature=True)
+        self.traffic()


### PR DESCRIPTION
This series exposes some DV APIs to enable configuring and using MKEY with crypto offloads.

With this, the device can encrypt/decrypt data when transmitting data from memory to network and when receiving data from network to memory. 
Crypto properties can be configured along with signature properties.

Detailed man pages were added to describe the expected usage and flow.

In addition, the series includes some pyverbs testing over the new functionality.