### PR TITLE
mlx5: Misc. items

### DIFF
--- a/providers/mlx5/dr_ste_v2.c
+++ b/providers/mlx5/dr_ste_v2.c
@@ -90,6 +90,9 @@ static const struct dr_ste_action_modify_field dr_ste_v2_action_modify_field_arr
 	[MLX5_ACTION_IN_FIELD_OUT_IP_DSCP] = {
 		.hw_field = DR_STE_V2_ACTION_MDFY_FLD_L3_OUT_0, .start = 18, .end = 23,
 	},
+	[MLX5_ACTION_IN_FIELD_OUT_IP_ECN] = {
+		.hw_field = DR_STE_V2_ACTION_MDFY_FLD_L3_OUT_0, .start = 16, .end = 17,
+	},
 	[MLX5_ACTION_IN_FIELD_OUT_TCP_FLAGS] = {
 		.hw_field = DR_STE_V2_ACTION_MDFY_FLD_L4_OUT_1, .start = 16, .end = 24,
 		.l4_type = DR_STE_ACTION_MDFY_TYPE_L4_TCP,

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -633,7 +633,7 @@ static inline int set_bind_wr(struct mlx5_qp *qp, enum ibv_mw_type type,
 	if (!bind_info->length)
 		return 0;
 
-	if (unlikely((seg == qend)))
+	if (unlikely((*seg == qend)))
 		*seg = mlx5_get_send_wqe(qp, 0);
 
 	set_umr_data_seg(qp, type, rkey, bind_info, qpn, seg, size);


### PR DESCRIPTION
This series handles the below 2 items.
- Add support for modify IP ECN action for CX7 in the DR area.
- Fix a check for SQ overflow in bind mw.


