### PR TITLE
pyverbs/mr.pyx: Make MR and MW print style indentical

### DIFF
--- a/pyverbs/mr.pyx
+++ b/pyverbs/mr.pyx
@@ -240,7 +240,7 @@ cdef class MR(PyverbsCM):
 
     def __str__(self):
         print_format = '{:22}: {:<20}\n'
-        return 'MR\n' + \
+        return 'MR:\n' + \
                print_format.format('lkey', self.lkey) + \
                print_format.format('rkey', self.rkey) + \
                print_format.format('length', self.length) + \


### PR DESCRIPTION
after this patch:

mw = MW:
Rkey		: 12345678
Handle		: 4
MW Type		: IBV_MW_TYPE_2

mr = MR:
lkey		: 432134
rkey		: 432134
length		: 1024
buf		: 9403912345678
handle		: 2

Reported-by: Bob Pearson <rpearsonhpe@gmail.com>
Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>