### PR TITLE
Do not use `__THROW` in prototypes

### DIFF
--- a/libibverbs/neigh.c
+++ b/libibverbs/neigh.c
@@ -30,7 +30,7 @@
 #if !HAVE_WORKING_IF_H
 /* We need this decl from net/if.h but old systems do not let use co-include
    net/if.h and netlink/route/link.h */
-extern unsigned int if_nametoindex(__const char *__ifname) __THROW;
+extern unsigned int if_nametoindex(__const char *__ifname);
 #endif
 
 /* for PFX */


### PR DESCRIPTION
`__THROW` is a glibc-internal macro, as indicated by the
preceding double underscore. The absence of this macro breaks
builds on musl.

Bug: https://bugs.gentoo.org/828894