### PR TITLE
libhns: Add vendor_err information for error WC

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -185,6 +185,9 @@ static void handle_error_cqe(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 			break;
 		}
 	}
+
+	wc->vendor_err = roce_get_field(cqe->byte_16, CQE_BYTE_16_SUB_STATUS_M,
+					CQE_BYTE_16_SUB_STATUS_S);
 }
 
 static struct hns_roce_v2_cqe *get_cqe_v2(struct hns_roce_cq *cq, int entry)

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -180,6 +180,9 @@ struct hns_roce_v2_cqe {
 #define CQE_BYTE_16_LCL_QPN_S 0
 #define CQE_BYTE_16_LCL_QPN_M   (((1UL << 24) - 1) << CQE_BYTE_16_LCL_QPN_S)
 
+#define CQE_BYTE_16_SUB_STATUS_S 24
+#define CQE_BYTE_16_SUB_STATUS_M (((1UL << 8) - 1) << CQE_BYTE_16_SUB_STATUS_S)
+
 #define CQE_BYTE_28_SMAC_S 0
 #define CQE_BYTE_28_SMAC_M   (((1UL << 16) - 1) << CQE_BYTE_28_SMAC_S)
 


### PR DESCRIPTION
ULP can get more error information of CQ though verbs.

Signed-off-by: Lang Cheng <chenglang@huawei.com>
Signed-off-by: Wenpeng Liang <liangwenpeng@huawei.com>