### PR TITLE
cmake: Fix cmake link property for static library

### DIFF
--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -105,7 +105,7 @@ function(rdma_library DEST VERSION_SCRIPT SOVERSION VERSION)
   # Create a static library
   if (ENABLE_STATIC)
     add_library(${DEST}-static STATIC ${ARGN})
-    target_link_libraries(${DEST}-static LINK ${COMMON_LIBS})
+    target_link_libraries(${DEST}-static LINK_PRIVATE ${COMMON_LIBS})
     rdma_public_static_lib(${DEST} ${DEST}-static ${VERSION_SCRIPT})
   endif()
 


### PR DESCRIPTION
In cmake, there are only LINK_PRIVATE and LINK_PUBLIC options (no LINK).
This patch fixes cmake link property (LINK_PRIVATE) for static library.
See:
https://cmake.org/cmake/help/latest/command/target_link_libraries.html

Signed-off-by: Wonsup Yoon <pusnow@kaist.ac.kr>