### PR TITLE
mlx5: Handle the EREMOTEIO upon DEVX usage

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -2100,7 +2100,7 @@ struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_flow_meter(struct mlx5dv_dr_flow_meter_attr *attr)
 {
 	struct mlx5dv_dr_domain *dmn = attr->next_table->dmn;
-	uint64_t rx_icm_addr, tx_icm_addr;
+	uint64_t rx_icm_addr = 0, tx_icm_addr = 0;
 	struct mlx5dv_devx_obj *devx_obj;
 	struct mlx5dv_dr_action *action;
 	int ret;
@@ -2410,7 +2410,7 @@ dr_action_create_sampler(struct mlx5dv_dr_domain *dmn,
 {
 	struct dr_devx_flow_sampler_attr sampler_attr = {};
 	struct dr_flow_sampler *sampler;
-	uint64_t icm_rx, icm_tx;
+	uint64_t icm_rx = 0, icm_tx = 0;
 	int ret;
 
 	sampler = calloc(1, sizeof(struct dr_flow_sampler));

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -193,8 +193,8 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 {
 	uint32_t out[DEVX_ST_SZ_DW(query_hca_cap_out)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(query_hca_cap_in)] = {};
-	bool host_pf_vhca_id_valid;
-	uint16_t host_pf_vhca_id;
+	bool host_pf_vhca_id_valid = false;
+	uint16_t host_pf_vhca_id = 0;
 	uint32_t max_sfs = 0;
 	bool roce, sf_supp;
 	int err;

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -53,6 +53,7 @@ int dr_devx_query_esw_vport_context(struct ibv_context *ctx,
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query eswitch vport context failed %d\n", err);
 		return err;
 	}
@@ -77,6 +78,7 @@ static int dr_devx_query_nic_vport_context(struct ibv_context *ctx,
 		 MLX5_CMD_OP_QUERY_NIC_VPORT_CONTEXT);
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query nic vport context failed %d\n", err);
 		return err;
 	}
@@ -102,6 +104,7 @@ int dr_devx_query_gvmi(struct ibv_context *ctx, bool other_vport,
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query general failed %d\n", err);
 		return err;
 	}
@@ -134,6 +137,7 @@ static int dr_devx_query_esw_func(struct ibv_context *ctx,
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, outsz);
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query esw func failed %d\n", err);
 		free(out);
 		return err;
@@ -162,6 +166,7 @@ int dr_devx_query_esw_caps(struct ibv_context *ctx, struct dr_esw_caps *caps)
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query general failed %d\n", err);
 		return err;
 	}
@@ -206,6 +211,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query general failed %d\n", err);
 		return err;
 	}
@@ -301,6 +307,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query flow tables failed %d\n", err);
 		return err;
 	}
@@ -363,6 +370,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 		err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 		if (err) {
+			err = mlx5_get_cmd_status_err(err, out);
 			dr_dbg_ctx(ctx, "Query eswitch capabilities failed %d\n", err);
 			return err;
 		}
@@ -385,6 +393,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Query flow device memory caps failed %d\n", err);
 		return err;
 	}
@@ -410,6 +419,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 
 		err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 		if (err) {
+			err = mlx5_get_cmd_status_err(err, out);
 			dr_dbg_ctx(ctx, "Query RoCE capabilities failed %d\n", err);
 			return err;
 		}
@@ -433,8 +443,10 @@ int dr_devx_sync_steering(struct ibv_context *ctx)
 	DEVX_SET(sync_steering_in, in, opcode, MLX5_CMD_OP_SYNC_STEERING);
 
 	err = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
-	if (err)
+	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
 		dr_dbg_ctx(ctx, "Sync steering failed %d\n", err);
+	}
 
 	return err;
 }
