### PR TITLE
librdmacm: Don't rely on IB device index if not available

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -419,7 +419,8 @@ err1:
 
 static bool match(struct cma_device *cma_dev, __be64 guid, uint32_t idx)
 {
-	if (idx == UCMA_INVALID_IB_INDEX)
+	if ((idx == UCMA_INVALID_IB_INDEX) ||
+	    (cma_dev->ibv_idx == UCMA_INVALID_IB_INDEX))
 		return cma_dev->guid == guid;
 
 	return cma_dev->ibv_idx == idx && cma_dev->guid == guid;


### PR DESCRIPTION
When rdma-core is built with "-DENABLE_RESOLVE_NEIGH=0", it skips
linkage to libnl library. This causes to ibv_idx to stay in its default
value (-1).
Update the match function to treat such scenario to be the same as
not-supported by the kernel flow.

Fixes: 28da4a8deb06 ("librdmacm: Rely on IB device index if available")
Signed-off-by: Mark Zhang <markzhang@nvidia.com>
Reviewed-by: Leon Romanovsky <leonro@nvidia.com>