### PR TITLE
mlx5: Few enhancements including rping related fix

### DIFF
--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -2394,9 +2394,10 @@ static int mlx5_set_context(struct mlx5_context *context,
 	for (i = 0; i < MLX5_MKEY_TABLE_SIZE; ++i)
 		context->mkey_table[i].refcnt = 0;
 
-	context->db_list = NULL;
+	list_head_init(&context->dbr_available_pages);
+	cl_qmap_init(&context->dbr_map);
 
-	pthread_mutex_init(&context->db_list_mutex, NULL);
+	pthread_mutex_init(&context->dbr_map_mutex, NULL);
 
 	context->prefer_bf = get_always_bf();
 	context->shut_up_bf = get_shut_up_bf();

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -584,6 +584,11 @@ struct mlx5_wq {
 	unsigned			tail;
 	unsigned			cur_post;
 	int				max_gs;
+	/*
+	 * Equal to max_gs when qp is in RTS state for sq, or in INIT state for
+	 * rq, equal to -1 otherwise, used to verify qp_state in data path.
+	 */
+	int				qp_state_max_gs;
 	int				wqe_shift;
 	int				offset;
 	void			       *qend;
@@ -1275,6 +1280,8 @@ void mlx5_unimport_mr(struct ibv_mr *mr);
 struct ibv_pd *mlx5_import_pd(struct ibv_context *context,
 			      uint32_t pd_handle);
 void mlx5_unimport_pd(struct ibv_pd *pd);
+void mlx5_qp_fill_wr_complete_error(struct mlx5_qp *mqp);
+void mlx5_qp_fill_wr_complete_real(struct mlx5_qp *mqp);
 int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
 			 const struct ibv_qp_init_attr_ex *attr,
 			 const struct mlx5dv_qp_init_attr *mlx5_attr);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -42,6 +42,7 @@
 
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>
+#include <util/cl_qmap.h>
 #include <util/util.h>
 #include "mlx5-abi.h"
 #include <util/bitmap.h>
@@ -345,8 +346,9 @@ struct mlx5_context {
 	pthread_mutex_t			mkey_table_mutex;
 
 	struct mlx5_uar_info		uar[MLX5_MAX_UARS];
-	struct mlx5_db_page	       *db_list;
-	pthread_mutex_t			db_list_mutex;
+	struct list_head		dbr_available_pages;
+	cl_qmap_t		        dbr_map;
+	pthread_mutex_t			dbr_map_mutex;
 	int				cache_line_size;
 	int				max_sq_desc_sz;
 	int				max_rq_desc_sz;

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -846,7 +846,7 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 			goto out;
 		}
 
-		if (unlikely(wr->num_sge > qp->sq.max_gs)) {
+		if (unlikely(wr->num_sge > qp->sq.qp_state_max_gs)) {
 			mlx5_dbg(fp, MLX5_DBG_QP_SEND, "max gs exceeded %d (max = %d)\n",
 				 wr->num_sge, qp->sq.max_gs);
 			err = ENOMEM;
@@ -1184,6 +1184,17 @@ static void mlx5_send_wr_start(struct ibv_qp_ex *ibqp)
 	mqp->err = 0;
 	mqp->nreq = 0;
 	mqp->inl_wqe = 0;
+}
+
+static int mlx5_send_wr_complete_error(struct ibv_qp_ex *ibqp)
+{
+	struct mlx5_qp *mqp = to_mqp((struct ibv_qp *)ibqp);
+
+	/* Rolling back */
+	mqp->sq.cur_post = mqp->cur_post_rb;
+	mqp->fm_cache = mqp->fm_cache_rb;
+	mlx5_spin_unlock(&mqp->sq.lock);
+	return EINVAL;
 }
 
 static int mlx5_send_wr_complete(struct ibv_qp_ex *ibqp)
@@ -3453,6 +3464,22 @@ static void fill_wr_setters_eth(struct ibv_qp_ex *ibqp)
 	ibqp->wr_set_inline_data_list = mlx5_send_wr_set_inline_data_list_eth;
 }
 
+void mlx5_qp_fill_wr_complete_error(struct mlx5_qp *mqp)
+{
+	struct ibv_qp_ex *ibqp = &mqp->verbs_qp.qp_ex;
+
+	if (ibqp->wr_complete)
+		ibqp->wr_complete = mlx5_send_wr_complete_error;
+}
+
+void mlx5_qp_fill_wr_complete_real(struct mlx5_qp *mqp)
+{
+	struct ibv_qp_ex *ibqp = &mqp->verbs_qp.qp_ex;
+
+	if (ibqp->wr_complete)
+		ibqp->wr_complete = mlx5_send_wr_complete;
+}
+
 int mlx5_qp_fill_wr_pfns(struct mlx5_qp *mqp,
 			 const struct ibv_qp_init_attr_ex *attr,
 			 const struct mlx5dv_qp_init_attr *mlx5_attr)
@@ -3743,7 +3770,7 @@ int mlx5_post_recv(struct ibv_qp *ibqp, struct ibv_recv_wr *wr,
 			goto out;
 		}
 
-		if (unlikely(wr->num_sge > qp->rq.max_gs)) {
+		if (unlikely(wr->num_sge > qp->rq.qp_state_max_gs)) {
 			err = EINVAL;
 			*bad_wr = wr;
 			goto out;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1893,7 +1893,7 @@ static int mlx5_alloc_qp_buf(struct ibv_context *context,
 	}
 
 	/* compatibility support */
-	qp_huge_key  = qptype2key(qp->ibv_qp->qp_type);
+	qp_huge_key = qptype2key(attr->qp_type);
 	if (mlx5_use_huge(qp_huge_key))
 		default_alloc_type = MLX5_ALLOC_TYPE_HUGE;
 


### PR DESCRIPTION
This series includes few enhancements in mlx5 driver as follows.

- Fix to be IB spec compliant with regards to post_send/recv() based on QP state.
- Fix rping to match the IB spec when external QP is used.
- Optimize dbrec data structure to achieve better performance.
- Fix to determine wqe buffer allocation type per QP type - the legacy compatibility mode.