### PR TITLE
debian: add riscv64 to COHERENT_DMA_ARCHS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ include /usr/share/dpkg/architecture.mk
 
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
-COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 powerpc powerpcspe ppc64 ppc64el s390x sparc64 x32
+COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
 
 dh_params = --with python3,systemd --builddirectory=build-deb
 


### PR DESCRIPTION
DMA coherence has recently been added for RISC-V.
See commit 63b41f22a9f5 ("util: Add barriers support for RISC-V")

Signed-off-by: Heinrich Schuchardt <heinrich.schuchardt@canonical.com>