### PR TITLE
tests: Add new DR steering and RDMA tests

### DIFF
--- a/pyverbs/CMakeLists.txt
+++ b/pyverbs/CMakeLists.txt
@@ -37,6 +37,7 @@ rdma_cython_module(pyverbs ""
   qp.pyx
   spec.pyx
   srq.pyx
+  wq.pyx
   wr.pyx
   xrcd.pyx
 )

--- a/pyverbs/addr.pyx
+++ b/pyverbs/addr.pyx
@@ -416,7 +416,8 @@ cdef class AH(PyverbsCM):
 
     cpdef close(self):
         if self.ah != NULL:
-            self.logger.debug('Closing AH')
+            if self.logger:
+                self.logger.debug('Closing AH')
             rc = v.ibv_destroy_ah(self.ah)
             if rc:
                 raise PyverbsRDMAError('Failed to destroy AH', rc)

--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -210,7 +210,8 @@ cdef class AddrInfo(PyverbsObject):
 
     cpdef close(self):
         if self.addr_info != NULL:
-            self.logger.debug('Closing AddrInfo')
+            if self.logger:
+                self.logger.debug('Closing AddrInfo')
             cm.rdma_freeaddrinfo(self.addr_info)
         self.addr_info = NULL
 
@@ -234,7 +235,8 @@ cdef class CMEvent(PyverbsObject):
 
     cpdef close(self):
         if self.event != NULL:
-            self.logger.debug('Closing CMEvent')
+            if self.logger:
+                self.logger.debug('Closing CMEvent')
             self.ack_cm_event()
             self.event = NULL
 
@@ -283,7 +285,8 @@ cdef class CMEventChannel(PyverbsObject):
 
     cpdef close(self):
         if self.event_channel != NULL:
-            self.logger.debug('Closing CMEventChannel')
+            if self.logger:
+                self.logger.debug('Closing CMEventChannel')
             cm.rdma_destroy_event_channel(self.event_channel)
             self.event_channel = NULL
 
@@ -378,7 +381,8 @@ cdef class CMID(PyverbsCM):
 
     cpdef close(self):
         if self.id != NULL:
-            self.logger.debug('Closing CMID')
+            if self.logger:
+                self.logger.debug('Closing CMID')
             if self.event_channel is None:
                 cm.rdma_destroy_ep(self.id)
             else:

--- a/pyverbs/cq.pxd
+++ b/pyverbs/cq.pxd
@@ -22,6 +22,7 @@ cdef class CQ(PyverbsCM):
     cdef object srqs
     cdef object channel
     cdef object num_events
+    cdef object wqs
 
 cdef class CqInitAttrEx(PyverbsObject):
     cdef v.ibv_cq_init_attr_ex attr

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -10,6 +10,8 @@ cimport pyverbs.libibverbs_enums as e
 from pyverbs.device cimport Context
 from pyverbs.srq cimport SRQ
 from pyverbs.qp cimport QP
+from pyverbs.wq cimport WQ
+
 
 cdef class CompChannel(PyverbsCM):
     """
@@ -101,6 +103,7 @@ cdef class CQ(PyverbsCM):
         context.add_ref(self)
         self.qps = weakref.WeakSet()
         self.srqs = weakref.WeakSet()
+        self.wqs = weakref.WeakSet()
         self.num_events = 0
         self.logger.debug('Created a CQ')
 
@@ -109,6 +112,8 @@ cdef class CQ(PyverbsCM):
             self.qps.add(obj)
         elif isinstance(obj, SRQ):
             self.srqs.add(obj)
+        elif isinstance(obj, WQ):
+            self.wqs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 
@@ -118,7 +123,7 @@ cdef class CQ(PyverbsCM):
     cpdef close(self):
         if self.cq != NULL:
             self.logger.debug('Closing CQ')
-            close_weakrefs([self.qps, self.srqs])
+            close_weakrefs([self.qps, self.srqs, self.wqs])
             if self.num_events:
                 self.ack_events(self.num_events)
             rc = v.ibv_destroy_cq(self.cq)

--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -40,7 +40,8 @@ cdef class CompChannel(PyverbsCM):
 
     cpdef close(self):
         if self.cc != NULL:
-            self.logger.debug('Closing completion channel')
+            if self.logger:
+                self.logger.debug('Closing completion channel')
             close_weakrefs([self.cqs])
             rc = v.ibv_destroy_comp_channel(self.cc)
             if rc != 0:
@@ -122,7 +123,8 @@ cdef class CQ(PyverbsCM):
 
     cpdef close(self):
         if self.cq != NULL:
-            self.logger.debug('Closing CQ')
+            if self.logger:
+                self.logger.debug('Closing CQ')
             close_weakrefs([self.qps, self.srqs, self.wqs])
             if self.num_events:
                 self.ack_events(self.num_events)
@@ -342,7 +344,8 @@ cdef class CQEX(PyverbsCM):
 
     cpdef close(self):
         if self.cq != NULL:
-            self.logger.debug('Closing CQEx')
+            if self.logger:
+                self.logger.debug('Closing CQEx')
             close_weakrefs([self.srqs, self.qps])
             rc = v.ibv_destroy_cq(<v.ibv_cq*>self.cq)
             if rc != 0:

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -24,6 +24,7 @@ cdef class Context(PyverbsCM):
     cdef object sched_nodes
     cdef object sched_leafs
     cdef object dr_domains
+    cdef object wqs
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -25,6 +25,7 @@ cdef class Context(PyverbsCM):
     cdef object sched_leafs
     cdef object dr_domains
     cdef object wqs
+    cdef object rwq_ind_tbls
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -178,6 +178,10 @@ cdef class Context(PyverbsCM):
             self.context = NULL
 
     @property
+    def context(self):
+        return <object>self.context
+
+    @property
     def num_comp_vectors(self):
         return self.context.num_comp_vectors
 

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -22,6 +22,7 @@ from pyverbs.addr cimport GID
 from pyverbs.mr import DMMR
 from pyverbs.pd cimport PD
 from pyverbs.qp cimport QP
+from pyverbs.wq cimport WQ
 from libc.stdlib cimport free, malloc
 from libc.string cimport memset
 from libc.stdint cimport uint64_t
@@ -118,6 +119,7 @@ cdef class Context(PyverbsCM):
         self.sched_nodes = weakref.WeakSet()
         self.sched_leafs = weakref.WeakSet()
         self.dr_domains = weakref.WeakSet()
+        self.wqs = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -169,7 +171,7 @@ cdef class Context(PyverbsCM):
     cpdef close(self):
         if self.context != NULL:
             self.logger.debug('Closing Context')
-            close_weakrefs([self.qps, self.ccs, self.cqs, self.dms, self.pds,
+            close_weakrefs([self.qps, self.wqs, self.ccs, self.cqs, self.dms, self.pds,
                             self.xrcds, self.vars, self.sched_leafs,
                             self.sched_nodes, self.dr_domains])
             rc = v.ibv_close_device(self.context)
@@ -328,6 +330,8 @@ cdef class Context(PyverbsCM):
             self.qps.add(obj)
         elif isinstance(obj, XRCD):
             self.xrcds.add(obj)
+        elif isinstance(obj, WQ):
+            self.wqs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -171,7 +171,8 @@ cdef class Context(PyverbsCM):
 
     cpdef close(self):
         if self.context != NULL:
-            self.logger.debug('Closing Context')
+            if self.logger:
+                self.logger.debug('Closing Context')
             close_weakrefs([self.qps, self.rwq_ind_tbls, self.wqs, self.ccs, self.cqs,
                             self.dms, self.pds, self.xrcds, self.vars, self.sched_leafs,
                             self.sched_nodes, self.dr_domains])
@@ -806,7 +807,8 @@ cdef class DM(PyverbsCM):
         original DM object, in order to prevent double free by Python GC.
         """
         if self.dm != NULL:
-            self.logger.debug('Closing DM')
+            if self.logger:
+                self.logger.debug('Closing DM')
             close_weakrefs([self.dm_mrs])
             if not self._is_imported:
                 rc = v.ibv_free_dm(self.dm)

--- a/pyverbs/flow.pyx
+++ b/pyverbs/flow.pyx
@@ -120,7 +120,8 @@ cdef class Flow(PyverbsCM):
 
     cpdef close(self):
         if self.flow != NULL:
-            self.logger.debug('Closing Flow')
+            if self.logger:
+                self.logger.debug('Closing Flow')
             rc = v.ibv_destroy_flow(self.flow)
             if rc != 0:
                 raise PyverbsRDMAError('Failed to destroy Flow', rc)

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -391,10 +391,16 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    events_completed
 
     cdef struct ibv_rwq_ind_table:
-        pass
+        ibv_context *context
+        int         ind_tbl_handle
+        int         ind_tbl_num
+        uint32_t    comp_mask
 
     cdef struct ibv_rx_hash_conf:
-        pass
+        uint8_t  rx_hash_function
+        uint8_t  rx_hash_key_len
+        uint8_t  *rx_hash_key
+        uint64_t rx_hash_fields_mask
 
     cdef struct ibv_qp_init_attr_ex:
         void                *qp_context
@@ -603,6 +609,11 @@ cdef extern from 'infiniband/verbs.h':
         uint32_t    flags
         uint32_t    flags_mask
 
+    cdef struct ibv_rwq_ind_table_init_attr:
+        uint32_t log_ind_tbl_size
+        ibv_wq   **ind_tbl
+        uint32_t comp_mask
+
     ibv_device **ibv_get_device_list(int *n)
     int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)
@@ -758,6 +769,8 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_modify_wq(ibv_wq *wq, ibv_wq_attr *wq_attr)
     int ibv_destroy_wq(ibv_wq *wq)
     int ibv_post_wq_recv(ibv_wq *wq, ibv_recv_wr *recv_wr, ibv_recv_wr **bad_recv_wr)
+    ibv_rwq_ind_table *ibv_create_rwq_ind_table(ibv_context *context, ibv_rwq_ind_table_init_attr *init_attr)
+    int ibv_destroy_rwq_ind_table(ibv_rwq_ind_table *rwq_ind_table)
 
 
 cdef extern from 'infiniband/driver.h':

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -574,6 +574,35 @@ cdef extern from 'infiniband/verbs.h':
         ibv_async_event_element element
         ibv_event_type event_type
 
+    cdef struct ibv_wq:
+        ibv_context *context
+        void         *wq_context
+        ibv_pd       *pd
+        ibv_cq       *cq
+        uint32_t     wq_num
+        uint32_t     handle
+        ibv_wq_state state
+        ibv_wq_type  wq_type
+        uint32_t     events_completed
+        uint32_t     comp_mask
+
+    cdef struct ibv_wq_init_attr:
+        void        *wq_context
+        ibv_wq_type wq_type
+        uint32_t    max_wr
+        uint32_t    max_sge
+        ibv_pd      *pd
+        ibv_cq      *cq
+        uint32_t    comp_mask
+        uint32_t    create_flags
+
+    cdef struct ibv_wq_attr:
+        uint32_t    attr_mask
+        ibv_wq_state wq_state
+        ibv_wq_state curr_wq_state
+        uint32_t    flags
+        uint32_t    flags_mask
+
     ibv_device **ibv_get_device_list(int *n)
     int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)
@@ -725,6 +754,10 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_query_qp_data_in_order(ibv_qp *qp, ibv_wr_opcode op, uint32_t flags)
     int ibv_fork_init()
     ibv_fork_status ibv_is_fork_initialized()
+    ibv_wq *ibv_create_wq(ibv_context *context, ibv_wq_init_attr *wq_init_attr)
+    int ibv_modify_wq(ibv_wq *wq, ibv_wq_attr *wq_attr)
+    int ibv_destroy_wq(ibv_wq *wq)
+    int ibv_post_wq_recv(ibv_wq *wq, ibv_recv_wr *recv_wr, ibv_recv_wr **bad_recv_wr)
 
 
 cdef extern from 'infiniband/driver.h':

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -115,6 +115,10 @@ cdef extern from 'infiniband/verbs.h':
         unsigned int    max_ops
         unsigned int    max_sge
 
