### PR TITLE
cma: Release allocated port array

### DIFF
--- a/librdmacm/cma.c
+++ b/librdmacm/cma.c
@@ -304,6 +304,7 @@ static void remove_cma_dev(struct cma_device *cma_dev)
 		ibv_dealloc_pd(cma_dev->pd);
 	if (cma_dev->verbs)
 		ibv_close_device(cma_dev->verbs);
+	free(cma_dev->port);
 	list_del_from(&cma_dev_list, &cma_dev->entry);
 	free(cma_dev);
 }


### PR DESCRIPTION
Fix mem leak for allocated port array

Fixes: 1b9125689fec ("cma: Workaround for rdma_ucm kernel bug")
Signed-off-by: Kirill Martynov <k.martynov@yadro.com>