### PR TITLE
libhns: Fix the size setting error when copying CQE in clean cq()

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -1401,7 +1401,7 @@ static void __hns_roce_v2_cq_clean(struct hns_roce_cq *cq, uint32_t qpn,
 				       (prod_index + nfreed) & cq->ibv_cq.cqe);
 			owner_bit = roce_get_bit(dest->byte_4,
 						 CQE_BYTE_4_OWNER_S);
-			memcpy(dest, cqe, sizeof(*cqe));
+			memcpy(dest, cqe, cq->cqe_size);
 			roce_set_bit(dest->byte_4, CQE_BYTE_4_OWNER_S,
 				     owner_bit);
 		}


### PR DESCRIPTION
The size of CQE is different for different versions of hardware, so the
driver needs to specify the size of CQE explicitly.

Fixes: 3546e6b69ac8 ("libhns: Add support for CQE in size of 64 Bytes")
Signed-off-by: Wenpeng Liang <liangwenpeng@huawei.com>