### PR TITLE
ibverbs: Fix missing copy for srq field in ibv_cmd_create_qp

### DIFF
--- a/libibverbs/cmd_qp.c
+++ b/libibverbs/cmd_qp.c
@@ -385,6 +385,7 @@ int ibv_cmd_create_qp(struct ibv_pd *pd,
 	attr_ex.qp_context = attr->qp_context;
 	attr_ex.send_cq = attr->send_cq;
 	attr_ex.recv_cq = attr->recv_cq;
+	attr_ex.srq = attr->srq;
 	attr_ex.cap = attr->cap;
 	attr_ex.qp_type = attr->qp_type;
 	attr_ex.sq_sig_all = attr->sq_sig_all;


### PR DESCRIPTION
This fix sets the srq field in ibv_qp_init_attr, which wasn't being
copied into ibv_qp_init_attr_ex, causing kernel drivers to not get
the srq field in the create QP path.

Fixes: 74af92ae ("ibverbs: Don't memcpy padding in ibv_qp_init_attr")
Signed-off-by: Bryan Tan <bryantan@vmware.com>