### PR TITLE
srp_daemon: Prevent starting when the link layer is not InfiniBand

### DIFF
--- a/srp_daemon/start_on_all_ports.in
+++ b/srp_daemon/start_on_all_ports.in
@@ -2,6 +2,7 @@
 
 for p in /sys/class/infiniband/*/ports/*; do
     [ -e "$p" ] || continue
+    [ "$(cat ${p}/link_layer)" == "InfiniBand" ] || continue
     p=${p#/sys/class/infiniband/}
     nohup @SYSTEMCTL_BIN@ start "srp_daemon_port@${p/\/ports\//:}" </dev/null >&/dev/null &
 done


### PR DESCRIPTION
The srp_daemon uses the InfiniBand specific features and cannot work
with other networks. So let's check the link layer and prevent running
the srp_dameon with unsupported networks. It is needed to avoid running
redundant srp_daemon instances and noise in the logs. The change is
primarily helpful for hosts that mix InfiniBand and RoCE devices.

Signed-off-by: Sergey Gorenko <sergeygo@nvidia.com>