### PR TITLE
Libirdma 11 30 fixes

### DIFF
--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -556,6 +556,12 @@ static enum ibv_wc_status irdma_flush_err_to_ib_wc_status(enum irdma_flush_opcod
 		return IBV_WC_LOC_LEN_ERR;
 	case FLUSH_GENERAL_ERR:
 		return IBV_WC_WR_FLUSH_ERR;
+	case FLUSH_MW_BIND_ERR:
+		return IBV_WC_MW_BIND_ERR;
+	case FLUSH_REM_INV_REQ_ERR:
+		return IBV_WC_REM_INV_REQ_ERR;
+	case FLUSH_RETRY_EXC_ERR:
+		return IBV_WC_RETRY_EXC_ERR;
 	case FLUSH_FATAL_ERR:
 	default:
 		return IBV_WC_FATAL_ERR;


### PR DESCRIPTION
This series includes two patches. One to return the appropriate WC
return codes and the other to validate the input during memory window bind.