### PR TITLE
Add support for creating extended CQ

### DIFF
--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -66,6 +66,7 @@ static const struct verbs_context_ops hns_common_ops = {
 	.bind_mw = hns_roce_u_bind_mw,
 	.cq_event = hns_roce_u_cq_event,
 	.create_cq = hns_roce_u_create_cq,
+	.create_cq_ex = hns_roce_u_create_cq_ex,
 	.create_qp = hns_roce_u_create_qp,
 	.create_qp_ex = hns_roce_u_create_qp_ex,
 	.dealloc_mw = hns_roce_u_dealloc_mw,

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -247,6 +247,7 @@ struct hns_roce_cq {
 	int				arm_sn;
 	unsigned long			flags;
 	unsigned int			cqe_size;
+	struct hns_roce_v2_cqe		*cqe;
 };
 
 struct hns_roce_idx_que {

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -236,7 +236,7 @@ struct hns_roce_pd {
 };
 
 struct hns_roce_cq {
-	struct ibv_cq			ibv_cq;
+	struct verbs_cq			verbs_cq;
 	struct hns_roce_buf		buf;
 	pthread_spinlock_t		lock;
 	unsigned int			cqn;
@@ -406,7 +406,7 @@ static inline struct hns_roce_pd *to_hr_pd(struct ibv_pd *ibv_pd)
 
 static inline struct hns_roce_cq *to_hr_cq(struct ibv_cq *ibv_cq)
 {
-	return container_of(ibv_cq, struct hns_roce_cq, ibv_cq);
+	return container_of(ibv_cq, struct hns_roce_cq, verbs_cq.cq);
 }
 
 static inline struct hns_roce_srq *to_hr_srq(struct ibv_srq *ibv_srq)
@@ -447,6 +447,8 @@ int hns_roce_u_bind_mw(struct ibv_qp *qp, struct ibv_mw *mw,
 struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
 				    struct ibv_comp_channel *channel,
 				    int comp_vector);
+struct ibv_cq_ex *hns_roce_u_create_cq_ex(struct ibv_context *context,
+					  struct ibv_cq_init_attr_ex *cq_attr);
 
 int hns_roce_u_modify_cq(struct ibv_cq *cq, struct ibv_modify_cq_attr *attr);
 int hns_roce_u_destroy_cq(struct ibv_cq *cq);

--- a/providers/hns/hns_roce_u_abi.h
+++ b/providers/hns/hns_roce_u_abi.h
@@ -39,8 +39,13 @@
 
 DECLARE_DRV_CMD(hns_roce_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD,
 		empty, hns_roce_ib_alloc_pd_resp);
+
 DECLARE_DRV_CMD(hns_roce_create_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		hns_roce_ib_create_cq, hns_roce_ib_create_cq_resp);
+
+DECLARE_DRV_CMD(hns_roce_create_cq_ex, IB_USER_VERBS_EX_CMD_CREATE_CQ,
+		hns_roce_ib_create_cq, hns_roce_ib_create_cq_resp);
+
 DECLARE_DRV_CMD(hns_roce_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
 		empty, hns_roce_ib_alloc_ucontext_resp);
 

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -337,5 +337,6 @@ struct hns_roce_ud_sq_wqe {
 #define MAX_SERVICE_LEVEL 0x7
 
 void hns_roce_v2_clear_qp(struct hns_roce_context *ctx, struct hns_roce_qp *qp);
+void hns_roce_attach_cq_ex_ops(struct ibv_cq_ex *cq_ex, uint64_t wc_flags);
 
 #endif /* _HNS_ROCE_U_HW_V2_H */

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -276,12 +276,17 @@ int hns_roce_u_dealloc_mw(struct ibv_mw *mw)
 	return 0;
 }
 
-static int hns_roce_verify_cq(int *cqe, struct hns_roce_context *context)
+static int verify_cq_create_attr(struct ibv_cq_init_attr_ex *attr,
+				 struct hns_roce_context *context)
 {
-	if (*cqe < 1 || *cqe > context->max_cqe)
+	if (!attr->cqe || attr->cqe > context->max_cqe)
 		return -EINVAL;
 
-	*cqe = max((uint64_t)HNS_ROCE_MIN_CQE_NUM, roundup_pow_of_two(*cqe));
+	if (attr->comp_mask || attr->wc_flags)
+		return -EOPNOTSUPP;
+
+	attr->cqe = max_t(uint32_t, HNS_ROCE_MIN_CQE_NUM,
+			  roundup_pow_of_two(attr->cqe));
 
 	return 0;
 }
@@ -297,25 +302,25 @@ static int hns_roce_alloc_cq_buf(struct hns_roce_cq *cq)
 }
 
 static int exec_cq_create_cmd(struct ibv_context *context,
-			      struct hns_roce_cq *cq, int cqe,
-			      struct ibv_comp_channel *channel, int comp_vector)
+			      struct hns_roce_cq *cq,
+			      struct ibv_cq_init_attr_ex *attr)
 {
+	struct hns_roce_create_cq_ex_resp resp_ex = {};
 	struct hns_roce_ib_create_cq_resp *resp_drv;
-	struct hns_roce_create_cq_resp resp = {};
+	struct hns_roce_create_cq_ex cmd_ex = {};
 	struct hns_roce_ib_create_cq *cmd_drv;
-	struct hns_roce_create_cq cmd = {};
 	int ret;
 
-	cmd_drv = &cmd.drv_payload;
-	resp_drv = &resp.drv_payload;
+	cmd_drv = &cmd_ex.drv_payload;
+	resp_drv = &resp_ex.drv_payload;
 
 	cmd_drv->buf_addr = (uintptr_t)cq->buf.buf;
 	cmd_drv->db_addr = (uintptr_t)cq->db;
 	cmd_drv->cqe_size = (uintptr_t)cq->cqe_size;
 
-	ret = ibv_cmd_create_cq(context, cqe, channel, comp_vector,
-				&cq->ibv_cq, &cmd.ibv_cmd, sizeof(cmd),
-				&resp.ibv_resp, sizeof(resp));
+	ret = ibv_cmd_create_cq_ex(context, attr, &cq->verbs_cq,
+				   &cmd_ex.ibv_cmd, sizeof(cmd_ex),
+				   &resp_ex.ibv_resp, sizeof(resp_ex), 0);
 	if (ret)
 		return ret;
 
@@ -325,16 +330,15 @@ static int exec_cq_create_cmd(struct ibv_context *context,
 	return 0;
 }
 
-struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
-				    struct ibv_comp_channel *channel,
-				    int comp_vector)
+static struct ibv_cq_ex *create_cq(struct ibv_context *context,
+			 struct ibv_cq_init_attr_ex *attr)
 {
 	struct hns_roce_device *hr_dev = to_hr_dev(context->device);
 	struct hns_roce_context *hr_ctx = to_hr_ctx(context);
 	struct hns_roce_cq *cq;
 	int ret;
 
-	ret = hns_roce_verify_cq(&cqe, hr_ctx);
+	ret = verify_cq_create_attr(attr, hr_ctx);
 	if (ret)
 		goto err;
 
@@ -348,7 +352,7 @@ struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
 	if (ret)
 		goto err_lock;
 
-	cq->cq_depth = cqe;
+	cq->cq_depth = attr->cqe;
 	cq->cqe_size = hr_ctx->cqe_size;
 
 	ret = hns_roce_alloc_cq_buf(cq);
@@ -363,13 +367,13 @@ struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
 
 	*cq->db = 0;
 
-	ret = exec_cq_create_cmd(context, cq, cqe, channel, comp_vector);
+	ret = exec_cq_create_cmd(context, cq, attr);
 	if (ret)
 		goto err_cmd;
 
 	cq->arm_sn = 1;
 
-	return &cq->ibv_cq;
+	return &cq->verbs_cq.cq_ex;
 
 err_cmd:
 	if (hr_dev->hw_version != HNS_ROCE_HW_VER1)
@@ -385,6 +389,27 @@ err:
 
 	errno = ret;
 	return NULL;
+}
+
+struct ibv_cq *hns_roce_u_create_cq(struct ibv_context *context, int cqe,
+				    struct ibv_comp_channel *channel,
+				    int comp_vector)
+{
+	struct ibv_cq_ex *cq;
+	struct ibv_cq_init_attr_ex attr = {
+		.cqe = cqe,
+		.channel = channel,
+		.comp_vector = comp_vector,
+	};
+
+	cq = create_cq(context, &attr);
+	return cq ? ibv_cq_ex_to_cq(cq) : NULL;
+}
+
+struct ibv_cq_ex *hns_roce_u_create_cq_ex(struct ibv_context *context,
+					  struct ibv_cq_init_attr_ex *attr)
+{
+	return create_cq(context, attr);
 }
 
 void hns_roce_u_cq_event(struct ibv_cq *cq)


### PR DESCRIPTION
Support for creating an extended CQ using ibv_create_cq_ex(). Support
extended CQ to use the new polling mechanism provided by ofed. The last two
patches refactor of the polling function.