@@ -445,6 +457,7 @@ dr_devx_create_flow_table(struct ibv_context *ctx,
 {
 	uint32_t out[DEVX_ST_SZ_DW(create_flow_table_out)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_flow_table_in)] = {};
+	struct mlx5dv_devx_obj *obj;
 	void *ft_ctx;
 
 	DEVX_SET(create_flow_table_in, in, opcode, MLX5_CMD_OP_CREATE_FLOW_TABLE);
@@ -476,7 +489,11 @@ dr_devx_create_flow_table(struct ibv_context *ctx,
 		}
 	}
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
+
 }
 
 int dr_devx_query_flow_table(struct mlx5dv_devx_obj *obj, uint32_t type,
@@ -494,7 +511,7 @@ int dr_devx_query_flow_table(struct mlx5dv_devx_obj *obj, uint32_t type,
 	if (ret) {
 		dr_dbg_ctx(obj->context, "Failed to query flow table id %u\n",
 			   obj->object_id);
-		return ret;
+		return mlx5_get_cmd_status_err(ret, out);
 	}
 
 	*tx_icm_addr = DEVX_GET64(query_flow_table_out, out,
@@ -525,6 +542,9 @@ dr_devx_create_flow_group(struct ibv_context *ctx,
 	DEVX_SET(create_flow_group_in, in, table_id, fg_attr->table_id);
 
 	obj = mlx5dv_devx_obj_create(ctx, in, inlen, out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+
 	free(in);
 
 	return obj;
@@ -630,6 +650,8 @@ dr_devx_set_fte(struct ibv_context *ctx,
 	}
 
 	obj = mlx5dv_devx_obj_create(ctx, in, inlen, out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
 
 	free(in);
 	return obj;
@@ -705,6 +727,7 @@ dr_devx_create_flow_sampler(struct ibv_context *ctx,
 {
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_flow_sampler_in)] = {};
+	struct mlx5dv_devx_obj *obj;
 	void *attr;
 
 	attr = DEVX_ADDR_OF(create_flow_sampler_in, in, hdr);
@@ -724,7 +747,10 @@ dr_devx_create_flow_sampler(struct ibv_context *ctx,
 	DEVX_SET(flow_sampler, attr, sample_table_id,
 		 sampler_attr->sample_table_id);
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
 }
 
 int dr_devx_query_flow_sampler(struct mlx5dv_devx_obj *obj,
@@ -745,7 +771,7 @@ int dr_devx_query_flow_sampler(struct mlx5dv_devx_obj *obj,
 	if (ret) {
 		dr_dbg_ctx(obj->context, "Failed to query flow sampler id %u\n",
 			   obj->object_id);
-		return ret;
+		return mlx5_get_cmd_status_err(ret, out);
 	}
 
 	attr = DEVX_ADDR_OF(query_flow_sampler_out, out, obj);
@@ -763,6 +789,7 @@ struct mlx5dv_devx_obj *dr_devx_create_definer(struct ibv_context *ctx,
 {
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_definer_in)] = {};
+	struct mlx5dv_devx_obj *obj;
 	void *ptr;
 
 	DEVX_SET(general_obj_in_cmd_hdr,
@@ -776,7 +803,10 @@ struct mlx5dv_devx_obj *dr_devx_create_definer(struct ibv_context *ctx,
 	ptr = DEVX_ADDR_OF(definer, ptr, match_mask_dw_7_0);
 	memcpy(ptr, match_mask, DEVX_FLD_SZ_BYTES(definer, match_mask_dw_7_0));
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
 }
 
 struct mlx5dv_devx_obj *dr_devx_create_reformat_ctx(struct ibv_context *ctx,
@@ -812,6 +842,8 @@ struct mlx5dv_devx_obj *dr_devx_create_reformat_ctx(struct ibv_context *ctx,
 	memcpy(pdata, reformat_data, reformat_size);
 
 	obj = mlx5dv_devx_obj_create(ctx, in, insz, out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
 	free(in);
 
 	return obj;
@@ -823,6 +855,7 @@ struct mlx5dv_devx_obj *dr_devx_create_meter(struct ibv_context *ctx,
 {
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_flow_meter_in)] = {};
+	struct mlx5dv_devx_obj *obj;
 	void *attr;
 
 	if (meter_attr->flow_meter_parameter_sz >
@@ -849,7 +882,10 @@ struct mlx5dv_devx_obj *dr_devx_create_meter(struct ibv_context *ctx,
 	memcpy(attr, meter_attr->flow_meter_parameter,
 	       meter_attr->flow_meter_parameter_sz);
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
 }
 
 int dr_devx_query_meter(struct mlx5dv_devx_obj *obj, uint64_t *rx_icm_addr,
@@ -870,7 +906,7 @@ int dr_devx_query_meter(struct mlx5dv_devx_obj *obj, uint64_t *rx_icm_addr,
 	if (ret) {
 		dr_dbg_ctx(obj->context, "Failed to query flow meter id %u\n",
 			   obj->object_id);
-		return ret;
+		return mlx5_get_cmd_status_err(ret, out);
 	}
 
 	attr = DEVX_ADDR_OF(query_flow_meter_out, out, obj);
@@ -887,6 +923,7 @@ int dr_devx_modify_meter(struct mlx5dv_devx_obj *obj,
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_flow_meter_in)] = {};
 	void *attr;
+	int ret;
 
 	if (meter_attr->flow_meter_parameter_sz >
 	    DEVX_FLD_SZ_BYTES(flow_meter, flow_meter_params)) {
@@ -911,7 +948,8 @@ int dr_devx_modify_meter(struct mlx5dv_devx_obj *obj,
 	memcpy(attr, meter_attr->flow_meter_parameter,
 	       meter_attr->flow_meter_parameter_sz);
 
-	return mlx5dv_devx_obj_modify(obj, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_obj_modify(obj, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,
@@ -920,6 +958,7 @@ struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,
 	uint32_t in[DEVX_ST_SZ_DW(create_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(create_qp_out)] = {};
 	void *qpc = DEVX_ADDR_OF(create_qp_in, in, qpc);
+	struct mlx5dv_devx_obj *obj;
 
 	DEVX_SET(create_qp_in, in, opcode, MLX5_CMD_OP_CREATE_QP);
 
@@ -938,7 +977,10 @@ struct mlx5dv_devx_obj *dr_devx_create_qp(struct ibv_context *ctx,
 
 	DEVX_SET(create_qp_in, in, wq_umem_id, attr->buff_umem_id);
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
 }
 
 int dr_devx_modify_qp_rst2init(struct ibv_context *ctx,
@@ -948,6 +990,7 @@ int dr_devx_modify_qp_rst2init(struct ibv_context *ctx,
 	uint32_t in[DEVX_ST_SZ_DW(rst2init_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(rst2init_qp_out)] = {};
 	void *qpc = DEVX_ADDR_OF(rst2init_qp_in, in, qpc);
+	int ret;
 
 	DEVX_SET(rst2init_qp_in, in, opcode, MLX5_CMD_OP_RST2INIT_QP);
 	DEVX_SET(rst2init_qp_in, in, qpn, qp_obj->object_id);
@@ -957,8 +1000,8 @@ int dr_devx_modify_qp_rst2init(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, rre, 1);
 	DEVX_SET(qpc, qpc, rwe, 1);
 
-	return mlx5dv_devx_obj_modify(qp_obj, in,
-				      sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_obj_modify(qp_obj, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 #define DR_DEVX_ICM_UDP_PORT 49999
@@ -970,6 +1013,7 @@ int dr_devx_modify_qp_init2rtr(struct ibv_context *ctx,
 	uint32_t in[DEVX_ST_SZ_DW(init2rtr_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(init2rtr_qp_out)] = {};
 	void *qpc = DEVX_ADDR_OF(init2rtr_qp_in, in, qpc);
+	int ret;
 
 	DEVX_SET(init2rtr_qp_in, in, opcode, MLX5_CMD_OP_INIT2RTR_QP);
 	DEVX_SET(init2rtr_qp_in, in, qpn, qp_obj->object_id);
@@ -995,8 +1039,8 @@ int dr_devx_modify_qp_init2rtr(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, primary_address_path.vhca_port_num, attr->port_num);
 	DEVX_SET(qpc, qpc, min_rnr_nak, 1);
 
-	return mlx5dv_devx_obj_modify(qp_obj, in,
-				      sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_obj_modify(qp_obj, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 int dr_devx_modify_qp_rtr2rts(struct ibv_context *ctx,
@@ -1006,6 +1050,7 @@ int dr_devx_modify_qp_rtr2rts(struct ibv_context *ctx,
 	uint32_t in[DEVX_ST_SZ_DW(rtr2rts_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(rtr2rts_qp_out)] = {};
 	void *qpc = DEVX_ADDR_OF(rtr2rts_qp_in, in, qpc);
+	int ret;
 
 	DEVX_SET(rtr2rts_qp_in, in, opcode, MLX5_CMD_OP_RTR2RTS_QP);
 	DEVX_SET(rtr2rts_qp_in, in, qpn, qp_obj->object_id);
@@ -1014,8 +1059,8 @@ int dr_devx_modify_qp_rtr2rts(struct ibv_context *ctx,
 	DEVX_SET(qpc, qpc, retry_count, attr->retry_cnt);
 	DEVX_SET(qpc, qpc, rnr_retry, attr->rnr_retry);
 
-	return mlx5dv_devx_obj_modify(qp_obj, in,
-				      sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_obj_modify(qp_obj, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 int dr_devx_query_gid(struct ibv_context *ctx, uint8_t vhca_port_num,
@@ -1033,7 +1078,7 @@ int dr_devx_query_gid(struct ibv_context *ctx, uint8_t vhca_port_num,
 
 	ret = mlx5dv_devx_general_cmd(ctx, in, sizeof(in), out, sizeof(out));
 	if (ret)
-		return ret;
+		return mlx5_get_cmd_status_err(ret, out);
 
 	memcpy(&attr->gid,
 	       DEVX_ADDR_OF(query_roce_address_out,

--- a/providers/mlx5/man/mlx5dv_devx_create_eq.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_create_eq.3.md
@@ -74,6 +74,8 @@ On error NULL will be returned and errno will be set.
 
 Upon success *mlx5dv_devx_destroy_eq* will return 0, on error errno will be returned.
 
+If the error value is EREMOTEIO, outbox.status and outbox.syndrome will contain the command failure details.
+
 # SEE ALSO
 
 *mlx5dv_devx_alloc_msi_vector(3)*, *mlx5dv_devx_query_eqn(3)*

--- a/providers/mlx5/man/mlx5dv_devx_obj_create.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_obj_create.3.md
@@ -118,6 +118,8 @@ mlx5dv_devx_obj* on error NULL will be returned and errno will be set.
 
 Upon success query, modify, destroy, general commands, 0 is returned or the value of errno on a failure.
 
+If the error value is EREMOTEIO, outbox.status and outbox.syndrome will contain the command failure details.
+
 # SEE ALSO
 
 **mlx5dv_open_device**, **mlx5dv_devx_create_cmd_comp**, **mlx5dv_devx_get_async_cmd_comp**

--- a/providers/mlx5/man/mlx5dv_devx_qp_modify.3.md
+++ b/providers/mlx5/man/mlx5dv_devx_qp_modify.3.md
@@ -90,6 +90,8 @@ object via DEVX (e.g. mlx5dv_devx_qp_modify).
 
 Upon success 0 is returned or the value of errno on a failure.
 
+If the error value is EREMOTEIO, outbox.status outbox.syndrome will contain the command failure details.
+
 # SEE ALSO
 
 **mlx5dv_open_device**, **mlx5dv_devx_obj_create**

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1145,7 +1145,7 @@ static bool lag_operation_supported(struct ibv_qp *qp)
 static int _mlx5dv_query_qp_lag_port(struct ibv_qp *qp, uint8_t *port_num,
 				     uint8_t *active_port_num)
 {
-	uint8_t lag_state, tx_remap_affinity_1, tx_remap_affinity_2;
+	uint8_t lag_state = 0, tx_remap_affinity_1 = 0, tx_remap_affinity_2 = 0;
 	uint32_t in_tis[DEVX_ST_SZ_DW(query_tis_in)] = {};
 	uint32_t out_tis[DEVX_ST_SZ_DW(query_tis_out)] = {};
 	uint32_t in_qp[DEVX_ST_SZ_DW(query_qp_in)] = {};

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -224,6 +224,36 @@ static int32_t get_free_uidx(struct mlx5_context *ctx)
 	return (tind << MLX5_UIDX_TABLE_SHIFT) | i;
 }
 
+int mlx5_cmd_status_to_err(uint8_t status)
+{
+	switch (status) {
+	case MLX5_CMD_STAT_OK:				return 0;
+	case MLX5_CMD_STAT_INT_ERR:			return EIO;
+	case MLX5_CMD_STAT_BAD_OP_ERR:			return EINVAL;
+	case MLX5_CMD_STAT_BAD_PARAM_ERR:		return EINVAL;
+	case MLX5_CMD_STAT_BAD_SYS_STATE_ERR:		return EIO;
+	case MLX5_CMD_STAT_BAD_RES_ERR:			return EINVAL;
+	case MLX5_CMD_STAT_RES_BUSY:			return EBUSY;
+	case MLX5_CMD_STAT_LIM_ERR:			return ENOMEM;
+	case MLX5_CMD_STAT_BAD_RES_STATE_ERR:		return EINVAL;
+	case MLX5_CMD_STAT_IX_ERR:			return EINVAL;
+	case MLX5_CMD_STAT_NO_RES_ERR:			return EAGAIN;
+	case MLX5_CMD_STAT_BAD_INP_LEN_ERR:		return EIO;
+	case MLX5_CMD_STAT_BAD_OUTP_LEN_ERR:		return EIO;
+	case MLX5_CMD_STAT_BAD_QP_STATE_ERR:		return EINVAL;
+	case MLX5_CMD_STAT_BAD_PKT_ERR:			return EINVAL;
+	case MLX5_CMD_STAT_BAD_SIZE_OUTS_CQES_ERR:	return EINVAL;
+	default:					return EIO;
+	}
+}
+
+int mlx5_get_cmd_status_err(int err, void *out)
+{
+	if (err == EREMOTEIO)
+		err = mlx5_cmd_status_to_err(DEVX_GET(mbox_out, out, status));
+	return err;
+}
+
 int32_t mlx5_store_uidx(struct mlx5_context *ctx, void *rsc)
 {
 	int32_t tind;
@@ -334,8 +364,10 @@ struct mlx5_psv *mlx5_create_psv(struct ibv_pd *pd)
 
 	psv->devx_obj = mlx5dv_devx_obj_create(pd->context, in, sizeof(in),
 					       out, sizeof(out));
-	if (!psv->devx_obj)
+	if (!psv->devx_obj) {
+		errno = mlx5_get_cmd_status_err(errno, out);
 		goto err_free_psv;
+	}
 
 	psv->index = DEVX_GET(create_psv_out, out, psv0_index);
 
@@ -1108,7 +1140,7 @@ static int query_lag(struct ibv_context *ctx, uint8_t *lag_state,
 	ret = mlx5dv_devx_general_cmd(ctx, in_lag, sizeof(in_lag), out_lag,
 				      sizeof(out_lag));
 	if (ret)
-		return ret;
+		return mlx5_get_cmd_status_err(ret, out_lag);
 
 	*lag_state = DEVX_GET(query_lag_out, out_lag, ctx.lag_state);
 	if (tx_remap_affinity_1)
@@ -1172,7 +1204,7 @@ static int _mlx5dv_query_qp_lag_port(struct ibv_qp *qp, uint8_t *port_num,
 		ret = mlx5dv_devx_qp_query(qp, in_tis, sizeof(in_tis), out_tis,
 					   sizeof(out_tis));
 		if (ret)
-			return ret;
+			return mlx5_get_cmd_status_err(ret, out_tis);
 
 		*port_num = DEVX_GET(query_tis_out, out_tis,
 				     tis_context.lag_tx_port_affinity);
@@ -1184,7 +1216,7 @@ static int _mlx5dv_query_qp_lag_port(struct ibv_qp *qp, uint8_t *port_num,
 		ret = mlx5dv_devx_qp_query(qp, in_qp, sizeof(in_qp), out_qp,
 					   sizeof(out_qp));
 		if (ret)
-			return ret;
+			return mlx5_get_cmd_status_err(ret, out_qp);
 
 		*port_num = DEVX_GET(query_qp_out, out_qp,
 				     qpc.lag_tx_port_affinity);
@@ -1224,12 +1256,14 @@ static int modify_tis_lag_port(struct ibv_qp *qp, uint8_t port_num)
 	uint32_t out[DEVX_ST_SZ_DW(modify_tis_out)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(modify_tis_in)] = {};
 	struct mlx5_qp *mqp = to_mqp(qp);
+	int ret;
 
 	DEVX_SET(modify_tis_in, in, opcode, MLX5_CMD_OP_MODIFY_TIS);
 	DEVX_SET(modify_tis_in, in, tisn, mqp->tisn);
 	DEVX_SET(modify_tis_in, in, bitmask.lag_tx_port_affinity, 1);
 	DEVX_SET(modify_tis_in, in, ctx.lag_tx_port_affinity, port_num);
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static int modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num)
@@ -1237,6 +1271,7 @@ static int modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num)
 	uint32_t out[DEVX_ST_SZ_DW(rts2rts_qp_out)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(rts2rts_qp_in)] = {};
 	struct mlx5_context *mctx = to_mctx(qp->context);
+	int ret;
 
 	if (!mctx->entropy_caps.rts2rts_lag_tx_port_affinity ||
 	    qp->state != IBV_QPS_RTS)
@@ -1247,7 +1282,8 @@ static int modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num)
 	DEVX_SET(rts2rts_qp_in, in, opt_param_mask,
 		 MLX5_QPC_OPT_MASK_RTS2RTS_LAG_TX_PORT_AFFINITY);
 	DEVX_SET(rts2rts_qp_in, in, qpc.lag_tx_port_affinity, port_num);
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static int _mlx5dv_modify_qp_lag_port(struct ibv_qp *qp, uint8_t port_num)
@@ -1297,6 +1333,7 @@ static int _mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport)
 	uint32_t in[DEVX_ST_SZ_DW(rts2rts_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(rts2rts_qp_out)] = {};
 	struct mlx5_context *mctx = to_mctx(qp->context);
+	int ret;
 
 	switch (qp->qp_type) {
 	case IBV_QPT_RC:
@@ -1315,8 +1352,8 @@ static int _mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport)
 	DEVX_SET(rts2rts_qp_in, in, qpc.primary_address_path.udp_sport,
 		 udp_sport);
 
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out,
-				     sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 int mlx5dv_modify_qp_udp_sport(struct ibv_qp *qp, uint16_t udp_sport)
@@ -1336,6 +1373,7 @@ int mlx5dv_dci_stream_id_reset(struct ibv_qp *qp, uint16_t stream_id)
 	struct mlx5_context *mctx = to_mctx(qp->context);
 	struct mlx5_qp *mqp = to_mqp(qp);
 	void *qpce = DEVX_ADDR_OF(rts2rts_qp_in, in, qpc_data_ext);
+	int ret;
 
 	if (!is_mlx5_dev(qp->context->device) ||
 	    !mctx->dci_streams_caps.max_log_num_errored ||
@@ -1354,7 +1392,8 @@ int mlx5dv_dci_stream_id_reset(struct ibv_qp *qp, uint16_t stream_id)
 
 	DEVX_SET(qpc_ext, qpce, dci_stream_channel_id, stream_id);
 
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static bool sched_supported(struct ibv_context *ctx)
@@ -1374,6 +1413,7 @@ mlx5dv_sched_nic_create(struct ibv_context *ctx,
 {
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_sched_elem_in)] = {};
+	struct mlx5dv_devx_obj *obj;
 	uint32_t parent_id;
 	void *attr;
 
@@ -1404,7 +1444,10 @@ mlx5dv_sched_nic_create(struct ibv_context *ctx,
 	DEVX_SET(sched_elem_attr_tsar, attr, tsar_type,
 		 MLX5_SCHED_TSAR_TYPE_DWRR);
 
-	return mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	obj = mlx5dv_devx_obj_create(ctx, in, sizeof(in), out, sizeof(out));
+	if (!obj)
+		errno = mlx5_get_cmd_status_err(errno, out);
+	return obj;
 }
 
 static int
@@ -1415,6 +1458,7 @@ mlx5dv_sched_nic_modify(struct mlx5dv_devx_obj *obj,
 	uint32_t out[DEVX_ST_SZ_DW(general_obj_out_cmd_hdr)] = {};
 	uint32_t in[DEVX_ST_SZ_DW(create_sched_elem_in)] = {};
 	void *attr;
+	int ret;
 
 	attr = DEVX_ADDR_OF(create_sched_elem_in, in, hdr);
 	DEVX_SET(general_obj_in_cmd_hdr,
@@ -1441,7 +1485,8 @@ mlx5dv_sched_nic_modify(struct mlx5dv_devx_obj *obj,
 	DEVX_SET(sched_elem_attr_tsar, attr, tsar_type,
 		 MLX5_SCHED_TSAR_TYPE_DWRR);
 
-	return mlx5dv_devx_obj_modify(obj, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_obj_modify(obj, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 #define MLX5DV_SCHED_ELEM_ATTR_ALL_FLAGS \
@@ -1684,6 +1729,7 @@ static int modify_ib_qp_sched_elem_init(struct ibv_qp *qp,
 	uint32_t in[DEVX_ST_SZ_DW(init2init_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(init2init_qp_out)] = {};
 	void *qpce = DEVX_ADDR_OF(init2init_qp_in, in, qpc_data_ext);
+	int ret;
 
 	DEVX_SET(init2init_qp_in, in, opcode, MLX5_CMD_OP_INIT2INIT_QP);
 	DEVX_SET(init2init_qp_in, in, qpc_ext, 1);
@@ -1693,7 +1739,8 @@ static int modify_ib_qp_sched_elem_init(struct ibv_qp *qp,
 	DEVX_SET(qpc_ext, qpce, qos_queue_group_id_requester, req_id);
 	DEVX_SET(qpc_ext, qpce, qos_queue_group_id_responder, resp_id);
 
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static int modify_ib_qp_sched_elem_rts(struct ibv_qp *qp,
@@ -1703,6 +1750,7 @@ static int modify_ib_qp_sched_elem_rts(struct ibv_qp *qp,
 	uint32_t in[DEVX_ST_SZ_DW(rts2rts_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(rts2rts_qp_out)] = {};
 	void *qpce = DEVX_ADDR_OF(rts2rts_qp_in, in, qpc_data_ext);
+	int ret;
 
 	DEVX_SET(rts2rts_qp_in, in, opcode, MLX5_CMD_OP_RTS2RTS_QP);
 	DEVX_SET(rts2rts_qp_in, in, qpc_ext, 1);
@@ -1712,7 +1760,8 @@ static int modify_ib_qp_sched_elem_rts(struct ibv_qp *qp,
 	DEVX_SET(qpc_ext, qpce, qos_queue_group_id_requester, req_id);
 	DEVX_SET(qpc_ext, qpce, qos_queue_group_id_responder, resp_id);
 
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static int modify_ib_qp_sched_elem(struct ibv_qp *qp,
@@ -1743,6 +1792,7 @@ static int modify_raw_qp_sched_elem(struct ibv_qp *qp, uint32_t qos_id)
 	uint32_t min[DEVX_ST_SZ_DW(modify_sq_in)] = {};
 	struct mlx5_qp *mqp = to_mqp(qp);
 	void *sqc;
+	int ret;
 
 	if (qp->state != IBV_QPS_RTS || !qc->nic_sq_scheduling)
 		return EOPNOTSUPP;
@@ -1756,7 +1806,8 @@ static int modify_raw_qp_sched_elem(struct ibv_qp *qp, uint32_t qos_id)
 	DEVX_SET(sqc, sqc, state, MLX5_SQC_STATE_RDY);
 	DEVX_SET(sqc, sqc, qos_queue_group_id, qos_id);
 
-	return mlx5dv_devx_qp_modify(qp, min, sizeof(min), mout, sizeof(mout));
+	ret = mlx5dv_devx_qp_modify(qp, min, sizeof(min), mout, sizeof(mout));
+	return ret ? mlx5_get_cmd_status_err(ret, mout) : 0;
 }
 
 static int _mlx5dv_modify_qp_sched_elem(struct ibv_qp *qp,
@@ -1806,6 +1857,7 @@ int mlx5_modify_qp_drain_sigerr(struct ibv_qp *qp)
 	uint32_t in[DEVX_ST_SZ_DW(init2init_qp_in)] = {};
 	uint32_t out[DEVX_ST_SZ_DW(init2init_qp_out)] = {};
 	void *qpc = DEVX_ADDR_OF(init2init_qp_in, in, qpc);
+	int ret;
 
 	DEVX_SET(init2init_qp_in, in, opcode, MLX5_CMD_OP_INIT2INIT_QP);
 	DEVX_SET(init2init_qp_in, in, qpn, qp->qp_num);
@@ -1813,7 +1865,8 @@ int mlx5_modify_qp_drain_sigerr(struct ibv_qp *qp)
 
 	DEVX_SET(qpc, qpc, drain_sigerr, 1);
 
-	return mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	ret = mlx5dv_devx_qp_modify(qp, in, sizeof(in), out, sizeof(out));
+	return ret ? mlx5_get_cmd_status_err(ret, out) : 0;
 }
 
 static struct reserved_qpn_blk *reserved_qpn_blk_alloc(struct mlx5_context *mctx)
@@ -1845,8 +1898,10 @@ static struct reserved_qpn_blk *reserved_qpn_blk_alloc(struct mlx5_context *mctx
 
 	blk->obj = mlx5dv_devx_obj_create(&mctx->ibv_ctx.context,
 					  in, sizeof(in), out, sizeof(out));
-	if (!blk->obj)
+	if (!blk->obj) {
+		errno = mlx5_get_cmd_status_err(errno, out);
 		goto obj_alloc_fail;
+	}
 
 	blk->first_qpn = blk->obj->object_id;
 	blk->next_avail_slot = 0;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1594,4 +1594,7 @@ struct mlx5_dv_context_ops {
 struct mlx5_dv_context_ops *mlx5_get_dv_ops(struct ibv_context *context);
 void mlx5_set_dv_ctx_ops(struct mlx5_dv_context_ops *ops);
 
+int mlx5_cmd_status_to_err(uint8_t status);
+int mlx5_get_cmd_status_err(int err, void *out);
+
 #endif /* MLX5_H */

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -184,29 +184,6 @@ end:
 	pthread_mutex_unlock(&ctx->mem_alloc.block_list_mutex);
 }
 
-static int cmd_status_to_err(uint8_t status)
-{
-	switch (status) {
-	case MLX5_CMD_STAT_OK:				return 0;
-	case MLX5_CMD_STAT_INT_ERR:			return EIO;
-	case MLX5_CMD_STAT_BAD_OP_ERR:			return EINVAL;
-	case MLX5_CMD_STAT_BAD_PARAM_ERR:		return EINVAL;
-	case MLX5_CMD_STAT_BAD_SYS_STATE_ERR:		return EIO;
-	case MLX5_CMD_STAT_BAD_RES_ERR:			return EINVAL;
-	case MLX5_CMD_STAT_RES_BUSY:			return EBUSY;
-	case MLX5_CMD_STAT_LIM_ERR:			return ENOMEM;
-	case MLX5_CMD_STAT_BAD_RES_STATE_ERR:		return EINVAL;
-	case MLX5_CMD_STAT_IX_ERR:			return EINVAL;
-	case MLX5_CMD_STAT_NO_RES_ERR:			return EAGAIN;
-	case MLX5_CMD_STAT_BAD_INP_LEN_ERR:		return EIO;
-	case MLX5_CMD_STAT_BAD_OUTP_LEN_ERR:		return EIO;
-	case MLX5_CMD_STAT_BAD_QP_STATE_ERR:		return EINVAL;
-	case MLX5_CMD_STAT_BAD_PKT_ERR:			return EINVAL;
-	case MLX5_CMD_STAT_BAD_SIZE_OUTS_CQES_ERR:	return EINVAL;
-	default:					return EIO;
-	}
-}
-
 static const char *cmd_status_str(uint8_t status)
 {
 	switch (status) {
@@ -319,7 +296,7 @@ static int mlx5_vfio_cmd_check(struct mlx5_vfio_context *ctx, void *in, void *ou
 		 opcode, op_mod,
 		 cmd_status_str(status), status, syndrome);
 
-	errno = cmd_status_to_err(status);
+	errno = mlx5_cmd_status_to_err(status);
 	return errno;
 }
 

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -4071,8 +4071,10 @@ static int mlx5_qp_query_sqd(struct mlx5_qp *mqp, unsigned int *cur_idx)
 	DEVX_SET(query_qp_in, in, qpn, ibqp->qp_num);
 
 	err = mlx5dv_devx_qp_query(ibqp, in, sizeof(in), out, sizeof(out));
-	if (err)
-		return -errno;
+	if (err) {
+		err = mlx5_get_cmd_status_err(err, out);
+		return -err;
+	}
 
 	qpc = DEVX_ADDR_OF(query_qp_out, out, qpc);
 	if (DEVX_GET(qpc, qpc, state) != MLX5_QPC_STATE_SQDRAINED)


### PR DESCRIPTION
This series handles the EREMOTEIO return code upon DEVX usage.

When a DEVX command is executed by FW and failed, EREMOTEIO is returned to indicate the caller that the command status and syndrome are available in the outbox.
 
- Add this info to the DEVX man pages.
- Translate the EREMOTEIO to the real error when DEVX is used internally.
- Align VFIO DEVX APIs return codes to the regular DEVX APIs.