### PR TITLE
pyverbs: add property to get cmid's dev name and port num

### DIFF
--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -359,6 +359,10 @@ cdef class CMID(PyverbsCM):
             raise PyverbsError('Unrecognized object type')
 
     @property
+    def dev_name(self):
+        return str(v.ibv_get_device_name(self.id.verbs.device).decode('utf-8'))
+
+    @property
     def event_channel(self):
         return self.event_channel
 

--- a/pyverbs/cmid.pyx
+++ b/pyverbs/cmid.pyx
@@ -363,6 +363,10 @@ cdef class CMID(PyverbsCM):
         return str(v.ibv_get_device_name(self.id.verbs.device).decode('utf-8'))
 
     @property
+    def port_num(self):
+        return self.id.port_num
+
+    @property
     def event_channel(self):
         return self.event_channel
 

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -128,12 +128,14 @@ cdef class Context(PyverbsCM):
         cmd_fd = kwargs.get('cmd_fd')
         if cmid is not None:
             self.context = cmid.id.verbs
+            self.name = str(v.ibv_get_device_name(self.context.device).decode('utf-8'))
             cmid.ctx = self
             return
         if cmd_fd is not None:
             self.context = v.ibv_import_device(cmd_fd)
             if self.context == NULL:
                 raise PyverbsRDMAErrno('Failed to import device')
+            self.name = str(v.ibv_get_device_name(self.context.device).decode('utf-8'))
             return
 
         if self.name is None:

--- a/pyverbs/libibverbs.pxd
+++ b/pyverbs/libibverbs.pxd
@@ -640,6 +640,7 @@ cdef extern from 'infiniband/verbs.h':
     ibv_device **ibv_get_device_list(int *n)
     int ibv_get_device_index(ibv_device *device);
     void ibv_free_device_list(ibv_device **list)
+    const char *ibv_get_device_name(ibv_device *device)
     ibv_context *ibv_open_device(ibv_device *device)
     int ibv_close_device(ibv_context *context)
     int ibv_query_device(ibv_context *context, ibv_device_attr *device_attr)


### PR DESCRIPTION
- After ```rdma bind/resolve addr``` operation, it can get the dev name and port num.
Add API to get these information.

There's below scenario to use rdmacm:
1. create rdma_cm_id
2. resolve addr and route to server
3. get which device is used, create extra ibv_context and ibv_pd to create QP
4. send QP info in the private data space when calling rdma_connect.
5. rdma_connect failed. e.g. get rejected event such as that server doesn't start running the service.
6. repeat 1 & 2 & 4 until get the response event from server. There's no need to go through the 3 step again. 

- fix error when creating Context with cmid without setting device name