### PR TITLE
mlx5: Improve the AES-XTS functionality

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -31,6 +31,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.21@MLX5_1.21 37
  MLX5_1.22@MLX5_1.22 38
  MLX5_1.23@MLX5_1.23 40
+ MLX5_1.24@MLX5_1.24 42
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -154,6 +155,9 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_create_eq@MLX5_1.23 40
  mlx5dv_devx_destroy_eq@MLX5_1.23 40
  mlx5dv_devx_free_msi_vector@MLX5_1.23 40
+ mlx5dv_crypto_login_create@MLX5_1.24 42
+ mlx5dv_crypto_login_destroy@MLX5_1.24 42
+ mlx5dv_crypto_login_query@MLX5_1.24 42
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -11,7 +11,7 @@ if (MLX5_MW_DEBUG)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.23.${PACKAGE_VERSION}
+  1 1.24.${PACKAGE_VERSION}
   buf.c
   cq.c
   dbrec.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -219,3 +219,10 @@ MLX5_1.23 {
 		mlx5dv_devx_destroy_eq;
 		mlx5dv_devx_free_msi_vector;
 } MLX5_1.22;
+
+MLX5_1.24 {
+	global:
+		mlx5dv_crypto_login_create;
+		mlx5dv_crypto_login_destroy;
+		mlx5dv_crypto_login_query;
+} MLX5_1.23;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -9,6 +9,7 @@ rdma_man_pages(
   mlx5dv_create_mkey.3.md
   mlx5dv_create_qp.3.md
   mlx5dv_crypto_login.3.md
+  mlx5dv_crypto_login_create.3.md
   mlx5dv_dci_stream_id_reset.3.md
   mlx5dv_dek_create.3.md
   mlx5dv_devx_alloc_msi_vector.3.md
@@ -57,6 +58,8 @@ rdma_alias_man_pages(
  mlx5dv_create_mkey.3 mlx5dv_destroy_mkey.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_login_query_state.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_logout.3
+ mlx5dv_crypto_login_create.3 mlx5dv_crypto_login_destroy.3
+ mlx5dv_crypto_login_create.3 mlx5dv_crypto_login_query.3
  mlx5dv_dek_create.3 mlx5dv_dek_query.3
  mlx5dv_dek_create.3 mlx5dv_dek_destroy.3
  mlx5dv_devx_alloc_msi_vector.3 mlx5dv_devx_free_msi_vector.3

--- a/providers/mlx5/man/mlx5dv_crypto_login_create.3.md
+++ b/providers/mlx5/man/mlx5dv_crypto_login_create.3.md
@@ -1,0 +1,160 @@
+---
+layout: page
+title: mlx5dv_crypto_login_create / mlx5dv_crypto_login_query / mlx5dv_crypto_login_destroy
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_crypto_login_create - Creates a crypto login object
+
+mlx5dv_crypto_login_query - Queries the given crypto login object
+
+mlx5dv_crypto_login_destroy - Destroys the given crypto login object
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_crypto_login_obj *
+mlx5dv_crypto_login_create(struct ibv_context *context,
+			   struct mlx5dv_crypto_login_attr_ex *login_attr);
+
+int mlx5dv_crypto_login_query(struct mlx5dv_crypto_login_obj *crypto_login,
+			      struct mlx5dv_crypto_login_query_attr *query_attr);
+
+int mlx5dv_crypto_login_destroy(struct mlx5dv_crypto_login_obj *crypto_login);
+```
+
+# DESCRIPTION
+
+When using a crypto engine that is in wrapped import method, a valid crypto
+login object must be provided in order to create and query wrapped Data
+Encryption Keys (DEKs).
+
+A valid crypto login object is necessary only to create and query wrapped DEKs.
+Existing DEKs that were previously created don't need a valid crypto login
+object in order to be used (in MKey or during traffic).
+
+**mlx5dv_crypto_login_create()** creates and returns a crypto login object with
+the credential given in *login_attr*. Only one crypto login object can be
+created per device context. The created crypto login object must be provided to
+**mlx5dv_dek_create()** in order to create wrapped DEKs.
+
+**mlx5dv_crypto_login_query()** queries the crypto login object *crypto_login*
+and returns the queried attributes in *query_attr*.
+
+**mlx5dv_crypto_login_destroy()** destroys the given crypto login object.
+
+# ARGUMENTS
+
+## context
+
+The device context that will be associated with the crypto login object.
+
+## login_attr
+
+Crypto extended login attributes specify the credential to login with and
+the import KEK to be used for secured communications done with the crypto
+login object.
+
+```c
+struct mlx5dv_crypto_login_attr_ex {
+	uint32_t credential_id;
+	uint32_t import_kek_id;
+	const void *credential;
+	size_t credential_len;
+	uint64_t comp_mask;
+};
+```
+
+*credential_id*
+
+:	An ID of a credential, from the credentials stored on the device,
+	that indicates the credential that should be validated against the
+	credential provided in *credential*.
+
+*import_kek_id*
+
+:	An ID of an import KEK, from the import KEKs stored on the device,
+	that indicates the import KEK that will be used for unwrapping the
+	credential provided in *credential* and also for all other secured
+	communications done with the crypto login object.
+
+*credential*
+
+:	The credential to login with. Credential is a piece of data used to
+	authenticate the user for crypto login. The credential in *credential*
+	is validated against the credential indicated by *credential_id*, which
+	is stored on the device. The credentials must match in order for the
+	crypto login to succeed.
+	*credential* must be provided wrapped by the AES key wrap algorithm
+	using the import KEK indicated by *import_kek_id*.
+	*credential* format is ENC(iv_64b + plaintext_credential) where ENC()
+	is AES key wrap algorithm and iv_64b is 0xA6A6A6A6A6A6A6A6 as per the
+	NIST SP 800-38F AES key wrap spec, and plaintext_credential is the
+	credential value stored on the device.
+
+*credential_len*
+
+:	The length of the provided *credential* value in bytes.
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+## query_attr
+
+	Crypto login attributes to be populated when querying a crypto login
+	object.
+
+```c
+struct mlx5dv_crypto_login_query_attr {
+	enum mlx5dv_crypto_login_state state;
+	uint64_t comp_mask;
+};
+```
+
+*state*
+
+:	The state of the crypto login object, can be one of the following
+
+	**MLX5DV_CRYPTO_LOGIN_STATE_VALID**
+
+	:	The crypto login object is valid and can be used.
+
+	**MLX5DV_CRYPTO_LOGIN_STATE_INVALID**
+
+	:	The crypto login object is invalid and cannot be used. A valid
+		crypto login object can become invalid if the credential or the
+		import KEK used in the crypto login object were deleted while in
+		use (for example by a crypto officer). In this case,
+		**mlx5dv_crypto_login_destroy()** should be called to destroy
+		the invalid crypto login object and if still necessary,
+		**mlx5dv_crypto_login_create()** should be called to create a
+		new crypto login object with valid credential and import KEK.
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+# RETURN VALUE
+
+**mlx5dv_crypto_login_create()** returns a pointer to a new valid
+*struct mlx5dv_crypto_login_obj* on success. On error NULL is returned and errno
+is set.
+
+**mlx5dv_crypto_login_query()** returns 0 on success and fills *query_attr* with
+the queried attributes. On error, errno is returned.
+
+**mlx5dv_crypto_login_destroy()** returns 0 on success and errno on error.
+
+# SEE ALSO
+
+**mlx5dv_dek_create**(3), **mlx5dv_query_device**(3)
+
+# AUTHORS
+
+Avihai Horon <avihaih@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -197,9 +197,16 @@ uint32_t flags; /* use enum mlx5dv_crypto_caps_flags */
 .in -8
 };
 
+/* This bitmap indicates which crypto engines are supported by the device. */
 enum mlx5dv_crypto_engines_caps {
 .in +8
+	/* Deprecated, replaced by MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS_SINGLE_BLOCK */
 	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS = 1 << 0,
+	/*
+	 * Indicates that AES-XTS only supports encrypting a single block
+	 * at a time.
+	 */
+	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS_SINGLE_BLOCK = 1 << 1,
 .in -8
 };
 

--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -210,6 +210,16 @@ enum mlx5dv_crypto_engines_caps {
 .in -8
 };
 
+/*
+ * This bitmap indicates the import method of each crypto engine.
+ *
+ * If a bit is not set, the corresponding crypto engine is in plaintext import method and the
+ * application must use plaintext DEKs for this crypto engine.
+ *
+ * Otherwise, the corresponding crypto engine is in wrapped import method and the application
+ * must use wrapped DEKs for this crypto engine. To load wrapped DEKs the application must perform
+ * crypto login, which in turn requires MLX5DV_CRYPTO_CAPS_WRAPPED_CRYPTO_OPERATIONAL below to be set.
+ */
 enum mlx5dv_crypto_wrapped_import_method_caps {
 .in +8
 	MLX5DV_CRYPTO_WRAPPED_IMPORT_METHOD_CAP_AES_XTS = 1 << 0,

--- a/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
@@ -386,7 +386,7 @@ A DEVX context should be opened by using **mlx5dv_open_device**(3).
 # SEE ALSO
 
 **mlx5dv_create_mkey**(3), **mlx5dv_create_qp**(3),
-**mlx5dv_wr_set_mkey_sig_block**(3)
+**mlx5dv_wr_set_mkey_sig_block**(3), **mlx5dv_wr_set_mkey_crypto**(3)
 
 # AUTHORS
 

--- a/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
@@ -308,7 +308,8 @@ When *data_unit_size* = 520B:
 
 **mlx5dv_wr_mkey_configure**(3), **mlx5dv_wr_set_mkey_sig_block**(3),
 **mlx5dv_create_mkey**(3), **mlx5dv_destroy_mkey**(3),
-**mlx5dv_crypto_login**(3), **mlx5dv_dek_create**(3)
+**mlx5dv_crypto_login**(3), **mlx5dv_crypto_login_create**(3),
+**mlx5dv_dek_create**(3)
 
 # AUTHORS
 

--- a/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_set_mkey_crypto.3.md
@@ -239,11 +239,12 @@ struct mlx5dv_crypto_attr {
 
 *initial_tweak*
 
-:	A value to be used during encryption of each data unit. This value is
-	incremented by the device for every data unit in the message. For
-	storage encryption, this will normally be the LBA of the first block
-	in the message, so that the increments represent the LBAs of the rest
-	of the blocks in the message.
+:	A value to be used during encryption of each data unit. Must be
+	supplied in little endian. This value is incremented by the device
+	for every data unit in the message.
+	For storage encryption, this will normally be the LBA of the first
+	block in the message, so that the increments represent the LBAs of
+	the rest of the blocks in the message.
 
 *dek*
 
@@ -283,6 +284,26 @@ re-configured or reset, as required. For example, assuming
 then on the next configuration of the MKey, if signature is not needed, it
 should be reset using **MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR**.
 
+When configuring a MKey with AES-XTS crypto offload, and using the former for
+traffic (send/receive), the amount of data to send/receive must meet one
+of the following conditions for successful encryption/decryption process (per
+AES-XTS spec):
+
+Let's refer to the amount of data to send/receive as 'job_size'
+1.job_size % *data_unit_size* == 0
+2.(job_size % 16 == 0) && (job_size % *data_unit_size* <= *data_unit_size* - 16)
+
+For example:
+When *data_unit_size* = 512B:
+1. job_size = 512B is valid (1 holds).
+2. job_size = 128B is valid (2 holds).
+3. job_size = 47B is invalid (neither 1 nor 2 holds).
+
+When *data_unit_size* = 520B:
+1. job_size = 520B is valid (1 holds).
+2. job_size = 496B is valid (2 holds).
+3. job_size = 512B is invalid (neither 1 nor 2 holds).
+
 # SEE ALSO
 
 **mlx5dv_wr_mkey_configure**(3), **mlx5dv_wr_set_mkey_sig_block**(3),
@@ -294,3 +315,5 @@ should be reset using **MLX5DV_MKEY_CONF_FLAG_RESET_SIG_ATTR**.
 Oren Duer  <oren@nvidia.com>
 
 Avihai Horon <avihaih@nvidia.com>
+
+Maher Sanalla <msanalla@nvidia.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -892,6 +892,10 @@ struct mlx5_mkey {
 	struct mlx5_crypto_attr *crypto;
 };
 
+struct mlx5dv_crypto_login_obj {
+	struct mlx5dv_devx_obj *devx_obj;
+};
+
 struct mlx5dv_dek {
 	struct mlx5dv_devx_obj *devx_obj;
 };
@@ -1498,6 +1502,15 @@ struct mlx5_dv_context_ops {
 	int (*crypto_login_query_state)(struct ibv_context *context,
 					enum mlx5dv_crypto_login_state *state);
 	int (*crypto_logout)(struct ibv_context *context);
+
+	struct mlx5dv_crypto_login_obj *(*crypto_login_create)(
+		struct ibv_context *context,
+		struct mlx5dv_crypto_login_attr_ex *login_attr);
+	int (*crypto_login_query)(
+		struct mlx5dv_crypto_login_obj *crypto_login,
+		struct mlx5dv_crypto_login_query_attr *query_attr);
+	int (*crypto_login_destroy)(
+		struct mlx5dv_crypto_login_obj *crypto_login);
 
 	struct mlx5dv_dek *(*dek_create)(struct ibv_context *context,
 					 struct mlx5dv_dek_init_attr *init_attr);

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1143,7 +1143,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         log_min_hairpin_wq_data_sz[0x5];
 	u8         reserved_at_3e8[0x3];
 	u8         log_max_vlan_list[0x5];
-	u8         reserved_at_3f0[0x3];
+	u8         reserved_at_3f0[0x1];
+	u8         aes_xts_single_block_le_tweak[0x1];
+	u8         reserved_at_3f2[0x1];
 	u8         log_max_current_mc_list[0x5];
 	u8         reserved_at_3f8[0x3];
 	u8         log_max_current_uc_list[0x5];
@@ -1154,8 +1156,7 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         steering_format_version[0x4];
 	u8         create_qp_start_hint[0x18];
 
-	u8         reserved_at_460[0x8];
-	u8         aes_xts[0x1];
+	u8         reserved_at_460[0x9];
 	u8         crypto[0x1];
 	u8         reserved_at_46a[0x6];
 	u8         max_num_eqs[0x10];

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -613,6 +613,8 @@ static inline void mlx5dv_wr_raw_wqe(struct mlx5dv_qp_ex *mqp, const void *wqe)
 	mqp->wr_raw_wqe(mqp, wqe);
 }
 
+struct mlx5dv_crypto_login_obj;
+
 struct mlx5dv_crypto_login_attr {
 	uint32_t credential_id;
 	uint32_t import_kek_id;
@@ -620,10 +622,22 @@ struct mlx5dv_crypto_login_attr {
 	uint64_t comp_mask;
 };
 
+struct mlx5dv_crypto_login_attr_ex {
+	uint32_t credential_id;
+	uint32_t import_kek_id;
+	const void *credential;
+	size_t credential_len;
+	uint64_t comp_mask;
+};
 enum mlx5dv_crypto_login_state {
 	MLX5DV_CRYPTO_LOGIN_STATE_VALID,
 	MLX5DV_CRYPTO_LOGIN_STATE_NO_LOGIN,
 	MLX5DV_CRYPTO_LOGIN_STATE_INVALID,
+};
+
+struct mlx5dv_crypto_login_query_attr {
+	enum mlx5dv_crypto_login_state state;
+	uint64_t comp_mask;
 };
 
 int mlx5dv_crypto_login(struct ibv_context *context,
@@ -633,6 +647,15 @@ int mlx5dv_crypto_login_query_state(struct ibv_context *context,
 				    enum mlx5dv_crypto_login_state *state);
 
 int mlx5dv_crypto_logout(struct ibv_context *context);
+
+struct mlx5dv_crypto_login_obj *
+mlx5dv_crypto_login_create(struct ibv_context *context,
+			   struct mlx5dv_crypto_login_attr_ex *login_attr);
+
+int mlx5dv_crypto_login_query(struct mlx5dv_crypto_login_obj *crypto_login,
+			      struct mlx5dv_crypto_login_query_attr *query_attr);
+
+int mlx5dv_crypto_login_destroy(struct mlx5dv_crypto_login_obj *crypto_login);
 
 enum mlx5dv_crypto_key_size {
 	MLX5DV_CRYPTO_KEY_SIZE_128,

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -184,6 +184,7 @@ struct mlx5dv_sig_caps {
 
 enum mlx5dv_crypto_engines_caps {
 	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS = 1 << 0,
+	MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS_SINGLE_BLOCK = 1 << 1,
 };
 
 enum mlx5dv_crypto_wrapped_import_method_caps {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -671,6 +671,10 @@ enum mlx5dv_dek_state {
 	MLX5DV_DEK_STATE_ERROR,
 };
 
+enum mlx5dv_dek_init_attr_mask {
+	MLX5DV_DEK_INIT_ATTR_CRYPTO_LOGIN = 1 << 0,
+};
+
 struct mlx5dv_dek_init_attr {
 	enum mlx5dv_crypto_key_size key_size;
 	bool has_keytag;
@@ -679,6 +683,7 @@ struct mlx5dv_dek_init_attr {
 	char opaque[8];
 	char key[128];
 	uint64_t comp_mask;
+	struct mlx5dv_crypto_login_obj *crypto_login;
 };
 
 struct mlx5dv_dek_attr {

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2414,7 +2414,8 @@ static int mlx5_umr_fill_crypto_bsf(struct mlx5_crypto_bsf *crypto_bsf,
 
 	memset(crypto_bsf, 0, sizeof(*crypto_bsf));
 
-	crypto_bsf->bsf_size_type |= MLX5_BSF_SIZE_WITH_INLINE
+	crypto_bsf->bsf_size_type |= (block ? MLX5_BSF_SIZE_SIG_AND_CRYPTO :
+					      MLX5_BSF_SIZE_WITH_INLINE)
 				     << MLX5_BSF_SIZE_SHIFT;
 	crypto_bsf->bsf_size_type |= MLX5_BSF_TYPE_CRYPTO;
 	order = get_crypto_order(attr->encrypt_on_tx,

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2580,8 +2580,27 @@ static inline void umr_finalize_and_set_psvs(struct mlx5_qp *mqp,
 	}
 }
 
+static inline int block_size_to_bytes(enum mlx5dv_block_size data_unit_size)
+{
+	switch (data_unit_size) {
+	case MLX5DV_BLOCK_SIZE_512:
+		return 512;
+	case MLX5DV_BLOCK_SIZE_520:
+		return 520;
+	case MLX5DV_BLOCK_SIZE_4048:
+		return 4048;
+	case MLX5DV_BLOCK_SIZE_4096:
+		return 4096;
+	case MLX5DV_BLOCK_SIZE_4160:
+		return 4160;
+	default:
+		return -1;
+	}
+}
+
 static void crypto_umr_wqe_finalize(struct mlx5_qp *mqp)
 {
+	struct mlx5_context *ctx = to_mctx(mqp->ibv_qp->context);
 	struct mlx5_mkey *mkey = mqp->cur_mkey;
 	void *seg;
 	void *qend = mqp->sq.qend;
@@ -2604,6 +2623,19 @@ static void crypto_umr_wqe_finalize(struct mlx5_qp *mqp)
 	if (mkey->sig && upd_mkc_sig_err_cnt(mkey, umr_ctrl, mk) &&
 	    mkey->sig->block.state == MLX5_MKEY_BSF_STATE_SET)
 		set_psv = true;
+
+	/* Length must fit block size in single block encryption. */
+	if ((mkey->crypto->state == MLX5_MKEY_BSF_STATE_UPDATED ||
+	     mkey->crypto->state == MLX5_MKEY_BSF_STATE_SET) &&
+	    ctx->crypto_caps.crypto_engines &
+		    MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS_SINGLE_BLOCK) {
+		int block_size =
+			block_size_to_bytes(mkey->crypto->data_unit_size);
+		if (block_size < 0 || mkey->length > block_size) {
+			mqp->err = EINVAL;
+			return;
+		}
+	}
 
 	if (!(mkey->sig &&
 	      mkey->sig->block.state == MLX5_MKEY_BSF_STATE_UPDATED) &&

--- a/pyverbs/device.pxd
+++ b/pyverbs/device.pxd
@@ -26,6 +26,7 @@ cdef class Context(PyverbsCM):
     cdef object dr_domains
     cdef object wqs
     cdef object rwq_ind_tbls
+    cdef object crypto_logins
 
 cdef class DeviceAttr(PyverbsObject):
     cdef v.ibv_device_attr dev_attr

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -121,6 +121,7 @@ cdef class Context(PyverbsCM):
         self.dr_domains = weakref.WeakSet()
         self.wqs = weakref.WeakSet()
         self.rwq_ind_tbls = weakref.WeakSet()
+        self.crypto_logins = weakref.WeakSet()
 
         self.name = kwargs.get('name')
         provider_attr = kwargs.get('attr')
@@ -175,7 +176,7 @@ cdef class Context(PyverbsCM):
         if self.context != NULL:
             if self.logger:
                 self.logger.debug('Closing Context')
-            close_weakrefs([self.qps, self.rwq_ind_tbls, self.wqs, self.ccs, self.cqs,
+            close_weakrefs([self.qps, self.crypto_logins, self.rwq_ind_tbls, self.wqs, self.ccs, self.cqs,
                             self.dms, self.pds, self.xrcds, self.vars, self.sched_leafs,
                             self.sched_nodes, self.dr_domains])
             rc = v.ibv_close_device(self.context)

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -342,10 +342,24 @@ cdef extern from 'infiniband/mlx5dv.h':
     cdef struct mlx5dv_dek:
         pass
 
+    cdef struct mlx5dv_crypto_login_obj:
+        pass
+
     cdef struct mlx5dv_crypto_login_attr:
         uint32_t credential_id
         uint32_t import_kek_id
         char *credential
+        uint64_t comp_mask
+
+    cdef struct mlx5dv_crypto_login_attr_ex:
+        uint32_t credential_id
+        uint32_t import_kek_id
+        const void *credential
+        size_t credential_len
+        uint64_t comp_mask
+
+    cdef struct mlx5dv_crypto_login_query_attr:
+        mlx5dv_crypto_login_state state
         uint64_t comp_mask
 
     cdef struct mlx5dv_crypto_attr:
@@ -366,6 +380,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         char *opaque
         char *key
         uint64_t comp_mask
+        mlx5dv_crypto_login_obj *crypto_login
 
     cdef struct mlx5dv_dek_attr:
         mlx5dv_dek_state state
@@ -536,3 +551,8 @@ cdef extern from 'infiniband/mlx5dv.h':
     mlx5dv_dek *mlx5dv_dek_create(v.ibv_context *context, mlx5dv_dek_init_attr *init_attr)
     int mlx5dv_dek_query(mlx5dv_dek *dek, mlx5dv_dek_attr *attr)
     int mlx5dv_dek_destroy(mlx5dv_dek *dek)
+    mlx5dv_crypto_login_obj *mlx5dv_crypto_login_create(v.ibv_context *context,
+                                                        mlx5dv_crypto_login_attr_ex *login_attr)
+    int mlx5dv_crypto_login_query(mlx5dv_crypto_login_obj *crypto_login,
+                                  mlx5dv_crypto_login_query_attr *query_attr)
+    int mlx5dv_crypto_login_destroy(mlx5dv_crypto_login_obj *crypto_login)

--- a/pyverbs/providers/mlx5/mlx5dv_crypto.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_crypto.pxd
@@ -5,11 +5,16 @@
 
 from pyverbs.base cimport PyverbsObject, PyverbsCM
 cimport pyverbs.providers.mlx5.libmlx5 as dv
+from pyverbs.device cimport Context
 from pyverbs.pd cimport PD
 
 
 cdef class Mlx5CryptoLoginAttr(PyverbsObject):
     cdef dv.mlx5dv_crypto_login_attr mlx5dv_crypto_login_attr
+
+cdef class Mlx5CryptoExtLoginAttr(PyverbsObject):
+    cdef dv.mlx5dv_crypto_login_attr_ex mlx5dv_crypto_login_attr_ex
+    cdef object credential
 
 cdef class Mlx5DEKInitAttr(PyverbsObject):
     cdef dv.mlx5dv_dek_init_attr mlx5dv_dek_init_attr
@@ -24,3 +29,7 @@ cdef class Mlx5CryptoAttr(PyverbsObject):
 cdef class Mlx5DEK(PyverbsCM):
     cdef dv.mlx5dv_dek *mlx5dv_dek
     cdef PD pd
+
+cdef class Mlx5CryptoLogin(PyverbsCM):
+    cdef dv.mlx5dv_crypto_login_obj *crypto_login_obj
+    cdef Context context

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -253,8 +253,12 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_DEK_STATE_READY
         MLX5DV_DEK_STATE_ERROR
 
+    cpdef enum mlx5dv_dek_init_attr_mask:
+        MLX5DV_DEK_INIT_ATTR_CRYPTO_LOGIN
+
     cpdef enum mlx5dv_crypto_engines_caps:
         MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS
+        MLX5DV_CRYPTO_ENGINES_CAP_AES_XTS_SINGLE_BLOCK
 
     cpdef enum mlx5dv_crypto_wrapped_import_method_caps:
         MLX5DV_CRYPTO_WRAPPED_IMPORT_METHOD_CAP_AES_XTS


### PR DESCRIPTION
This series improves the existing AES-XTS functionality as of below.

- Add new AES-XTS single block capability while fixing some issues in previous code.
- Add new crypto login DV APIs to enable supporting plaintext DEKs.
- Improve and clarify man pages in few places.

In addition, some pyverbs stuff was added to demonstrate and test both plaintext and wrapped DEKs by using the new crypto login APIs.
