### PR TITLE
cmake: Add -DSYSTEMCTL_BIN option to set path to systemctl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,6 +220,9 @@ else()
 endif()
 
 find_program(SYSTEMCTL_BIN systemctl HINTS "/usr/bin" "/bin")
+if (NOT SYSTEMCTL_BIN)
+  set (SYSTEMCTL_BIN "/bin/systemctl")
+endif()
 
 RDMA_CheckSparse()
 


### PR DESCRIPTION
Make cmake fails if systemctl is not found automatically, unless
its path is manually set using -DSYSTEMCTL_BIN
This fixes build issues on debian systems where the minimal chroot does
not contain systemd.

Fixes: 05a19e050278 ("srp_daemon: Detect proper path to systemctl")
Reported-by: Benjamin Drung <benjamin.drung@ionos.com>
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>