+    cdef struct ibv_tm_cap:
+        uint32_t        max_num_tags
+        uint32_t        max_ops
+
     cdef struct ibv_cq_moderation_caps:
         unsigned int    max_cq_count
         unsigned int    max_cq_period
@@ -280,6 +284,25 @@ cdef extern from 'infiniband/verbs.h':
         ibv_sge         *sg_list
         int             num_sge
 
+    cdef struct _add:
+        uint64_t        recv_wr_id
+        ibv_sge         *sg_list
+        int             num_sge
+        uint64_t        tag
+        uint64_t        mask
+
+    cdef struct _tm:
+        uint32_t        unexpected_cnt
+        uint32_t        handle
+        _add             add
+
+    cdef struct ibv_ops_wr:
+        uint64_t            wr_id
+        ibv_ops_wr          *next
+        ibv_ops_wr_opcode   opcode
+        int                 flags
+        _tm                  tm
+
     cdef struct rdma:
         unsigned long   remote_addr
         unsigned int    rkey
@@ -381,7 +404,7 @@ cdef extern from 'infiniband/verbs.h':
         ibv_pd          *pd
         ibv_xrcd        *xrcd
         ibv_cq          *cq
-        ibv_tm_caps      tm_cap
+        ibv_tm_cap      tm_cap
 
     cdef struct ibv_srq:
         ibv_context     *context
@@ -711,6 +734,7 @@ cdef extern from 'infiniband/verbs.h':
     int ibv_destroy_srq(ibv_srq *srq)
     int ibv_post_srq_recv(ibv_srq *srq, ibv_recv_wr *recv_wr,
                           ibv_recv_wr **bad_recv_wr)
+    int ibv_post_srq_ops(ibv_srq *srq, ibv_ops_wr *op, ibv_ops_wr **bad_op)
     ibv_pd *ibv_alloc_parent_domain(ibv_context *context,
                                     ibv_parent_domain_init_attr *attr)
     uint32_t ibv_inc_rkey(uint32_t rkey)

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -141,12 +141,24 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WR_SEND_WITH_INV
         IBV_WR_TSO
 
+    cpdef enum ibv_ops_wr_opcode:
+        IBV_WR_TAG_ADD
+        IBV_WR_TAG_DEL
+        IBV_WR_TAG_SYNC
+
+    cpdef enum ibv_ops_flags:
+        IBV_OPS_SIGNALED
+        IBV_OPS_TM_SYNC
+
     cpdef enum ibv_send_flags:
         IBV_SEND_FENCE
         IBV_SEND_SIGNALED
         IBV_SEND_SOLICITED
         IBV_SEND_INLINE
         IBV_SEND_IP_CSUM
+
+    cpdef enum ibv_tm_cap_flags:
+        IBV_TM_CAP_RC
 
     cpdef enum ibv_qp_type:
         IBV_QPT_RC
@@ -194,6 +206,8 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_FATAL_ERR
         IBV_WC_RESP_TIMEOUT_ERR
         IBV_WC_GENERAL_ERR
+        IBV_WC_TM_ERR
+        IBV_WC_TM_RNDV_INCOMPLETE
 
     cpdef enum ibv_wc_opcode:
         IBV_WC_SEND
@@ -206,6 +220,11 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_TSO
         IBV_WC_RECV
         IBV_WC_RECV_RDMA_WITH_IMM
+        IBV_WC_TM_ADD
+        IBV_WC_TM_DEL
+        IBV_WC_TM_SYNC
+        IBV_WC_TM_RECV
+        IBV_WC_TM_NO_TAG
         IBV_WC_DRIVER2
         IBV_WC_DRIVER3
 
@@ -220,6 +239,7 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_EX_WITH_COMPLETION_TIMESTAMP
         IBV_WC_EX_WITH_CVLAN
         IBV_WC_EX_WITH_FLOW_TAG
+        IBV_WC_EX_WITH_TM_INFO
         IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK
 
     cpdef enum ibv_wc_flags:
@@ -227,6 +247,9 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_WC_WITH_IMM
         IBV_WC_IP_CSUM_OK
         IBV_WC_WITH_INV
+        IBV_WC_TM_SYNC_REQ
+        IBV_WC_TM_MATCH
+        IBV_WC_TM_DATA_VALID
 
     cpdef enum ibv_srq_attr_mask:
         IBV_SRQ_MAX_WR
@@ -235,12 +258,14 @@ cdef extern from '<infiniband/verbs.h>':
     cpdef enum ibv_srq_type:
         IBV_SRQT_BASIC
         IBV_SRQT_XRC
+        IBV_SRQT_TM
 
     cpdef enum ibv_srq_init_attr_mask:
         IBV_SRQ_INIT_ATTR_TYPE
         IBV_SRQ_INIT_ATTR_PD
         IBV_SRQ_INIT_ATTR_XRCD
         IBV_SRQ_INIT_ATTR_CQ
+        IBV_SRQ_INIT_ATTR_TM
 
     cpdef enum ibv_mig_state:
         IBV_MIG_MIGRATED
@@ -476,3 +501,10 @@ cdef extern from '<infiniband/driver.h>':
     cpdef enum ibv_gid_type_sysfs:
         IBV_GID_TYPE_SYSFS_IB_ROCE_V1
         IBV_GID_TYPE_SYSFS_ROCE_V2
+
+cdef extern from "<infiniband/tm_types.h>":
+    cpdef enum ibv_tmh_op:
+        IBV_TMH_NO_TAG
+        IBV_TMH_RNDV
+        IBV_TMH_FIN
+        IBV_TMH_EAGER

--- a/pyverbs/mr.pyx
+++ b/pyverbs/mr.pyx
@@ -135,7 +135,8 @@ cdef class MR(PyverbsCM):
         :return: None
         """
         if self.mr != NULL:
-            self.logger.debug('Closing MR')
+            if self.logger:
+                self.logger.debug('Closing MR')
             if not self._is_imported:
                 rc = v.ibv_dereg_mr(self.mr)
                 if rc != 0:
@@ -320,7 +321,8 @@ cdef class MW(PyverbsCM):
         :return: None
         """
         if self.mw is not NULL:
-            self.logger.debug('Closing MW')
+            if self.logger:
+                self.logger.debug('Closing MW')
             rc = v.ibv_dealloc_mw(self.mw)
             if rc != 0:
                 raise PyverbsRDMAError('Failed to dealloc MW', rc)
@@ -423,7 +425,8 @@ cdef class DmaBufMR(MR):
         :return: None
         """
         if self.mr != NULL:
-            self.logger.debug('Closing dma-buf MR')
+            if self.logger:
+                self.logger.debug('Closing dma-buf MR')
             rc = v.ibv_dereg_mr(self.mr)
             if rc != 0:
                 raise PyverbsRDMAError('Failed to dereg dma-buf MR', rc)

--- a/pyverbs/pd.pxd
+++ b/pyverbs/pd.pxd
@@ -20,6 +20,7 @@ cdef class PD(PyverbsCM):
     cdef object ahs
     cdef object qps
     cdef object parent_domains
+    cdef object wqs
     cdef object mkeys
     cdef object deks
     cdef object _is_imported

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -56,7 +56,8 @@ cdef class PD(PyverbsCM):
             raise PyverbsUserError('Cannot create PD from {type}'
                                    .format(type=type(creator)))
         self.ctx.add_ref(self)
-        self.logger.debug('Created PD')
+        if self.logger:
+            self.logger.debug('Created PD')
         self.srqs = weakref.WeakSet()
         self.mrs = weakref.WeakSet()
         self.mws = weakref.WeakSet()
@@ -106,7 +107,8 @@ cdef class PD(PyverbsCM):
         :return: None
         """
         if self.pd != NULL:
-            self.logger.debug('Closing PD')
+            if self.logger:
+                self.logger.debug('Closing PD')
             close_weakrefs([self.deks, self.mkeys, self.parent_domains, self.qps,
                             self.wqs, self.ahs, self.mws, self.mrs, self.srqs])
             if not self._is_imported:
@@ -266,7 +268,8 @@ cdef class ParentDomain(PD):
 
     cpdef close(self):
         if self.pd != NULL:
-            self.logger.debug('Closing ParentDomain')
+            if self.logger:
+                self.logger.debug('Closing ParentDomain')
             close_weakrefs([self.cqs])
             super(ParentDomain, self).close()
 

--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -17,6 +17,7 @@ from pyverbs.srq cimport SRQ
 from pyverbs.addr cimport AH
 from pyverbs.cq cimport CQEX
 from pyverbs.qp cimport QP
+from pyverbs.wq cimport WQ
 
 
 cdef class PD(PyverbsCM):
@@ -64,6 +65,7 @@ cdef class PD(PyverbsCM):
         self.parent_domains = weakref.WeakSet()
         self.mkeys = weakref.WeakSet()
         self.deks = weakref.WeakSet()
