### PR TITLE
bnxt_re/lib: Fix the Send WQE size calulation for inline data

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1215,7 +1215,7 @@ static int bnxt_re_calc_posted_wqe_slots(struct bnxt_re_queue *que, void *wr,
 	if (!is_rq && (swr->send_flags & IBV_SEND_INLINE)) {
 		ilsize = bnxt_re_calc_inline_len(swr, max_ils);
 		wqe_byte = get_aligned(ilsize, sizeof(struct bnxt_re_sge));
-		wqe_byte += sizeof(struct bnxt_re_bsqe);
+		wqe_byte += bnxt_re_get_sqe_hdr_sz();
 	}
 
 	return (wqe_byte / que->stride);


### PR DESCRIPTION
For work requests with inline data, the WQE size is not calculated
correctly. Fix this by calling bnxt_re_get_sqe_hdr_sz to get the correct
WQE header size.

Fixes: 66aba73d4a7a ("bnxt_re/lib: Move hardware queue to 16B aligned indices")
Signed-off-by: Selvin Xavier <selvin.xavier@broadcom.com>