### PR TITLE
debian: Exclude compressing python files while building the rdma-core

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -90,6 +90,9 @@ override_dh_installsystemd:
 	dh_installsystemd -pibacm ibacm.socket
 	dh_installsystemd --remaining-packages
 
+override_dh_compress:
+	dh_compress -X .py
+
 # Provider plugin libaries are not shared libraries and do not belong in the
 # shlibs file.
 # librspreload is a LD_PRELOAD library and does not belong in the shlib files


### PR DESCRIPTION
Over Debian, the large packages are compressed while building the
rdma-core, due this the rdma-core tests are compressed and this cause it
to fail.

So, we need to exclude compressing python files over debian.

Signed-off-by: Lena Asfour <lenaa@nvidia.com>
Reviewed-by: Tzafrir Cohen <tzafrirc@mellanox.com>
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>