### PR TITLE
mlx5: Add cyclic SRQ topology

### DIFF
--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -522,6 +522,12 @@ struct mlx5_tag_entry {
 	int8_t		       expect_cqe;
 };
 
+enum mlx5_srq_topo {
+	MLX5_SRQ_TOPO_LIST,
+	MLX5_SRQ_TOPO_CYCLIC,
+	MLX5_SRQ_TOPO_MAX
+};
+
 struct mlx5_srq_op {
 	struct mlx5_tag_entry *tag;
 	uint64_t	       wr_id;
@@ -556,6 +562,7 @@ struct mlx5_srq {
 	int				op_tail;
 	int				unexp_in;
 	int				unexp_out;
+	enum mlx5_srq_topo topo;
 };
 
 

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -1190,7 +1190,8 @@ struct mlx5_wqe_srq_next_seg {
 	uint8_t			rsvd0[2];
 	__be16			next_wqe_index;
 	uint8_t			signature;
-	uint8_t			rsvd1[11];
+	uint8_t			free;
+	uint8_t			rsvd1[10];
 };
 
 struct mlx5_wqe_data_seg {

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1306,6 +1306,7 @@ struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 	struct mlx5_context	   *ctx;
 	int			    max_sge;
 	struct ibv_srq		   *ibsrq;
+	char *topo;
 
 	ctx = to_mctx(pd->context);
 	srq = calloc(1, sizeof *srq);
@@ -1391,6 +1392,12 @@ struct ibv_srq *mlx5_create_srq(struct ibv_pd *pd,
 	srq->srqn = resp.srqn;
 	srq->rsc.rsn = resp.srqn;
 	srq->rsc.type = MLX5_RSC_TYPE_SRQ;
+	topo = getenv("MLX5_SRQ_TOPO");
+	if (topo && strcmp(topo, "cyclic") == 0) {
+		srq->topo = MLX5_SRQ_TOPO_CYCLIC;
+	} else {
+		srq->topo = MLX5_SRQ_TOPO_LIST;
+	}
 
 	return ibsrq;
 


### PR DESCRIPTION
To utilize HW prefetch optimization, we add a new SRQ topology to consume/free wqe in a cyclic manner.
with MLX5_SRQ_TOPO=cyclic, this PR will be used and BW improves a lot when SRQ is used.

verify:
ib_send_bw -q 2 -d mlx5_bond_0 --report_gbits --run_infinitely -s $((4 * 1024))
#bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 4096       27179800         0.00               178.11             5.435563
ib_send_bw --use-srq -q 2 -d mlx5_bond_0 --report_gbits --run_infinitely -s $((4 * 1024))
#bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 4096       8972700          0.00               58.64              1.789596
MLX5_SRQ_TOPO=cyclic ib_send_bw --use-srq -q 2 -d mlx5_bond_0 --report_gbits --run_infinitely -s $((4 * 1024))
 #bytes     #iterations    BW peak[Gb/sec]    BW average[Gb/sec]   MsgRate[Mpps]
 4096       27015100         0.00               176.57             5.388494