### PR TITLE
redhat: move four files into sub-package infiniband-diags-compat

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -485,6 +485,10 @@ fi
 %{_sbindir}/ibprintrt.pl
 %{_mandir}/man8/ibprintrt*
 %{_sbindir}/set_nodedesc.sh
+%{_sbindir}/ibclearerrors
+%{_mandir}/man8/ibclearerrors*
+%{_sbindir}/ibclearcounters
+%{_mandir}/man8/ibclearcounters*
 
 %files -n infiniband-diags
 %{_sbindir}/ibaddr
@@ -545,10 +549,6 @@ fi
 %{_mandir}/man8/dump_lfts*
 %{_sbindir}/dump_mfts.sh
 %{_mandir}/man8/dump_mfts*
-%{_sbindir}/ibclearerrors
-%{_mandir}/man8/ibclearerrors*
-%{_sbindir}/ibclearcounters
-%{_mandir}/man8/ibclearcounters*
 %{_sbindir}/ibstatus
 %{_mandir}/man8/ibstatus*
 %{_mandir}/man8/infiniband-diags*


### PR DESCRIPTION
%{_sbindir}/ibclearerrors
%{_mandir}/man8/ibclearerrors*
%{_sbindir}/ibclearcounters
%{_mandir}/man8/ibclearcounters*

Those four files are available when infiniband-diags-compat was created.

Signed-off-by: Honggang Li <honli@redhat.com>