### PR TITLE
debian: Remove i40iw provider conffile

### DIFF
--- a/debian/ibverbs-providers.maintscript
+++ b/debian/ibverbs-providers.maintscript
@@ -1,2 +1,3 @@
 rm_conffile /etc/libibverbs.d/cxgb3.driver 27.0-2~
+rm_conffile /etc/libibverbs.d/i40iw.driver 39.0-1~
 rm_conffile /etc/libibverbs.d/nes.driver 27.0-2~


### PR DESCRIPTION
i40iw provider was removed and replaced by irdma provider. Remove the
obsolete conffile.
Fixes the following warning:

libibverbs: Warning: couldn't load driver 'libi40iw-rdmav34.so':
libi40iw-rdmav34.so: cannot open shared object file: No such file or
directory

Fixes: dbbd9dcd ("rdma-core/i40iw: Remove provider i40iw")

---

The second argument (`prior-version`) for `rm_conffile` is intentionally left empty because I'm not sure what to do here. There are already two major releases with this issue.

This also raises the question of why uninstallation is not removing all created conffiles?

Thanks,
Firas