### PR TITLE
ibdiags:remove the error printing in the ibchecknet command

### DIFF
--- a/infiniband-diags/scripts/ibchecknet.in
+++ b/infiniband-diags/scripts/ibchecknet.in
@@ -126,7 +126,7 @@ function check_node(lid, port)
 /iberror:/	{print $0}
 
 END {
-	printf "\n*** WARNING ***: this command is deprecated; Please use \"ibqueryerrors -f\""
+	printf "\n*** WARNING ***: this command is deprecated\n"
 	printf "\n## Summary: %d nodes checked, %d bad nodes found\n", nnodes, ne
 	printf "##          %d ports checked, %d bad ports found\n", nports, pe
 	printf "##          %d ports have errors beyond threshold\n", pcnterr


### PR DESCRIPTION
Use ibchecknet command will print " this command is deprecated; Please use \"ibqueryerrors -f\" ".
But use "ibqueryerrors -f" will print "invalid option -- 'f'".
That means the printing in the ibchecknet command is error.

Signed-off-by: Suwan Sun <swimlessbird@gmail.com>

![image](https://user-images.githubusercontent.com/52704385/134531957-8aa32352-9b01-411f-86bf-59d4fa800da6.png)
