### PR TITLE
libibverbs: Check for valid completion channel before arming CQ

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2873,6 +2873,9 @@ static inline int ibv_poll_cq(struct ibv_cq *cq, int num_entries, struct ibv_wc 
  */
 static inline int ibv_req_notify_cq(struct ibv_cq *cq, int solicited_only)
 {
+	if (!cq->channel)
+		return EINVAL;
+
 	return cq->context->ops.req_notify_cq(cq, solicited_only);
 }
 


### PR DESCRIPTION
Check for valid completion channel before arming the CQ.

Fixes: 91fc39561d04 ("Commit libibverbs code from roland-uverbs branch back onto trunk")

Signed-off-by: Sindhu Devale <sindhu.devale@intel.com>
Signed-off-by: Tatyana Nikolova <tatyana.e.nikolova@intel.com>