### PR TITLE
cmake: Use PROJECT_SOURCE_DIR in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,26 +89,26 @@ set(IBVERBS_PROVIDER_SUFFIX "-rdmav${IBVERBS_PABI_VERSION}.so")
 
 # Override the CMAKE_INSTALL_ dirs to be under the build/ directory
 if (IN_PLACE)
-  set(CMAKE_INSTALL_SYSCONFDIR "${CMAKE_BINARY_DIR}/etc")
-  set(CMAKE_INSTALL_BINDIR "${CMAKE_BINARY_DIR}/bin")
-  set(CMAKE_INSTALL_SBINDIR "${CMAKE_BINARY_DIR}/bin")
-  set(CMAKE_INSTALL_PREFIX "${CMAKE_BINARY_DIR}")
+  set(CMAKE_INSTALL_SYSCONFDIR "${PROJECT_BINARY_DIR}/etc")
+  set(CMAKE_INSTALL_BINDIR "${PROJECT_BINARY_DIR}/bin")
+  set(CMAKE_INSTALL_SBINDIR "${PROJECT_BINARY_DIR}/bin")
+  set(CMAKE_INSTALL_PREFIX "${PROJECT_BINARY_DIR}")
   set(CMAKE_INSTALL_LIBDIR "lib")
   set(CMAKE_INSTALL_INCLUDEDIR "include")
 endif()
 
 include(GNUInstallDirs)
 # C include root
-set(BUILD_INCLUDE ${CMAKE_BINARY_DIR}/include)
+set(BUILD_INCLUDE ${PROJECT_BINARY_DIR}/include)
 # Executables
-set(BUILD_BIN ${CMAKE_BINARY_DIR}/bin)
+set(BUILD_BIN ${PROJECT_BINARY_DIR}/bin)
 # Libraries
-set(BUILD_LIB ${CMAKE_BINARY_DIR}/lib)
+set(BUILD_LIB ${PROJECT_BINARY_DIR}/lib)
 # Static library pre-processing
-set(BUILD_STATIC_LIB ${CMAKE_BINARY_DIR}/lib/statics)
+set(BUILD_STATIC_LIB ${PROJECT_BINARY_DIR}/lib/statics)
 # Used for IN_PLACE configuration
-set(BUILD_ETC ${CMAKE_BINARY_DIR}/etc)
-set(BUILD_PYTHON ${CMAKE_BINARY_DIR}/python)
+set(BUILD_ETC ${PROJECT_BINARY_DIR}/etc)
+set(BUILD_PYTHON ${PROJECT_BINARY_DIR}/python)
 
 set(IBDIAG_CONFIG_PATH "${CMAKE_INSTALL_FULL_SYSCONFDIR}/infiniband-diags")
 set(IBDIAG_NODENAME_MAP_PATH "${CMAKE_INSTALL_FULL_SYSCONFDIR}/rdma/ib-node-name-map")
@@ -614,7 +614,7 @@ RDMA_DoFixup("${HAVE_GLIBC_FXSTAT}" "sys/stat.h")
 # Write out a git ignore file to the build directory if it isn't the source
 # directory. For developer convenience
 if (NOT ${CMAKE_CURRENT_BINARY_DIR} STREQUAL ${CMAKE_CURRENT_SOURCE_DIR})
-  file(WRITE ${CMAKE_BINARY_DIR}/.gitignore "*")
+  file(WRITE ${PROJECT_BINARY_DIR}/.gitignore "*")
 endif()
 
 if ("${IOCTL_MODE}" STREQUAL "both")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ set(DISTRO_FLAVOUR "None" CACHE
 
 #-------------------------
 # Load CMake components
-set(BUILDLIB "${CMAKE_SOURCE_DIR}/buildlib")
+set(BUILDLIB "${PROJECT_SOURCE_DIR}/buildlib")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BUILDLIB}")
 
 include(CMakeParseArguments)
@@ -759,14 +759,14 @@ if (NO_MAN_PAGES)
   message(STATUS " man pages NOT built")
 else()
   if (NOT PANDOC_FOUND)
