### PR TITLE
mlx5: Expose steering anchor DV APIs

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -155,9 +155,11 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_devx_create_eq@MLX5_1.23 40
  mlx5dv_devx_destroy_eq@MLX5_1.23 40
  mlx5dv_devx_free_msi_vector@MLX5_1.23 40
+ mlx5dv_create_steering_anchor@MLX5_1.24 42
  mlx5dv_crypto_login_create@MLX5_1.24 42
  mlx5dv_crypto_login_destroy@MLX5_1.24 42
  mlx5dv_crypto_login_query@MLX5_1.24 42
+ mlx5dv_destroy_steering_anchor@MLX5_1.24 42
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -160,6 +160,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_crypto_login_destroy@MLX5_1.24 42
  mlx5dv_crypto_login_query@MLX5_1.24 42
  mlx5dv_destroy_steering_anchor@MLX5_1.24 42
+ mlx5dv_dr_action_create_dest_root_table@MLX5_1.24 42
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -228,6 +228,7 @@ enum mlx5_ib_objects {
 	MLX5_IB_OBJECT_VAR,
 	MLX5_IB_OBJECT_PP,
 	MLX5_IB_OBJECT_UAR,
+	MLX5_IB_OBJECT_STEERING_ANCHOR,
 };
 
 enum mlx5_ib_flow_matcher_create_attrs {
@@ -246,6 +247,22 @@ enum mlx5_ib_flow_matcher_destroy_attrs {
 enum mlx5_ib_flow_matcher_methods {
 	MLX5_IB_METHOD_FLOW_MATCHER_CREATE = (1U << UVERBS_ID_NS_SHIFT),
 	MLX5_IB_METHOD_FLOW_MATCHER_DESTROY,
+};
+
+enum mlx5_ib_flow_steering_anchor_create_attrs {
+	MLX5_IB_ATTR_STEERING_ANCHOR_CREATE_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_ATTR_STEERING_ANCHOR_FT_TYPE,
+	MLX5_IB_ATTR_STEERING_ANCHOR_PRIORITY,
+	MLX5_IB_ATTR_STEERING_ANCHOR_FT_ID,
+};
+
+enum mlx5_ib_flow_steering_anchor_destroy_attrs {
+	MLX5_IB_ATTR_STEERING_ANCHOR_DESTROY_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum mlx5_ib_steering_anchor_methods {
+	MLX5_IB_METHOD_STEERING_ANCHOR_CREATE = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_METHOD_STEERING_ANCHOR_DESTROY,
 };
 
 enum mlx5_ib_device_query_context_attrs {

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -82,6 +82,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FLOW_METER]	= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_DECAP] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -99,6 +100,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -114,6 +116,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_POP_VLAN] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -130,6 +133,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_PUSH_VLAN] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -143,6 +147,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -164,6 +169,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ASO] = {
 			[DR_ACTION_TYP_QP]              = DR_ACTION_STATE_TERM,
@@ -174,6 +180,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]          = DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ENCAP] = {
 			[DR_ACTION_TYP_QP]		= DR_ACTION_STATE_TERM,
@@ -184,6 +191,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_TAG]		= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -204,12 +212,14 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ENCAP] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -219,6 +229,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_PUSH_VLAN,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_POP_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -230,6 +241,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MODIFY_HDR]	= DR_ACTION_STATE_MODIFY_HDR,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_PUSH_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -239,6 +251,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_PUSH_VLAN,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -254,6 +267,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ASO] = {
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
@@ -267,6 +281,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_DROP]            = DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_FT]              = DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_MISS]            = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -292,6 +307,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_DECAP] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -308,6 +324,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ENCAP] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -317,6 +334,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_METER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_ASO_FIRST_HIT]	= DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -331,6 +349,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_POP_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -346,6 +365,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_PUSH_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -359,6 +379,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -379,6 +400,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_L2_TO_TNL_L3]    = DR_ACTION_STATE_ENCAP,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ASO] = {
 			[DR_ACTION_TYP_VPORT]           = DR_ACTION_STATE_TERM,
@@ -389,6 +411,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]          = DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -412,6 +435,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]		= DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ENCAP] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -421,6 +445,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_MODIFY_HDR] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -433,6 +458,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_L2_TO_TNL_L3]	= DR_ACTION_STATE_ENCAP,
 			[DR_ACTION_TYP_PUSH_VLAN]	= DR_ACTION_STATE_PUSH_VLAN,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_POP_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -447,6 +473,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]         = DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]      = DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]           = DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_PUSH_VLAN] = {
 			[DR_ACTION_TYP_FT]		= DR_ACTION_STATE_TERM,
@@ -459,6 +486,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_SAMPLER]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_DEST_ARRAY]	= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_VPORT]		= DR_ACTION_STATE_TERM,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_NON_TERM] = {
 			[DR_ACTION_TYP_DROP]		= DR_ACTION_STATE_TERM,
@@ -477,6 +505,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_MISS]		= DR_ACTION_STATE_TERM,
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]          = DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_ASO] = {
 			[DR_ACTION_TYP_L2_TO_TNL_L2]    = DR_ACTION_STATE_ENCAP,
@@ -491,6 +520,7 @@ static const enum dr_action_valid_state next_action_state[DR_ACTION_DOMAIN_MAX]
 			[DR_ACTION_TYP_ASO_FIRST_HIT]   = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_FLOW_METER]  = DR_ACTION_STATE_ASO,
 			[DR_ACTION_TYP_ASO_CT]          = DR_ACTION_STATE_ASO,
