### PR TITLE
rsockets: Fix allocation size

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -3173,7 +3173,7 @@ static struct pollfd *rs_fds_alloc(nfds_t nfds)
 		else if (rs_pollinit())
 			return NULL;
 
-		rfds = malloc(sizeof(*rfds) * nfds + 1);
+		rfds = malloc(sizeof(*rfds) * (nfds + 1));
 		rnfds = rfds ? nfds + 1 : 0;
 	}
 


### PR DESCRIPTION
There is memory allocation for (nfds + 1) elements, but actually less space is allocated (1 byte for new element instead of sizeof(struct pollfd)). This is caused by operators precedence mistake.

Signed-off-by: Mikhail Sokolovskiy <sokolmish@gmail.com>