### PR TITLE
redhat: rdma-core-devel should not require ibacm

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -101,7 +101,6 @@ Obsoletes: libibumad-devel < %{version}-%{release}
 Requires: librdmacm%{?_isa} = %{version}-%{release}
 Provides: librdmacm-devel = %{version}-%{release}
 Obsoletes: librdmacm-devel < %{version}-%{release}
-Requires: ibacm%{?_isa} = %{version}-%{release}
 Provides: ibacm-devel = %{version}-%{release}
 Obsoletes: ibacm-devel < %{version}-%{release}
 Requires: infiniband-diags%{?_isa} = %{version}-%{release}


### PR DESCRIPTION
%{_libdir}/ibacm/libibacmp.so is a plugin for librdmacm dlopen.
It is not for library linking.

Signed-off-by: Honggang Li <honli@redhat.com>