### PR TITLE
MAINTAINERS: Update hfi1 and qib entries

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -62,10 +62,8 @@ S:	Supported
 F:	providers/efa/
 
 HF1 USERSPACE PROVIDER (for hf1.ko)
-M:	Mike Marciniszyn <mike.marciniszyn@intel.com>
-M:	Dennis Dalessandro <dennis.dalessandro@intel.com>
+M:	Dennis Dalessandro <dennis.dalessandro@cornelisnetworks.com>
 S:	Supported
-L:	intel-opa@lists.01.org (moderated for non-subscribers)
 F:	providers/hfi1verbs/
 
 HNS USERSPACE PROVIDER (for hns-roce.ko)
@@ -87,9 +85,7 @@ S:	Supported
 F:	ibacm/*
 
 IPATH/QIB USERSPACE PROVIDER (for ib_qib.ko)
-M:	Mike Marciniszyn <mike.marciniszyn@intel.com>
-M:	Dennis Dalessandro <dennis.dalessandro@intel.com>
-L:	infinipath@intel.com
+M:	Dennis Dalessandro <dennis.dalessandro@cornelisnetworks.com>
 S:	Supported
 F:	providers/ipathverbs/
 


### PR DESCRIPTION
Remove Mike, outdated mailing lists, and change my address to Cornelis. After the
spinout from Intel we apparently neglected to update.

Signed-off-by: Dennis Dalessandro <dennis.dalessandro@cornelisnetworks.com>