### PR TITLE
providers/irdma: Report correct WC errors

### DIFF
--- a/providers/irdma/user.h
+++ b/providers/irdma/user.h
@@ -104,6 +104,8 @@ enum irdma_flush_opcode {
 	FLUSH_REM_OP_ERR,
 	FLUSH_LOC_LEN_ERR,
 	FLUSH_FATAL_ERR,
+	FLUSH_RETRY_EXC_ERR,
+	FLUSH_MW_BIND_ERR,
 };
 
 enum irdma_cmpl_status {

--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -556,6 +556,10 @@ static enum ibv_wc_status irdma_flush_err_to_ib_wc_status(enum irdma_flush_opcod
 		return IBV_WC_LOC_LEN_ERR;
 	case FLUSH_GENERAL_ERR:
 		return IBV_WC_WR_FLUSH_ERR;
+	case FLUSH_RETRY_EXC_ERR:
+		return IBV_WC_RETRY_EXC_ERR;
+	case FLUSH_MW_BIND_ERR:
+		return IBV_WC_MW_BIND_ERR;
 	case FLUSH_FATAL_ERR:
 	default:
 		return IBV_WC_FATAL_ERR;


### PR DESCRIPTION
Return specific WC errors for certain type of error
events as opposed to a generic IBV_WC_FATAL_ERR.

In particular,

Return IBV_WC_MW_BIND_ERR for memory window
related asynchronous events.

Return IBV_WC_RETRY_EXC_ERR when transport retry
counter is exceeded.

Fixes: 14a0fc824f16 ("rdma-core/irdma: Implement device supported verb APIs")
Signed-off-by: Sindhu-Devale <sindhu.devale@intel.com>