### PR TITLE
tests: Add coverage for mlx5 dr steering

### DIFF
--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -23,6 +23,7 @@ cdef class Context(PyverbsCM):
     cdef object pps
     cdef object sched_nodes
     cdef object sched_leafs
+    cdef object dr_domains
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -117,6 +117,7 @@ cdef class Context(PyverbsCM):
         self.pps = weakref.WeakSet()
         self.sched_nodes = weakref.WeakSet()
         self.sched_leafs = weakref.WeakSet()
+        self.dr_domains = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -170,7 +171,7 @@ cdef class Context(PyverbsCM):
             self.logger.debug('Closing Context')
             close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
                             self.xrcds, self.vars, self.sched_leafs,
-                            self.sched_nodes])
+                            self.sched_nodes, self.dr_domains])
             rc = v.ibv_close_device(self.context)
             if rc != 0:
                 raise PyverbsRDMAErrno(f'Failed to close device {self.name}')

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -48,3 +48,6 @@ cdef class DrActionDestAttr(PyverbsCM):
 cdef class DrActionDestArray(DrAction):
     cdef DrDomain domain
     cdef object dest_actions
+
+cdef class DrActionDefMiss(DrAction):
+    pass

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -4,6 +4,7 @@
 #cython: language_level=3
 
 from pyverbs.providers.mlx5.dr_domain cimport DrDomain
+from pyverbs.providers.mlx5.mlx5dv cimport Mlx5DevxObj
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsCM
 from pyverbs.qp cimport QP
@@ -19,3 +20,6 @@ cdef class DrActionQp(DrAction):
 
 cdef class DrActionModify(DrAction):
     cdef DrDomain domain
+
+cdef class DrActionFlowCounter(DrAction):
+    cdef Mlx5DevxObj devx_obj

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -5,6 +5,7 @@
 
 from pyverbs.providers.mlx5.dr_domain cimport DrDomain
 from pyverbs.providers.mlx5.mlx5dv cimport Mlx5DevxObj
+from pyverbs.providers.mlx5.dr_table cimport DrTable
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsCM
 from pyverbs.qp cimport QP
@@ -29,3 +30,6 @@ cdef class DrActionDrop(DrAction):
 
 cdef class DrActionTag(DrAction):
     pass
+
+cdef class DrActionDestTable(DrAction):
+    cdef DrTable table

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -23,3 +23,6 @@ cdef class DrActionModify(DrAction):
 
 cdef class DrActionFlowCounter(DrAction):
     cdef Mlx5DevxObj devx_obj
+
+cdef class DrActionDrop(DrAction):
+    pass

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -26,3 +26,6 @@ cdef class DrActionFlowCounter(DrAction):
 
 cdef class DrActionDrop(DrAction):
     pass
+
+cdef class DrActionTag(DrAction):
+    pass

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -33,3 +33,9 @@ cdef class DrActionTag(DrAction):
 
 cdef class DrActionDestTable(DrAction):
     cdef DrTable table
+
+cdef class DrActionPushVLan(DrAction):
+    cdef DrDomain domain
+
+cdef class DrActionPopVLan(DrAction):
+    pass

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -39,3 +39,12 @@ cdef class DrActionPushVLan(DrAction):
 
 cdef class DrActionPopVLan(DrAction):
     pass
+
+cdef class DrActionDestAttr(PyverbsCM):
+    cdef DrAction dest
+    cdef dv.mlx5dv_dr_action_dest_attr *action_dest_attr
+    cdef dv.mlx5dv_dr_action_dest_reformat *dest_reformat
+
+cdef class DrActionDestArray(DrAction):
+    cdef DrDomain domain
+    cdef object dest_actions

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -3,9 +3,11 @@
 
 #cython: language_level=3
 
+from pyverbs.providers.mlx5.dr_domain cimport DrDomain
 cimport pyverbs.providers.mlx5.libmlx5 as dv
 from pyverbs.base cimport PyverbsCM
 from pyverbs.qp cimport QP
+
 
 cdef class DrAction(PyverbsCM):
     cdef dv.mlx5dv_dr_action *action
@@ -15,3 +17,5 @@ cdef class DrAction(PyverbsCM):
 cdef class DrActionQp(DrAction):
     cdef QP qp
 
+cdef class DrActionModify(DrAction):
+    cdef DrDomain domain

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -51,3 +51,11 @@ cdef class DrActionDestArray(DrAction):
 
 cdef class DrActionDefMiss(DrAction):
     pass
+
+cdef class DrActionVPort(DrAction):
+    cdef DrDomain domain
+    cdef int vport
+
+cdef class DrActionIBPort(DrAction):
+    cdef DrDomain domain
+    cdef int ib_port

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -283,3 +283,14 @@ cdef class DrActionDestArray(DrAction):
             super(DrActionDestArray, self).close()
             self.domain = None
             self.dest_actions = None
+
+
+cdef class DrActionDefMiss(DrAction):
+    def __init__(self):
+        """
+        Create DR default miss action.
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_default_miss()
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('DrActionDefMiss creation failed.')

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -2,10 +2,17 @@
 # Copyright (c) 2020 Nvidia, Inc. All rights reserved. See COPYING file
 
 from pyverbs.base import PyverbsRDMAErrno, PyverbsRDMAError
+from pyverbs.providers.mlx5.dr_domain cimport DrDomain
 from pyverbs.providers.mlx5.dr_rule cimport DrRule
 from pyverbs.pyverbs_error import PyverbsError
 from pyverbs.base cimport close_weakrefs
+from libc.stdlib cimport calloc, free
 import weakref
+import struct
+import errno
+
+be64toh = lambda num: struct.unpack('Q'.encode(), struct.pack('!8s'.encode(), num))[0]
+ACTION_SIZE = 8
 
 
 cdef class DrAction(PyverbsCM):
@@ -48,3 +55,38 @@ cdef class DrActionQp(DrAction):
         if self.action != NULL:
             super(DrActionQp, self).close()
             self.qp = None
+
+cdef class DrActionModify(DrAction):
+    def __init__(self, DrDomain domain, flags=0, actions=list()):
+        """
+        Create DR modify header actions.
+        :param domain: DrDomain object where the action should be located.
+        :param flags: Modify action flags.
+        :param actions: List of Bytes of the actions command input data
+                        provided in a device specification format
+                        (Stream of bytes or __bytes__ is implemented).
+        """
+        super().__init__()
+        action_buf_size = len(actions) * ACTION_SIZE
+        cdef unsigned long long *buf = <unsigned long long*>calloc(1, action_buf_size)
+        if buf == NULL:
+           raise MemoryError('Failed to allocate memory', errno)
+
+        for i in range(len(actions)):
+            buf[i] = be64toh(bytes(actions[i]))
+        self.action = dv.mlx5dv_dr_action_create_modify_header(domain.domain, flags,
+                                                               action_buf_size, buf)
+        free(buf)
+
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('Failed to create dr action modify header')
+        self.domain = domain
+        domain.dr_actions.add(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.action != NULL:
+            super(DrActionModify, self).close()
+            self.domain = None

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -126,3 +126,15 @@ cdef class DrActionModify(DrAction):
         if self.action != NULL:
             super(DrActionModify, self).close()
             self.domain = None
+
+
+cdef class DrActionTag(DrAction):
+    def __init__(self, tag):
+        """
+        Create DR tag action.
+        :param tag: Tag value
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_tag(tag)
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('DrActionTag creation failed.')

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -294,3 +294,51 @@ cdef class DrActionDefMiss(DrAction):
         self.action = dv.mlx5dv_dr_action_create_default_miss()
         if self.action == NULL:
             raise PyverbsRDMAErrno('DrActionDefMiss creation failed.')