+        self.wqs = weakref.WeakSet()
 
     def advise_mr(self, advise, uint32_t flags, sg_list not None):
         """
@@ -106,7 +108,7 @@ cdef class PD(PyverbsCM):
         if self.pd != NULL:
             self.logger.debug('Closing PD')
             close_weakrefs([self.deks, self.mkeys, self.parent_domains, self.qps,
-                            self.ahs, self.mws, self.mrs, self.srqs])
+                            self.wqs, self.ahs, self.mws, self.mrs, self.srqs])
             if not self._is_imported:
                 rc = v.ibv_dealloc_pd(self.pd)
                 if rc != 0:
@@ -127,6 +129,8 @@ cdef class PD(PyverbsCM):
             self.srqs.add(obj)
         elif isinstance(obj, ParentDomain):
             self.parent_domains.add(obj)
+        elif isinstance(obj, WQ):
+            self.wqs.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -62,3 +62,6 @@ cdef class DrActionIBPort(DrAction):
 
 cdef class DrActionDestTir(DrAction):
     cdef Mlx5DevxObj devx_obj
+
+cdef class DrActionPacketReformat(DrAction):
+    cdef DrDomain domain

--- a/pyverbs/providers/mlx5/dr_action.pxd
+++ b/pyverbs/providers/mlx5/dr_action.pxd
@@ -59,3 +59,6 @@ cdef class DrActionVPort(DrAction):
 cdef class DrActionIBPort(DrAction):
     cdef DrDomain domain
     cdef int ib_port
+
+cdef class DrActionDestTir(DrAction):
+    cdef Mlx5DevxObj devx_obj

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -342,3 +342,16 @@ cdef class DrActionIBPort(DrAction):
         if self.action != NULL:
             super(DrActionIBPort, self).close()
             self.domain = None
+
+cdef class DrActionDestTir(DrAction):
+    def __init__(self, Mlx5DevxObj devx_tir):
+        """
+        Create DR dest devx tir action.
+        :param devx_tir: Destination Mlx5DevxObj tir.
+        """
+        super().__init__()
+        self.action = dv.mlx5dv_dr_action_create_dest_devx_tir(devx_tir.obj)
+        if self.action == NULL:
+            raise PyverbsRDMAErrno('Failed to create TIR action')
+        self.devx_obj = devx_tir
+        devx_tir.add_ref(self)

--- a/pyverbs/providers/mlx5/dr_action.pyx
+++ b/pyverbs/providers/mlx5/dr_action.pyx
@@ -34,7 +34,8 @@ cdef class DrAction(PyverbsCM):
 
     cpdef close(self):
         if self.action != NULL:
-            self.logger.debug('Closing DrAction.')
+            if self.logger:
+                self.logger.debug('Closing DrAction.')
             close_weakrefs([self.dr_rules])
             rc = dv.mlx5dv_dr_action_destroy(self.action)
             if rc:
@@ -235,7 +236,8 @@ cdef class DrActionDestAttr(PyverbsCM):
 
     cpdef close(self):
         super(DrActionDestAttr, self).close()
-        self.logger.debug('Closing DrActionDestAttr')
+        if self.logger:
+            self.logger.debug('Closing DrActionDestAttr')
         if self.action_dest_attr != NULL:
             free(self.action_dest_attr)
             self.action_dest_attr = NULL

--- a/pyverbs/providers/mlx5/dr_domain.pyx
+++ b/pyverbs/providers/mlx5/dr_domain.pyx
@@ -80,7 +80,8 @@ cdef class DrDomain(PyverbsCM):
 
     cpdef close(self):
         if self.domain != NULL:
-            self.logger.debug('Closing DrDomain.')
+            if self.logger:
+                self.logger.debug('Closing DrDomain.')
             close_weakrefs([self.dr_actions, self.dr_tables])
             rc = dv.mlx5dv_dr_domain_destroy(self.domain)
             if rc:

--- a/pyverbs/providers/mlx5/dr_matcher.pyx
+++ b/pyverbs/providers/mlx5/dr_matcher.pyx
@@ -62,7 +62,8 @@ cdef class DrMatcher(PyverbsCM):
 
     cpdef close(self):
         if self.matcher != NULL:
-            self.logger.debug('Closing Matcher.')
+            if self.logger:
+                self.logger.debug('Closing Matcher.')
             close_weakrefs([self.dr_rules])
             if dv.mlx5dv_dr_matcher_destroy(self.matcher):
                 raise PyverbsRDMAErrno('Failed to destroy DrMatcher.')

--- a/pyverbs/providers/mlx5/dr_rule.pyx
+++ b/pyverbs/providers/mlx5/dr_rule.pyx
@@ -42,7 +42,8 @@ cdef class DrRule(PyverbsCM):
 
     cpdef close(self):
         if self.rule != NULL:
-            self.logger.debug('Closing DrRule.')
+            if self.logger:
+                self.logger.debug('Closing DrRule.')
             rc = dv.mlx5dv_dr_rule_destroy(self.rule)
             if rc:
                 raise PyverbsRDMAError('Failed to destroy DrRule.', rc)

--- a/pyverbs/providers/mlx5/dr_table.pyx
+++ b/pyverbs/providers/mlx5/dr_table.pyx
@@ -39,7 +39,8 @@ cdef class DrTable(PyverbsCM):
 
     cpdef close(self):
         if self.table != NULL:
-            self.logger.debug('Closing DrTable.')
+            if self.logger:
+                self.logger.debug('Closing DrTable.')
             close_weakrefs([self.dr_matchers, self.dr_actions])
             rc = dv.mlx5dv_dr_table_destroy(self.table)
             if rc:

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -468,6 +468,10 @@ cdef extern from 'infiniband/mlx5dv.h':
                                                          uint32_t vport)
     mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ib_port(mlx5dv_dr_domain *dmn,
                                                            uint32_t ib_port)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_packet_reformat(mlx5dv_dr_domain *domain,
+                                                              uint32_t flags,
+                                                              unsigned char reformat_type,
+                                                              size_t data_sz, void *data)
     int mlx5dv_dr_rule_destroy(mlx5dv_dr_rule *rule)
     void mlx5dv_dr_domain_allow_duplicate_rules(mlx5dv_dr_domain *dmn, bool allow)
 

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -478,6 +478,7 @@ cdef extern from 'infiniband/mlx5dv.h':
     v.ibv_device **mlx5dv_get_vfio_device_list(mlx5dv_vfio_context_attr *attr)
     int mlx5dv_vfio_get_events_fd(v.ibv_context *ibctx)
     int mlx5dv_vfio_process_events(v.ibv_context *context)
+    mlx5dv_dr_action *mlx5dv_dr_action_create_dest_devx_tir(mlx5dv_devx_obj *devx_obj)
 
     # DevX APIs
     mlx5dv_devx_uar *mlx5dv_devx_alloc_uar(v.ibv_context *context, uint32_t flags)

--- a/pyverbs/providers/mlx5/mlx5_vfio.pyx
+++ b/pyverbs/providers/mlx5/mlx5_vfio.pyx
@@ -108,7 +108,8 @@ cdef class Mlx5VfioContext(Mlx5Context):
 
     cpdef close(self):
         if self.context != NULL:
-            self.logger.debug('Closing Mlx5VfioContext')
+            if self.logger:
+                self.logger.debug('Closing Mlx5VfioContext')
             close_weakrefs([self.pds, self.devx_objs, self.devx_umems, self.uars])
             rc = v.ibv_close_device(self.context)
             if rc != 0:

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -87,6 +87,7 @@ cdef class Mlx5DevxObj(PyverbsCM):
     cdef Context context
     cdef object out_view
     cdef object flow_counter_actions
+    cdef object dest_tir_actions
     cdef add_ref(self, obj)
 
 cdef class Mlx5Cqe64(PyverbsObject):

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -12,7 +12,7 @@ from pyverbs.providers.mlx5.mlx5dv_mkey cimport Mlx5MrInterleaved, Mlx5Mkey, \
     Mlx5MkeyConfAttr, Mlx5SigBlockAttr
 from pyverbs.providers.mlx5.mlx5dv_crypto cimport Mlx5CryptoLoginAttr, Mlx5CryptoAttr
 from pyverbs.pyverbs_error import PyverbsUserError, PyverbsRDMAError, PyverbsError
-from pyverbs.providers.mlx5.dr_action cimport DrActionFlowCounter
+from pyverbs.providers.mlx5.dr_action cimport DrActionFlowCounter, DrActionDestTir
 from pyverbs.providers.mlx5.mlx5dv_sched cimport Mlx5dvSchedLeaf
 cimport pyverbs.providers.mlx5.mlx5dv_enums as dve
 cimport pyverbs.providers.mlx5.libmlx5 as dv
@@ -177,6 +177,7 @@ cdef class Mlx5DevxObj(PyverbsCM):
         self.context = context
         self.context.add_ref(self)
         self.flow_counter_actions = weakref.WeakSet()
+        self.dest_tir_actions = weakref.WeakSet()
 
     def query(self, in_, outlen):
         """
@@ -227,6 +228,8 @@ cdef class Mlx5DevxObj(PyverbsCM):
     cdef add_ref(self, obj):
         if isinstance(obj, DrActionFlowCounter):
             self.flow_counter_actions.add(obj)
+        elif isinstance(obj, DrActionDestTir):
+            self.dest_tir_actions.add(obj)
         else:
             raise PyverbsError('Unrecognized object type')
 
@@ -244,7 +247,7 @@ cdef class Mlx5DevxObj(PyverbsCM):
     cpdef close(self):
         if self.obj != NULL:
             self.logger.debug('Closing Mlx5DvexObj')
-            close_weakrefs([self.flow_counter_actions])
+            close_weakrefs([self.flow_counter_actions, self.dest_tir_actions])
             rc = dv.mlx5dv_devx_obj_destroy(self.obj)
             if rc:
                 raise PyverbsRDMAError('Failed to destroy a DevX object', rc)

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -234,6 +234,10 @@ cdef class Mlx5DevxObj(PyverbsCM):
     def out_view(self):
         return self.out_view
 
+    @property
+    def obj(self):
+        return <object>self.obj
+
     def __dealloc__(self):
         self.close()
 

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -246,7 +246,8 @@ cdef class Mlx5DevxObj(PyverbsCM):
 
     cpdef close(self):
         if self.obj != NULL:
-            self.logger.debug('Closing Mlx5DvexObj')
+            if self.logger:
+                self.logger.debug('Closing Mlx5DvexObj')
             close_weakrefs([self.flow_counter_actions, self.dest_tir_actions])
             rc = dv.mlx5dv_devx_obj_destroy(self.obj)
             if rc:
@@ -1667,7 +1668,8 @@ cdef class Mlx5UMEM(PyverbsCM):
 
     cpdef close(self):
         if self.umem != NULL:
-            self.logger.debug('Closing Mlx5UMEM')
+            if self.logger:
+                self.logger.debug('Closing Mlx5UMEM')
             rc = dv.mlx5dv_devx_umem_dereg(self.umem)
             try:
                 if rc:

--- a/pyverbs/providers/mlx5/mlx5dv_flow.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_flow.pyx
@@ -44,7 +44,8 @@ cdef class Mlx5FlowMatchParameters(PyverbsObject):
 
     cpdef close(self):
         if self.params != NULL:
-            self.logger.debug('Closing Mlx5FlowMatchParameters')
+            if self.logger:
+                self.logger.debug('Closing Mlx5FlowMatchParameters')
             free(self.params)
             self.params = NULL
 
@@ -123,7 +124,8 @@ cdef class Mlx5FlowMatcher(PyverbsObject):
 
     cpdef close(self):
         if self.flow_matcher != NULL:
-            self.logger.debug('Closing Mlx5FlowMatcher')
+            if self.logger:
+                self.logger.debug('Closing Mlx5FlowMatcher')
             close_weakrefs([self.flows])
             rc = dv.mlx5dv_destroy_flow_matcher(self.flow_matcher)
             if rc:

--- a/pyverbs/qp.pxd
+++ b/pyverbs/qp.pxd
@@ -22,6 +22,7 @@ cdef class QPInitAttrEx(PyverbsObject):
     cdef object _pd
     cdef object xrcd
     cdef object srq
+    cdef object ind_table
 
 cdef class QPAttr(PyverbsObject):
     cdef v.ibv_qp_attr attr
@@ -48,6 +49,7 @@ cdef class DataBuffer(PyverbsCM):
 
 cdef class QPEx(QP):
     cdef v.ibv_qp_ex *qp_ex
+    cdef object ind_table
 
 cdef class ECE(PyverbsCM):
     cdef v.ibv_ece ece

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -1038,7 +1038,8 @@ cdef class QP(PyverbsCM):
 
     cpdef close(self):
         if self.qp != NULL:
-            self.logger.debug('Closing QP')
+            if self.logger:
+                self.logger.debug('Closing QP')
             close_weakrefs([self.mws, self.flows, self.dr_actions])
             rc = v.ibv_destroy_qp(self.qp)
             if rc:

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -8,6 +8,7 @@ import weakref
 from pyverbs.pyverbs_error import PyverbsUserError, PyverbsError, PyverbsRDMAError
 from pyverbs.utils import gid_str, qp_type_to_str, qp_state_to_str, mtu_to_str
 from pyverbs.utils import access_flags_to_str, mig_state_to_str
+from pyverbs.wq cimport RwqIndTable, RxHashConf
 from pyverbs.mr cimport MW, MWBindInfo, MWBind
 from pyverbs.wr cimport RecvWR, SendWR, SGE
 from pyverbs.base import PyverbsRDMAErrno
@@ -252,8 +253,8 @@ cdef class QPInitAttrEx(PyverbsObject):
                  PyverbsObject scq=None, PyverbsObject rcq=None,
                  SRQ srq=None, QPCap cap=None, sq_sig_all=0, comp_mask=0,
                  PD pd=None, XRCD xrcd=None, create_flags=0,
