### PR TITLE
mlx5: DR, Extend support in few areas

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -29,6 +29,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.19@MLX5_1.19 35
  MLX5_1.20@MLX5_1.20 36
  MLX5_1.21@MLX5_1.21 37
+ MLX5_1.22@MLX5_1.22 38
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -146,6 +147,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_get_vfio_device_list@MLX5_1.21 37
  mlx5dv_vfio_get_events_fd@MLX5_1.21 37
  mlx5dv_vfio_process_events@MLX5_1.21 37
+ mlx5dv_dr_aso_other_domain_link@MLX5_1.22 38
+ mlx5dv_dr_aso_other_domain_unlink@MLX5_1.22 38
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.21.${PACKAGE_VERSION}
+  1 1.22.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -625,6 +625,16 @@ static int dr_matcher_set_definer_builders(struct mlx5dv_dr_matcher *matcher,
 		idx = 0;
 	}
 
+	if (dmn->info.caps.definer_format_sup & (1ULL << DR_MATCHER_DEFINER_33)) {
+		dr_matcher_copy_mask(&mask, &matcher->mask, matcher->match_criteria);
+		ret = dr_ste_build_def33(ste_ctx, &sb[idx++], &mask, false, rx);
+		if (!ret && dr_matcher_is_mask_consumed(&mask))
+			goto done;
+
+		memset(sb, 0, sizeof(*sb));
+		idx = 0;
+	}
+
 	return ENOTSUP;
 
 done:

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -1555,6 +1555,23 @@ int dr_ste_build_def28(struct dr_ste_ctx *ste_ctx,
 	return 0;
 }
 
