### PR TITLE
Providers/rxe: Fix bugs in rxe_post_recv

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -683,12 +683,12 @@ static int rxe_post_one_recv(struct rxe_wq *rq, struct ibv_recv_wr *recv_wr)
 	int rc = 0;
 
 	if (queue_full(q)) {
-		rc  = -ENOMEM;
+		rc  = ENOMEM;
 		goto out;
 	}
 
 	if (recv_wr->num_sge > rq->max_sge) {
-		rc = -EINVAL;
+		rc = EINVAL;
 		goto out;
 	}
 
@@ -1608,6 +1608,10 @@ static int rxe_post_recv(struct ibv_qp *ibqp,
 	*bad_wr = NULL;
 
 	if (!rq || !recv_wr || !rq->queue)
+		return EINVAL;
+
+	/* see C10-97.2.1 */
+	if (ibqp->state == IBV_QPS_RESET)
 		return EINVAL;
 
 	pthread_spin_lock(&rq->lock);


### PR DESCRIPTION
Recent test case additions in tests/test_qpex.py surfaced three
API errors in rxe.c for post_recv. Two errors were returned with
the wrong sign and an immediate error was not returned if the qp
was in the reset state. This patch fixes these errors.

Signed-off-by: Bob Pearson <rpearsonhpe@gmail.com>