+
+
+cdef class DrActionVPort(DrAction):
+    def __init__(self, DrDomain domain, vport):
+        """
+        Create DR vport action.
+        :param domain: DrDomain object where the action should be placed.
+        :param vport: VPort number.
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_dest_vport(domain.domain, vport)
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('Failed to create dr VPort action')
+        self.domain = domain
+        self.vport = vport
+        domain.dr_actions.add(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.action != NULL:
+            super(DrActionVPort, self).close()
+            self.domain = None
+
+
+cdef class DrActionIBPort(DrAction):
+    def __init__(self, DrDomain domain, ib_port):
+        """
+        Create DR IB port action.
+        :param domain: DrDomain object where the action should be placed.
+        :param ib_port: IB port number.
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_dest_ib_port(domain.domain, ib_port)
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('Failed to create dr IB port action')
+        self.domain = domain
+        self.ib_port = ib_port
+        domain.dr_actions.add(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.action != NULL:
+            super(DrActionIBPort, self).close()
+            self.domain = None

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -138,3 +138,25 @@ cdef class DrActionTag(DrAction):
         self.action = dv.mlx5dv_dr_action_create_tag(tag)
         if self.action == NULL:
             raise PyverbsRDMAErrno('DrActionTag creation failed.')
+
+
+cdef class DrActionDestTable(DrAction):
+    def __init__(self, DrTable table):
+        """
+        Create DR destination table action.
+        :param table: Destination table
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_dest_table(table.table)
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('DrActionDestTable creation failed.')
+        self.table = table
+        table.dr_actions.add(self)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.action != NULL:
+            super(DrActionDestTable, self).close()
+            self.table = None

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -81,6 +81,17 @@ cdef class DrActionFlowCounter(DrAction):
             self.devx_obj = None
 
 
+cdef class DrActionDrop(DrAction):
+    def __init__(self):
+        """
+        Create DR flow drop action.
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_drop()
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('DrActionDrop creation failed.')
+
+
 cdef class DrActionModify(DrAction):
     def __init__(self, DrDomain domain, flags=0, actions=list()):
         """

--- a/pyverbs/providers/mlx5/dr_domain.pxd
+++ b/pyverbs/providers/mlx5/dr_domain.pxd
@@ -9,4 +9,5 @@ from pyverbs.base cimport PyverbsCM
 cdef class DrDomain(PyverbsCM):
     cdef dv.mlx5dv_dr_domain *domain
     cdef object dr_tables
+    cdef object context
     cdef add_ref(self, obj)

--- a/pyverbs/providers/mlx5/dr_domain.pxd
+++ b/pyverbs/providers/mlx5/dr_domain.pxd
@@ -10,4 +10,5 @@ cdef class DrDomain(PyverbsCM):
     cdef dv.mlx5dv_dr_domain *domain
     cdef object dr_tables
     cdef object context
+    cdef object dr_actions
     cdef add_ref(self, obj)

--- a/pyverbs/providers/mlx5/dr_domain.pyx
+++ b/pyverbs/providers/mlx5/dr_domain.pyx
@@ -23,6 +23,14 @@ cdef class DrDomain(PyverbsCM):
             raise PyverbsRDMAErrno('DrDomain creation failed.')
         self.dr_tables = weakref.WeakSet()
 
+    def allow_duplicate_rules(self, allow):
+        """
+        Allows or prevents duplicate rules insertion, by default this feature is
+        allowed.
+        :param allow: Boolean to allow or prevent
+        """
+        dv.mlx5dv_dr_domain_allow_duplicate_rules(self.domain, allow)
+
     cdef add_ref(self, obj):
         if isinstance(obj, DrTable):
             self.dr_tables.add(obj)

--- a/pyverbs/providers/mlx5/dr_domain.pyx
+++ b/pyverbs/providers/mlx5/dr_domain.pyx
@@ -22,6 +22,8 @@ cdef class DrDomain(PyverbsCM):
         if self.domain == NULL:
             raise PyverbsRDMAErrno('DrDomain creation failed.')
         self.dr_tables = weakref.WeakSet()
+        self.context = context
+        context.dr_domains.add(self)
 
     def allow_duplicate_rules(self, allow):
         """

--- a/pyverbs/providers/mlx5/dr_domain.pyx
+++ b/pyverbs/providers/mlx5/dr_domain.pyx
@@ -43,6 +43,22 @@ cdef class DrDomain(PyverbsCM):
         else:
             raise PyverbsError('Unrecognized object type')
 
+    def sync(self, flags=dv.MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW |
+                         dv.MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW):
+        """
+        Sync is used in order to flush the rule submission queue.
+        :param flags:
+            MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW - block until completion of all
+                                             software queued tasks
+            MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW - clear the steering HW cache to
+                                             enforce next packet hits the
+                                             latest rules.
+            MLX5DV_DR_DOMAIN_SYNC_FLAGS_MEM - sync device memory to free cached
+                                              memory.
+        """
+        if dv.mlx5dv_dr_domain_sync(self.domain, flags):
+            raise PyverbsRDMAErrno('DrDomain sync failed.')
+
     def __dealloc__(self):
         self.close()
 

--- a/pyverbs/providers/mlx5/dr_table.pxd
+++ b/pyverbs/providers/mlx5/dr_table.pxd
@@ -10,4 +10,5 @@ cdef class DrTable(PyverbsCM):
     cdef dv.mlx5dv_dr_table *table
     cdef object dr_domain
     cdef object dr_matchers
+    cdef object dr_actions
     cdef add_ref(self, obj)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -432,6 +432,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                           size_t num_actions,
                                           mlx5dv_dr_action *actions[])
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
+    void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
+
     uint64_t mlx5dv_ts_to_ns(mlx5dv_clock_info *clock_info,
                              uint64_t device_timestamp)
     int mlx5dv_get_clock_info(v.ibv_context *ctx_in, mlx5dv_clock_info *clock_info)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -435,6 +435,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                           mlx5dv_dr_action *actions[])
     mlx5dv_dr_action *mlx5dv_dr_action_create_modify_header(mlx5dv_dr_domain *dmn, uint32_t flags,
                                                             size_t actions_sz, uint64_t actions[])
+    mlx5dv_dr_action *mlx5dv_dr_action_create_flow_counter(mlx5dv_devx_obj *devx_obj,
+                                                           uint32_t offset)
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -463,6 +463,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     mlx5dv_dr_action *mlx5dv_dr_action_create_flow_counter(mlx5dv_devx_obj *devx_obj,
                                                            uint32_t offset)
     mlx5dv_dr_action *mlx5dv_dr_action_create_drop()
+    mlx5dv_dr_action *mlx5dv_dr_action_create_default_miss()
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -416,6 +416,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                                  void *data,
                                                                  unsigned char reformat_type,
                                                                  unsigned char ft_type)
+
+    # Direct rules verbs
     mlx5dv_dr_domain *mlx5dv_dr_domain_create(v.ibv_context *ctx, mlx5dv_dr_domain_type type)
     int mlx5dv_dr_domain_destroy(mlx5dv_dr_domain *dmn)
     mlx5dv_dr_table *mlx5dv_dr_table_create(mlx5dv_dr_domain *dmn, uint32_t level)
@@ -431,6 +433,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                           mlx5dv_flow_match_parameters *value,
                                           size_t num_actions,
                                           mlx5dv_dr_action *actions[])
+    mlx5dv_dr_action *mlx5dv_dr_action_create_modify_header(mlx5dv_dr_domain *dmn, uint32_t flags,
+                                                            size_t actions_sz, uint64_t actions[])
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -419,6 +419,7 @@ cdef extern from 'infiniband/mlx5dv.h':
 
     # Direct rules verbs
     mlx5dv_dr_domain *mlx5dv_dr_domain_create(v.ibv_context *ctx, mlx5dv_dr_domain_type type)
