### PR TITLE
Update my email address to @ubuntu.com

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -42,7 +42,7 @@ F:	*/lib*.map
 F:	buildlib/
 
 DEBIAN PACKAGING
-M:	Benjamin Drung <benjamin.drung@ionos.com>
+M:	Benjamin Drung <bdrung@ubuntu.com>
 S:	Supported
 F:	debian/
 

--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: rdma-core
 Maintainer: Linux RDMA Mailing List <linux-rdma@vger.kernel.org>
-Uploaders: Benjamin Drung <benjamin.drung@ionos.com>,
+Uploaders: Benjamin Drung <bdrung@ubuntu.com>,
            Talat Batheesh <talatb@mellanox.com>
 Section: net
 Priority: optional

--- a/debian/copyright
+++ b/debian/copyright
@@ -12,7 +12,7 @@ Files: debian/*
 Copyright: 2008, Genome Research Ltd
            2014, Ana Beatriz Guerrero Lopez <ana@debian.org>
            2015-2016, Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
-           2016-2022, Benjamin Drung <benjamin.drung@ionos.com>
+           2016-2022, Benjamin Drung <bdrung@ubuntu.com>
            2016-2017, Talat Batheesh <talatb@mellanox.com>
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify


### PR DESCRIPTION
I left IONOS by end of March 2022 and joined the Foundation team at Canonical. I will continue maintaining the rdma-core Debian/Ubuntu package as part of my new job.