### PR TITLE
providers/irdma: Validate input before memory window bind

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2634,8 +2634,16 @@ static inline uint32_t ibv_inc_rkey(uint32_t rkey)
 static inline int ibv_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 			      struct ibv_mw_bind *mw_bind)
 {
+	struct ibv_mw_bind_info *bind_info = &mw_bind->bind_info;
+
 	if (mw->type != IBV_MW_TYPE_1)
 		return EINVAL;
+
+	if (!bind_info->mr && (bind_info->addr || bind_info->length))
+		return EINVAL;
+
+	if (bind_info->mr && (mw->pd != bind_info->mr->pd))
+		return EPERM;
 
 	return mw->context->ops.bind_mw(qp, mw, mw_bind);
 }

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -221,18 +221,6 @@ int hns_roce_u_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 	struct ibv_send_wr wr = {};
 	int ret;
 
-	if (!bind_info->mr && bind_info->length)
-		return EINVAL;
-
-	if (mw->pd != qp->pd)
-		return EINVAL;
-
-	if (bind_info->mr && (mw->pd != bind_info->mr->pd))
-		return EINVAL;
-
-	if (mw->type != IBV_MW_TYPE_1)
-		return EINVAL;
-
 	if (bind_info->mw_access_flags & ~(IBV_ACCESS_REMOTE_WRITE |
 	    IBV_ACCESS_REMOTE_READ | IBV_ACCESS_REMOTE_ATOMIC))
 		return EINVAL;

--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -213,7 +213,7 @@ int irdma_ubind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 	struct ibv_send_wr *bad_wr;
 	int err;
 
-	if (vmr->mr_type != IBV_MR_TYPE_MR || mw->type != IBV_MW_TYPE_1)
+	if (vmr->mr_type != IBV_MR_TYPE_MR)
 		return ENOTSUP;
 
 	if (umr->acc_flags & IBV_ACCESS_ZERO_BASED)

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -3585,11 +3585,6 @@ int mlx5_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 	struct ibv_send_wr *bad_wr = NULL;
 	int ret;
 
-	if (!bind_info->mr && (bind_info->addr || bind_info->length)) {
-		errno = EINVAL;
-		return errno;
-	}
-
 	if (bind_info->mw_access_flags & IBV_ACCESS_ZERO_BASED) {
 		errno = EINVAL;
 		return errno;
@@ -3606,10 +3601,6 @@ int mlx5_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 			return errno;
 		}
 
-		if (mw->pd != bind_info->mr->pd) {
-			errno = EPERM;
-			return errno;
-		}
 	}
 
 	wr.opcode = IBV_WR_BIND_MW;

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -177,21 +177,9 @@ static int rxe_bind_mw(struct ibv_qp *ibqp, struct ibv_mw *ibmw,
 	struct ibv_send_wr ibwr;
 	struct ibv_send_wr *bad_wr;
 
-	if (!bind_info->mr && (bind_info->addr || bind_info->length)) {
-		ret = EINVAL;
-		goto err;
-	}
-
 	if (bind_info->mw_access_flags & IBV_ACCESS_ZERO_BASED) {
 		ret = EINVAL;
 		goto err;
-	}
-
-	if (bind_info->mr) {
-		if (ibmw->pd != bind_info->mr->pd) {
-			ret = EPERM;
-			goto err;
-		}
 	}
 
 	memset(&ibwr, 0, sizeof(ibwr));


### PR DESCRIPTION
Check for a non null MR, address and length
before allowing bind operation.

Also, add check to make sure the MR and MW are in
same PD before posting a bind MW op.

Fixes: 14a0fc824f16 ("rdma-core/irdma: Implement device supported verb APIs")
Signed-off-by: Tatyana Nikolova <tatyana.e.nikolova@intel.com>
Signed-off-by: Sindhu-Devale <sindhu.devale@intel.com>