+    int mlx5dv_dr_domain_sync(mlx5dv_dr_domain *domain, uint32_t flags)
     int mlx5dv_dr_domain_destroy(mlx5dv_dr_domain *dmn)
     mlx5dv_dr_table *mlx5dv_dr_table_create(mlx5dv_dr_domain *dmn, uint32_t level)
     int mlx5dv_dr_table_destroy(mlx5dv_dr_table *tbl)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -430,6 +430,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     int mlx5dv_dr_matcher_destroy(mlx5dv_dr_matcher *matcher)
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ibv_qp(v.ibv_qp *ibqp)
     mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_dest_table(mlx5dv_dr_table *tbl)
 
     int mlx5dv_dr_action_destroy(mlx5dv_dr_action *action)
     mlx5dv_dr_rule *mlx5dv_dr_rule_create(mlx5dv_dr_matcher *matcher,

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -464,6 +464,10 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                            uint32_t offset)
     mlx5dv_dr_action *mlx5dv_dr_action_create_drop()
     mlx5dv_dr_action *mlx5dv_dr_action_create_default_miss()
+    mlx5dv_dr_action *mlx5dv_dr_action_create_dest_vport(mlx5dv_dr_domain *dmn,
+                                                         uint32_t vport)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ib_port(mlx5dv_dr_domain *dmn,
+                                                           uint32_t ib_port)
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -162,6 +162,15 @@ cdef extern from 'infiniband/mlx5dv.h':
 
     cdef struct mlx5dv_dr_rule
 
+    cdef struct mlx5dv_dr_action_dest_reformat:
+        mlx5dv_dr_action *reformat
+        mlx5dv_dr_action *dest
+
+    cdef struct mlx5dv_dr_action_dest_attr:
+        mlx5dv_dr_action_dest_type type
+        mlx5dv_dr_action *dest
+        mlx5dv_dr_action_dest_reformat *dest_reformat
+
     cdef struct mlx5dv_clock_info:
         pass
 
@@ -441,6 +450,9 @@ cdef extern from 'infiniband/mlx5dv.h':
     mlx5dv_dr_action *mlx5dv_dr_action_create_pop_vlan()
     mlx5dv_dr_action *mlx5dv_dr_action_create_push_vlan(mlx5dv_dr_domain *dmn,
                                                         uint32_t vlan_hdr)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_dest_array(
+            mlx5dv_dr_domain *domain, size_t num_dest,
+            mlx5dv_dr_action_dest_attr *dests[])
     int mlx5dv_dr_action_destroy(mlx5dv_dr_action *action)
     mlx5dv_dr_rule *mlx5dv_dr_rule_create(mlx5dv_dr_matcher *matcher,
                                           mlx5dv_flow_match_parameters *value,

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -6,6 +6,7 @@ include 'mlx5dv_enums.pxd'
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t, uintptr_t
 from posix.types cimport off_t
 from libcpp cimport bool
+cimport libc.stdio as s
 
 cimport pyverbs.libibverbs as v
 
@@ -420,6 +421,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     # Direct rules verbs
     mlx5dv_dr_domain *mlx5dv_dr_domain_create(v.ibv_context *ctx, mlx5dv_dr_domain_type type)
     int mlx5dv_dr_domain_sync(mlx5dv_dr_domain *domain, uint32_t flags)
+    int mlx5dv_dump_dr_domain(s.FILE *fout, mlx5dv_dr_domain *domain)
     int mlx5dv_dr_domain_destroy(mlx5dv_dr_domain *dmn)
     mlx5dv_dr_table *mlx5dv_dr_table_create(mlx5dv_dr_domain *dmn, uint32_t level)
     int mlx5dv_dr_table_destroy(mlx5dv_dr_table *tbl)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -154,6 +154,10 @@ cdef extern from 'infiniband/mlx5dv.h':
 
     cdef struct mlx5dv_dr_matcher
 
+    cdef struct mlx5dv_dr_matcher_layout:
+        uint32_t flags
+        uint32_t log_num_of_rules_hint
+
     cdef struct mlx5dv_dr_action
 
     cdef struct mlx5dv_dr_rule
@@ -429,6 +433,7 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                 uint16_t priority,
                                                 uint8_t match_criteria_enable,
                                                 mlx5dv_flow_match_parameters *mask)
