### PR TITLE
bnxt_re/lib: Check pointer validity while freeing queue pointers

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -820,10 +820,14 @@ static int bnxt_re_check_qp_limits(struct bnxt_re_context *cntx,
 
 static void bnxt_re_free_queue_ptr(struct bnxt_re_qp *qp)
 {
-	free(qp->jrqq->hwque);
-	free(qp->jrqq);
-	free(qp->jsqq->hwque);
-	free(qp->jsqq);
+	if (qp->jrqq) {
+		free(qp->jrqq->hwque);
+		free(qp->jrqq);
+	}
+	if (qp->jsqq) {
+		free(qp->jsqq->hwque);
+		free(qp->jsqq);
+	}
 }
 
 static int bnxt_re_alloc_queue_ptr(struct bnxt_re_qp *qp,


### PR DESCRIPTION
qp->jrqq can be NULL in SRQ case or when accessed from error path.
Avoid segfault by adding check before accessing qp->jrqq and qp->jsqq.

Fixes: f92837e29fd4 ("bnxt_re/lib: consolidate hwque and swque in common structure")
Signed-off-by: Selvin Xavier <selvin.xavier@broadcom.com>