-                 max_tso_header=0, source_qpn=0, object hash_conf=None,
-                 object ind_table=None, send_ops_flags=0):
+                 max_tso_header=0, source_qpn=0, RxHashConf hash_conf=None,
+                 RwqIndTable ind_table=None, send_ops_flags=0):
         """
         Initialize a QPInitAttrEx object with user-defined or default values.
         :param qp_type: QP type to be created
@@ -272,8 +273,8 @@ cdef class QPInitAttrEx(PyverbsObject):
         :param max_tso_header: Maximum TSO header size
         :param source_qpn: Source QP number (requires IBV_QP_CREATE_SOURCE_QPN
                            set in create_flags)
-        :param hash_conf: Not yet supported
-        :param ind_table: Not yet supported
+        :param hash_conf: A RxHashConf object, config of RX hash key.
+        :param ind_table: A RwqIndTable object, indirection table of RWQs.
         :param send_ops_flags: Send opcodes to be supported by the extended QP.
                                Use ibv_qp_create_send_ops_flags enum
         :return: An initialized QPInitAttrEx object
@@ -304,12 +305,12 @@ cdef class QPInitAttrEx(PyverbsObject):
         self.attr.srq = srq.srq if srq else NULL
         self.xrcd = xrcd
         self.attr.xrcd = xrcd.xrcd if xrcd else NULL
-        self.attr.rwq_ind_tbl = NULL  # Until RSS support is added
+        if hash_conf:
+            self.attr.rx_hash_conf = hash_conf.rx_hash_conf
+        self.ind_table = ind_table
+        self.attr.rwq_ind_tbl = ind_table.rwq_ind_table if ind_table else NULL
         self.attr.qp_type = qp_type
         self.attr.sq_sig_all = sq_sig_all
-        unsupp_flags = e.IBV_QP_INIT_ATTR_IND_TABLE | e.IBV_QP_INIT_ATTR_RX_HASH
-        if comp_mask & unsupp_flags:
-            raise PyverbsUserError('RSS is not yet supported in pyverbs')
         self.attr.comp_mask = comp_mask
         if pd is not None:
             self._pd = pd
@@ -452,6 +453,14 @@ cdef class QPInitAttrEx(PyverbsObject):
     @max_inline_data.setter
     def max_inline_data(self, val):
         self.attr.cap.max_inline_data = val
+
+    @property
+    def ind_table(self):
+        return self.ind_table
+    @ind_table.setter
+    def ind_table(self, RwqIndTable val):
+        self.attr.rwq_ind_tbl = <v.ibv_rwq_ind_table*>val.rwq_ind_table
+        self.ind_table = val
 
     def mask_to_str(self, mask):
         comp_masks = {1: 'PD', 2: 'XRCD', 4: 'Create Flags',
@@ -1274,6 +1283,10 @@ cdef class QPEx(QP):
         :return: An initialized QPEx object
         """
         super().__init__(creator, init_attr, qp_attr)
+        if init_attr.ind_table is not None:
+            ind_table = <RwqIndTable>init_attr.ind_table
+            ind_table.add_ref(self)
+            self.ind_table = ind_table
         if init_attr.comp_mask & v.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS:
             self.qp_ex = v.ibv_qp_to_qp_ex(self.qp)
             if self.qp_ex == NULL:
@@ -1301,6 +1314,10 @@ cdef class QPEx(QP):
     @wr_flags.setter
     def wr_flags(self, val):
         self.qp_ex.wr_flags = val
+
+    @property
+    def ind_table(self):
+        return self.ind_table
 
     def wr_atomic_cmp_swp(self, rkey, remote_addr, compare, swap):
         v.ibv_wr_atomic_cmp_swp(self.qp_ex, rkey, remote_addr, compare, swap)

--- a/pyverbs/srq.pxd
+++ b/pyverbs/srq.pxd
@@ -18,6 +18,9 @@ cdef class SrqInitAttrEx(PyverbsObject):
     cdef object _pd
     cdef object _xrcd
 
+cdef class OpsWr(PyverbsCM):
+    cdef v.ibv_ops_wr ops_wr
+
 cdef class SRQ(PyverbsCM):
     cdef v.ibv_srq *srq
     cdef object cq

--- a/pyverbs/srq.pyx
+++ b/pyverbs/srq.pyx
@@ -1,16 +1,18 @@
 import weakref
-from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
-from pyverbs.base import PyverbsRDMAErrno
-from pyverbs.base cimport close_weakrefs
-from pyverbs.device cimport Context
-from pyverbs.cq cimport CQEX, CQ
-from pyverbs.xrcd cimport XRCD
-from pyverbs.wr cimport RecvWR
-from pyverbs.qp cimport QP
-from pyverbs.pd cimport PD
 from libc.errno cimport errno
 from libc.string cimport memcpy
-
+from libc.stdlib cimport malloc, free
+from pyverbs.pyverbs_error import PyverbsRDMAError, PyverbsError
+from pyverbs.wr cimport RecvWR, SGE, copy_sg_array
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
+cimport pyverbs.libibverbs_enums as e
+from pyverbs.device cimport Context
+from pyverbs.cq cimport CQEX, CQ
+cimport pyverbs.libibverbs as v
+from pyverbs.xrcd cimport XRCD
+from pyverbs.qp cimport QP
+from pyverbs.pd cimport PD
 
 cdef class SrqAttr(PyverbsObject):
     def __init__(self, max_wr=100, max_sge=1, srq_limit=0):
@@ -115,6 +117,20 @@ cdef class SrqInitAttrEx(PyverbsObject):
         self.attr.xrcd = val.xrcd
 
     @property
+    def max_num_tags(self):
+        return self.attr.tm_cap.max_num_tags
+    @max_num_tags.setter
+    def max_num_tags(self, val):
+        self.attr.tm_cap.max_num_tags = val
+
+    @property
+    def max_ops(self):
+        return self.attr.tm_cap.max_ops
+    @max_ops.setter
+    def max_ops(self, val):
+        self.attr.tm_cap.max_ops = val
+
+    @property
     def cq(self):
         return self._cq
     @cq.setter
@@ -125,6 +141,105 @@ cdef class SrqInitAttrEx(PyverbsObject):
         else:
             self.attr.cq = (<CQEX>val).ibv_cq
             self._cq = val
+
+
+cdef class OpsWr(PyverbsCM):
+    def __init__(self, wr_id=0, opcode=e.IBV_WR_TAG_ADD, flags=e.IBV_OPS_SIGNALED,
+                 OpsWr next_wr=None, unexpected_cnt=0, recv_wr_id=0,
+                 num_sge=None, tag=0, mask=0, sg_list=None):
+        self.ops_wr.wr_id = wr_id
+        self.ops_wr.opcode = opcode
+        self.ops_wr.flags = flags
+        self.ops_wr.tm.unexpected_cnt = unexpected_cnt
+        self.ops_wr.tm.add.recv_wr_id = recv_wr_id
+        self.ops_wr.tm.add.tag = tag
+        self.ops_wr.tm.add.mask = mask
+        if next_wr is not None:
+            self.ops_wr.next = &next_wr.ops_wr
+        if num_sge is not None:
+            self.ops_wr.tm.add.num_sge = num_sge
+        cdef v.ibv_sge *dst
+        if sg_list is not None:
+            self.ops_wr.tm.add.sg_list = <v.ibv_sge*>malloc(num_sge * sizeof(v.ibv_sge))
+            if self.ops_wr.tm.add.sg_list == NULL:
+                raise MemoryError('Failed to malloc SG buffer')
+            dst = self.ops_wr.tm.add.sg_list
+            copy_sg_array(dst, sg_list, num_sge)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.ops_wr.tm.add.sg_list != NULL:
+            free(self.ops_wr.tm.add.sg_list)
+            self.ops_wr.tm.add.sg_list = NULL
+
+    @property
+    def wr_id(self):
+        return self.ops_wr.wr_id
+    @wr_id.setter
+    def wr_id(self, val):
+        self.ops_wr.wr_id = val
+
+    @property
+    def next_wr(self):
+        if self.ops_wr.next == NULL:
+            return None
+        val = OpsWr()
+        val.ops_wr = self.ops_wr.next[0]
+        return val
+    @next_wr.setter
+    def next_wr(self, OpsWr val not None):
+        self.ops_wr.next = &val.ops_wr
+
+    @property
+    def opcode(self):
+        return self.ops_wr.opcode
+    @opcode.setter
+    def opcode(self, val):
+        self.ops_wr.opcode = val
+
+    @property
+    def flags(self):
+        return self.ops_wr.flags
+    @flags.setter
+    def flags(self, val):
+        self.ops_wr.flags = val
+
+    @property
+    def unexpected_cnt(self):
+        return self.ops_wr.tm.unexpected_cnt
+    @unexpected_cnt.setter
+    def unexpected_cnt(self, val):
+        self.ops_wr.tm.unexpected_cnt = val
+
+    @property
+    def recv_wr_id(self):
+        return self.ops_wr.tm.add.recv_wr_id
+    @recv_wr_id.setter
+    def recv_wr_id(self, val):
+        self.ops_wr.tm.add.recv_wr_id = val
+
+    @property
+    def tag(self):
+        return self.ops_wr.tm.add.tag
+    @tag.setter
+    def tag(self, val):
+        self.ops_wr.tm.add.tag = val
+
+    @property
+    def handle(self):
+        return self.ops_wr.tm.handle
+    @handle.setter
+    def handle(self, val):
+        self.ops_wr.tm.handle = val
+
+    @property
+    def mask(self):
+        return self.ops_wr.tm.add.mask
+    @mask.setter
+    def mask(self, val):
+        self.ops_wr.tm.add.mask = val
 
 
 cdef class SRQ(PyverbsCM):
@@ -199,6 +314,20 @@ cdef class SRQ(PyverbsCM):
         if rc != 0:
             raise PyverbsRDMAError('Failed to query SRQ', rc)
         return attr
+
+    def post_srq_ops(self, OpsWr wr not None, OpsWr bad_wr=None):
+        """
+        Perform on a special shared receive queue (SRQ) configuration manipulations
+        :param wr: Ops Work Requests to be posted to the TM-Shared Receive Queue
+        :param bad_wr: A pointer that will be filled with the first Ops Work Request,
+                       that its processing failed
+        """
+        cdef v.ibv_ops_wr *my_bad_wr
+        rc= v.ibv_post_srq_ops(self.srq, &wr.ops_wr, &my_bad_wr)
+        if rc != 0:
+            if bad_wr:
+                memcpy(&bad_wr.ops_wr, my_bad_wr, sizeof(bad_wr.ops_wr))
+            raise PyverbsRDMAError('post SRQ ops failed.', rc)
 
     def post_recv(self, RecvWR wr not None, RecvWR bad_wr=None):
         cdef v.ibv_recv_wr *my_bad_wr

--- a/pyverbs/srq.pyx
+++ b/pyverbs/srq.pyx
@@ -149,7 +149,8 @@ cdef class SRQ(PyverbsCM):
 
     cpdef close(self):
         if self.srq != NULL:
-            self.logger.debug('Closing SRQ')
+            if self.logger:
+                self.logger.debug('Closing SRQ')
             close_weakrefs([self.qps])
             rc = v.ibv_destroy_srq(self.srq)
             if rc != 0:

--- a/pyverbs/wq.pxd
+++ b/pyverbs/wq.pxd
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia Inc. All rights reserved. See COPYING file
+
+#cython: language_level=3
+
+from pyverbs.base cimport PyverbsObject, PyverbsCM
+from pyverbs.device cimport Context
+cimport pyverbs.libibverbs as v
+from pyverbs.cq cimport CQ
+from pyverbs.pd cimport PD
+
+
+cdef class WQInitAttr(PyverbsObject):
+    cdef v.ibv_wq_init_attr attr
+    cdef PD pd
+    cdef CQ cq
+
+cdef class WQAttr(PyverbsObject):
+    cdef v.ibv_wq_attr attr
+
+cdef class WQ(PyverbsCM):
+    cdef v.ibv_wq *wq
+    cdef Context context
+    cdef PD pd
+    cdef CQ cq

--- a/pyverbs/wq.pxd
+++ b/pyverbs/wq.pxd
@@ -23,3 +23,19 @@ cdef class WQ(PyverbsCM):
     cdef Context context
     cdef PD pd
     cdef CQ cq