+    int mlx5dv_dr_matcher_set_layout(mlx5dv_dr_matcher *matcher, mlx5dv_dr_matcher_layout *layout)
     int mlx5dv_dr_matcher_destroy(mlx5dv_dr_matcher *matcher)
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ibv_qp(v.ibv_qp *ibqp)
     mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -428,6 +428,8 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                 mlx5dv_flow_match_parameters *mask)
     int mlx5dv_dr_matcher_destroy(mlx5dv_dr_matcher *matcher)
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ibv_qp(v.ibv_qp *ibqp)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value)
+
     int mlx5dv_dr_action_destroy(mlx5dv_dr_action *action)
     mlx5dv_dr_rule *mlx5dv_dr_rule_create(mlx5dv_dr_matcher *matcher,
                                           mlx5dv_flow_match_parameters *value,

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -438,7 +438,9 @@ cdef extern from 'infiniband/mlx5dv.h':
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ibv_qp(v.ibv_qp *ibqp)
     mlx5dv_dr_action *mlx5dv_dr_action_create_tag(uint32_t tag_value)
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_table(mlx5dv_dr_table *tbl)
-
+    mlx5dv_dr_action *mlx5dv_dr_action_create_pop_vlan()
+    mlx5dv_dr_action *mlx5dv_dr_action_create_push_vlan(mlx5dv_dr_domain *dmn,
+                                                        uint32_t vlan_hdr)
     int mlx5dv_dr_action_destroy(mlx5dv_dr_action *action)
     mlx5dv_dr_rule *mlx5dv_dr_rule_create(mlx5dv_dr_matcher *matcher,
                                           mlx5dv_flow_match_parameters *value,

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -437,6 +437,7 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                             size_t actions_sz, uint64_t actions[])
     mlx5dv_dr_action *mlx5dv_dr_action_create_flow_counter(mlx5dv_devx_obj *devx_obj,
                                                            uint32_t offset)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_drop()
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -86,6 +86,8 @@ cdef class Mlx5DevxObj(PyverbsCM):
     cdef dv.mlx5dv_devx_obj *obj
     cdef Context context
     cdef object out_view
+    cdef object flow_counter_actions
+    cdef add_ref(self, obj)
 
 cdef class Mlx5Cqe64(PyverbsObject):
     cdef dv.mlx5_cqe64 *cqe

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -264,6 +264,9 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL
         MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_GOING_TO_COMMISSIONING
 
+    cpdef enum mlx5dv_dr_action_flags:
+        MLX5DV_DR_ACTION_FLAGS_ROOT_LEVEL
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -267,6 +267,11 @@ cdef extern from 'infiniband/mlx5dv.h':
     cpdef enum mlx5dv_dr_action_flags:
         MLX5DV_DR_ACTION_FLAGS_ROOT_LEVEL
 
+    cpdef enum mlx5dv_dr_domain_sync_flags:
+        MLX5DV_DR_DOMAIN_SYNC_FLAGS_SW
+        MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW
+        MLX5DV_DR_DOMAIN_SYNC_FLAGS_MEM
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -272,6 +272,10 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_DR_DOMAIN_SYNC_FLAGS_HW
         MLX5DV_DR_DOMAIN_SYNC_FLAGS_MEM
 
+    cpdef enum mlx5dv_dr_matcher_layout_flags:
+       MLX5DV_DR_MATCHER_LAYOUT_RESIZABLE
+       MLX5DV_DR_MATCHER_LAYOUT_NUM_RULE
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -276,6 +276,10 @@ cdef extern from 'infiniband/mlx5dv.h':
        MLX5DV_DR_MATCHER_LAYOUT_RESIZABLE
        MLX5DV_DR_MATCHER_LAYOUT_NUM_RULE
 
+    cpdef enum mlx5dv_dr_action_dest_type:
+        MLX5DV_DR_ACTION_DEST
+        MLX5DV_DR_ACTION_DEST_REFORMAT
+
     cpdef unsigned long long MLX5DV_RES_TYPE_QP
     cpdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cpdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/pyverbs/providers/mlx5/mlx5dv_flow.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_flow.pyx
@@ -16,15 +16,18 @@ import weakref
 
 
 cdef class Mlx5FlowMatchParameters(PyverbsObject):
-    def __init__(self, size=0, values=bytes()):
+    def __init__(self, size, values):
         """
         Initialize a Mlx5FlowMatchParameters object over an underlying
         mlx5dv_flow_match_parameters C object that defines match parameters for
         steering flow.
         :param size: Length of the mask/value in bytes
         :param values: Bytes with mask/value to use in format of Flow Table
-                       Entry Match Parameters Format table in PRM.
+                       Entry Match Parameters Format table in PRM or instance
+                       of FlowTableEntryMatchParam class.
+
         """
+        cdef char *py_bytes_c
         super().__init__()
         struct_size = sizeof(size_t) + size
         self.params = <dv.mlx5dv_flow_match_parameters *>calloc(1, struct_size)
@@ -32,7 +35,9 @@ cdef class Mlx5FlowMatchParameters(PyverbsObject):
             raise PyverbsError(f'Failed to allocate buffer of size {struct_size}')
         self.params.match_sz = size
         if size:
-            memcpy(self.params.match_buf, <char*>values, size)
+            py_bytes = bytes(values)
+            py_bytes_c = py_bytes
+            memcpy(self.params.match_buf, py_bytes_c, len(values))
 
     def __dealloc__(self):
         self.close()

--- a/tests/args_parser.py
+++ b/tests/args_parser.py
@@ -24,6 +24,8 @@ class ArgsParser(object):
         parser.add_argument('--port',
                             help='Use port <port> of RDMA device', type=int,
                             default=1)
+        parser.add_argument('--gid',
+                            help='Use gid index <gid> of RDMA device', type=int)
         parser.add_argument('--gpu', nargs='?', type=int, const=0, default=0,
                             help='GPU unit to allocate dmabuf from')
         parser.add_argument('--gtt', action='store_true', default=False,

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -1247,3 +1247,15 @@ class FlowTableEntryMatchParam(Packet):
         # supported fields only.
         # StrFixedLenField('reserved1', None, length=128),
     ]
+
+
+class SetActionIn(Packet):
+    fields_desc = [
+        BitField('action_type', 0, 4),
+        BitField('field', 0, 12),
+        BitField('reserved1', 0, 3),
+        BitField('offset', 0, 5),
+        BitField('reserved2', 0, 3),
+        BitField('length', 0, 5),
+        IntField('data', 0),
+    ]

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -34,6 +34,9 @@ class DevxOps:
     MLX5_QPC_ST_RC = 0X0
     MLX5_QPC_PM_STATE_MIGRATED = 0x3
     MLX5_CMD_OP_QUERY_HCA_CAP = 0x100
+    MLX5_CMD_OP_ALLOC_FLOW_COUNTER = 0x939
+    MLX5_CMD_OP_DEALLOC_FLOW_COUNTER = 0x93a
+    MLX5_CMD_OP_QUERY_FLOW_COUNTER = 0x93b
 
 
 # Common
@@ -1258,4 +1261,79 @@ class SetActionIn(Packet):
         BitField('reserved2', 0, 3),
         BitField('length', 0, 5),
         IntField('data', 0),
+    ]
+
+
+class AllocFlowCounterIn(Packet):
+    fields_desc = [
+        ShortField('opcode', DevxOps.MLX5_CMD_OP_ALLOC_FLOW_COUNTER),
+        ShortField('uid', 0),
+        ShortField('reserved1', 0),
+        ShortField('op_mod', 0),
+        IntField('flow_counter_id', 0),
+        BitField('reserved2', 0, 24),
+        ByteField('flow_counter_bulk', 0),
+    ]
+
+
+class AllocFlowCounterOut(Packet):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('reserved1', 0, 24),
+        IntField('syndrome', 0),
+        IntField('flow_counter_id', 0),
+        StrFixedLenField('reserved2', None, length=4),
+    ]
+
+
+class DeallocFlowCounterIn(Packet):
+    fields_desc = [
+        ShortField('opcode', DevxOps.MLX5_CMD_OP_DEALLOC_FLOW_COUNTER),
+        ShortField('uid', 0),
+        ShortField('reserved1', 0),
+        ShortField('op_mod', 0),
+        IntField('flow_counter_id', 0),
+        StrFixedLenField('reserved2', None, length=4),
+    ]
+
+
+class DeallocFlowCounterOut(Packet):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('reserved1', 0, 24),
+        IntField('syndrome', 0),
+        StrFixedLenField('reserved2', None, length=8),
+    ]
+
+
+class QueryFlowCounterIn(Packet):
+    fields_desc = [
+        ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_FLOW_COUNTER),
+        ShortField('uid', 0),
+        ShortField('reserved1', 0),
+        ShortField('op_mod', 0),
+        StrFixedLenField('reserved2', None, length=4),
+        IntField('mkey', 0),
+        LongField('address', 0),
+        BitField('clear', 0, 1),
+        BitField('dump_to_memory', 0, 1),
+        BitField('num_of_counters', 0, 30),
+        IntField('flow_counter_id', 0),
+    ]
+
+
+class TrafficCounter(Packet):
+    fields_desc = [
+        LongField('packets', 0),
+        LongField('octets', 0),
+    ]
+
+
+class QueryFlowCounterOut(Packet):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('reserved1', 0, 24),
+        IntField('syndrome', 0),
+        StrFixedLenField('reserved2', None, length=8),
+        PacketField('flow_statistics', TrafficCounter(), TrafficCounter),
     ]

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -10,9 +10,10 @@ try:
     import logging
     logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
     from scapy.packet import Packet
-    from scapy.fields import BitField, ByteField, IntField, \
+    from scapy.fields import BitField, ByteField, IntField, IPField, \
         ShortField, LongField, StrFixedLenField, PacketField, \
         PacketListField, ConditionalField, PadField, FieldListField, MACField
+    from scapy.layers.inet6 import IP6Field
 except ImportError:
     raise unittest.SkipTest('scapy package is needed in order to run DevX tests')
 
@@ -1043,4 +1044,206 @@ class QueryCmdHcaCapOut(Packet):
         IntField('syndrome', 0),
         StrFixedLenField('reserved2', None, length=8),
         PadField(PacketField('capability', CmdHcaCap(), CmdHcaCap), 2048, padwith=b"\x00"),
