### PR TITLE
libibverbs: consistently parse environment variables in ibverbs_init

### DIFF
--- a/libibverbs/init.c
+++ b/libibverbs/init.c
@@ -665,20 +665,14 @@ static void verbs_set_log_file(void)
 
 int ibverbs_init(void)
 {
-	char *env_value;
-
-	if (getenv("RDMAV_FORK_SAFE") || getenv("IBV_FORK_SAFE"))
+	if (check_env("RDMAV_FORK_SAFE") || check_env("IBV_FORK_SAFE"))
 		if (ibv_fork_init())
 			fprintf(stderr, PFX "Warning: fork()-safety requested "
 				"but init failed\n");
 
-	/* Backward compatibility for the mlx4 driver env */
-	env_value = getenv("MLX4_DEVICE_FATAL_CLEANUP");
-	if (env_value)
-		verbs_allow_disassociate_destroy = strcmp(env_value, "0") != 0;
-
-	if (getenv("RDMAV_ALLOW_DISASSOC_DESTROY"))
-		verbs_allow_disassociate_destroy = true;
+	verbs_allow_disassociate_destroy = check_env("RDMAV_ALLOW_DISASSOC_DESTROY")
+		/* Backward compatibility for the mlx4 driver env */
+		|| check_env("MLX4_DEVICE_FATAL_CLEANUP");
 
 	if (!ibv_get_sysfs_path())
 		return -errno;

--- a/util/util.c
+++ b/util/util.c
@@ -1,5 +1,6 @@
 /* GPLv2 or OpenIB.org BSD (MIT) See COPYING file */
 #include <stdlib.h>
+#include <string.h>
 #include <sys/random.h>
 #include <sys/types.h>
 #include <time.h>
@@ -44,4 +45,11 @@ unsigned int get_random(void)
 	}
 
 	return rand_r(&seed);
+}
+
+bool check_env(const char *var)
+{
+	const char *env_value = getenv(var);
+
+	return env_value && (strcmp(env_value, "0") != 0);
 }

--- a/util/util.h
+++ b/util/util.h
@@ -90,4 +90,6 @@ int set_fd_nonblock(int fd, bool nonblock);
 int open_cdev(const char *devname_hint, dev_t cdev);
 
 unsigned int get_random(void);
+
+bool check_env(const char *var);
 #endif


### PR DESCRIPTION
Prior to this change, setting some of the variables to "0" would be confusingly interpreted as enabling the feature. 