### PR TITLE
mlx5: Fix to prevent unexpected WC opcode 

### DIFF
--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -871,6 +871,7 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 
 		seg += sizeof *ctrl;
 		size = sizeof *ctrl / 16;
+		qp->sq.wr_data[idx] = 0;
 
 		switch (ibqp->qp_type) {
 		case IBV_QPT_XRC_SEND:
@@ -1251,6 +1252,8 @@ static inline void _common_wqe_init_op(struct ibv_qp_ex *ibqp, int ib_op,
 		mqp->sq.wr_data[idx] = IBV_WC_DRIVER1;
 	else if (mlx5_op == MLX5_OPCODE_MMO)
 		mqp->sq.wr_data[idx] = IBV_WC_DRIVER3;
+	else
+		mqp->sq.wr_data[idx] = 0;
 
 	ctrl = mlx5_get_send_wqe(mqp, idx);
 	*(uint32_t *)((void *)ctrl + 8) = 0;

--- a/tests/test_mlx5_raw_wqe.py
+++ b/tests/test_mlx5_raw_wqe.py
@@ -23,7 +23,7 @@ class Mlx5RawWqeResources(Mlx5RcResources):
         than the max_send_wr.
         :return:
         """
-        return QPCap(max_send_wr=4, max_recv_wr=4, max_recv_sge=2, max_send_sge=2)
+        return QPCap(max_send_wr=1, max_recv_wr=4, max_recv_sge=2, max_send_sge=2)
 
 
 class RawWqeTest(Mlx5RDMATestCase):
@@ -79,10 +79,11 @@ class RawWqeTest(Mlx5RDMATestCase):
             u.poll_cq_ex(self.client.cq)
             u.poll_cq_ex(self.server.cq)
             u.post_recv(self.server, s_recv_wr)
+            expected_opcode = e.IBV_WC_SEND if i % 2 else e.IBV_WC_DRIVER2
 
-            if not i % 2 and self.client.cq.read_opcode() != e.IBV_WC_DRIVER2:
+            if self.client.cq.read_opcode() != expected_opcode:
                 raise PyverbsError('Opcode validation failed: expected '
-                                   f'{e.IBV_WC_DRIVER2}, received {self.client.cq.read_opcode()}')
+                                   f'{expected_opcode}, received {self.client.cq.read_opcode()}')
 
             act_buffer = self.server.mr.read(self.server.mr.length, 0)
             u.validate(act_buffer, i % 2, self.server.mr.length)


### PR DESCRIPTION
Fix to prevent unexpected WC opcode when RAW WQE is used.

In addition, add some pyverbs patch to cover the problematic scenario.