+    ]
+
+
+class FlowTableEntryMatchSetMisc(Packet):
+    fields_desc = [
+        BitField('gre_c_present', 0, 1),
+        BitField('reserved1', 0, 1),
+        BitField('gre_k_present', 0, 1),
+        BitField('gre_s_present', 0, 1),
+        BitField('source_vhca_port', 0, 4),
+        BitField('source_sqn', 0, 24),
+        ShortField('src_esw_owner_vhca_id', 0),
+        ShortField('source_port', 0),
+        BitField('outer_second_prio', 0, 3),
+        BitField('outer_second_cfi', 0, 1),
+        BitField('outer_second_vid', 0, 12),
+        BitField('inner_second_prio', 0, 3),
+        BitField('inner_second_cfi', 0, 1),
+        BitField('inner_second_vid', 0, 12),
+        BitField('outer_second_cvlan_tag', 0, 1),
+        BitField('inner_second_cvlan_tag', 0, 1),
+        BitField('outer_second_svlan_tag', 0, 1),
+        BitField('inner_second_svlan_tag', 0, 1),
+        BitField('outer_emd_tag', 0, 1),
+        BitField('reserved2', 0, 11),
+        ShortField('gre_protocol', 0),
+        BitField('gre_key_h', 0, 24),
+        ByteField('gre_key_l', 0),
+        BitField('vxlan_vni', 0, 24),
+        ByteField('reserved3', 0),
+        BitField('geneve_vni', 0, 24),
+        BitField('reserved4', 0, 7),
+        BitField('geneve_oam', 0, 1),
+        BitField('reserved5', 0, 12),
+        BitField('outer_ipv6_flow_label', 0, 20),
+        BitField('reserved6', 0, 12),
+        BitField('inner_ipv6_flow_label', 0, 20),
+        BitField('reserved7', 0, 10),
+        BitField('geneve_opt_len', 0, 6),
+        ShortField('geneve_protocol_type', 0),
+        ByteField('reserved8', 0),
+        BitField('bth_dst_qp', 0, 24),
+        IntField('inner_esp_spi', 0),
+        IntField('outer_esp_spi', 0),
+        StrFixedLenField('reserved9', None, length=4),
+        IntField('outer_emd_tag_data_47_16', 0),
+        ShortField('outer_emd_tag_data_15_0', 0),
+        ShortField('reserved10', 0),
+    ]
+
+
+class FlowTableEntryMatchSetMisc2(Packet):
+    fields_desc = [
+        BitField('outer_first_mpls_label', 0, 20),
+        BitField('outer_first_mpls_exp', 0, 3),
+        BitField('outer_first_mpls_s_bos', 0, 1),
+        ByteField('outer_first_mpls_ttl', 0),
+        BitField('inner_first_mpls_label', 0, 20),
+        BitField('inner_first_mpls_exp', 0, 3),
+        BitField('inner_first_mpls_s_bos', 0, 1),
+        ByteField('inner_first_mpls_ttl', 0),
+        BitField('outer_last_mpls_over_gre_label', 0, 20),
+        BitField('outer_last_mpls_over_gre_exp', 0, 3),
+        BitField('outer_last_mpls_over_gre_s_bos', 0, 1),
+        ByteField('outer_last_mpls_over_gre_ttl', 0),
+        BitField('outer_last_mpls_over_udp_label', 0, 20),
+        BitField('outer_last_mpls_over_udp_exp', 0, 3),
+        BitField('outer_last_mpls_over_udp_s_bos', 0, 1),
+        ByteField('outer_last_mpls_over_udp_ttl', 0),
+        IntField('metadata_reg_c_7', 0),
+        IntField('metadata_reg_c_6', 0),
+        IntField('metadata_reg_c_5', 0),
+        IntField('metadata_reg_c_4', 0),
+        IntField('metadata_reg_c_3', 0),
+        IntField('metadata_reg_c_2', 0),
+        IntField('metadata_reg_c_1', 0),
+        IntField('metadata_reg_c_0', 0),
+        IntField('metadata_reg_a', 0),
+        IntField('metadata_reg_b', 0),
+        StrFixedLenField('reserved1', None, length=8),
+    ]
+
+
+class FlowTableEntryMatchSetMisc3(Packet):
+    fields_desc = [
+        IntField('inner_tcp_seq_num', 0),
+        IntField('outer_tcp_seq_num', 0),
+        IntField('inner_tcp_ack_num', 0),
+        IntField('outer_tcp_ack_num', 0),
+        ByteField('reserved1', 0),
+        BitField('outer_vxlan_gpe_vni', 0, 24),
+        ByteField('outer_vxlan_gpe_next_protocol', 0),
+        ByteField('outer_vxlan_gpe_flags', 0),
+        ShortField('reserved2', 0),
+        IntField('icmp_header_data', 0),
+        IntField('icmpv6_header_data', 0),
+        ByteField('icmp_type', 0),
+        ByteField('icmp_code', 0),
+        ByteField('icmpv6_type', 0),
+        ByteField('icmpv6_code', 0),
+        IntField('geneve_tlv_option_0_data', 0),
+        IntField('gtpu_teid', 0),
+        ByteField('gtpu_msg_type', 0),
+        BitField('reserved3', 0, 5),
+        BitField('gtpu_flags', 0, 3),
+        ShortField('reserved4', 0),
+        IntField('gtpu_dw_2', 0),
+        IntField('gtpu_first_ext_dw_0', 0),
+        IntField('gtpu_dw_0', 0),
+        StrFixedLenField('reserved5', None, length=4),
+    ]
+
+
+class FlowTableEntryMatchSetLyr24(Packet):
+    fields_desc = [
+        MACField('smac', '00:00:00:00:00:00'),
+        ShortField('ethertype', 0),
+        MACField('dmac', '00:00:00:00:00:00'),
+        BitField('first_prio', 0, 3),
+        BitField('first_cfi', 0, 1),
+        BitField('first_vid', 0, 12),
+        ByteField('ip_protocol', 0),
+        BitField('ip_dscp', 0, 6),
+        BitField('ip_ecn', 0, 2),
+        BitField('cvlan_tag', 0, 1),
+        BitField('svlan_tag', 0, 1),
+        BitField('frag', 0, 1),
+        BitField('ip_version', 0, 4),
+        BitField('tcp_flags', 0, 9),
+        ShortField('tcp_sport', 0),
+        ShortField('tcp_dport', 0),
+        BitField('reserved1', 0, 16),
+        BitField('ipv4_ihl', 0, 4),
+        BitField('l3_ok', 0, 1),
+        BitField('l4_ok', 0, 1),
+        BitField('ipv4_checksum_ok', 0, 1),
+        BitField('l4_checksum_ok', 0, 1),
+        ByteField('ip_ttl_hoplimit', 0),
+        ShortField('udp_sport', 0),
+        ShortField('udp_dport', 0),
+        # Ipv4 and IPv6 fields are edited manually:
+        # Added lambda conditioning
+        # Field names must be different
+        ConditionalField(BitField('src_ip_mask', 0, 128),
+                        lambda pkt: pkt.ip_version != 4 and pkt.ip_version != 6),
+        ConditionalField(BitField('reserved', 0, 96),
+                         lambda pkt: pkt.ip_version == 4),
+        ConditionalField(IPField("src_ip4", "0.0.0.0"),
+                         lambda pkt: pkt.ip_version == 4),
+        ConditionalField(IP6Field("src_ip6", "::"),
+                         lambda pkt: pkt.ip_version == 6),
+        ConditionalField(BitField('dst_ip_mask', 0, 128),
+                        lambda pkt: pkt.ip_version != 4 and pkt.ip_version != 6),
+        ConditionalField(BitField('reserved', 0, 96),
+                         lambda pkt: pkt.ip_version == 4),
+        ConditionalField(IPField("dst_ip4", "0.0.0.0"),
+                         lambda pkt: pkt.ip_version == 4),
+        ConditionalField(IP6Field("dst_ip6", "::"),
+                         lambda pkt: pkt.ip_version == 6),
+    ]
+
+
+class ProgSampleField(Packet):
+    fields_desc = [
+        IntField('prog_sample_field_value', 0),
+        IntField('prog_sample_field_id', 0),
+    ]
+
+
+class FlowTableEntryMatchSetMisc4(Packet):
+    fields_desc = [
+        PacketListField('prog_sample_field', [ProgSampleField() for x in range(4)], ProgSampleField, count_from=lambda pkt:4),
+        StrFixedLenField('reserved1', None, length=32),
+    ]
+
+
+class FlowTableEntryMatchSetMisc5(Packet):
+    fields_desc = [
+        IntField('macsec_tag_0', 0),
+        IntField('macsec_tag_1', 0),
+        IntField('macsec_tag_2', 0),
+        IntField('macsec_tag_3', 0),
+        IntField('tunnel_header_0', 0),
+        IntField('tunnel_header_1', 0),
+        IntField('tunnel_header_2', 0),
+        IntField('tunnel_header_3', 0),
+        StrFixedLenField('reserved1', None, length=32),
+    ]
+
+
+class FlowTableEntryMatchParam(Packet):
+    fields_desc = [
+        PacketField('outer_headers', FlowTableEntryMatchSetLyr24(), FlowTableEntryMatchSetLyr24),
+        PacketField('misc_parameters', FlowTableEntryMatchSetMisc(), FlowTableEntryMatchSetMisc),
+        PacketField('inner_headers', FlowTableEntryMatchSetLyr24(), FlowTableEntryMatchSetLyr24),
+        PacketField('misc_parameters_2', FlowTableEntryMatchSetMisc2(), FlowTableEntryMatchSetMisc2),
+        PacketField('misc_parameters_3', FlowTableEntryMatchSetMisc3(), FlowTableEntryMatchSetMisc3),
+        PacketField('misc_parameters_4', FlowTableEntryMatchSetMisc4(), FlowTableEntryMatchSetMisc4),
+        PacketField('misc_parameters_5', FlowTableEntryMatchSetMisc5(), FlowTableEntryMatchSetMisc5),
+        # Keep reserved commented out since SW steering checks the size with
+        # supported fields only.
+        # StrFixedLenField('reserved1', None, length=128),
     ]

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -5,9 +5,9 @@ Test module for pyverbs' mlx5 dr module.
 """
 
 from tests.utils import skip_unsupported, requires_root_on_eth, PacketConsts
+from pyverbs.providers.mlx5.dr_action import DrActionQp, DrActionModify
 from pyverbs.providers.mlx5.mlx5dv_flow import Mlx5FlowMatchParameters
 from pyverbs.providers.mlx5.dr_matcher import DrMatcher
-from pyverbs.providers.mlx5.dr_action import DrActionQp
 from pyverbs.providers.mlx5.dr_domain import DrDomain
 from pyverbs.providers.mlx5.dr_table import DrTable
 from pyverbs.providers.mlx5.dr_rule import DrRule
@@ -16,6 +16,12 @@ from tests.mlx5_base import Mlx5RDMATestCase
 from tests.base import RawResources
 import tests.utils as u
 import struct
+
+OUT_SMAC_47_16_FIELD_ID = 0x1
+OUT_SMAC_47_16_FIELD_LENGTH = 32
+OUT_SMAC_15_0_FIELD_ID = 0x2
+OUT_SMAC_15_0_FIELD_LENGTH = 16
+SET_ACTION = 0x1
 
 
 class Mlx5DrResources(RawResources):
@@ -33,6 +39,7 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         self.iters = 10
         self.server = None
         self.client = None
+        self.rules = []
 
     def tearDown(self):
         if self.server:
@@ -52,20 +59,64 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         self.server = resource(**self.dev_info, **resource_arg)
 
     @skip_unsupported
+    def create_rx_recv_qp_rule(self, smac_value):
+        """
+        Creates a rule on RX domain that forwards packets that match the smac
+        in the matcher to the server QP.
+        :param smac_value: The smac matcher value.
+        """
+        domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
+        table = DrTable(domain_rx, 0)
+        smac_mask = bytes([0xff] * 6)
+        mask_param = Mlx5FlowMatchParameters(len(smac_mask), smac_mask)
+        matcher = DrMatcher(table, 0, u.MatchCriteriaEnable.OUTER, mask_param)
+        self.qp_action = DrActionQp(self.server.qp)
+        value_param = Mlx5FlowMatchParameters(len(smac_value), smac_value)
+        self.rules.append(DrRule(matcher, value_param, [self.qp_action]))
+
+    @skip_unsupported
+    def create_tx_modify_rule(self):
+        """
+        Creares a rule on TX domain that modifies smac in the packet and sends
+        it to the wire.
+        """
+        from tests.mlx5_prm_structs import SetActionIn
+        self.domain_tx = DrDomain(self.client.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_TX)
+        table = DrTable(self.domain_tx, 0)
+        smac_mask = bytes([0xff] * 6)
+        mask_param = Mlx5FlowMatchParameters(len(smac_mask), smac_mask)
+        matcher = DrMatcher(table, 0, u.MatchCriteriaEnable.OUTER, mask_param)
+        smac_value = struct.pack('!6s', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
+        value_param = Mlx5FlowMatchParameters(len(smac_value), smac_value)
+        action1 = SetActionIn(action_type=SET_ACTION, field=OUT_SMAC_47_16_FIELD_ID,
+                              data=0x88888888, length=OUT_SMAC_47_16_FIELD_LENGTH)
+        action2 = SetActionIn(action_type=SET_ACTION, field=OUT_SMAC_15_0_FIELD_ID,
+                              data=0x8888, length=OUT_SMAC_15_0_FIELD_LENGTH)
+        self.modify_actions = DrActionModify(self.domain_tx, dve.MLX5DV_DR_ACTION_FLAGS_ROOT_LEVEL,
+                                             [action1, action2])
+        self.rules.append(DrRule(matcher, value_param, [self.modify_actions]))
+
+    @skip_unsupported
     def test_root_tbl_qp_rule(self):
         """
         Creates RX domain, root table with matcher on source mac. Creates QP
         action and a rule with this action on the matcher.
         """
         self.create_players(Mlx5DrResources)
-        domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
-        table = DrTable(domain_rx, 0)
-        smac_mask = bytes([0xff] * 6)
-        mask_param = Mlx5FlowMatchParameters(len(smac_mask), smac_mask)
-        matcher = DrMatcher(table, 0, u.MatchCriteriaEnable.OUTER, mask_param)
-        qp_action = DrActionQp(self.server.qp)
-        smac_value = struct.pack('!6s',
-                                 bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
-        value_param = Mlx5FlowMatchParameters(len(smac_value), smac_value)
-        self.rule = DrRule(matcher, value_param, [qp_action])
+        smac_value = struct.pack('!6s', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
+        self.create_rx_recv_qp_rule(smac_value)
         u.raw_traffic(self.client, self.server, self.iters)
+
+    @skip_unsupported
+    def test_root_tbl_modify_header_rule(self):
+        """
+        Creates TX domain, root table with matcher on source mac and modify
+        the smac. Then creates RX domain and rule that forwards packets with
+        the new smac to server QP. Perform traffic that do this flow.
+        """
+        self.create_players(Mlx5DrResources)
+        self.create_tx_modify_rule()
+        src_mac = struct.pack('!6s', bytes.fromhex("88:88:88:88:88:88".replace(':', '')))
+        self.create_rx_recv_qp_rule(src_mac)
+        exp_packet = u.gen_packet(self.client.msg_size, src_mac=src_mac)
+        u.raw_traffic(self.client, self.server, self.iters, expected_packet=exp_packet)

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -121,8 +121,8 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         :param smac_value: The smac matcher value.
         :param actions: List of actions to attach to the recv rule.
         """
