### PR TITLE
pyverbs: update srq parameter usage in QPInitAttr

### DIFF
--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -103,8 +103,6 @@ cdef class QPInitAttr(PyverbsObject):
                  SRQ srq=None, QPCap cap=None, sq_sig_all=1):
         """
         Initializes a QpInitAttr object representing ibv_qp_init_attr struct.
-        Note that SRQ object is not yet supported in pyverbs so can't be passed
-        as a parameter. None should be used until such support is added.
         :param qp_type: The desired QP type (see enum ibv_qp_type)
         :param qp_context: Associated QP context
         :param scq: Send CQ to be used for this QP


### PR DESCRIPTION
srq is supported by the commit:1ca14a974892. Update its usage.

Signed-off-by: Liu, Changcheng <changcheng.liu@aliyun.com>