### PR TITLE
Fix spelling mistake

### DIFF
--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -43,7 +43,7 @@ struct ibv_cq_moderation_caps  cq_mod_caps;        /* CQ moderation max capabili
 uint64_t     	       max_dm_size;		   /* Max Device Memory size (in bytes) available for allocation */
 struct ibv_pci_atomic_caps atomic_caps;            /* PCI atomic operations capabilities, use enum ibv_pci_atomic_op_size */
 uint32_t               xrc_odp_caps;               /* Mask with enum ibv_odp_transport_cap_bits to know which operations are supported. */
-uint32_t	       phys_port_cnt_ex		   /* Extended number of physical port count, allows to expose more than 255 ports device */
+uint32_t	       phys_port_cnt_ex		   /* Extended number of physical port count, allows exposing more than 255 ports device */
 .in -8
 };
 

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -325,7 +325,7 @@ HW will perform the set of **num_actions** from the **action** array of type *st
 *mlx5dv_dr_rule_destroy()* destroys the rule.
 
 ## Other
-*mlx5dv_dr_aso_other_domain_link()* links the ASO devx object, **devx_obj** to a domain **dmn**, this will allow to create a rule with ASO action using the given object on the linked domain **dmn**.
+*mlx5dv_dr_aso_other_domain_link()* links the ASO devx object, **devx_obj** to a domain **dmn**, this will allow creating a rule with ASO action using the given object on the linked domain **dmn**.
 **peer_dmn** is the domain that the ASO devx object was created on.
 **dmn** is the domain that ASO devx object will be linked to.
 **flags** choose the specific wanted behavior of this object according to the flags, same as for ASO action creation flags.

--- a/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
@@ -55,7 +55,7 @@ signature offload.
 These APIs are intended to be used to access additional functionality beyond
 what is provided by **mlx5dv_wr_mr_list**() and **mlx5dv_wr_mr_interleaved**().
 The MKEY features can be optionally enabled using the mkey configure setters.
-It allows to use different features in the same MKEY.
+It allows using different features in the same MKEY.
 
 # USAGE
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -384,7 +384,7 @@ static struct mlx5_bf *mlx5_get_qp_uar(struct ibv_context *context)
 				break;
 		}
 
-		/* Looking for a shared uuar with the less concurent usage */
+		/* Looking for a shared uuar with the less concurrent usage */
 		list_for_each(&ctx->dyn_uar_qp_shared_list, bf_entry, uar_entry) {
 			if (!bf) {
 				bf = bf_entry;

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -535,7 +535,7 @@ cdef class Mlx5DVContext(PyverbsObject):
                ident_format.format('supported QP types',
                                    qpts_to_str(self.dv.striding_rq_caps.supported_qpts))
         stream = 'DCI stream caps:\n' +\
-                  ident_format.format('max log num concurent streams',
+                  ident_format.format('max log num concurrent streams',
                                       self.dv.dci_streams_caps.max_log_num_concurent) +\
                   ident_format.format('max log num errored streams',
                                       self.dv.dci_streams_caps.max_log_num_errored)

--- a/pyverbs/providers/mlx5/mlx5dv_flow.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_flow.pyx
@@ -137,8 +137,8 @@ cdef class Mlx5PacketReformatFlowAction(FlowAction):
                  ft_type=dv.MLX5DV_FLOW_TABLE_TYPE_NIC_RX):
         """
         Initialize a Mlx5PacketReformatFlowAction object derived from FlowAction
-        class and represents reformat flow steering action that allows to
-        add/remove packet headers.
+        class and represents reformat flow steering action that allows
+        adding/removing packet headers.
         :param context: Context object
         :param data: Encap headers (if needed)
         :param reformat_type: L2 or L3 encap or decap


### PR DESCRIPTION
The word `concurrent` is misspelled in several places (including structs and variables). Fix the spelling mistake in the comment and text output. Fixing `concurrent` in the structs and variables should be done separately.

The expression "allow(s) to" is not correct. It must be either "allow(s) doing" or "allow(s) one to".