-        domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
-        table = DrTable(domain_rx, 0)
+        self.domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
+        table = DrTable(self.domain_rx, 0)
         smac_mask = bytes([0xff] * 6)
         mask_param = Mlx5FlowMatchParameters(len(smac_mask), smac_mask)
         matcher = DrMatcher(table, 0, u.MatchCriteriaEnable.OUTER, mask_param)
@@ -291,6 +291,7 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         tag_action = DrActionTag(tag)
         smac_value = struct.pack('!6s', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
         self.create_rx_recv_qp_rule(smac_value, [tag_action, qp_action])
+        self.domain_rx.sync()
         u.raw_traffic(self.client, self.server, self.iters)
         # Verify tag
         self.assertEqual(self.server.cq.read_flow_tag(), tag, 'Wrong tag value')

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -4,9 +4,17 @@
 Test module for pyverbs' mlx5 dr module.
 """
 
+import unittest
+import struct
+import errno
+
+
+from pyverbs.providers.mlx5.dr_action import DrActionQp, DrActionModify, \
+    DrActionFlowCounter
+from pyverbs.providers.mlx5.mlx5dv import Mlx5DevxObj, Mlx5Context, Mlx5DVContextAttr
 from tests.utils import skip_unsupported, requires_root_on_eth, PacketConsts
-from pyverbs.providers.mlx5.dr_action import DrActionQp, DrActionModify
 from pyverbs.providers.mlx5.mlx5dv_flow import Mlx5FlowMatchParameters
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsUserError
 from pyverbs.providers.mlx5.dr_matcher import DrMatcher
 from pyverbs.providers.mlx5.dr_domain import DrDomain
 from pyverbs.providers.mlx5.dr_table import DrTable
@@ -15,7 +23,6 @@ import pyverbs.providers.mlx5.mlx5_enums as dve
 from tests.mlx5_base import Mlx5RDMATestCase
 from tests.base import RawResources
 import tests.utils as u
-import struct
 
 OUT_SMAC_47_16_FIELD_ID = 0x1
 OUT_SMAC_47_16_FIELD_LENGTH = 32
@@ -28,6 +35,35 @@ class Mlx5DrResources(RawResources):
     """
     Test various functionalities of the mlx5 direct rules class.
     """
+    def create_context(self):
+        mlx5dv_attr = Mlx5DVContextAttr()
+        try:
+            self.ctx = Mlx5Context(mlx5dv_attr, name=self.dev_name)
+        except PyverbsUserError as ex:
+            raise unittest.SkipTest(f'Could not open mlx5 context ({ex})')
+        except PyverbsRDMAError:
+            raise unittest.SkipTest('Opening mlx5 context is not supported')
+
+    def create_counter(self):
+        """
+        Create flow counter.
+        :param player: The player to create the counter on.
+        """
+        from tests.mlx5_prm_structs import AllocFlowCounterIn, AllocFlowCounterOut
+        self.counter = Mlx5DevxObj(self.ctx, AllocFlowCounterIn(), len(AllocFlowCounterOut()))
+        self.flow_counter_id = AllocFlowCounterOut(self.counter.out_view).flow_counter_id
+
+    def query_counter_packets(self):
+        """
+        Query flow counter packets count.
+        :return: Number of packets on this counter.
+        """
+        from tests.mlx5_prm_structs import QueryFlowCounterIn, QueryFlowCounterOut
+        query_in = QueryFlowCounterIn(flow_counter_id=self.flow_counter_id)
+        counter_out = QueryFlowCounterOut(self.counter.query(query_in,
+                                                             len(QueryFlowCounterOut())))
+        return counter_out.flow_statistics.packets
+
     @requires_root_on_eth()
     def create_qps(self):
         super().create_qps()
@@ -59,20 +95,20 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         self.server = resource(**self.dev_info, **resource_arg)
 
     @skip_unsupported
-    def create_rx_recv_qp_rule(self, smac_value):
+    def create_rx_recv_qp_rule(self, smac_value, actions):
         """
-        Creates a rule on RX domain that forwards packets that match the smac
-        in the matcher to the server QP.
+        Creates a rule on RX domain that perform actions on packets that match
+        the smac in the matcher.
         :param smac_value: The smac matcher value.
+        :param actions: List of actions to attach to the recv rule.
         """
         domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
         table = DrTable(domain_rx, 0)
         smac_mask = bytes([0xff] * 6)
         mask_param = Mlx5FlowMatchParameters(len(smac_mask), smac_mask)
         matcher = DrMatcher(table, 0, u.MatchCriteriaEnable.OUTER, mask_param)
-        self.qp_action = DrActionQp(self.server.qp)
         value_param = Mlx5FlowMatchParameters(len(smac_value), smac_value)
-        self.rules.append(DrRule(matcher, value_param, [self.qp_action]))
+        self.rules.append(DrRule(matcher, value_param, actions))
 
     @skip_unsupported
     def create_tx_modify_rule(self):
@@ -103,8 +139,9 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         action and a rule with this action on the matcher.
         """
         self.create_players(Mlx5DrResources)
+        self.qp_action = DrActionQp(self.server.qp)
         smac_value = struct.pack('!6s', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
-        self.create_rx_recv_qp_rule(smac_value)
+        self.create_rx_recv_qp_rule(smac_value, [self.qp_action])
         u.raw_traffic(self.client, self.server, self.iters)
 
     @skip_unsupported
@@ -117,6 +154,24 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         self.create_players(Mlx5DrResources)
         self.create_tx_modify_rule()
         src_mac = struct.pack('!6s', bytes.fromhex("88:88:88:88:88:88".replace(':', '')))
-        self.create_rx_recv_qp_rule(src_mac)
+        self.qp_action = DrActionQp(self.server.qp)
+        self.create_rx_recv_qp_rule(src_mac, [self.qp_action])
         exp_packet = u.gen_packet(self.client.msg_size, src_mac=src_mac)
         u.raw_traffic(self.client, self.server, self.iters, expected_packet=exp_packet)
+
+    @skip_unsupported
+    def test_root_tbl_counter_action(self):
+        """
+        Create flow counter object, attach it to a rule using counter action
+        and perform traffic that hit this rule. Verify that the counter packets
+        increased.
+        """
+        self.create_players(Mlx5DrResources)
+        self.server.create_counter()
+        self.server_counter_action = DrActionFlowCounter(self.server.counter)
+        smac_value = struct.pack('!6s', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
+        self.qp_action = DrActionQp(self.server.qp)
+        self.create_rx_recv_qp_rule(smac_value, [self.qp_action, self.server_counter_action])
+        u.raw_traffic(self.client, self.server, self.iters)
+        recv_packets = self.server.query_counter_packets()
+        self.assertEqual(recv_packets, self.iters, 'Counter missed some recv packets')

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -175,3 +175,12 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         u.raw_traffic(self.client, self.server, self.iters)
         recv_packets = self.server.query_counter_packets()
         self.assertEqual(recv_packets, self.iters, 'Counter missed some recv packets')
+
+    @skip_unsupported
+    def test_prevent_duplicate_rule(self):
+        """
+        Creates RX domain, sets duplicate rule to be not allowed on that domain
+        """
+        self.server = Mlx5DrResources(**self.dev_info)
+        domain_rx = DrDomain(self.server.ctx, dve.MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
+        domain_rx.allow_duplicate_rules(False)

--- a/tests/test_mlx5_flow.py
+++ b/tests/test_mlx5_flow.py
@@ -53,8 +53,11 @@ def requires_reformat_support(func):
         if status:
             raise PyverbsRDMAError('Query NIC Flow Table CAPs failed with status'
                                    f' ({status})')
-        # Verify that both NIC RX and TX support reformat actions
-        if not (cmd_view[80] & 0x1 and cmd_view[272] & 0x1):
+        # Verify that both NIC RX and TX support reformat actions by checking
+        # the following PRM fields: encap_general_header,
+        # log_max_packet_reformat, and reformat (for both RX and TX).
+        if not (cmd_view[20] & 0x80 and cmd_view[21] & 0x1f and
+                cmd_view[80] & 0x1 and cmd_view[272] & 0x1):
             raise unittest.SkipTest('NIC flow table does not support reformat')
         return func(instance)
     return func_wrapper

--- a/tests/test_mlx5_mkey.py
+++ b/tests/test_mlx5_mkey.py
@@ -56,7 +56,7 @@ class Mlx5MkeyResources(RCResources):
         try:
             self.mkey = Mlx5Mkey(self.pd, self.mkey_create_flags, 3)
         except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
+            if ex.error_code in [errno.EOPNOTSUPP, errno.EPROTONOSUPPORT]:
                 raise unittest.SkipTest('Create Mkey is not supported')
             raise ex
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -791,17 +791,18 @@ def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, **kwa
 
 
 def get_send_elements_raw_qp(agr_obj, l3=PacketConsts.IP_V4,
-                             l4=PacketConsts.UDP_PROTO):
+                             l4=PacketConsts.UDP_PROTO, **packet_args):
     """
     Creates a single SGE and a single Send WR for agr_obj's RAW QP type. The
     content of the message is Eth | Ipv4 | UDP packet.
     :param agr_obj: Aggregation object which contains all resources necessary
     :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
     :param l4: Packet layer 4 type: 'tcp' or 'udp'
+    :param packet_args: Pass packet_args to gen_packets method.
     :return: send wr, its SGE, and message
     """
     mr = agr_obj.mr
-    msg = gen_packet(agr_obj.msg_size, l3, l4)
+    msg = gen_packet(agr_obj.msg_size, l3, l4, **packet_args)
     mr.write(msg, agr_obj.msg_size)
     sge = SGE(mr.buf, agr_obj.msg_size, mr.lkey)
     send_wr = SendWR(opcode=e.IBV_WR_SEND, num_sge=1, sg=[sge])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -62,6 +62,7 @@ class PacketConsts:
     IPV6_HEADER_SIZE = 40
     UDP_HEADER_SIZE = 8
     TCP_HEADER_SIZE = 20
+    VLAN_HEADER_SIZE = 4
     TCP_HEADER_SIZE_WORDS = 5
     IP_V4 = 4
     IP_V6 = 6
@@ -89,6 +90,10 @@ class PacketConsts:
     VXLAN_VNI = 7777777
     VXLAN_FLAGS = 0x8
     VXLAN_HEADER_SIZE = 8
+    VLAN_TPID = 0x8100
+    VLAN_PRIO = 5
+    VLAN_CFI = 1
+    VLAN_ID = 0xc0c
 
 
 def get_mr_length():
@@ -731,13 +736,14 @@ def gen_outer_headers(msg_size):
     return outer
 
 
-def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, **kwargs):
+def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, with_vlan=False, **kwargs):
     """
     Generates a Eth | IPv4 or IPv6 | UDP or TCP packet with hardcoded values in
     the headers and randomized payload.
     :param msg_size: total packet size
     :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
     :param l4: Packet layer 4 type: 'tcp' or 'udp'
+    :param with_vlan: if True add VLAN header to the packet
     :param kwargs: Arguments:
             * *src_mac*
                 Source MAC address to use in the packet.
@@ -754,6 +760,12 @@ def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, **kwa
     src_mac = kwargs.get('src_mac', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
     packet = struct.pack('!6s6s',
                          bytes.fromhex(PacketConsts.DST_MAC.replace(':', '')), src_mac)
+    if with_vlan:
+        packet += struct.pack('!HH', PacketConsts.VLAN_TPID, (PacketConsts.VLAN_PRIO << 13) +
+                              (PacketConsts.VLAN_CFI << 12) + PacketConsts.VLAN_ID)
+        payload_size -= PacketConsts.VLAN_HEADER_SIZE
+        ip_total_len -= PacketConsts.VLAN_HEADER_SIZE
+
     if l3 == PacketConsts.IP_V4:
         packet += PacketConsts.ETHER_TYPE_IPV4.to_bytes(2, 'big')
     else:
@@ -791,18 +803,19 @@ def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, **kwa
 
 
 def get_send_elements_raw_qp(agr_obj, l3=PacketConsts.IP_V4,
-                             l4=PacketConsts.UDP_PROTO, **packet_args):
+                             l4=PacketConsts.UDP_PROTO, with_vlan=False, **packet_args):
     """
     Creates a single SGE and a single Send WR for agr_obj's RAW QP type. The
     content of the message is Eth | Ipv4 | UDP packet.
     :param agr_obj: Aggregation object which contains all resources necessary
     :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
     :param l4: Packet layer 4 type: 'tcp' or 'udp'
+    :param with_vlan: if True add VLAN header to the packet
     :param packet_args: Pass packet_args to gen_packets method.
     :return: send wr, its SGE, and message
     """
     mr = agr_obj.mr
-    msg = gen_packet(agr_obj.msg_size, l3, l4, **packet_args)
+    msg = gen_packet(agr_obj.msg_size, l3, l4, with_vlan, **packet_args)
     mr.write(msg, agr_obj.msg_size)
     sge = SGE(mr.buf, agr_obj.msg_size, mr.lkey)
     send_wr = SendWR(opcode=e.IBV_WR_SEND, num_sge=1, sg=[sge])
@@ -818,7 +831,7 @@ def validate_raw(msg_received, msg_expected, skip_idxs):
 
 
 def raw_traffic(client, server, iters, l3=PacketConsts.IP_V4,
-                l4=PacketConsts.UDP_PROTO, expected_packet=None, skip_idxs=[]):
+                l4=PacketConsts.UDP_PROTO, with_vlan=False, expected_packet=None, skip_idxs=[]):
     """
     Runs raw ethernet traffic between two sides
     :param client: client side, clients base class is BaseTraffic
@@ -826,6 +839,7 @@ def raw_traffic(client, server, iters, l3=PacketConsts.IP_V4,
     :param iters: number of traffic iterations
     :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
     :param l4: Packet layer 4 type: 'tcp' or 'udp'
+    :param with_vlan: if True add VLAN header to the packet
     :param expected_packet: Expected packet for validation (when different from
                             the originally sent).
     :param skip_idxs: indexes to skip during packet validation
@@ -841,7 +855,7 @@ def raw_traffic(client, server, iters, l3=PacketConsts.IP_V4,
     poll = poll_cq_ex if isinstance(client.cq, CQEX) else poll_cq
     for _ in range(iters):
         for qp_idx in range(server.qp_count):
-            c_send_wr, c_sg, msg = get_send_elements_raw_qp(client, l3, l4)
+            c_send_wr, c_sg, msg = get_send_elements_raw_qp(client, l3, l4, with_vlan)
             send(client, c_send_wr, e.IBV_WR_SEND, False, qp_idx)
             poll(client.cq)
             poll(server.cq)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -731,13 +731,16 @@ def gen_outer_headers(msg_size):
     return outer
 
 
-def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO):
+def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, **kwargs):
     """
     Generates a Eth | IPv4 or IPv6 | UDP or TCP packet with hardcoded values in
     the headers and randomized payload.
     :param msg_size: total packet size
     :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
     :param l4: Packet layer 4 type: 'tcp' or 'udp'
+    :param kwargs: Arguments:
+            * *src_mac*
+                Source MAC address to use in the packet.
     :return: packet
     """
     l3_header_size = getattr(PacketConsts, f'IPV{str(l3)}_HEADER_SIZE')
@@ -748,9 +751,9 @@ def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO):
     ip_total_len = msg_size - PacketConsts.ETHER_HEADER_SIZE
 
     # Ethernet header
+    src_mac = kwargs.get('src_mac', bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
     packet = struct.pack('!6s6s',
-                         bytes.fromhex(PacketConsts.DST_MAC.replace(':', '')),
-                         bytes.fromhex(PacketConsts.SRC_MAC.replace(':', '')))
+                         bytes.fromhex(PacketConsts.DST_MAC.replace(':', '')), src_mac)
     if l3 == PacketConsts.IP_V4:
         packet += PacketConsts.ETHER_TYPE_IPV4.to_bytes(2, 'big')
     else:


### PR DESCRIPTION
This series adds support for almost all the missing mlx5 direct rules (mlx5_dr) APIs in Pyverbs, as well as extends and adds more tests to cover the newly added domains, actions, matchers and rules.