### PR TITLE
tests: Modify eswitch mode checking

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1148,11 +1148,13 @@ def eswitch_mode_check(dev_name):
         raise unittest.SkipTest(f'Could not find the PCI device of {dev_name}')
     pci_name = pci_name[0].split('/')[5]
     try:
-        subprocess.check_output(['devlink', 'dev', 'eswitch', 'show', f'pci/{pci_name}'],
-                                stderr=subprocess.DEVNULL)
+        output = subprocess.check_output(['devlink', 'dev', 'eswitch', 'show', f'pci/{pci_name}'],
+                                         stderr=subprocess.DEVNULL).decode()
     except subprocess.CalledProcessError:
         raise unittest.SkipTest(f'ESwitch is off on device {dev_name}')
-    return True
+    if 'switchdev' in output:
+        return True
+    return False
 
 
 


### PR DESCRIPTION
The devlink output behavior would be changed by having two outputs for
Eswitch modes, which are legacy and switchdev, instead of having three
outputs which are None, legacy, and switchdev. So, the legacy mode will be
the default mode.

So, the function that checks the Eswitch mode should be adjusted, since
it only checks the legacy mode in case the command returns a non zero
value, but with the newer devlinks, the command will return zero value for
both legacy and switchdev, so there is important to check the value of
the output.