+int dr_ste_build_def33(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx)
+{
+	if (!ste_ctx->build_def33_init) {
+		errno = ENOTSUP;
+		return errno;
+	}
+
+	sb->rx = rx;
+	sb->inner = inner;
+	sb->format_id = DR_MATCHER_DEFINER_33;
+	ste_ctx->build_def33_init(sb, mask);
+	return 0;
+}
+
 struct dr_ste_ctx *dr_ste_get_ctx(uint8_t version)
 {
 	if (version == MLX5_HW_CONNECTX_5)

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -30,6 +30,7 @@
  * SOFTWARE.
  */
 
+#include "mlx5dv_dr.h"
 #include "dr_ste.h"
 
 struct dr_hw_ste_format {
@@ -139,6 +140,12 @@ void dr_ste_set_hit_addr(struct dr_ste_ctx *ste_ctx, uint8_t *hw_ste_p,
 			 uint64_t icm_addr, uint32_t ht_size)
 {
 	ste_ctx->set_hit_addr(hw_ste_p, icm_addr, ht_size);
+}
+
+void dr_ste_set_hit_gvmi(struct dr_ste_ctx *ste_ctx, uint8_t *hw_ste_p,
+			 uint16_t gvmi)
+{
+	ste_ctx->set_hit_gvmi(hw_ste_p, gvmi);
 }
 
 uint64_t dr_ste_get_icm_addr(struct dr_ste *ste)
@@ -1582,4 +1589,37 @@ struct dr_ste_ctx *dr_ste_get_ctx(uint8_t version)
 	errno = EOPNOTSUPP;
 
 	return NULL;
+}
+
+int mlx5dv_dr_aso_other_domain_link(struct mlx5dv_devx_obj *devx_obj,
+				    struct mlx5dv_dr_domain *peer_dmn,
+				    struct mlx5dv_dr_domain *dmn,
+				    uint32_t flags,
+				    uint8_t return_reg_c)
+{
+	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
+
+	if (devx_obj->type != MLX5_DEVX_ASO_CT)
+		goto out;
+
+	if (ste_ctx->aso_other_domain_link)
+		return ste_ctx->aso_other_domain_link(devx_obj, peer_dmn,
+						      dmn, flags,
+						      return_reg_c);
+
+out:
+	errno = EOPNOTSUPP;
+	return errno;
+}
+
+int mlx5dv_dr_aso_other_domain_unlink(struct mlx5dv_devx_obj *devx_obj,
+				      struct mlx5dv_dr_domain *dmn)
+{
+	struct dr_ste_ctx *ste_ctx = dmn->ste_ctx;
+
+	if (ste_ctx->aso_other_domain_unlink)
+		return ste_ctx->aso_other_domain_unlink(devx_obj);
+
+	errno = EOPNOTSUPP;
+	return errno;
 }

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -184,6 +184,7 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_def25_init;
 	dr_ste_builder_void_init build_def26_init;
 	dr_ste_builder_void_init build_def28_init;
+	dr_ste_builder_void_init build_def33_init;
 
 	/* Getters and Setters */
 	void (*ste_init)(uint8_t *hw_ste_p, uint16_t lu_type,

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -185,6 +185,12 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_def26_init;
 	dr_ste_builder_void_init build_def28_init;
 	dr_ste_builder_void_init build_def33_init;
+	int (*aso_other_domain_link)(struct mlx5dv_devx_obj *devx_obj,
+				     struct mlx5dv_dr_domain *peer_dmn,
+				     struct mlx5dv_dr_domain *dmn,
+				     uint32_t flags,
+				     uint8_t return_reg_c);
+	int (*aso_other_domain_unlink)(struct mlx5dv_devx_obj *devx_obj);
 
 	/* Getters and Setters */
 	void (*ste_init)(uint8_t *hw_ste_p, uint16_t lu_type,
@@ -202,6 +208,7 @@ struct dr_ste_ctx {
 	void (*set_ctrl_always_miss)(uint8_t *hw_ste,
 				     uint64_t miss_addr,
 				     uint16_t gvmi);
+	void (*set_hit_gvmi)(uint8_t *hw_ste, uint16_t gvmi);
 
 	/* Actions */
 	uint32_t actions_caps;
@@ -235,6 +242,9 @@ struct dr_ste_ctx {
 	int (*set_action_decap_l3_list)(void *data, uint32_t data_sz,
 					uint8_t *hw_action, uint32_t hw_action_sz,
 					uint16_t *used_hw_action_num);
+	void (*set_aso_ct_cross_dmn)(uint8_t *hw_ste, uint32_t object_id,
+				     uint32_t offset, uint8_t dest_reg_id,
+				     bool direction);
 
 	/* Send */
 	void (*prepare_for_postsend)(uint8_t *hw_ste_p, uint32_t ste_size);

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -1766,6 +1766,8 @@ static void dr_ste_set_flex_parser(uint16_t lu_type,
 		      lu_type != DR_STE_V0_LU_TYPE_FLEX_PARSER_0 :
 		      lu_type != DR_STE_V0_LU_TYPE_FLEX_PARSER_1;
 
+	skip_parser = skip_parser || (id >= NUM_OF_FLEX_PARSERS);
+
 	if (skip_parser || parser_is_used[id])
 		return;
 

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -1908,6 +1908,7 @@ static struct dr_ste_ctx ste_ctx_v0 = {
 	.get_byte_mask			= &dr_ste_v0_get_byte_mask,
 	.set_ctrl_always_hit_htbl	= &dr_ste_v0_set_ctrl_always_hit_htbl,
 	.set_ctrl_always_miss		= &dr_ste_v0_set_ctrl_always_miss,
+	.set_hit_gvmi			= &dr_ste_v0_set_hit_gvmi,
 	/* Actions */
 	.actions_caps			= DR_STE_CTX_ACTION_CAP_NONE,
 	.set_actions_rx			= &dr_ste_v0_set_actions_rx,

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2177,6 +2177,8 @@ static void dr_ste_set_flex_parser(uint16_t lu_type,
 		      lu_type != DR_STE_V1_LU_TYPE_FLEX_PARSER_0 :
 		      lu_type != DR_STE_V1_LU_TYPE_FLEX_PARSER_1;
 
+	skip_parser = skip_parser || (id >= NUM_OF_FLEX_PARSERS);
+
 	if (skip_parser || parser_is_used[id])
 		return;
 

--- a/providers/mlx5/dr_vports.c
+++ b/providers/mlx5/dr_vports.c
@@ -111,7 +111,6 @@ dr_vports_table_query_and_add_ib_port(struct ibv_context *ctx,
 	int ret;
 
 	wire_flags = MLX5DV_QUERY_PORT_VPORT |
-		     MLX5DV_QUERY_PORT_VPORT_REG_C0 |
 		     MLX5DV_QUERY_PORT_ESW_OWNER_VHCA_ID |
 		     MLX5DV_QUERY_PORT_VPORT_STEERING_ICM_TX;
 

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -205,3 +205,9 @@ MLX5_1.21 {
 		mlx5dv_vfio_get_events_fd;
 		mlx5dv_vfio_process_events;
 } MLX5_1.20;
+
+MLX5_1.22 {
+	global:
+		mlx5dv_dr_aso_other_domain_link;
+		mlx5dv_dr_aso_other_domain_unlink;
+} MLX5_1.21;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -98,6 +98,8 @@ rdma_alias_man_pages(
  mlx5dv_dr_flow.3 mlx5dv_dr_action_destroy.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_modify_flow_meter.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_aso_other_domain_link.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_aso_other_domain_unlink.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_allow_duplicate_rules.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_create.3
  mlx5dv_dr_flow.3 mlx5dv_dr_domain_destroy.3

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -54,6 +54,8 @@ mlx5dv_dr_action_create_push_vlan- Create push vlan action
 
 mlx5dv_dr_action_destroy - Destroy actions
 
+mlx5dv_dr_aso_other_domain_link, mlx5dv_dr_aso_other_domain_unlink - link/unlink ASO devx object to work with different domains
+
 # SYNOPSIS
 
 ```c
@@ -174,6 +176,15 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_push_vlan(
 		__be32 vlan_hdr)
 
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
+
+int mlx5dv_dr_aso_other_domain_link(struct mlx5dv_devx_obj *devx_obj,
+				    struct mlx5dv_dr_domain *peer_dmn,
+				    struct mlx5dv_dr_domain *dmn,
+				    uint32_t flags,
+				    uint8_t return_reg_c);
+
+int mlx5dv_dr_aso_other_domain_unlink(struct mlx5dv_devx_obj *devx_obj,
+				      struct mlx5dv_dr_domain *dmn);
 ```
 
 # DESCRIPTION
@@ -312,6 +323,16 @@ Action: Push Vlan
 HW will perform the set of **num_actions** from the **action** array of type *struct mlx5dv_dr_action*, once a packet matches the exact **value** of the rule (referred to as a 'hit').
 
 *mlx5dv_dr_rule_destroy()* destroys the rule.
+
+## Other
+*mlx5dv_dr_aso_other_domain_link()* links the ASO devx object, **devx_obj** to a domain **dmn**, this will allow to create a rule with ASO action using the given object on the linked domain **dmn**.
+**peer_dmn** is the domain that the ASO devx object was created on.
+**dmn** is the domain that ASO devx object will be linked to.
+**flags** choose the specific wanted behavior of this object according to the flags, same as for ASO action creation flags.
+**regc_index** After a packet hits the rule with the ASO object the value of the ASO object will be copied into the regc register indicated by this param, and then we can use the value for matching in the following DR rules.
+
+*mlx5dv_dr_aso_other_domain_unlink()* will unlink the **devx_obj** from the linked **dmn**.
+**dmn** is the domain that ASO devx object is linked to.
 
 # RETURN VALUE
 The create API calls will return a pointer to the relevant object: table, matcher, action, rule. on failure, NULL will be returned and errno will be set.

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -780,6 +780,7 @@ struct mlx5dv_devx_obj {
 	uint32_t object_id;
 	uint64_t rx_icm_addr;
 	uint8_t log_obj_range;
+	void *priv;
 };
 
 struct mlx5_var_obj {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -2951,6 +2951,48 @@ struct mlx5_ifc_ste_def28_v1_bits {
 	u8         functional_lb_dup[0x1];
 };
 
+struct mlx5_ifc_ste_def33_v1_bits {
+	u8         outer_ip_src_addr[0x20];
+
+	u8         outer_ip_dst_addr[0x20];
+
+	u8         outer_l4_sport[0x10];
+	u8         outer_l4_dport[0x10];
+
+	u8         reserved_at_60[0x1];
+	u8         sx_sniffer[0x1];
+	u8         functional_loopback[0x1];
+	u8         outer_ip_frag[0x1];
+	u8         qp_type[0x2];
+	u8         encapsulation_type[0x2];
+	u8         port[0x2];
+	u8         outer_l3_type[0x2];
+	u8         outer_l4_type[0x2];
+	u8         outer_first_vlan_type[0x2];
+	u8         outer_first_vlan_prio[0x3];
+	u8         outer_first_vlan_cfi[0x1];
+	u8         outer_first_vlan_vid[0xc];
+
+	u8         reserved_at_80[0x20];
+
+	u8         reserved_at_a0[0x20];
+
+	u8         reserved_at_c0[0x20];
+
+	u8         outer_ip_version[0x4];
+	u8         outer_ip_ihl[0x4];
+	u8         inner_ipv4_checksum_ok[0x1];
+	u8         inner_l4_checksum_ok[0x1];
+	u8         outer_ipv4_checksum_ok[0x1];
+	u8         outer_l4_checksum_ok[0x1];
+	u8         inner_l3_ok[0x1];
+	u8         inner_l4_ok[0x1];
+	u8         outer_l3_ok[0x1];
+	u8         outer_l4_ok[0x1];
+	u8         outer_ip_ttl[0x8];
+	u8         outer_ip_protocol[0x8];
+};
+
 struct mlx5_ifc_set_action_in_bits {
 	u8         action_type[0x4];
 	u8         field[0xc];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -2127,6 +2127,15 @@ int mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
 int mlx5dv_reserved_qpn_alloc(struct ibv_context *ctx, uint32_t *qpn);
 int mlx5dv_reserved_qpn_dealloc(struct ibv_context *ctx, uint32_t qpn);
 
+int mlx5dv_dr_aso_other_domain_link(struct mlx5dv_devx_obj *devx_obj,
+				    struct mlx5dv_dr_domain *peer_dmn,
+				    struct mlx5dv_dr_domain *dmn,
+				    uint32_t flags,
+				    uint8_t return_reg_c);
+int mlx5dv_dr_aso_other_domain_unlink(struct mlx5dv_devx_obj *devx_obj,
+				      struct mlx5dv_dr_domain *dmn);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -151,7 +151,8 @@ enum dr_matcher_definer {
 	DR_MATCHER_DEFINER_24	= 24,
 	DR_MATCHER_DEFINER_25	= 25,
 	DR_MATCHER_DEFINER_26	= 26,
-	DR_MATCHER_DEFINER_28   = 28
+	DR_MATCHER_DEFINER_28   = 28,
+	DR_MATCHER_DEFINER_33   = 33,
 };
 
 enum dr_action_type {
@@ -607,6 +608,10 @@ int dr_ste_build_def26(struct dr_ste_ctx *ste_ctx,
 		       struct dr_match_param *mask,
 		       bool inner, bool rx);
 int dr_ste_build_def28(struct dr_ste_ctx *ste_ctx,
+		       struct dr_ste_build *sb,
+		       struct dr_match_param *mask,
+		       bool inner, bool rx);
+int dr_ste_build_def33(struct dr_ste_ctx *ste_ctx,
 		       struct dr_ste_build *sb,
 		       struct dr_match_param *mask,
 		       bool inner, bool rx);


### PR DESCRIPTION
This series extends the DR support in few areas as of below.
- Add support for definer 33.
- Add support for ASO CT cross domain.

In addition, it includes two fixes from the team.