### PR TITLE
rdma-core: Add support for multicast loopback prevention to mckey

### DIFF
--- a/librdmacm/man/mckey.1
+++ b/librdmacm/man/mckey.1
@@ -45,6 +45,12 @@ than the MTU of the underlying RDMA transport, or an error will occur.
 Join the multicast group as a send-only full-member. Otherwise the group is
 joined as a full-member.
 .TP
+.TP
+\-l
+Prevent multicast message loopback. Other receivers on the local system will not receive
+the multicast messages. Otherwise all multicast messages are also send to the host they
+originated from and local listeners (and probably the sending process itself) will receive
+the messages.
 \-p port_space
 The port space of the datagram communication.  May be either the RDMA
 UDP (0x0111) or IPoIB (0x0002) port space.  (default RDMA_PS_UDP)


### PR DESCRIPTION
The rdma_create_qp createflags option IBV_QP_CREATE_BLOCK_SELF_MCAST_LB
should prevent multicast loopback. However, this feature seems to be
broken on a lot of RDMA NICs and there is no way to test this with the
existing RDMA tools. So add an option to mckey in order to allow to send
multicast messages without loopback. mckey's default has been and will
continue to be to loopback all multicast messages.

Loopback of multicast messages can have surprising effects because all
messages sent out also have to be processed locally by all members of
the multicast group. This usually also includes the sender.

In order to test multicast loop execute the following in two windows
on a host connected to an RDMA fabric.

First session (Receiver)

	mckey -b <RDMA IP address> -m239.1.2.1

Second session (Sender)

	mckey -b <RDMA IP address> -m239.1.2.2 -s -l

The sender will send 10 messages and the receiver will terminate
after 10 messages have been received.

If loopback prevention would work then the receiver should only
terminate on its own when the -l option has not been specified.

Signed-off-by: Christoph Lameter <cl@linux.com>