### PR TITLE
tests: Skip test_resize_cq if QP type is not supported

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -654,10 +654,15 @@ class UDResources(TrafficResources):
         qp_attr.qkey = self.UD_QKEY
         qp_attr.pkey_index = self.UD_PKEY_INDEX
         for _ in range(self.qp_count):
-            qp = QP(self.pd, qp_init_attr, qp_attr)
-            self.qps.append(qp)
-            self.qps_num.append(qp.qp_num)
-            self.psns.append(random.getrandbits(24))
+            try:
+                qp = QP(self.pd, qp_init_attr, qp_attr)
+                self.qps.append(qp)
+                self.qps_num.append(qp.qp_num)
+                self.psns.append(random.getrandbits(24))
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EOPNOTSUPP:
+                    raise unittest.SkipTest(f'Create QP type {qp_init_attr.qp_type} is not supported')
+                raise ex
 
     def pre_run(self, rpsns, rqps_num):
         self.rpsns = rpsns


### PR DESCRIPTION
Avoid the following failure when running test_resize_cq over the qedr provider
as UD QP is not supported.

```
======================================================================
ERROR: test_resize_cq (tests.test_cq.CQTest)
Test resize CQ, start with specific value and then increase and decrease
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/rdma-core/tests/test_cq.py", line 107, in test_resize_cq
    self.create_players(CQUDResources, cq_depth=3)
  File "/home/rdma-core/tests/test_cq.py", line 93, in create_players
    self.client = resource(**self.dev_info, **resource_arg)
  File "/home/rdma-core/tests/test_cq.py", line 22, in __init__
    super().__init__(dev_name, ib_port, gid_index)
  File "/home/rdma-core/tests/base.py", line 508, in __init__
    self.init_resources()
  File "/home/rdma-core/tests/base.py", line 529, in init_resources
    self.create_qps()
  File "/home/rdma-core/tests/base.py", line 657, in create_qps
    qp = QP(self.pd, qp_init_attr, qp_attr)
  File "qp.pyx", line 982, in pyverbs.qp.QP.__init__
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to create QP. Errno: 95, Operation not supported

----------------------------------------------------------------------
```

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>