+    cdef object rwq_ind_tables
+    cpdef add_ref(self, obj)
+
+cdef class RwqIndTableInitAttr(PyverbsObject):
+    cdef v.ibv_rwq_ind_table_init_attr attr
+    cdef object wqs_list
+
+cdef class RwqIndTable(PyverbsCM):
+    cdef v.ibv_rwq_ind_table *rwq_ind_table
+    cdef Context context
+    cdef object wqs
+    cdef object qps
+    cpdef add_ref(self, obj)
+
+cdef class RxHashConf(PyverbsObject):
+    cdef v.ibv_rx_hash_conf rx_hash_conf

--- a/pyverbs/wq.pyx
+++ b/pyverbs/wq.pyx
@@ -188,7 +188,8 @@ cdef class WQ(PyverbsCM):
         :return: None
         """
         if self.wq != NULL:
-            self.logger.debug('Closing WQ')
+            if self.logger:
+                self.logger.debug('Closing WQ')
             close_weakrefs([self.rwq_ind_tables])
             rc = v.ibv_destroy_wq(self.wq)
             if rc != 0:
@@ -274,7 +275,8 @@ cdef class RwqIndTable(PyverbsCM):
         :return: None
         """
         if self.rwq_ind_table != NULL:
-            self.logger.debug('Closing RWQ IND TBL')
+            if self.logger:
+                self.logger.debug('Closing RWQ IND TBL')
             close_weakrefs([self.qps])
             rc = v.ibv_destroy_rwq_ind_table(self.rwq_ind_table)
             if rc != 0:

--- a/pyverbs/wq.pyx
+++ b/pyverbs/wq.pyx
@@ -1,10 +1,14 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
 # Copyright (c) 2021 Nvidia Inc. All rights reserved. See COPYING file
 
+from libc.stdlib cimport calloc, free
+from libc.stdint cimport uint8_t
 from libc.string cimport memcpy
+import weakref
 
-from .pyverbs_error import PyverbsRDMAError
+from .pyverbs_error import PyverbsRDMAError, PyverbsError, PyverbsUserError
 from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.base cimport close_weakrefs
 cimport pyverbs.libibverbs_enums as e
 from pyverbs.device cimport Context
 from pyverbs.wr cimport RecvWR
@@ -139,6 +143,13 @@ cdef class WQ(PyverbsCM):
         cq = <CQ>attr.cq
         cq.add_ref(self)
         self.cq = cq
+        self.rwq_ind_tables = weakref.WeakSet()
+
+    cpdef add_ref(self, obj):
+        if isinstance(obj, RwqIndTable):
+            self.rwq_ind_tables.add(obj)
+        else:
+            raise PyverbsError('Unrecognized object type')
 
     def modify(self, WQAttr wq_attr not None):
         """
@@ -178,6 +189,7 @@ cdef class WQ(PyverbsCM):
         """
         if self.wq != NULL:
             self.logger.debug('Closing WQ')
+            close_weakrefs([self.rwq_ind_tables])
             rc = v.ibv_destroy_wq(self.wq)
             if rc != 0:
                 raise PyverbsRDMAError('Failed to dealloc WQ', rc)
@@ -189,3 +201,152 @@ cdef class WQ(PyverbsCM):
     @property
     def wqn(self):
         return self.wq.wq_num
+
+
+cdef class RwqIndTableInitAttr(PyverbsObject):
+    def __init__(self, log_ind_tbl_size=5, wqs_list=None, comp_mask=0):
+        """
+        Initializes a RwqIndTableInitAttr object representing ibv_rwq_ind_table_init_attr struct.
+        :param log_ind_tbl_size: Log, base 2, of Indirection table size
+        :param wqs_list: List of WQs
+        :param comp_mask: Identifies valid fields
+        :return: A RwqIndTableInitAttr object
+        """
+        super().__init__()
+        if log_ind_tbl_size <= 0:
+            raise PyverbsUserError('Invalid indirection table size. Log size must be > 0')
+        if (1 << log_ind_tbl_size) < len(wqs_list):
+            raise PyverbsUserError(f'Requested table size ({1 << log_ind_tbl_size}) is smaller '
+                                   f'than the number of wqs ({len(wqs_list)})')
+        self.attr.log_ind_tbl_size = log_ind_tbl_size
+        cdef v.ibv_wq **rwq_ind_table = <v.ibv_wq **>calloc(len(wqs_list), sizeof(v.ibv_wq*))
+        if rwq_ind_table == NULL:
+            raise MemoryError('Failed to allocate memory for Indirection Table')
+        for i in range(len(wqs_list)):
+            rwq_ind_table[i] = (<WQ>wqs_list[i]).wq
+        self.attr.ind_tbl = rwq_ind_table
+        self.wqs_list = wqs_list
+        self.attr.comp_mask = comp_mask
+
+    def __dealloc__(self):
+        """
+        Closes the rwq_ind_tbl init attr.
+        :return: None
+        """
+        free(self.attr.ind_tbl)
+
+
+cdef class RwqIndTable(PyverbsCM):
+    def __init__(self, Context ctx, RwqIndTableInitAttr attr):
+        """
+        Initializes a RwqIndTable object.
+        :param ctx: The context the RWQ IND TBL will be associated with.
+        :param attr: RWQ IND TBL initial attributes of type RwqIndTableInitAttr.
+        :return: A RwqIndTable object
+        """
+        super().__init__()
+        self.rwq_ind_table = v.ibv_create_rwq_ind_table(ctx.context, &attr.attr)
+        if self.rwq_ind_table == NULL:
+            raise PyverbsRDMAErrno('Failed to create RwqIndTable')
+        self.context = ctx
+        ctx.add_ref(self)
+        self.wqs = attr.wqs_list
+        for wq in self.wqs:
+            wq.add_ref(self)
+        self.qps = weakref.WeakSet()
+
+    cpdef add_ref(self, obj):
+        if isinstance(obj, QP):
+            self.qps.add(obj)
+        else:
+            raise PyverbsError('Unrecognized object type')
+
+    @property
+    def wqs(self):
+        return self.wqs
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        """
+        Closes the underlying C object of the RWQ IND TBL.
+        :return: None
+        """
+        if self.rwq_ind_table != NULL:
+            self.logger.debug('Closing RWQ IND TBL')
+            close_weakrefs([self.qps])
+            rc = v.ibv_destroy_rwq_ind_table(self.rwq_ind_table)
+            if rc != 0:
+                raise PyverbsRDMAError('Failed to dealloc RWQ IND TBL', rc)
+            self.rwq_ind_table = NULL
+            self.context = None
+
+
+cdef class RxHashConf(PyverbsObject):
+    def __init__(self, rx_hash_function=0, rx_hash_key_len=0,
+                 rx_hash_key=None, rx_hash_fields_mask=0):
+        """
+        Initializes a RxHashConf object representing ibv_rx_hash_conf struct.
+        :param rx_hash_function: RX hash function, use enum ibv_rx_hash_function_flags
+        :param rx_hash_key_len: RX hash key length
+        :param rx_hash_key: RX hash key data
+        :param rx_hash_fields_mask: RX fields that should participate in the hashing
+        :return: A RxHashConf object
+        """
+        super().__init__()
+        cdef uint8_t *rx_hash_key_c = NULL
+        if rx_hash_key:
+            if rx_hash_key_len != len(rx_hash_key):
+                raise PyverbsUserError('Length of rx_hash_key not equal to rx_hash_key_len')
+            self.rx_hash_key = rx_hash_key
+        self.rx_hash_conf.rx_hash_function = rx_hash_function
+        self.rx_hash_conf.rx_hash_key_len = rx_hash_key_len
+        self.rx_hash_conf.rx_hash_fields_mask = rx_hash_fields_mask
+
+    @property
+    def rx_hash_function(self):
+        return self.rx_hash_conf.rx_hash_function
+    @rx_hash_function.setter
+    def rx_hash_function(self, val):
+        self.rx_hash_conf.rx_hash_function = val
+
+    @property
+    def rx_hash_key_len(self):
+        return self.rx_hash_conf.rx_hash_key_len
+    @rx_hash_key_len.setter
+    def rx_hash_key_len(self, val):
+        if val <= 0:
+            raise PyverbsUserError('Invalid rx_hash_key_len. Must be greater then 0')
+        self.rx_hash_conf.rx_hash_key_len = val
+
+    @property
+    def rx_hash_fields_mask(self):
+        return self.rx_hash_conf.rx_hash_fields_mask
+    @rx_hash_fields_mask.setter
+    def rx_hash_fields_mask(self, val):
+        self.rx_hash_conf.rx_hash_fields_mask = val
+
+    @property
+    def rx_hash_key(self):
+        return self.rx_hash_conf.rx_hash_fields_mask
+    @rx_hash_key.setter
+    def rx_hash_key(self, vals_list):
+        if self.rx_hash_conf.rx_hash_key != NULL:
+            free(self.rx_hash_conf.rx_hash_key)
+            self.rx_hash_conf.rx_hash_key = NULL
+        cdef uint8_t *rx_hash_key_c = <uint8_t*>calloc(len(vals_list), sizeof(uint8_t))
+        if rx_hash_key_c == NULL:
+            raise MemoryError('Failed to allocate memory for RX hash key')
+        for i in range(len(vals_list)):
+            rx_hash_key_c[i] = vals_list[i]
+        self.rx_hash_conf.rx_hash_key = rx_hash_key_c
+        self.rx_hash_conf.rx_hash_key_len = len(vals_list)
+
+    def __dealloc__(self):
+        """
+        Frees rx hash key allocated memory.
+        :return: None
+        """
+        free(self.rx_hash_conf.rx_hash_key)
+        self.rx_hash_conf.rx_hash_key = NULL