+			[DR_ACTION_TYP_ROOT_FT]		= DR_ACTION_STATE_TERM,
 		},
 		[DR_ACTION_STATE_TERM] = {
 			[DR_ACTION_TYP_CTR]		= DR_ACTION_STATE_TERM,
@@ -643,6 +673,16 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			attr.final_icm_addr = rx_rule ?
 				action->dest_tbl->rx.s_anchor->chunk->icm_addr :
 				action->dest_tbl->tx.s_anchor->chunk->icm_addr;
+			break;
+		case DR_ACTION_TYP_ROOT_FT:
+			if (action->root_tbl.tbl->dmn != dmn) {
+				dr_dbg(dmn, "Destination anchor belongs to a different domain\n");
+				goto out_invalid_arg;
+
+			}
+			attr.final_icm_addr = rx_rule ?
+				action->root_tbl.rx_icm_addr :
+				action->root_tbl.tx_icm_addr;
 			break;
 		case DR_ACTION_TYP_QP:
 			if (action->dest_qp.is_qp)
@@ -1038,6 +1078,112 @@ mlx5dv_dr_action_create_dest_table(struct mlx5dv_dr_table *tbl)
 
 dec_ref:
 	atomic_fetch_sub(&tbl->refcount, 1);
+	return NULL;
+}
+
+static int dr_action_create_dest_root_table(struct mlx5dv_dr_action *action)
+{
+	struct mlx5dv_dr_domain *dmn = action->root_tbl.tbl->dmn;
+	struct dr_devx_flow_dest_info dest_info = {};
+	struct dr_devx_flow_table_attr ft_attr = {};
+	struct dr_devx_flow_group_attr fg_attr = {};
+	struct dr_devx_flow_fte_attr fte_attr = {};
+	int ret;
+
+	switch (dmn->type) {
+	case MLX5DV_DR_DOMAIN_TYPE_FDB:
+		ft_attr.type = FS_FT_FDB;
+		break;
+	case MLX5DV_DR_DOMAIN_TYPE_NIC_RX:
+		ft_attr.type = FS_FT_NIC_RX;
+		break;
+	case MLX5DV_DR_DOMAIN_TYPE_NIC_TX:
+		ft_attr.type = FS_FT_NIC_TX;
+		break;
+	default:
+		errno = EOPNOTSUPP;
+		return errno;
+	}
+
+	fte_attr.dest_arr = &dest_info;
+
+	fte_attr.action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
+	fte_attr.dest_arr[0].type = MLX5_FLOW_DEST_TYPE_FT;
+	fte_attr.dest_arr[0].ft_id = action->root_tbl.sa->id;
+	fte_attr.dest_size = 1;
+
+	action->root_tbl.devx_tbl = dr_devx_create_always_hit_ft(dmn->ctx,
+							       &ft_attr,
+							       &fg_attr,
+							       &fte_attr);
+	if (!action->root_tbl.devx_tbl)
+		return errno;
+
+	ret = dr_devx_query_flow_table(action->root_tbl.devx_tbl->ft_dvo,
+				       ft_attr.type,
+				       &action->root_tbl.rx_icm_addr,
+				       &action->root_tbl.tx_icm_addr);
+	if (ret)
+		goto destroy_devx_tbl;
+
+	return 0;
+
+destroy_devx_tbl:
+	dr_devx_destroy_always_hit_ft(action->root_tbl.devx_tbl);
+
+	return errno;
+}
+
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_root_table(struct mlx5dv_dr_table *tbl,
+					uint16_t priority)
+{
+	struct mlx5dv_steering_anchor_attr attr = {};
+	enum mlx5_ib_uapi_flow_table_type ft_type;
+	struct mlx5dv_steering_anchor *sa;
+	struct mlx5dv_dr_action *action;
+	int err;
+
+	if (!dr_is_root_table(tbl)) {
+		dr_dbg(tbl->dmn, "Supported only on root flow tables\n");
+		errno = EINVAL;
+		return NULL;
+	}
+
+	if (tbl->dmn->type == MLX5DV_DR_DOMAIN_TYPE_NIC_RX)
+		ft_type = MLX5_IB_UAPI_FLOW_TABLE_TYPE_NIC_RX;
+	else if (tbl->dmn->type == MLX5DV_DR_DOMAIN_TYPE_NIC_TX)
+		ft_type = MLX5_IB_UAPI_FLOW_TABLE_TYPE_NIC_TX;
+	else
+		ft_type = MLX5_IB_UAPI_FLOW_TABLE_TYPE_FDB;
+
+	attr.priority = priority;
+	attr.ft_type = ft_type;
+
+	sa = mlx5dv_create_steering_anchor(tbl->dmn->ctx, &attr);
+	if (!sa)
+		return NULL;
+
+	action = dr_action_create_generic(DR_ACTION_TYP_ROOT_FT);
+	if (!action)
+		goto free_steering_anchor;
+
+	action->root_tbl.sa = sa;
+	action->root_tbl.tbl = tbl;
+
+	err = dr_action_create_dest_root_table(action);
+	if (err)
+		goto free_action;
+
+	atomic_fetch_add(&tbl->refcount, 1);
+
+	return action;
+
+free_action:
+	free(action);
+free_steering_anchor:
+	mlx5dv_destroy_steering_anchor(sa);
+
 	return NULL;
 }
 
