### PR TITLE
Miscellaneous bugfixes

### DIFF
--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -108,7 +108,7 @@ Below members and functions are used in order to poll the current completion. Th
  Get the vendor error from the current completion.
 
 .BI "uint32_t ibv_wc_read_byte_len(struct ibv_cq_ex " "*cq"); \c
- Get the vendor error from the current completion.
+ Get the payload length from the current completion.
 
 .BI "__be32 ibv_wc_read_imm_data(struct ibv_cq_ex " "*cq"); \c
  Get the immediate data field from the current completion.

--- a/libibverbs/man/ibv_wr_post.3.md
+++ b/libibverbs/man/ibv_wr_post.3.md
@@ -271,8 +271,8 @@ the work request.
 **IBV_SEND_SIGNALED**
 :   A completion will be generated in the completion queue for the operation.
 
-**IBV_SEND_SOLICTED**
-:   Set the solicted bit in the RDMA packet. This informs the other side to
+**IBV_SEND_SOLICITED**
+:   Set the solicited bit in the RDMA packet. This informs the other side to
     generate a completion event upon receiving the RDMA operation.
 
 # CONCURRENCY

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -48,8 +48,7 @@
 #include "hns_roce_u_abi.h"
 
 #define HNS_ROCE_HW_VER1		('h' << 24 | 'i' << 16 | '0' << 8 | '6')
-
-#define HNS_ROCE_HW_VER2		('h' << 24 | 'i' << 16 | '0' << 8 | '8')
+#define HNS_ROCE_HW_VER2		0x100
 #define HNS_ROCE_HW_VER3		0x130
 
 #define PFX				"hns: "

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -771,21 +771,43 @@ static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 				 struct hns_roce_sge_info *sge_info)
 {
 	unsigned int sge_sz = sizeof(struct hns_roce_v2_wqe_data_seg);
-	void *dseg;
+	unsigned int sge_mask = qp->ex_sge.sge_cnt - 1;
+	void *dst_addr, *src_addr, *tail_bound_addr;
+	uint32_t src_len, tail_len;
 	int i;
+
 
 	if (sge_info->total_len > qp->sq.max_gs * sge_sz)
 		return EINVAL;
 
-	dseg = get_send_sge_ex(qp, sge_info->start_idx);
+	dst_addr = get_send_sge_ex(qp, sge_info->start_idx & sge_mask);
+	tail_bound_addr = get_send_sge_ex(qp, qp->ex_sge.sge_cnt & sge_mask);
 
 	for (i = 0; i < wr->num_sge; i++) {
-		memcpy(dseg, (void *)(uintptr_t)wr->sg_list[i].addr,
-		       wr->sg_list[i].length);
-		dseg += wr->sg_list[i].length;
+		tail_len = (uintptr_t)tail_bound_addr - (uintptr_t)dst_addr;
+
+		src_addr = (void *)(uintptr_t)wr->sg_list[i].addr;
+		src_len = wr->sg_list[i].length;
+
+		if (src_len < tail_len) {
+			memcpy(dst_addr, src_addr, src_len);
+			dst_addr += src_len;
+		} else if (src_len == tail_len) {
+			memcpy(dst_addr, src_addr, src_len);
+			dst_addr = get_send_sge_ex(qp, 0);
+		} else {
+			memcpy(dst_addr, src_addr, tail_len);
+			dst_addr = get_send_sge_ex(qp, 0);
+			src_addr += tail_len;
+			src_len -= tail_len;
+
+			memcpy(dst_addr, src_addr, src_len);
+			dst_addr += src_len;
+		}
 	}
 
-	sge_info->start_idx += DIV_ROUND_UP(sge_info->total_len, sge_sz);
+	sge_info->valid_num = DIV_ROUND_UP(sge_info->total_len, sge_sz);
+	sge_info->start_idx += sge_info->valid_num;
 
 	return 0;
 }
@@ -827,7 +849,6 @@ static int set_ud_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 		      struct hns_roce_ud_sq_wqe *ud_sq_wqe,
 		      struct hns_roce_sge_info *sge_info)
 {
-	unsigned int sge_idx = sge_info->start_idx;
 	int ret;
 
 	if (!check_inl_data_len(qp, sge_info->total_len))
@@ -843,8 +864,6 @@ static int set_ud_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 		ret = fill_ext_sge_inl_data(qp, wr, sge_info);
 		if (ret)
 			return ret;
-
-		sge_info->valid_num = sge_info->start_idx - sge_idx;
 
 		hr_reg_write(ud_sq_wqe, UDWQE_SGE_NUM, sge_info->valid_num);
 	}
@@ -968,7 +987,6 @@ static int set_rc_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 		      struct hns_roce_rc_sq_wqe *rc_sq_wqe,
 		      struct hns_roce_sge_info *sge_info)
 {
-	unsigned int sge_idx = sge_info->start_idx;
 	void *dseg = rc_sq_wqe;
 	int ret;
 	int i;
@@ -995,8 +1013,6 @@ static int set_rc_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 		ret = fill_ext_sge_inl_data(qp, wr, sge_info);
 		if (ret)
 			return ret;
-
-		sge_info->valid_num = sge_info->start_idx - sge_idx;
 
 		hr_reg_write(rc_sq_wqe, RCWQE_SGE_NUM, sge_info->valid_num);
 	}


### PR DESCRIPTION
The first two bugfixes are about the hns driver, the remaining bugfixes are
about the verbs manual.

Wenpeng Liang (3):
  libhns: Fix out-of-bounds write when filling inline data into extended
    sge space
  libhns: Fix wrong HIP08 version macro
  verbs: Fix a typo

Xinhao Liu (1):
  verbs: Fix description of manual for ibv_wc_read_byte_len function

 libibverbs/man/ibv_create_cq_ex.3 |  2 +-
 libibverbs/man/ibv_wr_post.3.md   |  4 ++--
 providers/hns/hns_roce_u.h        |  3 +--
 providers/hns/hns_roce_u_hw_v2.c  | 40 +++++++++++++++++++++----------
 4 files changed, 32 insertions(+), 17 deletions(-)