--- a/pyverbs/wq.pyx
+++ b/pyverbs/wq.pyx
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2021 Nvidia Inc. All rights reserved. See COPYING file
+
+from libc.string cimport memcpy
+
+from .pyverbs_error import PyverbsRDMAError
+from pyverbs.base import PyverbsRDMAErrno
+cimport pyverbs.libibverbs_enums as e
+from pyverbs.device cimport Context
+from pyverbs.wr cimport RecvWR
+from pyverbs.cq cimport CQ
+from pyverbs.pd cimport PD
+from pyverbs.qp cimport QP
+
+
+cdef class WQInitAttr(PyverbsObject):
+    def __init__(self, wq_context=None, PD wq_pd=None, CQ wq_cq=None, wq_type=e.IBV_WQT_RQ,
+                 max_wr=100, max_sge=1, comp_mask=0, create_flags=0):
+        """
+        Initializes a WqInitAttr object representing ibv_wq_init_attr struct.
+        :param wq_context: Associated WQ context
+        :param wq_pd: PD to be associated with the WQ
+        :param wq_cq: CQ to be associated with the WQ
+        :param wp_type: The desired WQ type
+        :param max_wr: Requested max number of outstanding WRs in the WQ
+        :param max_sge: Requested max number of scatter/gather (s/g) elements per WR in the WQ
+        :param comp_mask: Identifies valid fields
+        :param create_flags: Creation flags for the WQ
+        :return: A WqInitAttr object
+        """
+        super().__init__()
+        self.attr.wq_context = <void*>(wq_context) if wq_context else NULL
+        self.attr.wq_type = wq_type
+        self.attr.max_wr = max_wr
+        self.attr.max_sge = max_sge
+        self.pd = wq_pd
+        self.attr.pd = wq_pd.pd if wq_pd else NULL
+        self.cq = wq_cq
+        self.attr.cq = wq_cq.cq if wq_cq else NULL
+        self.attr.comp_mask = comp_mask
+        self.attr.create_flags = create_flags
+
+    @property
+    def wq_type(self):
+        return self.attr.wq_type
+    @wq_type.setter
+    def wq_type(self, val):
+        self.attr.wq_type = val
+
+    @property
+    def pd(self):
+        return self.pd
+    @pd.setter
+    def pd(self, PD val):
+        self.pd = val
+        self.attr.pd = <v.ibv_pd*>val.pd
+
+    @property
+    def cq(self):
+        return self.cq
+    @cq.setter
+    def cq(self, CQ val):
+        self.cq = val
+        self.attr.cq = <v.ibv_cq*>val.cq
+
+
+cdef class WQAttr(PyverbsObject):
+    def __init__(self, attr_mask=0, wq_state=0, curr_wq_state=0, flags=0, flags_mask=0):
+        """
+        Initializes a WQAttr object which represents ibv_wq_attr struct. It
+        can be used to modify a WQ.
+        :param attr_mask: Identifies valid fields
+        :param wq_state: Desired WQ state
+        :param curr_wq_state: Current WQ state
+        :param flags: Flags values to modify
+        :param flags_mask: Which flags to modify
+        :return: An initialized WQAttr object
+        """
+        super().__init__()
+        self.attr.attr_mask = attr_mask
+        self.attr.wq_state = wq_state
+        self.attr.curr_wq_state = curr_wq_state
+        self.attr.flags = flags
+        self.attr.flags_mask = flags_mask
+
+    @property
+    def wq_state(self):
+        return self.attr.wq_state
+    @wq_state.setter
+    def wq_state(self, val):
+        self.attr.wq_state = val
+
+    @property
+    def attr_mask(self):
+        return self.attr.attr_mask
+    @attr_mask.setter
+    def attr_mask(self, val):
+        self.attr.attr_mask = val
+
+    @property
+    def curr_wq_state(self):
+        return self.attr.curr_wq_state
+    @curr_wq_state.setter
+    def curr_wq_state(self, val):
+        self.attr.curr_wq_state = val
+
+    @property
+    def flags(self):
+        return self.attr.flags
+    @flags.setter
+    def flags(self, val):
+        self.attr.flags = val
+
+    @property
+    def flags_mask(self):
+        return self.attr.flags_mask
+    @flags_mask.setter
+    def flags_mask(self, val):
+        self.attr.flags_mask = val
+
+
+cdef class WQ(PyverbsCM):
+    def __init__(self, Context ctx, WQInitAttr attr):
+        """
+        Creates a WQ object.
+        :param ctx: The context the wq will be associated with.
+        :param attr: WQ initial attributes of type WQInitAttr.
+        :return: A WQ object
+        """
+        super().__init__()
+        self.wq = v.ibv_create_wq(ctx.context, &attr.attr)
+        if self.wq == NULL:
+            raise PyverbsRDMAErrno('Failed to create WQ')
+        self.context = ctx
+        ctx.add_ref(self)
+        pd = <PD>attr.pd
+        pd.add_ref(self)
+        self.pd = pd
+        cq = <CQ>attr.cq
+        cq.add_ref(self)
+        self.cq = cq
+
+    def modify(self, WQAttr wq_attr not None):
+        """
+        Modify the WQ
+        :param qp_attr: A WQAttr object with updated values to be applied to
+                        the WQ
+        :return: None
+        """
+        rc = v.ibv_modify_wq(self.wq, &wq_attr.attr)
+        if rc != 0:
+            raise PyverbsRDMAError('Failed to modify WQ', rc)
+
+    def post_recv(self, RecvWR wr not None, RecvWR bad_wr=None):
+        """
+        Post a receive WR on the WQ.
+        :param wr: The work request to post
+        :param bad_wr: A RecvWR object to hold the bad WR if it is available in
+                       case of a failure
+        :return: None
+        """
+        cdef v.ibv_recv_wr *my_bad_wr
+        # In order to provide a pointer to a pointer, use a temporary cdef'ed
+        # variable.
+        rc = v.ibv_post_wq_recv(self.wq, &wr.recv_wr, &my_bad_wr)
+        if rc != 0:
+            if (bad_wr):
+                memcpy(&bad_wr.recv_wr, my_bad_wr, sizeof(bad_wr.recv_wr))
+            raise PyverbsRDMAError('Failed to post recv', rc)
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        """
+        Closes the underlying C object of the WQ.
+        :return: None
+        """
+        if self.wq != NULL:
+            self.logger.debug('Closing WQ')
+            rc = v.ibv_destroy_wq(self.wq)
+            if rc != 0:
+                raise PyverbsRDMAError('Failed to dealloc WQ', rc)
+            self.wq = NULL
+            self.context = None
+            self.pd = None
+            self.cq = None
+
+    @property
+    def wqn(self):
+        return self.wq.wq_num

--- a/pyverbs/xrcd.pyx
+++ b/pyverbs/xrcd.pyx
@@ -74,7 +74,8 @@ cdef class XRCD(PyverbsCM):
         # so during destruction, need to check whether or not the C object
         # exists.
         if self.xrcd != NULL:
-            self.logger.debug('Closing XRCD')
+            if self.logger:
+                self.logger.debug('Closing XRCD')
             close_weakrefs([self.qps, self.srqs])
             rc = v.ibv_close_xrcd(self.xrcd)
             if rc != 0:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,6 +48,7 @@ rdma_python_test(tests
   test_qpex.py
   test_rdmacm.py
   test_relaxed_ordering.py
+  test_rss_traffic.py
   test_shared_pd.py
   utils.py
   )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -50,6 +50,7 @@ rdma_python_test(tests
   test_relaxed_ordering.py
   test_rss_traffic.py
   test_shared_pd.py
+  test_tag_matching.py
   utils.py
   )
 

