### PR TITLE
mlx5: Extend vfio to support async events and CQ interrupt mode

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -151,6 +151,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_dr_aso_other_domain_link@MLX5_1.22 38
  mlx5dv_dr_aso_other_domain_unlink@MLX5_1.22 38
  mlx5dv_devx_alloc_msi_vector@MLX5_1.23 40
+ mlx5dv_devx_create_eq@MLX5_1.23 40
+ mlx5dv_devx_destroy_eq@MLX5_1.23 40
  mlx5dv_devx_free_msi_vector@MLX5_1.23 40
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -30,6 +30,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.20@MLX5_1.20 36
  MLX5_1.21@MLX5_1.21 37
  MLX5_1.22@MLX5_1.22 38
+ MLX5_1.23@MLX5_1.23 40
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -149,6 +150,8 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_vfio_process_events@MLX5_1.21 37
  mlx5dv_dr_aso_other_domain_link@MLX5_1.22 38
  mlx5dv_dr_aso_other_domain_unlink@MLX5_1.22 38
+ mlx5dv_devx_alloc_msi_vector@MLX5_1.23 40
+ mlx5dv_devx_free_msi_vector@MLX5_1.23 40
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.22.${PACKAGE_VERSION}
+  1 1.23.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -211,3 +211,9 @@ MLX5_1.22 {
 		mlx5dv_dr_aso_other_domain_link;
 		mlx5dv_dr_aso_other_domain_unlink;
 } MLX5_1.21;
