### PR TITLE
libibverbs/examples: Fix gid query silent error in devinfo

### DIFF
--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -654,7 +654,8 @@ static int print_hca_cap(struct ibv_device *ib_dev, uint8_t ib_port)
 				printf("\t\t\tphys_state:\t\t%s (%d)\n",
 				       port_phy_state_str(port_attr.phys_state), port_attr.phys_state);
 
-			if (print_all_port_gids(ctx, &port_attr, port))
+			rc = print_all_port_gids(ctx, &port_attr, port);
+			if (rc)
 				goto cleanup;
 		}
 		printf("\n");


### PR DESCRIPTION
The print_all_port_gids() return value was not assigned to the rc
variable, hence it did not propagate the error in the cleanup flow and
return success in case of an error.

Signed-off-by: Gal Pressman <galpress@amazon.com>