--- a/tests/base.py
+++ b/tests/base.py
@@ -522,9 +522,9 @@ class TrafficResources(BaseResources):
         :return: None
         """
         self.port_attr = self.ctx.query_port(self.ib_port)
+        self.create_cq()
         if self.with_srq:
             self.create_srq()
-        self.create_cq()
         self.create_mr()
         self.create_qps()
 

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -37,6 +37,7 @@ class DevxOps:
     MLX5_CMD_OP_ALLOC_FLOW_COUNTER = 0x939
     MLX5_CMD_OP_DEALLOC_FLOW_COUNTER = 0x93a
     MLX5_CMD_OP_QUERY_FLOW_COUNTER = 0x93b
+    MLX5_CMD_OP_CREATE_TIR = 0x900
 
 
 # Common
@@ -1336,4 +1337,72 @@ class QueryFlowCounterOut(Packet):
         IntField('syndrome', 0),
         StrFixedLenField('reserved2', None, length=8),
         PacketField('flow_statistics', TrafficCounter(), TrafficCounter),
+    ]
+
+
+class RxHashFieldSelect(Packet):
+    fields_desc = [
+        BitField('l3_prot_type', 0, 1),
+        BitField('l4_prot_type', 0, 1),
+        BitField('selected_fields', 0, 30),
+    ]
+
+
+class Tirc(Packet):
+    fields_desc = [
+        StrFixedLenField('reserved1', None, length=4),
+        BitField('disp_type', 0, 4),
+        BitField('tls_en', 0, 1),
+        BitField('nvmeotcp_zerocopy_en', 0, 1),
+        BitField('nvmeotcp_crc_en', 0, 1),
+        BitField('reserved2', 0, 25),
+        StrFixedLenField('reserved3', None, length=8),
+        BitField('reserved4', 0, 4),
+        BitField('lro_timeout_period_usecs', 0, 16),
+        BitField('lro_enable_mask', 0, 4),
+        ByteField('lro_max_msg_sz', 0),
+        ByteField('reserved5', 0),
+        BitField('afu_id', 0, 24),
+        BitField('inline_rqn_vhca_id_valid', 0, 1),
+        BitField('reserved6', 0, 15),
+        ShortField('inline_rqn_vhca_id', 0),
+        BitField('reserved7', 0, 5),
+        BitField('inline_q_type', 0, 3),
+        BitField('inline_rqn', 0, 24),
+        BitField('rx_hash_symmetric', 0, 1),
+        BitField('reserved8', 0, 1),
+        BitField('tunneled_offload_en', 0, 1),
+        BitField('reserved9', 0, 5),
+        BitField('indirect_table', 0, 24),
+        BitField('rx_hash_fn', 0, 4),
+        BitField('reserved10', 0, 2),
+        BitField('self_lb_en', 0, 2),
+        BitField('transport_domain', 0, 24),
+        FieldListField('rx_hash_toeplitz_key', [0 for x in range(10)], IntField('', 0), count_from=lambda pkt:10),
+        PacketField('rx_hash_field_selector_outer', RxHashFieldSelect(), RxHashFieldSelect),
+        PacketField('rx_hash_field_selector_inner', RxHashFieldSelect(), RxHashFieldSelect),
+        IntField('nvmeotcp_tag_buffer_table_id', 0),
+        StrFixedLenField('reserved11', None, length=148),
+    ]
+
+
+class CreateTirIn(Packet):
+    fields_desc = [
+        ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_TIR),
+        ShortField('uid', 0),
+        ShortField('reserved1', 0),
+        ShortField('op_mod', 0),
+        StrFixedLenField('reserved2', None, length=24),
+        PacketField('tir_context', Tirc(), Tirc),
+    ]
+
+
+class CreateTirOut(Packet):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('icm_address_63_40', 0, 24),
+        IntField('syndrome', 0),
+        ByteField('icm_address_39_32', 0),
+        BitField('tirn', 0, 24),
+        IntField('icm_address_31_0', 0),
     ]

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -80,12 +80,15 @@ class FlowRes(RawResources):
         for spec in specs:
             flow_attr.specs.append(spec)
         try:
-            flow = Flow(self.qp, flow_attr)
+            flow = self._create_flow(flow_attr)
         except PyverbsRDMAError as ex:
             if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Flow creation is not supported')
             raise ex
         return flow
+
+    def _create_flow(self, flow_attr):
+        return Flow(self.qp, flow_attr)
 
 
 class FlowTest(RDMATestCase):

--- a/tests/test_rss_traffic.py
+++ b/tests/test_rss_traffic.py
@@ -1,0 +1,148 @@
+import unittest
+import random
+import errno
+
+from pyverbs.wq import WQInitAttr, WQAttr, WQ, RwqIndTableInitAttr, RwqIndTable, RxHashConf
+from tests.utils import requires_root_on_eth, PacketConsts
+from tests.base import RDMATestCase, PyverbsRDMAError, MLNX_VENDOR_ID, \
+    CX3_MLNX_PART_ID, CX3Pro_MLNX_PART_ID
+from pyverbs.qp import QPInitAttrEx, QPEx
+from tests.test_flow import FlowRes
+from pyverbs.flow import Flow
+from pyverbs.cq import CQ
+import pyverbs.enums as e
+import tests.utils as u
+
+
+WRS_PER_ROUND = 512
+CQS_NUM = 2
+TOEPLITZ_KEY_LEN = 40
+HASH_KEY = [0x2c, 0xc6, 0x81, 0xd1, 0x5b, 0xdb, 0xf4, 0xf7,
+            0xfc, 0xa2, 0x83, 0x19, 0xdb, 0x1a, 0x3e, 0x94,
+            0x6b, 0x9e, 0x38, 0xd9, 0x2c, 0x9c, 0x03, 0xd1,
+            0xad, 0x99, 0x44, 0xa7, 0xd9, 0x56, 0x3d, 0x59,
+            0x06, 0x3c, 0x25, 0xf3, 0xfc, 0x1f, 0xdc, 0x2a]
+
+
+def requires_indirection_table_support(func):
+    def wrapper(instance):
+        dev_attrs = instance.ctx.query_device()
+        vendor_id = dev_attrs.vendor_id
+        vendor_pid = dev_attrs.vendor_part_id
+        if vendor_id == MLNX_VENDOR_ID and vendor_pid in [CX3_MLNX_PART_ID,
+                                                          CX3Pro_MLNX_PART_ID]:
+            raise unittest.SkipTest('WQN must be aligned with the Indirection Table size in CX3')
+        return func(instance)
+    return wrapper
+
+
+class RssRes(FlowRes):
+    def __init__(self, dev_name, ib_port, gid_index, log_ind_tbl_size=3):
+        """
+        Initialize rss resources based on Flow resources that include RSS Raw QP.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        """
+        self.log_ind_tbl_size = log_ind_tbl_size
+        self.wqs = []
+        self.cqs = []
+        self.ind_table = None
+        super().__init__(dev_name=dev_name, ib_port=ib_port,
+                         gid_index=gid_index)
+
+    def create_cq(self):
+        self.cqs = [CQ(self.ctx, WRS_PER_ROUND) for _ in range(CQS_NUM)]
+
+    @requires_root_on_eth()
+    def create_qps(self):
+        """
+        Initializes self.qps with RSS QPs.
+        :return: None
+        """
+        qp_init_attr = self.create_qp_init_attr()
+        for _ in range(self.qp_count):
+            try:
+                qp = QPEx(self.ctx, qp_init_attr)
+                self.qps.append(qp)
+                self.qps_num.append(qp.qp_num)
+                self.psns.append(random.getrandbits(24))
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest(f'Create QPEx type {qp_init_attr.qp_type} is not '
+                                            'supported')
+                raise ex
+
+    def create_qp_init_attr(self):
+        self.create_ind_table()
+        mask = e.IBV_QP_INIT_ATTR_CREATE_FLAGS | e.IBV_QP_INIT_ATTR_PD | \
+                    e.IBV_QP_INIT_ATTR_RX_HASH | e.IBV_QP_INIT_ATTR_IND_TABLE
+        return QPInitAttrEx(qp_type=e.IBV_QPT_RAW_PACKET, comp_mask=mask, pd=self.pd,
+                            hash_conf=self.hash_conf, ind_table=self.ind_tbl)
+
+    @requires_indirection_table_support
+    def create_ind_table(self):
+        self.ind_tbl = RwqIndTable(self.ctx, self.initiate_table_attr())
+        self.hash_conf = self.init_rx_hash_config()
+
+    def initiate_table_attr(self):
+        self.create_wqs()
+        return RwqIndTableInitAttr(self.log_ind_tbl_size, self.wqs)
+
+    def create_wqs(self):
+        wqias = [self.initiate_wq_attr(cq) for cq in self.cqs]
+        for i in range(1 << self.log_ind_tbl_size):
+            wq = WQ(self.ctx, wqias[i % CQS_NUM])
+            wq.modify(WQAttr(attr_mask=e.IBV_WQ_ATTR_STATE, wq_state=e.IBV_WQS_RDY))
+            self.wqs.append(wq)
+        return self.wqs
+
+    def initiate_wq_attr(self, cq):
+        return WQInitAttr(wq_context=None, wq_pd=self.pd, wq_cq=cq, wq_type=e.IBV_WQT_RQ,
+                          max_wr=WRS_PER_ROUND, max_sge=self.ctx.query_device().max_sge,
+                          comp_mask=0, create_flags=0)
+
+    def init_rx_hash_config(self):
+        return RxHashConf(rx_hash_function=e.IBV_RX_HASH_FUNC_TOEPLITZ,
+                          rx_hash_key_len=len(HASH_KEY),
+                          rx_hash_key=HASH_KEY,
+                          rx_hash_fields_mask=e.IBV_RX_HASH_DST_IPV4 | e.IBV_RX_HASH_SRC_IPV4)
+
+    def _create_flow(self, flow_attr):
+        return [Flow(qp, flow_attr) for qp in self.qps]
+
+
+class RSSTrafficTest(RDMATestCase):
+    """
+    Test various functionalities of the RSS QPs.
+    """
+    def setUp(self):
+        super().setUp()
+        self.iters = 1
+        self.server = None
+        self.client = None
+
+    def create_players(self):
+        """
+        Init RSS tests resources.
+        RSS-QP can recive traffic only, so client will be based on Flow tests resources.
+        """
+        self.client = FlowRes(**self.dev_info)
+        self.server = RssRes(**self.dev_info)
+
+    def flow_traffic(self, specs, l3=PacketConsts.IP_V4,
+                     l4=PacketConsts.UDP_PROTO):
+        """
+        Execute raw ethernet traffic with given specs flow.
+        :param specs: List of flow specs to match on the QP
+        :param l3: Packet layer 3 type: 4 for IPv4 or 6 for IPv6
+        :param l4: Packet layer 4 type: 'tcp' or 'udp'
+        :return: None
+        """
+        self.flows = self.server.create_flow(specs)
+        u.raw_rss_traffic(self.client, self.server, self.iters, l3, l4,
+                          num_packets=32)
+
+    def test_rss_traffic(self):
+        self.create_players()
+        self.flow_traffic([self.server.create_eth_spec()])

--- a/tests/test_tag_matching.py
+++ b/tests/test_tag_matching.py
@@ -1,0 +1,327 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2022 Nvidia, Inc. All rights reserved. See COPYING file
+
+import unittest
+import errno
+import time
+
+from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
+from pyverbs.cq import CqInitAttrEx, PollCqAttr, CQEX
+from pyverbs.srq import SrqInitAttrEx, OpsWr, SRQ
+from tests.base import RDMATestCase, RCResources
+from pyverbs.wr import SGE, RecvWR, SendWR
+from pyverbs.base import PyverbsRDMAErrno
+from pyverbs.qp import QPAttr, QPCap
+from pyverbs.mr import MR
+import pyverbs.enums as e
+import tests.utils as u
+
+TAG_MASK = 0xffff
+TMH_SIZE = 16
+SYNC_WRID = 27
+HW_LIMITAION = 33
+FIXED_SEND_TAG = 0x1234
+# Tag matching header lengths and offsets
+TM_OPCODE_OFFSET = 0
+TM_OPCODE_LENGTH = 1
+TM_TAG_OFFSET = 8
+TM_TAG_LENGTH = 8
+RNDV_VA_OFFSET = 0x10
+RNDV_VA_LENGTH = 8
+RNDV_RKEY_OFFSET = 0x18
+RNDV_RKEY_LENGTH = 4
+RNDV_LEN_OFFSET = 0x1c
+RNDV_LEN_LENGTH = 4
+
+
+def write_tm_header(mr, tag, tm_opcode):
+    """
+    Build a tag matching header, the header is written on the base address of the given mr.
+    """
+    mr.write(int(tm_opcode).to_bytes(1, byteorder='big'), TM_OPCODE_LENGTH, TM_OPCODE_OFFSET)
+    mr.write(int(tag).to_bytes(8, byteorder='big'), TM_TAG_LENGTH, TM_TAG_OFFSET)
+
+
+def write_rndvu_header(player, mr, tag, tm_opcode):
+    """
+    Build a tag matching header + rendezvous header
+    """
+    write_tm_header(mr=mr, tag=tag, tm_opcode=tm_opcode)
+    mr.write(int(player.mr.buf).to_bytes(8, byteorder='big'),
+             RNDV_VA_LENGTH, RNDV_VA_OFFSET)
+    mr.write(int(player.mr.rkey).to_bytes(4, byteorder='big'),
+             RNDV_RKEY_LENGTH, RNDV_RKEY_OFFSET)
+    mr.write(int(player.msg_size).to_bytes(4, byteorder='big'),
+             RNDV_LEN_LENGTH, RNDV_LEN_OFFSET)
+
+
+class TMResources(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index, qp_count=1, with_srq=True):
+        self.unexp_cnt = 0
+        super().__init__(dev_name=dev_name, ib_port=ib_port,
+                         gid_index=gid_index, with_srq=with_srq,
+                         qp_count=qp_count)
+        if not self.ctx.query_device_ex().tm_caps.flags & e.IBV_TM_CAP_RC:
+            raise unittest.SkipTest("Tag matching is not supported")
+
+    def create_srq(self):
+        srq_attr = SrqInitAttrEx()
+        srq_attr.comp_mask = e.IBV_SRQ_INIT_ATTR_TYPE | e.IBV_SRQ_INIT_ATTR_PD | \
+                             e.IBV_SRQ_INIT_ATTR_CQ | e.IBV_SRQ_INIT_ATTR_TM
+        srq_attr.srq_type = e.IBV_SRQT_TM
+        srq_attr.pd = self.pd
+        srq_attr.cq = self.cq
+        srq_attr.max_num_tags = self.ctx.query_device_ex().tm_caps.max_num_tags
+        srq_attr.max_ops = 10
+        self.srq = SRQ(self.ctx, srq_attr)
+
+    def create_cq(self):
+        cq_init_attr = CqInitAttrEx(wc_flags=e.IBV_WC_EX_WITH_TM_INFO | e.IBV_WC_STANDARD_FLAGS)
+        try:
+            self.cq = CQEX(self.ctx, cq_init_attr)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Extended CQ is not supported')
+            raise ex
+
+    def create_qp_cap(self):
+        return QPCap(max_send_wr=0, max_send_sge=0, max_recv_wr=0, max_recv_sge=0) if self.with_srq \
+            else QPCap(max_send_wr=4, max_send_sge=1, max_recv_wr=self.num_msgs, max_recv_sge=4)
+
+    def create_qp_attr(self):
+        qp_attr = QPAttr(port_num=self.ib_port)
+        qp_attr.qp_access_flags = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_READ | \
+                                  e.IBV_ACCESS_REMOTE_WRITE
+        return qp_attr
+
+    def create_mr(self):
+        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_READ | e.IBV_ACCESS_REMOTE_WRITE
+        self.mr = MR(self.pd, self.msg_size, access=access)
+
+
+class TMTest(RDMATestCase):
+    """
+    Test various functionalities of tag matching.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.server = None
+        self.client = None
+        self.iters = 10
+        self.curr_unexpected_cnt = 1
+        self.create_players(TMResources)
+        self.prepare_to_traffic()
+
+    def create_players(self, resource):
+        self.client = resource(**self.dev_info, with_srq=False)
+        self.server = resource(**self.dev_info)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+
+    def prepare_to_traffic(self):
+        """
+        Prepare the TM SRQ for tag matching traffic by posing 33
+        (hardware limitation) recv WR for fill his queue
+        """
+        for _ in range(self.server.qp_count):
+            u.post_recv(self.client, u.get_recv_wr(self.client), num_wqes=HW_LIMITAION)
+            u.post_recv(self.server, u.get_recv_wr(self.server), num_wqes=HW_LIMITAION)
+
+    def get_send_elements(self, tag=0, tm_opcode=e.IBV_TMH_EAGER, tm=True):
+        """
+        Creates a single SGE and a single Send WR for client QP. The content
+        of the message is 'c' for client side. The function also generates TMH
+        and RVH to the msg
+        :return: Send wr and expected msg that is read from mr
+        """
+        sge = SGE(self.client.mr.buf, self.client.msg_size, self.client.mr_lkey)
+        if tm_opcode == e.IBV_TMH_RNDV:
+            max_rndv_hdr_size = self.server.ctx.query_device_ex().tm_caps.max_rndv_hdr_size
+            sge.length = max_rndv_hdr_size if max_rndv_hdr_size <= self.server.mr.length else \
+                self.server.mr.length
+            write_rndvu_header(player=self.client, mr=self.client.mr, tag=tag, tm_opcode=tm_opcode)
+            c_recv_wr = RecvWR(wr_id=tag, sg=[sge], num_sge=1)
+            # Need to post_recv client because the server sends rdma-read request to client
+            u.post_recv(self.client, c_recv_wr)
+        else:
+            msg = self.client.msg_size * 'c'
+            self.client.mr.write(msg, self.client.msg_size)
+            if tm:
+                write_tm_header(mr=self.client.mr, tag=tag, tm_opcode=tm_opcode)
+
+        send_wr = SendWR(opcode=e.IBV_WR_SEND, num_sge=1, sg=[sge])
+        exp_msg = self.client.mr.read(self.client.msg_size, 0)
+        return send_wr, exp_msg
+
+    def get_exp_wc_flags(self, tm_opcode=e.IBV_TMH_EAGER, fixed_send_tag=None):
+        if tm_opcode == e.IBV_TMH_RNDV:
+            return e.IBV_WC_TM_MATCH
+        return 0 if fixed_send_tag else e.IBV_WC_TM_MATCH | e.IBV_WC_TM_DATA_VALID
+
+    def get_exp_params(self, fixed_send_tag=None, send_tag=0, tm_opcode=e.IBV_TMH_EAGER):
+        wc_flags = self.get_exp_wc_flags(tm_opcode=tm_opcode, fixed_send_tag=fixed_send_tag)
+        return (fixed_send_tag, 0, 0, wc_flags) if fixed_send_tag else \
+            (send_tag, send_tag, send_tag, wc_flags)
+
+    def validate_msg(self, actual_msg, expected_msg, msg_size):
+        if actual_msg[0:msg_size] != expected_msg[0:msg_size]:
+            raise PyverbsError(f'Data validation failure: expected {expected_msg}, '
+                               f'received {actual_msg}')
+
+    def verify_cqe(self, actual_cqe, wr_id=0, opcode=None, wc_flags=0, tag=0, is_server=True):
+        expected_cqe = {'wr_id': wr_id, 'opcode': opcode, 'wc_flags': wc_flags}
+        if is_server:
+            expected_cqe['tag'] = tag
+        for key in expected_cqe:
+            if expected_cqe[key] != actual_cqe[key]:
+                raise PyverbsError(f'CQE validation failure: {key} expected value: '
+                                   f'{expected_cqe[key]}, received {actual_cqe[key]}')
+
+    def validate_exp_recv_params(self, exp_parm, recv_parm, descriptor):
+        if exp_parm != recv_parm:
+            raise PyverbsError(f'{descriptor} validation failure: expected value {exp_parm}, '
+                               f'received {recv_parm}')
+
+    def poll_cq_ex(self, cqex, is_server=True, to_valid=True):
+        start = time.perf_counter()
+        poll_attr = PollCqAttr()
+        ret = cqex.start_poll(poll_attr)
+        while ret == 2 and (time.perf_counter() - start < u.POLL_CQ_TIMEOUT):
+            ret = cqex.start_poll(poll_attr)
+        if ret != 0:
+            raise PyverbsRDMAErrno('Failed to poll CQ - got a timeout')
+        if cqex.status != e.IBV_WC_SUCCESS:
+            raise PyverbsError(f'Completion status is {cqex.status}')
+        actual_cqe_dict = {}
+        if to_valid:
+            recv_flags = cqex.read_wc_flags()
+            recv_opcode = cqex.read_opcode()
+            actual_cqe_dict = {'wr_id': cqex.wr_id, 'opcode': cqex.read_opcode(),
+                               'wc_flags': cqex.read_wc_flags()}
+            if is_server:
+                actual_cqe_dict['tag'] = cqex.read_tm_info().tag
+            if recv_opcode == e.IBV_WC_TM_RECV and not \
+                    (recv_flags & (e.IBV_WC_TM_MATCH | e.IBV_WC_TM_DATA_VALID)):
+                # In case of receiving unexpected tag, HW doesn't return such wc_flags
+                # updadte unexpected count and sync is required.
+                self.server.unexp_cnt += 1
+                cqex.end_poll()
+                self.post_sync()
+                return actual_cqe_dict
+            if recv_opcode == e.IBV_WC_TM_ADD and (recv_flags & e.IBV_WC_TM_SYNC_REQ):
+                # These completion is complemented by the IBV_WC_TM_SYNC_REQ flag,
+                # which indicates whether further HW synchronization is needed.
+                cqex.end_poll()
+                self.post_sync()
+                return actual_cqe_dict
+
+        cqex.end_poll()
+        return actual_cqe_dict
+
+    def post_sync(self, wr_id=SYNC_WRID):
+        """
+        Whenever HW deems a message unexpected, tag matching must be disabled
+        for new tags until SW and HW synchronize. This synchronization is
+        achieved by reporting to HW the number of unexpected messages handled by
+        SW (with respect to the current posted tags). When the SW and HW are in
+        sync, tag matching resumes normally.
+        """
+        wr = OpsWr(wr_id=wr_id, opcode=e.IBV_WR_TAG_SYNC, unexpected_cnt=self.server.unexp_cnt,
+                   recv_wr_id=wr_id, flags=e.IBV_OPS_SIGNALED | e.IBV_OPS_TM_SYNC)
+        self.server.srq.post_srq_ops(wr)
+        actual_cqe = self.poll_cq_ex(cqex=self.server.cq)
+        self.verify_cqe(actual_cqe=actual_cqe, wr_id=SYNC_WRID, opcode=e.IBV_WC_TM_SYNC)
+
+    def post_recv_tm(self, tag, wrid):
+        """
+        Create opswr according to user chooce of wr_id and a tag
+        and post recv it with the srq and the special func
+        post_srq_ops that posted opswr wqe.
+        :return: The opswr'
+        """
+        recv_sge = SGE(self.server.mr.buf, self.server.msg_size, self.server.mr.lkey)
+        wr = OpsWr(wr_id=wrid, unexpected_cnt=self.server.unexp_cnt, recv_wr_id=wrid, num_sge=1,
+                   tag=tag, mask=TAG_MASK, sg_list=[recv_sge])
+        self.server.srq.post_srq_ops(wr)
+        return wr
+
+    def build_expected_and_recv_msgs(self, exp_msg, tm_opcode=e.IBV_TMH_EAGER, fixed_send_tag=None):
+        no_tag = tm_opcode == e.IBV_TMH_RNDV or fixed_send_tag
+        actual_msg = self.server.mr.read(self.server.msg_size, 0)
+        return (actual_msg, exp_msg, self.client.msg_size) if no_tag else \
+            (actual_msg.decode(), (self.client.msg_size - TMH_SIZE) * 'c',
+             self.client.msg_size - TMH_SIZE)
+
+    def tm_traffic(self, tm_opcode=e.IBV_TMH_EAGER, fixed_send_tag=None):
+        """
+        Runs Tag matching traffic between two sides (server and client)
+        :param tm_opcode: The TM opcode in the send WR
+        :param fixed_send_tag: If not None complitions are expected to be with no tag
+        """
+        tags_list = list(range(1, self.iters))
+        for recv_tag in tags_list:
+            self.post_recv_tm(tag=recv_tag, wrid=recv_tag)
+            actual_cqe = self.poll_cq_ex(cqex=self.server.cq)
+            self.verify_cqe(actual_cqe=actual_cqe, wr_id=recv_tag, opcode=e.IBV_WC_TM_ADD)
+        tags_list.reverse()
+        for send_tag in tags_list:
+            send_tag, tag_exp, wrid_exp, wc_flags = self.get_exp_params(
+                fixed_send_tag=fixed_send_tag, send_tag=send_tag, tm_opcode=tm_opcode)
+            send_wr, exp_msg = self.get_send_elements(tag=send_tag, tm_opcode=tm_opcode)
+            u.send(self.client, send_wr)
+            self.poll_cq_ex(cqex=self.client.cq, to_valid=False)
+            actual_cqe = self.poll_cq_ex(cqex=self.server.cq)
+            exp_recv_tm_opcode = e.IBV_WC_TM_NO_TAG if tm_opcode == e.IBV_TMH_NO_TAG else \
+                e.IBV_WC_TM_RECV
+            self.verify_cqe(actual_cqe=actual_cqe, wr_id=wrid_exp, opcode=exp_recv_tm_opcode,
+                            wc_flags=wc_flags, tag=tag_exp)
+            if tm_opcode == e.IBV_TMH_RNDV:
+                actual_cqe = self.poll_cq_ex(cqex=self.client.cq)
+                self.verify_cqe(actual_cqe=actual_cqe, opcode=e.IBV_WC_RECV, is_server=False)
+                actual_cqe = self.poll_cq_ex(cqex=self.server.cq)
+                self.verify_cqe(actual_cqe=actual_cqe, wr_id=wrid_exp, opcode=e.IBV_WC_TM_RECV,
+                                wc_flags=e.IBV_WC_TM_DATA_VALID)
+            actual_msg, exp_msg, msg_size = self.build_expected_and_recv_msgs \
+                (exp_msg=exp_msg, tm_opcode=tm_opcode, fixed_send_tag=fixed_send_tag)
+            self.validate_msg(actual_msg, exp_msg, msg_size)
+            if fixed_send_tag and tm_opcode != e.IBV_TMH_NO_TAG:
+                self.validate_exp_recv_params(exp_parm=self.curr_unexpected_cnt,
+                                              recv_parm=self.server.unexp_cnt,
+                                              descriptor='unexpected_count')
+                self.curr_unexpected_cnt += 1
+            u.post_recv(self.server, u.get_recv_wr(self.server))
+
+    def test_tm_traffic(self):
+        """
+        Test basic Tag Matching traffic, client sends tagged WRs server receives
+        and validates it.
+        """
+        self.tm_traffic()
+
+    def test_tm_unexpected_tag(self):
+        """
+        Test unexpected Tag Matching traffic, client sends unexpected tagged WRs,
+        server receives and validates it,
+        completions are expected to be with no tag,
+        and unexpected_count field of the server TM-SRQ expected to be increased.
+        """
+        self.tm_traffic(fixed_send_tag=FIXED_SEND_TAG)
+
+    def test_tm_no_tag(self):
+        """
+        Test no_tag Tag Matching traffic,
+        client sends WRs with tag and with opcode NO_TAG,
+        server receives and validates it,
+        completions are expected to be with no tag.
+        """
+        self.tm_traffic(tm_opcode=e.IBV_TMH_NO_TAG, fixed_send_tag=FIXED_SEND_TAG)
+
+    def test_tm_rndv(self):
+        """
+        Test rendezvous Tag Matching traffic,
+        client sends WRs with tag and with opcode RNDV,
+        server receives and validates it,
+        2 completions are expected to be received for every WRs.
+        """
+        self.tm_traffic(tm_opcode=e.IBV_TMH_RNDV)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -21,7 +21,7 @@ from pyverbs.addr import AHAttr, AH, GlobalRoute
 from tests.base import XRCResources, DCT_KEY
 from tests.efa_base import SRDResources
 from pyverbs.wr import SGE, SendWR, RecvWR
-from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx, QPAttr, QPEx
+from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx, QPAttr, QPEx, QP
 from tests.mlx5_base import Mlx5DcResources, Mlx5DcStreamsRes
 from pyverbs.base import PyverbsRDMAErrno
 from pyverbs.cq import PollCqAttr, CQEX
@@ -405,7 +405,7 @@ def get_recv_wr(agr_obj):
     :return: recv wr
     """
     qp_type = agr_obj.rqp_lst[0].qp_type if isinstance(agr_obj, XRCResources) \
-                else agr_obj.qp.qp_type
+        else agr_obj.qp.qp_type if isinstance(agr_obj.qp, QP) else None
     mr = agr_obj.mr
     length = agr_obj.msg_size + GRH_SIZE if qp_type == e.IBV_QPT_UD \
              else agr_obj.msg_size


### PR DESCRIPTION
Extend the current mlx5 DR steering tests with new actions such as TIR and packet reformat actions.
In addition, more new tests are added, such as RSS traffic and Tag Matching.
The series includes some improvements required by the newly added tests or made for external Pyverbs usage support.