+
+MLX5_1.23 {
+	global:
+		mlx5dv_devx_alloc_msi_vector;
+		mlx5dv_devx_free_msi_vector;
+} MLX5_1.22;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -215,5 +215,7 @@ MLX5_1.22 {
 MLX5_1.23 {
 	global:
 		mlx5dv_devx_alloc_msi_vector;
+		mlx5dv_devx_create_eq;
+		mlx5dv_devx_destroy_eq;
 		mlx5dv_devx_free_msi_vector;
 } MLX5_1.22;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -11,6 +11,7 @@ rdma_man_pages(
   mlx5dv_crypto_login.3.md
   mlx5dv_dci_stream_id_reset.3.md
   mlx5dv_dek_create.3.md
+  mlx5dv_devx_alloc_msi_vector.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_create_cmd_comp.3.md
   mlx5dv_devx_create_event_channel.3.md
@@ -57,6 +58,7 @@ rdma_alias_man_pages(
  mlx5dv_crypto_login.3 mlx5dv_crypto_logout.3
  mlx5dv_dek_create.3 mlx5dv_dek_query.3
  mlx5dv_dek_create.3 mlx5dv_dek_destroy.3
+ mlx5dv_devx_alloc_msi_vector.3 mlx5dv_devx_free_msi_vector.3
  mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_destroy_cmd_comp.3
  mlx5dv_devx_create_event_channel.3 mlx5dv_devx_destroy_event_channel.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -14,6 +14,7 @@ rdma_man_pages(
   mlx5dv_devx_alloc_msi_vector.3.md
   mlx5dv_devx_alloc_uar.3.md
   mlx5dv_devx_create_cmd_comp.3.md
+  mlx5dv_devx_create_eq.3.md
   mlx5dv_devx_create_event_channel.3.md
   mlx5dv_devx_get_event.3.md
   mlx5dv_devx_obj_create.3.md
@@ -61,6 +62,7 @@ rdma_alias_man_pages(
  mlx5dv_devx_alloc_msi_vector.3 mlx5dv_devx_free_msi_vector.3
  mlx5dv_devx_alloc_uar.3 mlx5dv_devx_free_uar.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_destroy_cmd_comp.3
+ mlx5dv_devx_create_eq.3 mlx5dv_devx_destroy_eq.3
  mlx5dv_devx_create_event_channel.3 mlx5dv_devx_destroy_event_channel.3
  mlx5dv_devx_create_cmd_comp.3 mlx5dv_devx_get_async_cmd_comp.3
  mlx5dv_devx_obj_create.3 mlx5dv_devx_general_cmd.3

--- a/providers/mlx5/man/mlx5dv_devx_alloc_msi_vector.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_alloc_msi_vector.3.md
@@ -1,0 +1,68 @@
+---
+date: 2022-01-12
+footer: mlx5
+header: "mlx5 Programmer's Manual"
+tagline: Verbs
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: mlx5dv_devx_alloc_msi_vector
+---
+
+# NAME
+
+mlx5dv_devx_alloc_msi_vector - Allocate an msi vector to be used for creating an EQ.
+
+mlx5dv_devx_free_msi_vector - Release an msi vector.
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_devx_msi_vector *
+mlx5dv_devx_alloc_msi_vector(struct ibv_context *ibctx);
+
+int mlx5dv_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *msi);
+
+```
+
+# DESCRIPTION
+
+Allocate or free an msi vector to be used for creating an EQ.
+
+The allocate API exposes a mlx5dv_devx_msi_vector object, which includes an msi vector and a fd. The vector
+can be used as the "eqc.intr" field when creating an EQ, while the fd (created as non-blocking) can be polled
+to see once there is some data on that EQ.
+
+# ARGUMENTS
+*ibctx*
+:	RDMA device context to create the action on.
+
+*msi*
+:	The msi vector object to work on.
+
+## msi_vector
+
+```c
+struct mlx5dv_devx_msi_vector {
+	int vector;
+	int fd;
+};
+```
+*vector*
+:	The vector to be used when creating the EQ over the device specification.
+
+*fd*
+:	The FD that will be used for polling.
+
+# RETURN VALUE
+
+Upon success *mlx5dv_devx_alloc_msi_vector* will return a new *struct mlx5dv_devx_msi_vector*;
+On error NULL will be returned and errno will be set.
+
+Upon success *mlx5dv_devx_free_msi_vector* will return 0, on error errno will be returned.
+
+# AUTHOR
+
+Mark Zhang <markzhang@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_devx_create_eq.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_create_eq.3.md
@@ -1,0 +1,83 @@
+---
+date: 2022-01-12
+footer: mlx5
+header: "mlx5 Programmer's Manual"
+tagline: Verbs
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: mlx5dv_devx_create_eq
+---
+
+# NAME
+
+mlx5dv_devx_create_eq - Create an EQ object
+
+mlx5dv_devx_destroy_eq - Destroy an EQ object
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_devx_eq *
+mlx5dv_devx_create_eq(struct ibv_context *ibctx, const void *in, size_t inlen,
+		      void *out, size_t outlen);
+
+int mlx5dv_devx_destroy_eq(struct mlx5dv_devx_eq *eq);
+
+```
+
+# DESCRIPTION
+
+Create / Destroy an EQ object. Upon creation, the caller prepares the in/out mail boxes based on the device
+specification format; For the input mailbox, caller needs to prepare all fields except "eqc.log_page_size"
+and the pas list, which will be set by the driver. The "eqc.intr" field should be used from the output of
+mlx5dv_devx_alloc_msi_vector().
+
+# ARGUMENTS
+*ibctx*
+:	RDMA device context to create the action on.
+
+*in*
+:	A buffer which contains the command's input data provided in a device specification format.
+
+*inlen*
+:	The size of *in* buffer in bytes.
+
+*out*
+:	A buffer which contains the command's output data according to the device specification format.
+
+*outlen*
+:	The size of *out* buffer in bytes.
+
+*eq*
+:	The  EQ object to work on.
+
+```c
+struct mlx5dv_devx_eq {
+    void *vaddr;
+};
+```
+
+*vaddr*
+:	EQ VA that was allocated in the driver for.
+
+# NOTES
+
+mlx5dv_devx_query_eqn() will not support vectors which are used by mlx5dv_devx_create_eq().
+
+# RETURN VALUE
+
+Upon success *mlx5dv_devx_create_eq* will return a new *struct mlx5dv_devx_eq*;
+On error NULL will be returned and errno will be set.
+
+Upon success *mlx5dv_devx_destroy_eq* will return 0, on error errno will be returned.
+
+# SEE ALSO
+
+*mlx5dv_devx_alloc_msi_vector(3)*, *mlx5dv_devx_query_eqn(3)*
+
+# AUTHOR
+
+Mark Zhang <markzhang@nvidia.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -913,6 +913,11 @@ struct mlx5dv_sched_leaf {
 	struct mlx5dv_devx_obj *obj;
 };
 
+struct mlx5_devx_msi_vector {
+	struct mlx5dv_devx_msi_vector dv_msi;
+	struct ibv_context *ibctx;
+};
+
 struct ibv_flow *
 _mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		    struct mlx5dv_flow_match_parameters *match_value,
@@ -1561,6 +1566,8 @@ struct mlx5_dv_context_ops {
 	int (*query_port)(struct ibv_context *context, uint32_t port_num,
 			  struct mlx5dv_port *info, size_t info_len);
 	int (*map_ah_to_qp)(struct ibv_ah *ah, uint32_t qp_num);
+	struct mlx5dv_devx_msi_vector *(*devx_alloc_msi_vector)(struct ibv_context *ibctx);
+	int (*devx_free_msi_vector)(struct mlx5dv_devx_msi_vector *msi);
 };
 
 struct mlx5_dv_context_ops *mlx5_get_dv_ops(struct ibv_context *context);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -918,6 +918,14 @@ struct mlx5_devx_msi_vector {
 	struct ibv_context *ibctx;
 };
 
+struct mlx5_devx_eq {
+	struct mlx5dv_devx_eq dv_eq;
+	struct ibv_context *ibctx;
+	uint64_t iova;
+	size_t size;
+	int eqn;
+};
+
 struct ibv_flow *
 _mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		    struct mlx5dv_flow_match_parameters *match_value,
@@ -1568,6 +1576,10 @@ struct mlx5_dv_context_ops {
 	int (*map_ah_to_qp)(struct ibv_ah *ah, uint32_t qp_num);
 	struct mlx5dv_devx_msi_vector *(*devx_alloc_msi_vector)(struct ibv_context *ibctx);
 	int (*devx_free_msi_vector)(struct mlx5dv_devx_msi_vector *msi);
+	struct mlx5dv_devx_eq *(*devx_create_eq)(struct ibv_context *ibctx,
+						 const void *in, size_t inlen,
+						 void *out, size_t outlen);
+	int (*devx_destroy_eq)(struct mlx5dv_devx_eq *eq);
 };
 
 struct mlx5_dv_context_ops *mlx5_get_dv_ops(struct ibv_context *context);

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -1160,29 +1160,16 @@ static int mlx5_vfio_init_bar0(struct mlx5_vfio_context *ctx)
 	return 0;
 }
 
-#define MLX5_VFIO_MAX_INTR_VEC_ID 1
-#define MSIX_IRQ_SET_BUF_LEN (sizeof(struct vfio_irq_set) + \
-			      sizeof(int) * (MLX5_VFIO_MAX_INTR_VEC_ID))
-
-/* enable MSI-X interrupts */
-static int
-mlx5_vfio_enable_msix(struct mlx5_vfio_context *ctx)
+static int mlx5_vfio_msix_set_irqs(struct mlx5_vfio_context *ctx,
+				   int start, int count, void *irq_set_buf)
 {
-	char irq_set_buf[MSIX_IRQ_SET_BUF_LEN];
-	struct vfio_irq_set *irq_set;
-	int len;
-	int *fd_ptr;
+	struct vfio_irq_set *irq_set = (struct vfio_irq_set *)irq_set_buf;
 
-	len = sizeof(irq_set_buf);
-
-	irq_set = (struct vfio_irq_set *)irq_set_buf;
-	irq_set->argsz = len;
-	irq_set->count = 1;
+	irq_set->argsz = sizeof(*irq_set) + sizeof(int) * count;
 	irq_set->flags = VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER;
 	irq_set->index = VFIO_PCI_MSIX_IRQ_INDEX;
-	irq_set->start = 0;
-	fd_ptr = (int *)&irq_set->data;
-	fd_ptr[MLX5_VFIO_CMD_VEC_IDX] = ctx->cmd_comp_fd;
+	irq_set->start = start;
+	irq_set->count = count;
 
 	return ioctl(ctx->device_fd, VFIO_DEVICE_SET_IRQS, irq_set);
 }
@@ -1190,6 +1177,8 @@ mlx5_vfio_enable_msix(struct mlx5_vfio_context *ctx)
 static int mlx5_vfio_init_async_fd(struct mlx5_vfio_context *ctx)
 {
 	struct vfio_irq_info irq = { .argsz = sizeof(irq) };
+	struct vfio_irq_set *irq_set_buf;
+	int fdlen, i;
 
 	irq.index = VFIO_PCI_MSIX_IRQ_INDEX;
 	if (ioctl(ctx->device_fd, VFIO_DEVICE_GET_IRQ_INFO, &irq))
@@ -1199,27 +1188,65 @@ static int mlx5_vfio_init_async_fd(struct mlx5_vfio_context *ctx)
 	if ((irq.flags & VFIO_IRQ_INFO_EVENTFD) == 0)
 		return -1;
 
+	fdlen = sizeof(int) * irq.count;
+	ctx->msix_fds = calloc(1, fdlen);
+	if (!ctx->msix_fds) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	for (i = 0; i < irq.count; i++)
+		ctx->msix_fds[i] = -1;
+
 	/* set up an eventfd for command completion interrupts */
 	ctx->cmd_comp_fd = eventfd(0, EFD_CLOEXEC | O_NONBLOCK);
 	if (ctx->cmd_comp_fd < 0)
-		return -1;
+		goto err_eventfd;
 
-	if (mlx5_vfio_enable_msix(ctx))
+	ctx->msix_fds[MLX5_VFIO_CMD_VEC_IDX] = ctx->cmd_comp_fd;
+
+	irq_set_buf = calloc(1, sizeof(*irq_set_buf) + fdlen);
+	if (!irq_set_buf) {
+		errno = ENOMEM;
+		goto err_irq_set_buf;
+	}
+
+	/* Enable MSI-X interrupts; In the first time it is called, the count
+	 * must be the maximum that we need
+	 */
+	memcpy(irq_set_buf->data, ctx->msix_fds, fdlen);
+	if (mlx5_vfio_msix_set_irqs(ctx, 0, irq.count, irq_set_buf))
 		goto err_msix;
 
+	free(irq_set_buf);
+	pthread_mutex_init(&ctx->msix_fds_lock, NULL);
+	ctx->vctx.context.num_comp_vectors = irq.count;
 	return 0;
 
 err_msix:
+	free(irq_set_buf);
+err_irq_set_buf:
 	close(ctx->cmd_comp_fd);
+err_eventfd:
+	free(ctx->msix_fds);
 	return -1;
 }
 
 static void mlx5_vfio_close_fds(struct mlx5_vfio_context *ctx)
 {
+	int vec;
+
 	close(ctx->device_fd);
 	close(ctx->container_fd);
 	close(ctx->group_fd);
-	close(ctx->cmd_comp_fd);
+
+	pthread_mutex_lock(&ctx->msix_fds_lock);
+	for (vec = 0; vec < ctx->vctx.context.num_comp_vectors; vec++)
+		if (ctx->msix_fds[vec] >= 0)
+			close(ctx->msix_fds[vec]);
+
+	free(ctx->msix_fds);
+	pthread_mutex_unlock(&ctx->msix_fds_lock);
 }
 
 static int mlx5_vfio_open_fds(struct mlx5_vfio_context *ctx,
@@ -2463,7 +2490,7 @@ static int vfio_devx_query_eqn(struct ibv_context *ibctx, uint32_t vector,
 {
 	struct mlx5_vfio_context *ctx = to_mvfio_ctx(ibctx);
 
-	if (vector > ibctx->num_comp_vectors - 1)
+	if (vector != MLX5_VFIO_CMD_VEC_IDX)
 		return EINVAL;
 
 	/* For now use the singleton EQN created for async events */
@@ -3078,6 +3105,86 @@ static int vfio_devx_obj_destroy(struct mlx5dv_devx_obj *obj)
 	return 0;
 }
 
+static struct mlx5dv_devx_msi_vector *
+vfio_devx_alloc_msi_vector(struct ibv_context *ibctx)
+{
+	uint8_t buf[sizeof(struct vfio_irq_set) + sizeof(int)] = {};
+	struct mlx5_vfio_context *ctx = to_mvfio_ctx(ibctx);
+	struct mlx5_devx_msi_vector *msi;
+	int vector, *fd, err;
+
+	msi = calloc(1, sizeof(*msi));
+	if (!msi) {
+		errno = ENOMEM;
+		return NULL;
+	}
+
+	pthread_mutex_lock(&ctx->msix_fds_lock);
+	for (vector = 0; vector < ibctx->num_comp_vectors; vector++)
+		if (ctx->msix_fds[vector] < 0)
+			break;
+
+	if (vector == ibctx->num_comp_vectors) {
+		errno = ENOSPC;
+		goto fail;
+	}
+
+	fd = (int *)(buf + sizeof(struct vfio_irq_set));
+	*fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+	if (*fd < 0)
+		goto fail;
+
+	err = mlx5_vfio_msix_set_irqs(ctx, vector, 1, buf);
+	if (err)
+		goto fail_set_irqs;
+
+	ctx->msix_fds[vector] = *fd;
+	msi->dv_msi.vector = vector;
+	msi->dv_msi.fd = *fd;
+	msi->ibctx = ibctx;
+
+	pthread_mutex_unlock(&ctx->msix_fds_lock);
+	return &msi->dv_msi;
+
+fail_set_irqs:
+	close(*fd);
+fail:
+	pthread_mutex_unlock(&ctx->msix_fds_lock);
+	free(msi);
+	return NULL;
+}
+
+static int vfio_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *msi)
+{
+	struct mlx5_devx_msi_vector *msiv =
+		container_of(msi, struct mlx5_devx_msi_vector, dv_msi);
+	uint8_t buf[sizeof(struct vfio_irq_set) + sizeof(int)] = {};
+	struct mlx5_vfio_context *ctx = to_mvfio_ctx(msiv->ibctx);
+	int ret;
+
+	pthread_mutex_lock(&ctx->msix_fds_lock);
+	if ((msi->vector >= msiv->ibctx->num_comp_vectors) ||
+	    (msi->vector == MLX5_VFIO_CMD_VEC_IDX) ||
+	    (msi->fd != ctx->msix_fds[msi->vector])) {
+		ret = EINVAL;
+		goto out;
+	}
+
+	*(int *)(buf + sizeof(struct vfio_irq_set)) = -1;
+	ret = mlx5_vfio_msix_set_irqs(ctx, msi->vector, 1, buf);
+	if (ret) {
+		ret = errno;
+		goto out;
+	}
+
+	close(msi->fd);
+	ctx->msix_fds[msi->vector] = -1;
+	free(msiv);
+out:
+	pthread_mutex_unlock(&ctx->msix_fds_lock);
+	return ret;
+}
+
 static struct mlx5_dv_context_ops mlx5_vfio_dv_ctx_ops = {
 	.devx_general_cmd = vfio_devx_general_cmd,
 	.devx_obj_create = vfio_devx_obj_create,
@@ -3091,6 +3198,8 @@ static struct mlx5_dv_context_ops mlx5_vfio_dv_ctx_ops = {
 	.devx_umem_reg_ex = vfio_devx_umem_reg_ex,
 	.devx_umem_dereg = vfio_devx_umem_dereg,
 	.init_obj = vfio_init_obj,
+	.devx_alloc_msi_vector = vfio_devx_alloc_msi_vector,
+	.devx_free_msi_vector = vfio_devx_free_msi_vector,
 };
 
 static void mlx5_vfio_uninit_context(struct mlx5_vfio_context *ctx)
@@ -3159,9 +3268,6 @@ mlx5_vfio_alloc_context(struct ibv_device *ibdev,
 
 	verbs_set_ops(&mctx->vctx, &mlx5_vfio_common_ops);
 	mctx->dv_ctx_ops = &mlx5_vfio_dv_ctx_ops;
-
-	/* For now only a singelton EQ is supported */
-	mctx->vctx.context.num_comp_vectors = 1;
 
 	return &mctx->vctx;
 

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -1236,7 +1236,7 @@ static int mlx5_vfio_open_fds(struct mlx5_vfio_context *ctx,
 	if (ioctl(ctx->container_fd, VFIO_GET_API_VERSION) != VFIO_API_VERSION)
 		goto close_cont;
 
-	if (!ioctl(ctx->container_fd, VFIO_CHECK_EXTENSION, VFIO_TYPE1_IOMMU))
+	if (!ioctl(ctx->container_fd, VFIO_CHECK_EXTENSION, VFIO_TYPE1v2_IOMMU))
 		/* Doesn't support the IOMMU driver we want. */
 		goto close_cont;
 
@@ -1260,7 +1260,7 @@ static int mlx5_vfio_open_fds(struct mlx5_vfio_context *ctx,
 		goto close_group;
 
 	/* Enable the IOMMU model we want */
-	if (ioctl(ctx->container_fd, VFIO_SET_IOMMU, VFIO_TYPE1_IOMMU))
+	if (ioctl(ctx->container_fd, VFIO_SET_IOMMU, VFIO_TYPE1v2_IOMMU))
 		goto close_group;
 
 	/* Get a file descriptor for the device */

--- a/providers/mlx5/mlx5_vfio.h
+++ b/providers/mlx5/mlx5_vfio.h
@@ -302,6 +302,8 @@ struct mlx5_vfio_context {
 	struct mlx5_vfio_eqs_uar eqs_uar;
 	pthread_mutex_t eq_lock;
 	struct mlx5_dv_context_ops *dv_ctx_ops;
+	int *msix_fds;
+	pthread_mutex_t msix_fds_lock;
 };
 
 #define MLX5_MAX_DESTROY_INBOX_SIZE_DW	DEVX_ST_SZ_DW(delete_fte_in)

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -2145,6 +2145,15 @@ mlx5dv_devx_alloc_msi_vector(struct ibv_context *ibctx);
 
 int mlx5dv_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *msi);
 
+struct mlx5dv_devx_eq {
+	void *vaddr;
+};
+
+struct mlx5dv_devx_eq *
+mlx5dv_devx_create_eq(struct ibv_context *ibctx, const void *in, size_t inlen,
+		      void *out, size_t outlen);
+
+int mlx5dv_devx_destroy_eq(struct mlx5dv_devx_eq *eq);
 
 #ifdef __cplusplus
 }

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -2135,6 +2135,16 @@ int mlx5dv_dr_aso_other_domain_link(struct mlx5dv_devx_obj *devx_obj,
 int mlx5dv_dr_aso_other_domain_unlink(struct mlx5dv_devx_obj *devx_obj,
 				      struct mlx5dv_dr_domain *dmn);
 
+struct mlx5dv_devx_msi_vector {
+	int vector;
+	int fd;
+};
+
+struct mlx5dv_devx_msi_vector *
+mlx5dv_devx_alloc_msi_vector(struct ibv_context *ibctx);
+
+int mlx5dv_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *msi);
+
 
 #ifdef __cplusplus
 }

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -7360,6 +7360,32 @@ int mlx5dv_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *dvmsi)
 	return dvops->devx_free_msi_vector(dvmsi);
 }
 
+struct mlx5dv_devx_eq *
+mlx5dv_devx_create_eq(struct ibv_context *ibctx, const void *in, size_t inlen,
+		      void *out, size_t outlen)
+{
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(ibctx);
+
+	if (!dvops || !dvops->devx_create_eq) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	return dvops->devx_create_eq(ibctx, in, inlen, out, outlen);
+}
+
+int mlx5dv_devx_destroy_eq(struct mlx5dv_devx_eq *dveq)
+{
+	struct mlx5_devx_eq *eq =
+		container_of(dveq, struct mlx5_devx_eq, dv_eq);
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(eq->ibctx);
+
+	if (!dvops || !dvops->devx_destroy_eq)
+		return EOPNOTSUPP;
+
+	return dvops->devx_destroy_eq(dveq);
+}
+
 void mlx5_set_dv_ctx_ops(struct mlx5_dv_context_ops *ops)
 {
 	ops->devx_general_cmd = _mlx5dv_devx_general_cmd;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -7335,6 +7335,31 @@ void mlx5dv_pp_free(struct mlx5dv_pp *dv_pp)
 	dvops->pp_free(dv_pp);
 }
 
+struct mlx5dv_devx_msi_vector *
+mlx5dv_devx_alloc_msi_vector(struct ibv_context *ibctx)
+{
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(ibctx);
+
+	if (!dvops || !dvops->devx_alloc_msi_vector) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	return dvops->devx_alloc_msi_vector(ibctx);
+}
+
+int mlx5dv_devx_free_msi_vector(struct mlx5dv_devx_msi_vector *dvmsi)
+{
+	struct mlx5_devx_msi_vector *msi =
+		container_of(dvmsi, struct mlx5_devx_msi_vector, dv_msi);
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(msi->ibctx);
+
+	if (!dvops || !dvops->devx_free_msi_vector)
+		return EOPNOTSUPP;
+
+	return dvops->devx_free_msi_vector(dvmsi);
+}
+
 void mlx5_set_dv_ctx_ops(struct mlx5_dv_context_ops *ops)
 {
 	ops->devx_general_cmd = _mlx5dv_devx_general_cmd;

--- a/pyverbs/dma_util.pyx
+++ b/pyverbs/dma_util.pyx
@@ -3,7 +3,7 @@
 
 #cython: language_level=3
 
-from libc.stdint cimport uintptr_t, uint64_t
+from libc.stdint cimport uintptr_t, uint64_t, uint32_t
 
 cdef extern from 'util/udma_barrier.h':
     cdef void udma_to_device_barrier()
@@ -11,6 +11,7 @@ cdef extern from 'util/udma_barrier.h':
 
 cdef extern from 'util/mmio.h':
    cdef void mmio_write64_be(void *addr, uint64_t val)
+   cdef void mmio_write32_be(void *addr, uint32_t val)
 
 
 def udma_to_dev_barrier():
@@ -23,3 +24,7 @@ def udma_from_dev_barrier():
 
 def mmio_write64_as_be(addr, val):
     mmio_write64_be(<void*><uintptr_t> addr, val)
+
+
+def mmio_write32_as_be(addr, val):
+    mmio_write32_be(<void*><uintptr_t> addr, val)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -261,6 +261,13 @@ cdef extern from 'infiniband/mlx5dv.h':
         uint32_t    flags
         uint64_t    comp_mask
 
+    cdef struct mlx5dv_devx_msi_vector:
+        int         vector
+        int         fd
+
+    cdef struct mlx5dv_devx_eq:
+        void        *vaddr
+
     cdef struct mlx5dv_pd:
         uint32_t    pdn
         uint64_t    comp_mask
@@ -503,6 +510,11 @@ cdef extern from 'infiniband/mlx5dv.h':
                                size_t inlen, void *out, size_t outlen)
     int mlx5dv_devx_obj_destroy(mlx5dv_devx_obj *obj)
     int mlx5dv_init_obj(mlx5dv_obj *obj, uint64_t obj_type)
+    mlx5dv_devx_msi_vector *mlx5dv_devx_alloc_msi_vector(v.ibv_context *ibctx)
+    int mlx5dv_devx_free_msi_vector(mlx5dv_devx_msi_vector *msi)
+    mlx5dv_devx_eq *mlx5dv_devx_create_eq(v.ibv_context *context, const void *_in,
+                                          size_t inlen, void *out, size_t outlen)
+    int mlx5dv_devx_destroy_eq(mlx5dv_devx_eq *eq)
 
     # Mkey setters
     void mlx5dv_wr_mkey_configure(mlx5dv_qp_ex *mqp, mlx5dv_mkey *mkey,

--- a/pyverbs/providers/mlx5/mlx5_vfio.pyx
+++ b/pyverbs/providers/mlx5/mlx5_vfio.pyx
@@ -71,6 +71,7 @@ cdef class Mlx5VfioContext(Mlx5Context):
         self.devx_umems = weakref.WeakSet()
         self.devx_objs = weakref.WeakSet()
         self.uars = weakref.WeakSet()
+        self.devx_eqs = weakref.WeakSet()
 
         dev_list = dv.mlx5dv_get_vfio_device_list(&attr.attr)
         if dev_list == NULL:
@@ -110,7 +111,7 @@ cdef class Mlx5VfioContext(Mlx5Context):
         if self.context != NULL:
             if self.logger:
                 self.logger.debug('Closing Mlx5VfioContext')
-            close_weakrefs([self.pds, self.devx_objs, self.devx_umems, self.uars])
+            close_weakrefs([self.pds, self.devx_objs, self.devx_umems, self.uars, self.devx_eqs])
             rc = v.ibv_close_device(self.context)
             if rc != 0:
                 raise PyverbsRDMAErrno(f'Failed to close device {self.name}')

--- a/pyverbs/providers/mlx5/mlx5dv.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv.pxd
@@ -13,6 +13,7 @@ from pyverbs.cq cimport CQEX
 cdef class Mlx5Context(Context):
     cdef object devx_umems
     cdef object devx_objs
+    cdef object devx_eqs
     cdef add_ref(self, obj)
     cpdef close(self)
 
@@ -95,3 +96,11 @@ cdef class Mlx5Cqe64(PyverbsObject):
 
 cdef class Mlx5VfioAttr(PyverbsObject):
     cdef dv.mlx5dv_vfio_context_attr attr
+
+cdef class Mlx5DevxMsiVector(PyverbsCM):
+    cdef dv.mlx5dv_devx_msi_vector *msi_vector
+
+cdef class Mlx5DevxEq(PyverbsCM):
+    cdef dv.mlx5dv_devx_eq *eq
+    cdef Context context
+    cdef object out_view

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -276,6 +276,7 @@ cdef class Mlx5Context(Context):
                                    .format(dev=self.name))
         self.devx_umems = weakref.WeakSet()
         self.devx_objs = weakref.WeakSet()
+        self.devx_eqs = weakref.WeakSet()
 
     def query_mlx5_device(self, comp_mask=-1):
         """
@@ -438,6 +439,8 @@ cdef class Mlx5Context(Context):
                 self.devx_umems.add(obj)
             elif isinstance(obj, Mlx5DevxObj):
                 self.devx_objs.add(obj)
+            elif isinstance(obj, Mlx5DevxEq):
+                self.devx_eqs.add(obj)
             else:
                 raise PyverbsError('Unrecognized object type')
 
@@ -446,7 +449,7 @@ cdef class Mlx5Context(Context):
 
     cpdef close(self):
         if self.context != NULL:
-            close_weakrefs([self.pps, self.devx_objs, self.devx_umems])
+            close_weakrefs([self.pps, self.devx_objs, self.devx_umems, self.devx_eqs])
             super(Mlx5Context, self).close()
 
 
@@ -1764,3 +1767,84 @@ cdef class Mlx5Cqe64(PyverbsObject):
 
     def __str__(self):
         return (<dv.mlx5_cqe64>((<dv.mlx5_cqe64*>self.cqe)[0])).__str__()
+
+cdef class Mlx5DevxMsiVector(PyverbsCM):
+    """
+    Represents mlx5dv_devx_msi_vector C struct.
+    """
+    def __init__(self, Context context):
+        super().__init__()
+        self.msi_vector = dv.mlx5dv_devx_alloc_msi_vector(context.context)
+        if self.msi_vector == NULL:
+            raise PyverbsRDMAErrno('Failed to allocate an msi_vector')
+
+    @property
+    def vector(self):
+        return self.msi_vector.vector
+
+    @property
+    def fd(self):
+        return self.msi_vector.fd
+
+    cpdef close(self):
+        if self.msi_vector != NULL:
+            rc = dv.mlx5dv_devx_free_msi_vector(self.msi_vector)
+            if rc:
+                raise PyverbsRDMAError('Failed to free the msi_vector', rc)
+        self.msi_vector = NULL
+
+
+cdef class Mlx5DevxEq(PyverbsCM):
+    """
+    Represents mlx5dv_devx_eq C struct.
+    """
+    def __init__(self, Context context, in_, outlen):
+        """
+        Creates a DevX EQ object.
+        If the object was successfully created, the command's output would be
+        stored as a memoryview in self.out_view.
+        :param in_: Bytes of the obj_create command's input data provided in a
+                    device specification format.
+                    (Stream of bytes or __bytes__ is implemented)
+        :param outlen: Expected output length in bytes
+        """
+        super().__init__()
+        in_bytes = bytes(in_)
+        cdef char *in_mailbox = _prepare_devx_inbox(in_bytes)
+        cdef char *out_mailbox = _prepare_devx_outbox(outlen)
+        self.eq = dv.mlx5dv_devx_create_eq(context.context, in_mailbox,
+                                           len(in_bytes), out_mailbox, outlen)
+        try:
+            if self.eq == NULL:
+                raise PyverbsRDMAErrno('Failed to create async EQ object')
+            self.out_view = memoryview(out_mailbox[:outlen])
+            status = hex(self.out_view[0])
+            syndrome = self.out_view[4:8].hex()
+            if status != hex(0):
+                raise PyverbsRDMAError('Failed to create async EQ object with status'
+                                       f'({status}) and syndrome (0x{syndrome})')
+        finally:
+            free(in_mailbox)
+            free(out_mailbox)
+        self.context = context
+        self.context.add_ref(self)
+
+    @property
+    def out_view(self):
+        return self.out_view
+
+    @property
+    def vaddr(self):
+        return <uintptr_t><void*>self.eq.vaddr
+
+    def __dealloc__(self):
+        self.close()
+
+    cpdef close(self):
+        if self.eq != NULL:
+            self.logger.debug('Closing Mlx5DevxEq')
+            rc = dv.mlx5dv_devx_destroy_eq(self.eq)
+            if rc:
+                raise PyverbsRDMAError('Failed to destroy a DevX EQ object', rc)
+            self.eq = NULL
+            self.context = None

--- a/tests/test_mlx5_pp.py
+++ b/tests/test_mlx5_pp.py
@@ -54,3 +54,5 @@ class Mlx5PPTestCase(Mlx5RDMATestCase):
             if ex.error_code == errno.EOPNOTSUPP or ex.error_code == errno.EPROTONOSUPPORT:
                 raise unittest.SkipTest('Packet pacing entry allocation is not supported')
             raise ex
+        finally:
+            self.pp_res.ctx.close()

--- a/tests/test_mlx5_vfio.py
+++ b/tests/test_mlx5_vfio.py
@@ -6,12 +6,24 @@ Test module for pyverbs' mlx5_vfio module.
 
 from threading import Thread
 import unittest
+import logging
+import struct
 import select
 import errno
+import time
+import math
+import os
 
+from tests.mlx5_base import Mlx5DevxRcResources, Mlx5DevxTrafficBase, PortState, PortStatus
+from pyverbs.providers.mlx5.mlx5dv import Mlx5DevxMsiVector, Mlx5DevxEq, Mlx5UAR
 from pyverbs.providers.mlx5.mlx5_vfio import Mlx5VfioAttr, Mlx5VfioContext
-from tests.mlx5_base import Mlx5DevxRcResources, Mlx5DevxTrafficBase
 from pyverbs.pyverbs_error import PyverbsRDMAError
+import pyverbs.providers.mlx5.mlx5_enums as dve
+from pyverbs.base import PyverbsRDMAErrno
+import pyverbs.mem_alloc as mem
+import pyverbs.dma_util as dma
+
+PORT_STATE_TIMEOUT = 20  # In seconds
 
 
 class Mlx5VfioResources(Mlx5DevxRcResources):
@@ -47,6 +59,102 @@ class Mlx5VfioResources(Mlx5DevxRcResources):
         pass
 
 
+class Mlx5VfioEqResources(Mlx5VfioResources):
+    def __init__(self, ib_port, pci_name, gid_index=None, ctx=None):
+        self.cons_index = 0
+        super().__init__(ib_port, pci_name, gid_index, ctx)
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def create_uar(self):
+        super().create_uar()
+        self.uar['eq'] = Mlx5UAR(self.ctx, dve._MLX5DV_UAR_ALLOC_TYPE_NC)
+        if not self.uar['eq'].page_id:
+            raise PyverbsRDMAError('Failed to allocate UAR')
+
+    def get_eqe(self, cc):
+        from tests.mlx5_prm_structs import SwEqe
+
+        ci = self.cons_index + cc
+        entry = ci & (self.nent - 1)
+        eqe_bytes = mem.read64(self.eq.vaddr + entry * len(SwEqe()))
+        eqe_bytes = eqe_bytes.to_bytes(length=8, byteorder='little')
+        eqe = SwEqe(eqe_bytes)
+        if (eqe.owner & 1) ^ (not(not(ci & self.nent))):
+            eqe = None
+        elif eqe:
+            dma.udma_from_dev_barrier()
+
+        return eqe
+
+    def update_ci(self, cc, arm=0):
+        addr = self.doorbell
+        if arm:
+            addr += 8  # Adding 2 bytes according to PRM
+        self.cons_index += cc
+        val = (self.cons_index & 0xffffff) | (self.eqn << 24)
+        val_be = struct.unpack("<I", struct.pack(">I", val))[0]
+        dma.mmio_write32_as_be(addr, val_be)
+        dma.udma_to_dev_barrier()
+
+    def init_dveq_buff(self):
+        from tests.mlx5_prm_structs import SwEqe
+
+        for i in range(self.nent):
+            eqe_bytes = mem.read64(self.eq.vaddr + i * len(SwEqe()))
+            eqe_bytes = eqe_bytes.to_bytes(length=8, byteorder='little')
+            eqe = SwEqe(eqe_bytes)
+            eqe.owner = 0x1
+        self.update_ci(0)
+
+    def update_cc(self, cc):
+        if cc >= self.num_spare_eqe:
+            self.update_ci(cc)
+            cc = 0
+        return cc
+
+    def create_eq(self):
+        from tests.mlx5_prm_structs import CreateEqIn, SwEqc, CreateEqOut,\
+            EventType
+
+        # Using num_spare_eqe to guarantee that we update
+        # the ci before we polled all the entries in the EQ
+        self.num_spare_eqe = 0x80
+        self.nent = 0x80 + self.num_spare_eqe
+        self.msi_vector = Mlx5DevxMsiVector(self.ctx)
+        vector = self.msi_vector.vector
+        log_eq_size = math.ceil(math.log2(self.nent))
+        mask = 1 << EventType.PORT_STATE_CHANGE
+        cmd_in = CreateEqIn(sw_eqc=SwEqc(uar_page=self.uar['eq'].page_id,
+                                         log_eq_size=log_eq_size, intr=vector),
+                            event_bitmask_63_0=mask)
+        self.eq = Mlx5DevxEq(self.ctx, cmd_in, len(CreateEqOut()))
+        self.eqn = CreateEqOut(self.eq.out_view).eqn
+        self.doorbell = self.uar['eq'].base_addr + 0x40
+        self.init_dveq_buff()
+        self.update_ci(0, 1)
+
+    def query_eqn(self):
+        pass
+
+    def process_async_events(self, fd):
+        from tests.mlx5_prm_structs import EventType
+
+        cc = 0
+        ret = os.read(fd, 8)
+        if not ret:
+            raise PyverbsRDMAErrno('Failed to read FD')
+        eqe = self.get_eqe(cc)
+        while eqe:
+            if eqe.event_type == EventType.PORT_STATE_CHANGE:
+                self.logger.debug('Caught port state change event')
+                return eqe.event_type
+            elif eqe.event_type == EventType.CQ_ERROR:
+                raise PyverbsRDMAError('Event type Error')
+            cc = self.update_cc(cc + 1)
+            eqe = self.get_eqe(cc)
+        self.update_ci(cc, 1)
+
+
 class Mlx5VfioTrafficTest(Mlx5DevxTrafficBase):
     """
     Test various functionality of an mlx5-vfio device.
@@ -64,7 +172,12 @@ class Mlx5VfioTrafficTest(Mlx5DevxTrafficBase):
         self.client = Mlx5VfioResources(ib_port=self.ib_port, pci_name=self.pci_dev,
                                         ctx=self.server.ctx)
 
-    def vfio_processs_events(self):
+    def create_async_players(self):
+        self.server = Mlx5VfioEqResources(ib_port=self.ib_port, pci_name=self.pci_dev)
+        self.client = Mlx5VfioResources(ib_port=self.ib_port, pci_name=self.pci_dev,
+                                        ctx=self.server.ctx)
+
+    def vfio_process_events(self):
         """
         Processes mlx5 vfio device events.
         This method should run from application thread to maintain the events.
@@ -80,6 +193,25 @@ class Mlx5VfioTrafficTest(Mlx5DevxTrafficBase):
                             self.event_ex.append(PyverbsRDMAError(f'Unexpected vfio event: {event}'))
                         self.server.ctx.process_events()
 
+    def vfio_process_async_events(self):
+        """
+        Processes mlx5 vfio device async events.
+        This method should run from application thread to maintain the events.
+        """
+        from tests.mlx5_prm_structs import EventType
+
+        # Server and client use the same context
+        events_fd = self.server.msi_vector.fd
+        with select.epoll() as epoll_events:
+            epoll_events.register(events_fd, select.EPOLLIN)
+            while self.proc_events:
+                for fd, event in epoll_events.poll(timeout=0.1):
+                    if fd == events_fd:
+                        if not (event & select.EPOLLIN):
+                            self.event_ex.append(PyverbsRDMAError(f'Unexpected vfio event: {event}'))
+                        if self.server.process_async_events(events_fd) == EventType.PORT_STATE_CHANGE:
+                            self.caught_event = True
+
     def test_mlx5vfio_rc_qp_send_imm_traffic(self):
         """
         Opens one mlx5 vfio context, creates two DevX RC QPs on it, and modifies
@@ -91,9 +223,9 @@ class Mlx5VfioTrafficTest(Mlx5DevxTrafficBase):
             raise unittest.SkipTest(f'{self.__class__.__name__} is currently supported over IB only')
         self.event_ex = []
         self.proc_events = True
-        proc_events = Thread(target=self.vfio_processs_events)
+        proc_events = Thread(target=self.vfio_process_events)
         proc_events.start()
-        # Move the DevX QPs ro RTS state
+        # Move the DevX QPs to RTS state
         self.pre_run()
         try:
             # Send traffic
@@ -104,3 +236,44 @@ class Mlx5VfioTrafficTest(Mlx5DevxTrafficBase):
             proc_events.join()
             if self.event_ex:
                 raise PyverbsRDMAError(f'Received unexpected vfio events: {self.event_ex}')
+
+    def test_mlx5vfio_async_event(self):
+        """
+        Opens one mlx5 vfio context, creates DevX EQ on it.
+        Then activates the port and catches the port state change event.
+        """
+        self.create_async_players()
+        if self.server.is_eth():
+            raise unittest.SkipTest(f'{self.__class__.__name__} is currently supported over IB only')
+        self.event_ex = []
+        self.proc_events = True
+        self.caught_event = False
+        proc_events = Thread(target=self.vfio_process_events)
+        proc_async_events = Thread(target=self.vfio_process_async_events)
+        proc_events.start()
+        proc_async_events.start()
+        # Move the DevX QPs to RTS state
+        self.pre_run()
+        try:
+            # Change port state
+            self.server.change_port_state_with_registers(PortStatus.MLX5_PORT_UP)
+            admin_status, oper_status = self.server.query_port_state_with_registers()
+            start_state_t = time.perf_counter()
+            while admin_status != PortStatus.MLX5_PORT_UP or oper_status != PortStatus.MLX5_PORT_UP:
+                if time.perf_counter() - start_state_t >= PORT_STATE_TIMEOUT:
+                    raise PyverbsRDMAError('Could not change the port state to UP')
+                admin_status, oper_status = self.server.query_port_state_with_registers()
+            start_state_t = time.perf_counter()
+            while self.server.query_port_state_with_mads(self.ib_port) < PortState.ACTIVE:
+                if time.perf_counter() - start_state_t >= PORT_STATE_TIMEOUT:
+                    raise PyverbsRDMAError('Could not change the port state to ACTIVE')
+                time.sleep(1)
+        finally:
+            # Stop listening to events
+            self.proc_events = False
+            proc_events.join()
+            proc_async_events.join()
+            if self.event_ex:
+                raise PyverbsRDMAError(f'Received unexpected vfio events: {self.event_ex}')
+            if not self.caught_event:
+                raise PyverbsRDMAError('Failed to catch an async event')


### PR DESCRIPTION
This series in the mlx5 vfio driver area enables a DEVX based application the below new functionality.

- Register and get asynchronous events (e.g. port up/down) once occurred.
- Work with a CQ in an interrupt mode instead of polling, this mode may reduce power usage in the system when it’s needed.

To let that work we introduced the below new DEVX APIs:
- mlx5dv_devx_alloc_msi_vector / mlx5dv_devx_free_msi_vector - to allocate/free msi vector.
- mlx5dv_devx_create_eq / mlx5dv_devx_destroy_eq - to create/destroy EQ objects.

Detailed man pages were added to describe the expected usage.

With the above functionally in place, a vfio application which uses the DEVX interface has the ability to achieve the above goals.

A pyverbs test which uses the new APIs was added to demonstrate a use case of capturing a port change event.