### PR TITLE
fix mem leak for port in cma dev

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -304,6 +304,8 @@ static void remove_cma_dev(struct cma_device *cma_dev)
 		ibv_dealloc_pd(cma_dev->pd);
 	if (cma_dev->verbs)
 		ibv_close_device(cma_dev->verbs);
+	if (cma_dev->port)
+		free(cma_dev->port);
 	list_del_from(&cma_dev_list, &cma_dev->entry);
 	free(cma_dev);
 }


### PR DESCRIPTION
cma_dev->port is allocated, but never freed