### PR TITLE
tests: Skip test if QP type is not supported

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -362,6 +362,9 @@ class RDMACMBaseTest(RDMATestCase):
             res, side = self.notifier.get()
             proc_res[side] = res
         for ex in proc_res.values():
+            if isinstance(ex, PyverbsRDMAError) and \
+                    ex.error_code == errno.EOPNOTSUPP:
+                        raise unittest.SkipTest(ex)
             if isinstance(ex, unittest.case.SkipTest):
                 raise(ex)
         if proc_res:


### PR DESCRIPTION
Avoid the following failure when running the test_rdmacm_async_udp_traffic
test over the qedr provider, this is happening because UD QP is not
supported by the qedr provider.

```
======================================================================
ERROR: test_rdmacm_async_udp_traffic (tests.test_rdmacm.CMTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rdma-core/tests/test_rdmacm.py", line 57, in test_rdmacm_async_udp_traffic
    self.two_nodes_rdmacm_traffic(CMAsyncConnection, self.rdmacm_traffic,
  File "/home/rdma-core/tests/base.py", line 370, in two_nodes_rdmacm_traffic
    raise(res)
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to Create QP. Errno: 95, Operation not supported

----------------------------------------------------------------------
```

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>