### PR TITLE
ibdiags: fix small buffer

### DIFF
--- a/infiniband-diags/ibsysstat.c
+++ b/infiniband-diags/ibsysstat.c
@@ -158,7 +158,7 @@ static int mk_reply(int attr, void *data, int sz)
 	return ret;
 }
 
-static uint8_t buf[2048];
+static uint8_t buf[2048 * 32];
 
 static char *ibsystat_serv(void)
 {


### PR DESCRIPTION
increase maximum number of CPUs may result too much cpu info

Fixes: c381cfa26 ("ibdiags: Increase maximum number of CPUs")
Signed-off-by: Suwan Sun <swimlessbird@gmail.com>
Signed-off-by: Ying Lu <luying_hhu@163.com>