### PR TITLE
libhns: Extended QP supports the new post send mechanism

### DIFF
--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -338,6 +338,12 @@ struct hns_roce_qp {
 	unsigned long			flags;
 	int				refcnt; /* specially used for XRC */
 	void				*dwqe_page;
+
+	/* specific fields for the new post send APIs */
+	int				err;
+	void				*cur_wqe;
+	unsigned int			rb_sq_head; /* roll back sq head */
+	struct hns_roce_sge_info	sge_info;
 };
 
 struct hns_roce_av {

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -122,6 +122,11 @@ enum {
 	HNS_ROCE_V2_CQ_DB_NTR,
 };
 
+enum hns_roce_wr_buf_type {
+	WR_BUF_TYPE_POST_SEND,
+	WR_BUF_TYPE_SEND_WR_OPS,
+};
+
 struct hns_roce_db {
 	__le32	byte_4;
 	__le32	parameter;
@@ -339,5 +344,7 @@ struct hns_roce_ud_sq_wqe {
 
 void hns_roce_v2_clear_qp(struct hns_roce_context *ctx, struct hns_roce_qp *qp);
 void hns_roce_attach_cq_ex_ops(struct ibv_cq_ex *cq_ex, uint64_t wc_flags);
+int hns_roce_attach_qp_ex_ops(struct ibv_qp_init_attr_ex *attr,
+			      struct hns_roce_qp *qp);
 
 #endif /* _HNS_ROCE_U_HW_V2_H */


### PR DESCRIPTION
The ofed provides a new set of post send APIs for extended QP. With the new
APIs, users can post send WR more efficiently. The hns driver provides
support for the new APIs.

Signed-off-by: Xinhao Liu <liuxinhao5@hisilicon.com>
Signed-off-by: Yixing Liu <liuyixing1@huawei.com>
Signed-off-by: Wenpeng Liang <liangwenpeng@huawei.com>