### PR TITLE
rsocket: fix read_all/write_all to handle EINTR

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -430,15 +430,15 @@ struct ds_udp_header {
 
 static void write_all(int fd, const void *msg, size_t len)
 {
-	// FIXME: if fd is a socket this really needs to handle EINTR and other conditions.
-	ssize_t __attribute__((unused)) rc = write(fd, msg, len);
+	ssize_t __attribute__((unused)) rc;
+	while ((rc = write(fd, msg, len)) <  0 && errno == EINTR)
 	assert(rc == len);
 }
 
 static void read_all(int fd, void *msg, size_t len)
 {
-	// FIXME: if fd is a socket this really needs to handle EINTR and other conditions.
-	ssize_t __attribute__((unused)) rc = read(fd, msg, len);
+	ssize_t __attribute__((unused)) rc;
+	while ((rc = read(fd, msg, len)) < 0 && errno == EINTR)
 	assert(rc == len);
 }
 


### PR DESCRIPTION
Rsocket uses socket pair to communicate with threads. Sometimes EINTR is encountered when performing blocking calls on fd.

So add a loop to check the return value and error to handle EINTR and artificially restart the interrupted calls

Signed-off-by: Yilun-Li <420463729@qq.com>