### PR TITLE
srp_daemon: Detect proper path to systemctl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,6 +217,8 @@ else()
   set(CYTHON_EXECUTABLE "")
 endif()
 
+find_program(SYSTEMCTL_BIN systemctl HINTS "/usr/bin" "/bin")
+
 RDMA_CheckSparse()
 
 # Require GNU99 mode

--- a/srp_daemon/CMakeLists.txt
+++ b/srp_daemon/CMakeLists.txt
@@ -27,8 +27,9 @@ rdma_subst_install(FILES "srp_daemon.sh.in"
   RENAME "srp_daemon.sh"
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 
-install(FILES start_on_all_ports
+rdma_subst_install(FILES start_on_all_ports.in
   DESTINATION "${CMAKE_INSTALL_LIBEXECDIR}/srp_daemon"
+  RENAME start_on_all_ports
   PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE)
 
 rdma_subst_install(FILES srp_daemon.service.in
@@ -43,7 +44,7 @@ rdma_subst_install(FILES srp_daemon_port@.service.in
 
 install(FILES srp_daemon.conf DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}")
 
-install(FILES "srp_daemon.rules"
+rdma_subst_install(FILES "srp_daemon.rules.in"
   RENAME "60-srp_daemon.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 

--- a/srp_daemon/srp_daemon.rules
+++ b/srp_daemon/srp_daemon.rules
@@ -1,1 +1,0 @@
-SUBSYSTEM=="infiniband_mad", KERNEL=="*umad*", PROGRAM=="/bin/systemctl show srp_daemon -p ActiveState", RESULT=="ActiveState=active", ENV{SYSTEMD_WANTS}+="srp_daemon_port@$attr{ibdev}:$attr{port}.service"

--- a/srp_daemon/srp_daemon.rules.in
+++ b/srp_daemon/srp_daemon.rules.in
@@ -1,0 +1,1 @@
+SUBSYSTEM=="infiniband_mad", KERNEL=="*umad*", PROGRAM=="@SYSTEMCTL_BIN@ show srp_daemon -p ActiveState", RESULT=="ActiveState=active", ENV{SYSTEMD_WANTS}+="srp_daemon_port@$attr{ibdev}:$attr{port}.service"

--- a/srp_daemon/start_on_all_ports.in
+++ b/srp_daemon/start_on_all_ports.in
@@ -3,5 +3,5 @@
 for p in /sys/class/infiniband/*/ports/*; do
     [ -e "$p" ] || continue
     p=${p#/sys/class/infiniband/}
-    nohup /bin/systemctl start "srp_daemon_port@${p/\/ports\//:}" </dev/null >&/dev/null &
+    nohup @SYSTEMCTL_BIN@ start "srp_daemon_port@${p/\/ports\//:}" </dev/null >&/dev/null &
 done


### PR DESCRIPTION
While debian uses /bin/systemctl, SUSE only supports /usr/bin/systemctl,
causing srp_daemon to fail silently starting on all ports.
Detect at built which path is the right one and use it.

Fixes: b03beb142e0d ("srp_daemon: Call systemctl properly from udev")
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>