### PR TITLE
Revert "suse: fix build for riscv64"

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -50,7 +50,7 @@ Group:          Productivity/Networking/Other
 %define  mlx4_lname   libmlx4-%{mlx4_so_major}
 %define  mlx5_lname   libmlx5-%{mlx5_so_major}
 
-%ifnarch s390 %arm riscv64
+%ifnarch s390 %arm
 %define dma_coherent 1
 %endif
 


### PR DESCRIPTION
This reverts commit 6b748e875b242957e420adac3b8da59060a53701.
riscv has been made dma coherent by: 63b41f22a9f5 ("util: Add barriers support for RISC-V")

Fixes: 6b748e875b24 ("suse: fix build for riscv64")
Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>