### PR TITLE
mlx5: DR, Extend vports support

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -612,6 +612,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 	int i;
 
 	attr.gvmi = dmn->info.caps.gvmi;
+	attr.hit_gvmi = dmn->info.caps.gvmi;
 	attr.final_icm_addr = nic_dmn->default_icm_addr;
 	action_domain = dr_action_get_action_domain(dmn->type, nic_dmn->type);
 
@@ -742,6 +743,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				dr_dbg(dmn, "Destination vport belongs to a different domain\n");
 				goto out_invalid_arg;
 			}
+			attr.hit_gvmi = action->vport.caps->vhca_gvmi;
 			if (rx_rule) {
 				/* Loopback on WIRE vport is not supported */
 				if (action->vport.caps->num == WIRE_PORT)

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -269,6 +269,11 @@ static uint8_t dr_ste_v0_get_entry_type(uint8_t *hw_ste_p)
 	return DR_STE_GET(general, hw_ste_p, entry_type);
 }
 
+static void dr_ste_v0_set_hit_gvmi(uint8_t *hw_ste_p, uint16_t gvmi)
+{
+	DR_STE_SET(general, hw_ste_p, next_table_base_63_48, gvmi);
+}
+
 static void dr_ste_v0_set_miss_addr(uint8_t *hw_ste_p, uint64_t miss_addr)
 {
 	uint64_t index = miss_addr >> 6;
@@ -509,6 +514,7 @@ static void dr_ste_v0_set_actions_tx(uint8_t *action_type_set,
 	if (action_type_set[DR_ACTION_TYP_CTR])
 		dr_ste_v0_set_counter_id(last_ste, attr->ctr_id);
 
+	dr_ste_v0_set_hit_gvmi(last_ste, attr->hit_gvmi);
 	dr_ste_v0_set_hit_addr(last_ste, attr->final_icm_addr, 1);
 }
 
@@ -571,6 +577,7 @@ static void dr_ste_v0_set_actions_rx(uint8_t *action_type_set,
 		dr_ste_v0_set_rx_flow_tag(last_ste, attr->flow_tag);
 	}
 
+	dr_ste_v0_set_hit_gvmi(last_ste, attr->hit_gvmi);
 	dr_ste_v0_set_hit_addr(last_ste, attr->final_icm_addr, 1);
 }
 

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2105,9 +2105,13 @@ static void dr_ste_v1_build_register_1_init(struct dr_ste_build *sb,
 }
 
 static void dr_ste_v1_build_src_gvmi_qpn_bit_mask(struct dr_match_param *value,
-						  uint8_t *bit_mask)
+						  struct dr_ste_build *sb)
 {
 	struct dr_match_misc *misc_mask = &value->misc;
+	uint8_t *bit_mask = sb->bit_mask;
+
+	if (sb->rx && misc_mask->source_port)
+		DR_STE_SET(src_gvmi_qp_v1, bit_mask, functional_lb, 1);
 
 	DR_STE_SET_ONES(src_gvmi_qp_v1, bit_mask, source_gvmi, misc_mask, source_port);
 	DR_STE_SET_ONES(src_gvmi_qp_v1, bit_mask, source_qp, misc_mask, source_sqn);
@@ -2134,6 +2138,12 @@ static int dr_ste_v1_build_src_gvmi_qpn_tag(struct dr_match_param *value,
 		if (vport_cap->vport_gvmi)
 			DR_STE_SET(src_gvmi_qp_v1, tag, source_gvmi, vport_cap->vport_gvmi);
 
+		/* Make sure that this packet is not coming from the wire since
+		 * wire GVMI is set to 0 and can be aliased with another port
+		 */
+		if (sb->rx && misc->source_port != WIRE_PORT)
+			DR_STE_SET(src_gvmi_qp_v1, tag, functional_lb, 1);
+
 		misc->source_port = 0;
 	}
 
@@ -2143,7 +2153,7 @@ static int dr_ste_v1_build_src_gvmi_qpn_tag(struct dr_match_param *value,
 static void dr_ste_v1_build_src_gvmi_qpn_init(struct dr_ste_build *sb,
 					      struct dr_match_param *mask)
 {
-	dr_ste_v1_build_src_gvmi_qpn_bit_mask(mask, sb->bit_mask);
+	dr_ste_v1_build_src_gvmi_qpn_bit_mask(mask, sb);
 
 	sb->lu_type = DR_STE_V1_LU_TYPE_SRC_QP_GVMI;
 	sb->byte_mask = dr_ste_conv_bit_to_byte_mask(sb->bit_mask);

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -360,6 +360,11 @@ static void dr_ste_v1_set_next_lu_type(uint8_t *hw_ste_p, uint16_t lu_type)
 	DR_STE_SET(match_bwc_v1, hw_ste_p, hash_definer_ctx_idx, lu_type & 0xFF);
 }
 
+static void dr_ste_v1_set_hit_gvmi(uint8_t *hw_ste_p, uint16_t gvmi)
+{
+	DR_STE_SET(match_bwc_v1, hw_ste_p, next_table_base_63_48, gvmi);
+}
+
 static uint16_t dr_ste_v1_get_next_lu_type(uint8_t *hw_ste_p)
 {
 	uint8_t mode = DR_STE_GET(match_bwc_v1, hw_ste_p, next_entry_format);
@@ -810,6 +815,7 @@ static void dr_ste_v1_set_actions_tx(uint8_t *action_type_set,
 		action += DR_STE_ACTION_TRIPLE_SZ;
 	}
 
+	dr_ste_v1_set_hit_gvmi(last_ste, attr->hit_gvmi);
 	dr_ste_v1_set_hit_addr(last_ste, attr->final_icm_addr, 1);
 }
 
@@ -1012,6 +1018,7 @@ static void dr_ste_v1_set_actions_rx(uint8_t *action_type_set,
 		action_sz -= DR_STE_ACTION_TRIPLE_SZ;
 	}
 
+	dr_ste_v1_set_hit_gvmi(last_ste, attr->hit_gvmi);
 	dr_ste_v1_set_hit_addr(last_ste, attr->final_icm_addr, 1);
 }
 


### PR DESCRIPTION
This series extends vports support in the DR area as of below.
- Allow cross GVMI vport access.
- Set functional LB bit when matching on non-wire vports.