-    if (NOT EXISTS "${CMAKE_SOURCE_DIR}/buildlib/pandoc-prebuilt")
+    if (NOT EXISTS "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt")
       message(STATUS " pandoc NOT found and NO prebuilt man pages. 'install' disabled")
     else()
       message(STATUS " pandoc NOT found (using prebuilt man pages)")
     endif()
   endif()
   if (NOT RST2MAN_FOUND)
-    if (NOT EXISTS "${CMAKE_SOURCE_DIR}/buildlib/pandoc-prebuilt")
+    if (NOT EXISTS "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt")
       message(STATUS " rst2man NOT found and NO prebuilt man pages. 'install' disabled")
     else()
       message(STATUS " rst2man NOT found (using prebuilt man pages)")

--- a/buildlib/RDMA_Sparse.cmake
+++ b/buildlib/RDMA_Sparse.cmake
@@ -21,12 +21,12 @@ int main(int argc,const char *argv[]) {return 0;}
     # Replace various glibc headers with our own versions that have embedded sparse annotations.
     execute_process(COMMAND "${PYTHON_EXECUTABLE}" "${BUILDLIB}/gen-sparse.py"
       "--out" "${BUILD_INCLUDE}/"
-      "--src" "${CMAKE_SOURCE_DIR}/"
+      "--src" "${PROJECT_SOURCE_DIR}/"
       "--cc" "${CMAKE_C_COMPILER}"
       RESULT_VARIABLE retcode)
     if(NOT "${retcode}" STREQUAL "0")
       message(FATAL_ERROR "glibc header file patching for sparse failed. Review include/*.rej and fix the rejects, then do "
-	"${BUILDLIB}/gen-sparse.py -out ${BUILD_INCLUDE}/ --src ${CMAKE_SOURCE_DIR}/ --save")
+	"${BUILDLIB}/gen-sparse.py -out ${BUILD_INCLUDE}/ --src ${PROJECT_SOURCE_DIR}/ --save")
     endif()
 
     # Enable endian analysis in sparse

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -156,7 +156,7 @@ function(rdma_shared_provider DEST VERSION_SCRIPT SOVERSION VERSION)
   install(TARGETS ${DEST} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 
   # Compute a relative symlink from VERBS_PROVIDER_DIR to LIBDIR
-  execute_process(COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_SOURCE_DIR}/buildlib/relpath
+  execute_process(COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/buildlib/relpath
     "${CMAKE_INSTALL_FULL_LIBDIR}/lib${DEST}.so.${VERSION}"
     "${VERBS_PROVIDER_DIR}"
     OUTPUT_VARIABLE DEST_LINK_PATH OUTPUT_STRIP_TRAILING_WHITESPACE
@@ -284,10 +284,10 @@ function(rdma_finalize_libs)
 
   add_custom_command(
     OUTPUT ${OUTPUTS}
-    COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/buildlib/sanitize_static_lib.py"
+    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/sanitize_static_lib.py"
              --version ${PACKAGE_VERSION}
              --ar "${CMAKE_AR}" --nm "${CMAKE_NM}" --objcopy "${CMAKE_OBJCOPY}" ${ARGS}
-    DEPENDS ${DEPENDS} "${CMAKE_SOURCE_DIR}/buildlib/sanitize_static_lib.py"
+    DEPENDS ${DEPENDS} "${PROJECT_SOURCE_DIR}/buildlib/sanitize_static_lib.py"
     COMMENT "Building distributable static libraries"
     VERBATIM)
   add_custom_target("make_static" ALL DEPENDS ${OUTPUTS})

--- a/buildlib/rdma_man.cmake
+++ b/buildlib/rdma_man.cmake
@@ -10,7 +10,7 @@ function(rdma_man_get_prebuilt SRC OUT)
   # made the man pages are pre-built and included. This is done via install
   # so that ./build.sh never depends on pandoc, only 'ninja install'.
   execute_process(
-    COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --retrieve "${CMAKE_SOURCE_DIR}" "${SRC}"
+    COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --retrieve "${PROJECT_SOURCE_DIR}" "${SRC}"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     OUTPUT_VARIABLE OBJ
     RESULT_VARIABLE retcode)
@@ -26,7 +26,7 @@ function(rdma_md_man_page SRC MAN_SECT MANFN)
   if (PANDOC_EXECUTABLE)
     add_custom_command(
       OUTPUT "${OBJ}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --pandoc "${PANDOC_EXECUTABLE}" "${SRC}" "${OBJ}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --pandoc "${PANDOC_EXECUTABLE}" "${SRC}" "${OBJ}"
       MAIN_DEPENDENCY "${SRC}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Creating man page ${MANFN}"
@@ -48,7 +48,7 @@ function(rdma_rst_man_page SRC MAN_SECT MANFN)
   if (RST2MAN_EXECUTABLE)
     add_custom_command(
       OUTPUT "${OBJ}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --rst "${RST2MAN_EXECUTABLE}" "${SRC}" "${OBJ}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --rst "${RST2MAN_EXECUTABLE}" "${SRC}" "${OBJ}"
       MAIN_DEPENDENCY "${SRC}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Creating man page ${MANFN}"

--- a/buildlib/rdma_man.cmake
+++ b/buildlib/rdma_man.cmake
@@ -1,7 +1,7 @@
 # COPYRIGHT (c) 2017-2018 Mellanox Technologies Ltd
 # Licensed under BSD (MIT variant) or GPLv2. See COPYING.
 
-rdma_make_dir("${CMAKE_BINARY_DIR}/pandoc-prebuilt")
+rdma_make_dir("${PROJECT_BINARY_DIR}/pandoc-prebuilt")
 add_custom_target("docs" ALL DEPENDS "${OBJ}")
 
 function(rdma_man_get_prebuilt SRC OUT)
@@ -26,7 +26,7 @@ function(rdma_md_man_page SRC MAN_SECT MANFN)
   if (PANDOC_EXECUTABLE)
     add_custom_command(
       OUTPUT "${OBJ}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --pandoc "${PANDOC_EXECUTABLE}" "${SRC}" "${OBJ}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${PROJECT_BINARY_DIR}" --pandoc "${PANDOC_EXECUTABLE}" "${SRC}" "${OBJ}"
       MAIN_DEPENDENCY "${SRC}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Creating man page ${MANFN}"
@@ -48,7 +48,7 @@ function(rdma_rst_man_page SRC MAN_SECT MANFN)
   if (RST2MAN_EXECUTABLE)
     add_custom_command(
       OUTPUT "${OBJ}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${CMAKE_BINARY_DIR}" --rst "${RST2MAN_EXECUTABLE}" "${SRC}" "${OBJ}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/pandoc-prebuilt.py" --build "${PROJECT_BINARY_DIR}" --rst "${RST2MAN_EXECUTABLE}" "${SRC}" "${OBJ}"
       MAIN_DEPENDENCY "${SRC}"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Creating man page ${MANFN}"

--- a/kernel-headers/CMakeLists.txt
+++ b/kernel-headers/CMakeLists.txt
@@ -48,9 +48,9 @@ function(rdma_kernel_provider_abi)
     set(HDRS ${HDRS} ${OHDR})
     add_custom_command(
       OUTPUT "${OHDR}"
-      COMMAND "${PYTHON_EXECUTABLE}" "${CMAKE_SOURCE_DIR}/buildlib/make_abi_structs.py" "${IHDR}" "${OHDR}"
+      COMMAND "${PYTHON_EXECUTABLE}" "${PROJECT_SOURCE_DIR}/buildlib/make_abi_structs.py" "${IHDR}" "${OHDR}"
       MAIN_DEPENDENCY "${IHDR}"
-      DEPENDS "${CMAKE_SOURCE_DIR}/buildlib/make_abi_structs.py"
+      DEPENDS "${PROJECT_SOURCE_DIR}/buildlib/make_abi_structs.py"
       WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
       COMMENT "Creating ABI wrapper ${OHDR}"
       )


### PR DESCRIPTION
When using rdma-core via cmake's add_subdirectory, CMAKE_SOURCE_DIR
points project's root directory, and build fails. This patch replaces
CMAKE_SOURCE_DIR with PROJECT_SOURCE_DIR. It enables builing rdma-core
via add_subdirectory.

Signed-off-by: Wonsup Yoon <pusnow@kaist.ac.kr>