@@ -2854,6 +3000,11 @@ int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action)
 		dr_devx_destroy_always_hit_ft(action->dest_array.devx_tbl);
 		dr_action_remove_action_members(&action->dest_array.actions_list);
 		atomic_fetch_sub(&action->dest_array.dmn->refcount, 1);
+		break;
+	case DR_ACTION_TYP_ROOT_FT:
+		dr_devx_destroy_always_hit_ft(action->root_tbl.devx_tbl);
+		mlx5dv_destroy_steering_anchor(action->root_tbl.sa);
+		atomic_fetch_sub(&action->root_tbl.tbl->refcount, 1);
 		break;
 	default:
 		break;

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -82,6 +82,7 @@ enum dr_dump_rec_type {
 	DR_DUMP_REC_TYPE_ACTION_ASO_FLOW_METER = 3418,
 	DR_DUMP_REC_TYPE_ACTION_ASO_CT = 3419,
 	DR_DUMP_REC_TYPE_ACTION_MISS = 3423,
+	DR_DUMP_REC_TYPE_ACTION_ROOT_FT = 3424,
 };
 
 static uint64_t dr_dump_icm_to_idx(uint64_t icm_addr)
@@ -224,6 +225,12 @@ static int dr_dump_rule_action(FILE *f, const uint64_t rule_id,
 	case DR_ACTION_TYP_MISS:
 		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 "\n",
 			      DR_DUMP_REC_TYPE_ACTION_MISS, action_id, rule_id);
