### PR TITLE
debian: Bump Standards-Version to 4.6.0 and mark libraries as Multi-Arch: same

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -362,6 +362,7 @@ Description: InfiniBand diagnostic programs
 Package: libibmad5
 Section: libs
 Architecture: linux-any
+Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: Infiniband Management Datagram (MAD) library
@@ -390,6 +391,7 @@ Description: Debug symbols for Infiniband Management Datagram (MAD) library
 Package: libibmad-dev
 Section: libdevel
 Architecture: linux-any
+Multi-Arch: same
 Depends: libibmad5 (= ${binary:Version}), ${misc:Depends}
 Description: Development files for libibmad
  libibmad provides low layer Infiniband functions for use by the
@@ -404,6 +406,7 @@ Description: Development files for libibmad
 Package: libibnetdisc5
 Section: libs
 Architecture: linux-any
+Multi-Arch: same
 Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlibs:Depends}
 Description: InfiniBand diagnostics library
@@ -433,6 +436,7 @@ Description: Debug symbols for the libibnetdisc library
 Package: libibnetdisc-dev
 Section: libdevel
 Architecture: linux-any
+Multi-Arch: same
 Depends: libibnetdisc5 (= ${binary:Version}), ${misc:Depends}
 Breaks: infiniband-diags (<< 2.0.0)
 Replaces: infiniband-diags (<< 2.0.0)

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Build-Depends: cmake (>= 2.8.11),
                python3-docutils,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Rules-Requires-Root: no
-Standards-Version: 4.5.1
+Standards-Version: 4.6.0
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
 Homepage: https://github.com/linux-rdma/rdma-core


### PR DESCRIPTION
No changes are needed to support the new Debian policy version. See https://www.debian.org/doc/debian-policy/ for details.

The library packages do not contain any maintainer scripts and for any pair of architectures, the common files have equal content. Thus it should be safe to mark the package `Multi-Arch: same`.