### PR TITLE
util: Fix mmio memcpy on ARM

### DIFF
--- a/util/mmio.h
+++ b/util/mmio.h
@@ -225,6 +225,7 @@ static inline void _mmio_memcpy_x64(void *dest, const void *src, size_t bytecnt)
 		_mmio_memcpy_x64_64b(dest, src);
 		bytecnt -= sizeof(uint64x2x4_t);
 		src += sizeof(uint64x2x4_t);
+		dest += sizeof(uint64x2x4_t);
 	} while (bytecnt > 0);
 }
 


### PR DESCRIPTION
The below commit added a new implementation of mmio_memcpy_x64() for
ARM which was broken. The destination buffer must be advanced so we
don't copy to the same 64 bytes.

Fixes: 159933c37 ("libhns: Add support for direct wqe")