### PR TITLE
efa: Add support for ibv_reg_dmabuf_mr

### DIFF
--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -44,6 +44,7 @@ static const struct verbs_context_ops efa_ctx_ops = {
 	.query_device_ex = efa_query_device_ex,
 	.query_port = efa_query_port,
 	.query_qp = efa_query_qp,
+	.reg_dmabuf_mr = efa_reg_dmabuf_mr,
 	.reg_mr = efa_reg_mr,
 	.req_notify_cq = efa_arm_cq,
 	.free_context = efa_free_context,

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -224,6 +224,27 @@ int efa_dealloc_pd(struct ibv_pd *ibvpd)
 	return 0;
 }
 
+struct ibv_mr *efa_reg_dmabuf_mr(struct ibv_pd *ibvpd, uint64_t offset,
+				 size_t length, uint64_t iova, int fd, int acc)
+{
+	struct efa_mr *mr;
+	int err;
+
+	mr = calloc(1, sizeof(*mr));
+	if (!mr)
+		return NULL;
+
+	err = ibv_cmd_reg_dmabuf_mr(ibvpd, offset, length, iova, fd, acc,
+				    &mr->vmr);
+	if (err) {
+		free(mr);
+		errno = err;
+		return NULL;
+	}
+
+	return &mr->vmr.ibv_mr;
+}
+
 struct ibv_mr *efa_reg_mr(struct ibv_pd *ibvpd, void *sva, size_t len,
 			  uint64_t hca_va, int access)
 {

--- a/providers/efa/verbs.h
+++ b/providers/efa/verbs.h
@@ -17,6 +17,8 @@ int efa_query_device_ex(struct ibv_context *context,
 			struct ibv_device_attr_ex *attr, size_t attr_size);
 struct ibv_pd *efa_alloc_pd(struct ibv_context *uctx);
 int efa_dealloc_pd(struct ibv_pd *ibvpd);
+struct ibv_mr *efa_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+				 size_t length, uint64_t iova, int fd, int acc);
 struct ibv_mr *efa_reg_mr(struct ibv_pd *ibvpd, void *buf, size_t len,
 			  uint64_t hca_va, int ibv_access_flags);
 int efa_dereg_mr(struct verbs_mr *vmr);


### PR DESCRIPTION
Add support for ibv_reg_dmabuf_mr verb to the EFA provider.

Signed-off-by: Gal Pressman <gal.pressman@linux.dev>