### PR TITLE
libhns: Fix the calculation of QP/SRQ table size

### DIFF
--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -154,10 +154,8 @@
 
 #define hr_reg_read(ptr, field) _hr_reg_read(ptr, field)
 
-enum {
-	HNS_ROCE_QP_TABLE_BITS		= 8,
-	HNS_ROCE_QP_TABLE_SIZE		= 1 << HNS_ROCE_QP_TABLE_BITS,
-};
+#define HNS_ROCE_QP_TABLE_BITS 8
+#define HNS_ROCE_QP_TABLE_SIZE BIT(HNS_ROCE_QP_TABLE_BITS)
 
 #define HNS_ROCE_SRQ_TABLE_BITS 8
 #define HNS_ROCE_SRQ_TABLE_SIZE BIT(HNS_ROCE_SRQ_TABLE_BITS)
@@ -211,7 +209,6 @@ struct hns_roce_context {
 		int			refcnt;
 	} qp_table[HNS_ROCE_QP_TABLE_SIZE];
 	pthread_mutex_t			qp_table_mutex;
-	uint32_t			num_qps;
 	uint32_t			qp_table_shift;
 	uint32_t			qp_table_mask;
 
@@ -220,7 +217,6 @@ struct hns_roce_context {
 		int			refcnt;
 	} srq_table[HNS_ROCE_SRQ_TABLE_SIZE];
 	pthread_mutex_t			srq_table_mutex;
-	uint32_t			num_srqs;
 	uint32_t			srq_table_shift;
 	uint32_t			srq_table_mask;
 
@@ -380,6 +376,18 @@ static inline unsigned int to_hr_hem_entries_size(int count, int buf_shift)
 static inline unsigned int hr_ilog32(unsigned int count)
 {
 	return ilog32(count - 1);
+}
+
+static inline uint32_t to_hr_qp_table_index(uint32_t qpn,
+					    struct hns_roce_context *ctx)
+{
+	return (qpn >> ctx->qp_table_shift) & (HNS_ROCE_QP_TABLE_SIZE - 1);
+}
+
+static inline uint32_t to_hr_srq_table_index(uint32_t srqn,
+					     struct hns_roce_context *ctx)
+{
+	return (srqn >> ctx->srq_table_shift) & (HNS_ROCE_SRQ_TABLE_SIZE - 1);
 }
 
 static inline struct hns_roce_device *to_hr_dev(struct ibv_device *ibv_dev)

--- a/providers/hns/hns_roce_u_hw_v1.c
+++ b/providers/hns/hns_roce_u_hw_v1.c
@@ -220,7 +220,7 @@ static int hns_roce_wq_overflow(struct hns_roce_wq *wq, int nreq,
 static struct hns_roce_qp *hns_roce_find_qp(struct hns_roce_context *ctx,
 					    uint32_t qpn)
 {
-	uint32_t tind = (qpn & (ctx->num_qps - 1)) >> ctx->qp_table_shift;
+	uint32_t tind = to_hr_qp_table_index(qpn, ctx);
 
 	if (ctx->qp_table[tind].refcnt) {
 		return ctx->qp_table[tind].table[qpn & ctx->qp_table_mask];
@@ -232,7 +232,7 @@ static struct hns_roce_qp *hns_roce_find_qp(struct hns_roce_context *ctx,
 
 static void hns_roce_clear_qp(struct hns_roce_context *ctx, uint32_t qpn)
 {
-	uint32_t tind = (qpn & (ctx->num_qps - 1)) >> ctx->qp_table_shift;
+	uint32_t tind = to_hr_qp_table_index(qpn, ctx);
 
 	if (!--ctx->qp_table[tind].refcnt)
 		free(ctx->qp_table[tind].table);

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -342,7 +342,7 @@ static void update_cq_db(struct hns_roce_context *ctx, struct hns_roce_cq *cq)
 static struct hns_roce_qp *hns_roce_v2_find_qp(struct hns_roce_context *ctx,
 					       uint32_t qpn)
 {
-	uint32_t tind = (qpn & (ctx->num_qps - 1)) >> ctx->qp_table_shift;
+	uint32_t tind = to_hr_qp_table_index(qpn, ctx);
 
 	if (ctx->qp_table[tind].refcnt)
 		return ctx->qp_table[tind].table[qpn & ctx->qp_table_mask];
@@ -353,7 +353,7 @@ static struct hns_roce_qp *hns_roce_v2_find_qp(struct hns_roce_context *ctx,
 void hns_roce_v2_clear_qp(struct hns_roce_context *ctx, struct hns_roce_qp *qp)
 {
 	uint32_t qpn = qp->verbs_qp.qp.qp_num;
-	uint32_t tind = (qpn & (ctx->num_qps - 1)) >> ctx->qp_table_shift;
+	uint32_t tind = to_hr_qp_table_index(qpn, ctx);
 
 	pthread_mutex_lock(&ctx->qp_table_mutex);
 

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -431,8 +431,7 @@ int hns_roce_u_destroy_cq(struct ibv_cq *cq)
 static int hns_roce_store_srq(struct hns_roce_context *ctx,
 			      struct hns_roce_srq *srq)
 {
-	uint32_t tind = (srq->srqn & (ctx->num_srqs - 1)) >>
-			ctx->srq_table_shift;
+	uint32_t tind = to_hr_srq_table_index(srq->srqn, ctx);
 
 	pthread_mutex_lock(&ctx->srq_table_mutex);
 
@@ -457,7 +456,7 @@ static int hns_roce_store_srq(struct hns_roce_context *ctx,
 struct hns_roce_srq *hns_roce_find_srq(struct hns_roce_context *ctx,
 				       uint32_t srqn)
 {
-	uint32_t tind = (srqn & (ctx->num_srqs - 1)) >> ctx->srq_table_shift;
+	uint32_t tind = to_hr_srq_table_index(srqn, ctx);
 
 	if (ctx->srq_table[tind].refcnt)
 		return ctx->srq_table[tind].table[srqn & ctx->srq_table_mask];
@@ -467,7 +466,7 @@ struct hns_roce_srq *hns_roce_find_srq(struct hns_roce_context *ctx,
 
 static void hns_roce_clear_srq(struct hns_roce_context *ctx, uint32_t srqn)
 {
-	uint32_t tind = (srqn & (ctx->num_srqs - 1)) >> ctx->srq_table_shift;
+	uint32_t tind = to_hr_srq_table_index(srqn, ctx);
 
 	pthread_mutex_lock(&ctx->srq_table_mutex);
 
@@ -1108,7 +1107,7 @@ static int hns_roce_store_qp(struct hns_roce_context *ctx,
 			     struct hns_roce_qp *qp)
 {
 	uint32_t qpn = qp->verbs_qp.qp.qp_num;
-	uint32_t tind = (qpn & (ctx->num_qps - 1)) >> ctx->qp_table_shift;
+	uint32_t tind = to_hr_qp_table_index(qpn, ctx);
 
 	pthread_mutex_lock(&ctx->qp_table_mutex);
 	if (!ctx->qp_table[tind].refcnt) {


### PR DESCRIPTION
The table_size means the maximum number of QP/SRQ. This value may not be
a power of two. The old algorithm will lead to a result that allocates a
mismathed table.

Fixes: 887b78c ("libhns: Add initial main frame")
Fixes: 9e3df75 ("libhns: Support ibv_create_srq_ex")
Signed-off-by: Wenpeng Liang <liangwenpeng@huawei.com>