### PR TITLE
tests/mlx5: Update the PCI ids to include new devices

### DIFF
--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -55,10 +55,12 @@ MLX5_DEVS = {
     0x101e,  # ConnectX family mlx5Gen Virtual Function
     0x101f,  # ConnectX-6 LX
     0x1021,  # ConnectX-7
+    0x1023,  # ConnectX-8
     0xa2d2,  # BlueField integrated ConnectX-5 network controller
     0xa2d3,  # BlueField integrated ConnectX-5 network controller VF
     0xa2d6,  # BlueField-2 integrated ConnectX-6 Dx network controller
     0xa2dc,  # BlueField-3 integrated ConnectX-7 network controller
+    0xa2df,  # BlueField-4 integrated ConnectX-8 network controller
 }
 
 DCI_TEST_GOOD_FLOW = 0


### PR DESCRIPTION
Update the mlx5 devices list to include the new ConnectX-8 and
BlueField-4 devices.

Signed-off-by: Kamal Heib <kamalheib1@gmail.com>