### PR TITLE
pkg-config: fix double prefixed libdir= and includedir=

### DIFF
--- a/buildlib/template.pc.in
+++ b/buildlib/template.pc.in
@@ -1,7 +1,7 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 
 Name: lib@PC_LIB_NAME@
 Description: RDMA Core Userspace Library

--- a/buildlib/template.pc.in
+++ b/buildlib/template.pc.in
@@ -1,5 +1,3 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
 libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
 


### PR DESCRIPTION
According to [1], `CMAKE_INSTALL_<DIR>` variables are allowed to be either
relative or absolute. This means one should never prefix to them, in
case they are already absolute. Use `CMAKE_INSTALL_FULL_<DIR>` instead, to
not end up with double prefix when the build system uses absolute paths.

This patch fixes broken rdma-core *.pc files in
https://github.com/nixos/nixpkgs.

[1] https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html