### PR TITLE
rdma_xserver/xclient: Make recv/send WQs disjunctive

### DIFF
--- a/librdmacm/examples/rdma_xclient.c
+++ b/librdmacm/examples/rdma_xclient.c
@@ -87,8 +87,12 @@ static int test(void)
 	}
 
 	memset(&attr, 0, sizeof attr);
-	attr.cap.max_send_wr = attr.cap.max_recv_wr = 1;
-	attr.cap.max_send_sge = attr.cap.max_recv_sge = 1;
+	attr.cap.max_send_wr = 1;
+	attr.cap.max_send_sge = 1;
+	if (hints.ai_qp_type != IBV_QPT_XRC_SEND) {
+		attr.cap.max_recv_wr = 1;
+		attr.cap.max_recv_sge = 1;
+	}
 	attr.sq_sig_all = 1;
 	ret = rdma_create_ep(&id, res, NULL, &attr);
 	rdma_freeaddrinfo(res);

--- a/librdmacm/examples/rdma_xserver.c
+++ b/librdmacm/examples/rdma_xserver.c
@@ -84,8 +84,12 @@ static int test(void)
 	}
 
 	memset(&attr, 0, sizeof attr);
-	attr.cap.max_send_wr = attr.cap.max_recv_wr = 1;
-	attr.cap.max_send_sge = attr.cap.max_recv_sge = 1;
+	attr.cap.max_recv_wr = 1;
+	attr.cap.max_recv_sge = 1;
+	if (hints.ai_qp_type != IBV_QPT_XRC_RECV) {
+		attr.cap.max_send_wr = 1;
+		attr.cap.max_send_sge = 1;
+	}
 	ret = rdma_create_ep(&listen_id, res, NULL, &attr);
 	rdma_freeaddrinfo(res);
 	if (ret) {


### PR DESCRIPTION
Running rdma_xclient on a system with CX-5, yields the following
error:

$ rdma_xclient -s 192.168.77.1 -c x
rdma_xclient: start
rdma_create_ep: Invalid argument
rdma_xclient: end -1

Enabling dynamic tracing of the mlx5/qp.c file gives:

infiniband mlx5_0: create_qp:3035:(pid 53349): Create QP type 9 failed

This is because the rdma_xclient sets the max_recv_{wr,sge} in the
ibv_qp_init_attr struct before calling rdma_create_ep().

An XRC_SEND QP type shall not have a receive queue and an XRC_RECV QP
type shall not have a send queue.

Fixed by only configuring the send/recv queue in rdma_xserver/xclient
respectively.

Fixes: 6bda3d049bcf ("rdma_xserver/client: Add new test apps")
Signed-off-by: Håkon Bugge <haakon.bugge@oracle.com>