+		break;
+	case DR_ACTION_TYP_ROOT_FT:
+		ret = fprintf(f, "%d,0x%" PRIx64 ",0x%" PRIx64 ",0x%x\n",
+			      DR_DUMP_REC_TYPE_ACTION_ROOT_FT, action_id,
+			      rule_id,
+			      action->root_tbl.devx_tbl->ft_dvo->object_id);
 		break;
 	default:
 		return 0;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -227,4 +227,5 @@ MLX5_1.24 {
 		mlx5dv_crypto_login_destroy;
 		mlx5dv_crypto_login_query;
 		mlx5dv_destroy_steering_anchor;
+		mlx5dv_dr_action_create_dest_root_table;
 } MLX5_1.23;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -222,7 +222,9 @@ MLX5_1.23 {
 
 MLX5_1.24 {
 	global:
+		mlx5dv_create_steering_anchor;
 		mlx5dv_crypto_login_create;
 		mlx5dv_crypto_login_destroy;
 		mlx5dv_crypto_login_query;
+		mlx5dv_destroy_steering_anchor;
 } MLX5_1.23;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -89,6 +89,7 @@ rdma_alias_man_pages(
  mlx5dv_devx_umem_reg.3 mlx5dv_devx_umem_reg_ex.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_aso.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_table.3
+ mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_root_table.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ib_port.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_ibv_qp.3
  mlx5dv_dr_flow.3 mlx5dv_dr_action_create_dest_devx_tir.3

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -8,6 +8,7 @@ rdma_man_pages(
   mlx5dv_create_flow_matcher.3.md
   mlx5dv_create_mkey.3.md
   mlx5dv_create_qp.3.md
+  mlx5dv_create_steering_anchor.3.md
   mlx5dv_crypto_login.3.md
   mlx5dv_crypto_login_create.3.md
   mlx5dv_dci_stream_id_reset.3.md
@@ -56,6 +57,7 @@ rdma_man_pages(
 rdma_alias_man_pages(
  mlx5dv_alloc_var.3 mlx5dv_free_var.3
  mlx5dv_create_mkey.3 mlx5dv_destroy_mkey.3
+ mlx5dv_create_steering_anchor.3 mlx5dv_destroy_steering_anchor.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_login_query_state.3
  mlx5dv_crypto_login.3 mlx5dv_crypto_logout.3
  mlx5dv_crypto_login_create.3 mlx5dv_crypto_login_destroy.3

--- a/providers/mlx5/man/mlx5dv_create_steering_anchor.3.md
+++ b/providers/mlx5/man/mlx5dv_create_steering_anchor.3.md
@@ -1,0 +1,91 @@
+---
+layout: page
+title: mlx5dv_create_steering_anchor / mlx5dv_destroy_steering_anchor
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_create_steering_anchor - Creates a steering anchor
+
+mlx5dv_destroy_steering_anchor - Destroys a steering anchor
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct mlx5dv_steering_anchor *
+mlx5dv_create_steering_anchor(struct ibv_context *context,
+                              struct mlx5dv_steering_anchor_attr *attr);
+
+int mlx5dv_destroy_steering_anchor(struct mlx5dv_steering_anchor *sa);
+```
+
+# DESCRIPTION
+
+A user can take packets into a user-configured sandbox and do packet processing
+at the end of which a steering pipeline decision is made on what to do with
+the packet.
+
+A steering anchor allows the user to reinject the packet back into the kernel
+for additional processing.
+
+**mlx5dv_create_steering_anchor()** Creates an anchor which will allow to
+inject the packet back into the kernel steering pipeline.
+
+**mlx5dv_destroy_steering_anchor()** Destroys a steering anchor.
+
+# ARGUMENTS
+
+## context
+
+The device context to associate the steering anchor with.
+
+## attr
+
+Anchor attributes specify the priority and flow table type to which
+the anchor will point.
+
+```c
+struct mlx5dv_steering_anchor_attr {
+        enum mlx5dv_flow_table_type ft_type;
+        uint16_t priority;
+        uint64_t comp_mask;
+};
+```
+
+*ft_type*
+
+:	The flow table type to which the anchor will point.
+
+*priority*
+
+:	The priority inside *ft_type* to which the created anchor will point.
+
+*comp_mask*
+
+:	Reserved for future extension, must be 0 now.
+
+
+## mlx5dv_steering_anchor
+
+```c
+struct mlx5dv_steering_anchor {
+	uint32_t id;
+};
+```
+*id*
+:	The flow table ID to use as the destination when creating the flow table entry.
+
+# RETURN VALUE
+
+**mlx5dv_create_steering_anchor()** returns a pointer to a new
+*mlx5dv_steering_anchor* on success. On error NULL is returned and errno is set.
+
+**mlx5dv_destroy_steering_anchor()** returns 0 on success and errno value on error.
+
+# AUTHORS
+
+Mark Bloch <mbloch@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_dr_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_dr_flow.3.md
@@ -28,6 +28,8 @@ mlx5dv_dr_action_create_dest_ibv_qp - Create packet destination QP action
 
 mlx5dv_dr_action_create_dest_table  - Create packet destination dr table action
 
+mlx5dv_dr_action_create_dest_root_table  - Create packet destination root table action
+
 mlx5dv_dr_action_create_dest_vport - Create packet destination vport action
 
 mlx5dv_dr_action_create_dest_ib_port - Create packet destination IB port action
@@ -114,6 +116,9 @@ struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_ibv_qp(
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_table(
 		struct mlx5dv_dr_table *table);
+
+struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_root_table(
+		struct mlx5dv_dr_table *table, uint16_t priority);
 
 struct mlx5dv_dr_action *mlx5dv_dr_action_create_dest_vport(
 		struct mlx5dv_dr_domain *domain,
@@ -228,7 +233,7 @@ Default behavior: Forward packet to eSwitch manager vport.
 *mlx5dv_dr_domain_allow_duplicate_rules()* is used to allow or prevent insertion of rules matching on same fields(duplicates) on non root tables, by default this feature is allowed.
 
 ## Table
-*mlx5dv_dr_table_create()* creates a DR table in the **domain**, at the appropriate **level**, and can be used with *mlx5dv_dr_matcher_create()* and *mlx5dv_dr_action_create_dest_table()*.
+*mlx5dv_dr_table_create()* creates a DR table in the **domain**, at the appropriate **level**, and can be used with *mlx5dv_dr_matcher_create()*, *mlx5dv_dr_action_create_dest_table()* and *mlx5dv_dr_action_create_dest_root_table*.
 All packets start traversing the steering domain tree at table **level** zero (0).
 Using rule and action, packets can by redirected to other tables in the domain.
 
@@ -263,6 +268,7 @@ Action: Tag
 Action: Destination
 *mlx5dv_dr_action_create_dest_ibv_qp* creates a terminating action delivering the packet to a QP, defined by **ibqp**. Valid only on domain type NIC_RX.
 *mlx5dv_dr_action_create_dest_table* creates a forwarding action to another flow table, defined by **table**. The destination **table** must be from the same domain with a level higher than zero.
+*mlx5dv_dr_action_create_dest_root_table* creates a forwarding action to another priority inside a root flow table, defined by **table** and **priority**.
 *mlx5dv_dr_action_create_dest_vport* creates a forwarding action to a **vport** on the same **domain**. Valid only on domain type FDB.
 *mlx5dv_dr_action_create_dest_ib_port* creates a forwarding action to a **ib_port** on the same **domain**. The valid range of ports is a based on the capability phys_port_cnt_ex provided by ibq_query_device_ex and it is possible to query the ports details using mlx5dv_query_port. Action is supported only on domain type FDB.
 *mlx5dv_dr_action_create_dest_devx_tir* creates a terminating action delivering the packet to a TIR, defined by **devx_obj**. Valid only on domain type NIC_RX.

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -756,6 +756,12 @@ struct mlx5dv_flow_matcher {
 	uint32_t handle;
 };
 
+struct mlx5_steering_anchor {
+	struct ibv_context *context;
+	uint32_t handle;
+	struct mlx5dv_steering_anchor sa;
+};
+
 enum mlx5_devx_obj_type {
 	MLX5_DEVX_FLOW_TABLE		= 1,
 	MLX5_DEVX_FLOW_COUNTER		= 2,
@@ -1567,6 +1573,9 @@ struct mlx5_dv_context_ops {
 					struct mlx5dv_flow_action_attr actions_attr[],
 					struct mlx5_flow_action_attr_aux actions_attr_aux[]);
 
+	struct mlx5dv_steering_anchor *(*create_steering_anchor)(struct ibv_context *conterxt,
+								 struct mlx5dv_steering_anchor_attr *attr);
+	int (*destroy_steering_anchor)(struct mlx5_steering_anchor *sa);
 	int (*query_device)(struct ibv_context *ctx_in, struct mlx5dv_context *attrs_out);
 
 	int (*query_qp_lag_port)(struct ibv_qp *qp, uint8_t *port_num,

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -737,6 +737,21 @@ mlx5dv_create_flow_matcher(struct ibv_context *context,
 
 int mlx5dv_destroy_flow_matcher(struct mlx5dv_flow_matcher *matcher);
 
+struct mlx5dv_steering_anchor_attr {
+	enum mlx5dv_flow_table_type ft_type;
+	uint16_t priority;
+	uint64_t comp_mask;
+};
+
+struct mlx5dv_steering_anchor {
+	uint32_t id;
+};
+
+struct mlx5dv_steering_anchor *
+mlx5dv_create_steering_anchor(struct ibv_context *context,
+			      struct mlx5dv_steering_anchor_attr *attr);
+int mlx5dv_destroy_steering_anchor(struct mlx5dv_steering_anchor *sa);
+
 enum mlx5dv_flow_action_type {
 	MLX5DV_FLOW_ACTION_DEST_IBV_QP,
 	MLX5DV_FLOW_ACTION_DROP,

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -2104,6 +2104,10 @@ struct mlx5dv_dr_action *
 mlx5dv_dr_action_create_push_vlan(struct mlx5dv_dr_domain *domain,
 				  __be32 vlan_hdr);
 
+struct mlx5dv_dr_action *
+mlx5dv_dr_action_create_dest_root_table(struct mlx5dv_dr_table *table,
+					uint16_t priority);
+
 int mlx5dv_dr_action_destroy(struct mlx5dv_dr_action *action);
 
 int mlx5dv_dump_dr_domain(FILE *fout, struct mlx5dv_dr_domain *domain);

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -181,6 +181,7 @@ enum dr_action_type {
 	DR_ACTION_TYP_ASO_FIRST_HIT,
 	DR_ACTION_TYP_ASO_FLOW_METER,
 	DR_ACTION_TYP_ASO_CT,
+	DR_ACTION_TYP_ROOT_FT,
 	DR_ACTION_TYP_MAX,
 };
 
@@ -1288,6 +1289,13 @@ struct mlx5dv_dr_action {
 				struct ibv_qp           *qp;
 			};
 		} dest_qp;
+		struct {
+			struct mlx5dv_dr_table *tbl;
+			struct dr_devx_tbl *devx_tbl;
+			struct mlx5dv_steering_anchor *sa;
+			uint64_t rx_icm_addr;
+			uint64_t tx_icm_addr;
+		} root_tbl;
 		struct dr_action_aso	aso;
 		struct mlx5dv_devx_obj	*devx_obj;
 		uint32_t		flow_tag;


### PR DESCRIPTION
This series expose steering anchor DV APIs to allow users to re-inject packets back into default NIC pipeline for additional processing.

Specifically,
mlx5dv_create_steering_anchor() - creates a steering anchor which can be used as a destination in a FTE or via software steering to inject packets back into the kernel.

mlx5dv_dr_action_create_dest_root_table() - creates a packet destination root table action to inject packets back into a specific priority inside the root table.

The matching kernel part was sent already into rdma-next.
