### PR TITLE
libqedr: Verify the comp_mask before create qp

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -2725,6 +2725,14 @@ static struct ibv_qp *create_qp(struct ibv_context *context,
 
 	qelr_print_qp_init_attr(cxt, attrx);
 
+#define QELR_CREATE_QP_SUPP_ATTR_MASK \
+	(IBV_QP_INIT_ATTR_PD | IBV_QP_INIT_ATTR_XRCD)
+
+	if (!check_comp_mask(attrx->comp_mask, QELR_CREATE_QP_SUPP_ATTR_MASK)) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
 	qp = calloc(1, sizeof(*qp));
 	if (!qp)
 		return NULL;


### PR DESCRIPTION
Make sure to verify the comp_mask before trying to create QP.

Fixes: cae4a99ae679 ("libqedr: add support for XRC-SRQ's.")
Signed-off-by: Kamal Heib <kamalheib1@gmail.com>