### PR TITLE
efa: Add DV CQ with source GID capability

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -165,7 +165,10 @@ libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24
  EFA_1.1@EFA_1.1 26
+ EFA_1.2@EFA_1.2 43
  efadv_create_driver_qp@EFA_1.0 24
  efadv_create_qp_ex@EFA_1.1 26
  efadv_query_device@EFA_1.1 26
  efadv_query_ah@EFA_1.1 26
+ efadv_cq_from_ibv_cq_ex@EFA_1.2 43
+ efadv_create_cq@EFA_1.2 43

--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef EFA_ABI_USER_H
@@ -54,6 +54,7 @@ struct efa_ibv_alloc_pd_resp {
 
 enum {
 	EFA_CREATE_CQ_WITH_COMPLETION_CHANNEL = 1 << 0,
+	EFA_CREATE_CQ_WITH_SGID               = 1 << 1,
 };
 
 struct efa_ibv_create_cq {
@@ -118,6 +119,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_RDMA_READ = 1 << 0,
 	EFA_QUERY_DEVICE_CAPS_RNR_RETRY = 1 << 1,
 	EFA_QUERY_DEVICE_CAPS_CQ_NOTIFICATIONS = 1 << 2,
+	EFA_QUERY_DEVICE_CAPS_CQ_WITH_SGID     = 1 << 3,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/providers/efa/CMakeLists.txt
+++ b/providers/efa/CMakeLists.txt
@@ -1,5 +1,5 @@
 rdma_shared_provider(efa libefa.map
-	1 1.1.${PACKAGE_VERSION}
+	1 1.2.${PACKAGE_VERSION}
 	efa.c
 	verbs.c
 )

--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 /*
- * Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #include <stdio.h>
@@ -75,6 +75,7 @@ static struct verbs_context *efa_alloc_context(struct ibv_device *vdev,
 	ctx->sub_cqs_per_cq = resp.sub_cqs_per_cq;
 	ctx->cmds_supp_udata_mask = resp.cmds_supp_udata_mask;
 	ctx->cqe_size = sizeof(struct efa_io_rx_cdesc);
+	ctx->ex_cqe_size = sizeof(struct efa_io_rx_cdesc_ex);
 	ctx->inline_buf_size = resp.inline_buf_size;
 	ctx->max_llq_size = resp.max_llq_size;
 	ctx->max_tx_batch = resp.max_tx_batch;

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -42,6 +42,7 @@ struct efa_context {
 	uint16_t max_tx_batch;
 	uint16_t min_sq_wr;
 	size_t cqe_size;
+	size_t ex_cqe_size;
 	struct efa_qp **qp_table;
 	unsigned int qp_table_sz_m1;
 	pthread_spinlock_t qp_table_lock;
@@ -174,6 +175,11 @@ static inline struct efa_cq *to_efa_cq(struct ibv_cq *ibvcq)
 static inline struct efa_cq *to_efa_cq_ex(struct ibv_cq_ex *ibvcqx)
 {
 	return container_of(ibvcqx, struct efa_cq, verbs_cq.cq_ex);
+}
+
+static inline struct efa_cq *efadv_cq_to_efa_cq(struct efadv_cq *efadv_cq)
+{
+	return container_of(efadv_cq, struct efa_cq, dv_cq);
 }
 
 static inline struct efa_qp *to_efa_qp(struct ibv_qp *ibvqp)

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef __EFA_H__
@@ -15,6 +15,7 @@
 
 #include "efa-abi.h"
 #include "efa_io_defs.h"
+#include "efadv.h"
 
 #define EFA_GET(ptr, mask) FIELD_GET(mask##_MASK, *(ptr))
 
@@ -62,6 +63,7 @@ struct efa_sub_cq {
 
 struct efa_cq {
 	struct verbs_cq verbs_cq;
+	struct efadv_cq dv_cq;
 	uint32_t cqn;
 	size_t cqe_size;
 	uint8_t *buf;

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2018-2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef _EFA_IO_H_
@@ -219,9 +219,7 @@ struct efa_io_cdesc_common {
 	 * 2:1 : q_type - enum efa_io_queue_type: send/recv
 	 * 3 : has_imm - indicates that immediate data is
 	 *    present - for RX completions only
-	 * 4 : wide_completion - indicates that wide
-	 *    completion format is used
-	 * 7:5 : reserved29
+	 * 7:4 : reserved28 - MBZ
 	 */
 	uint8_t flags;
 
@@ -253,33 +251,15 @@ struct efa_io_rx_cdesc {
 };
 
 /* Extended Rx Completion Descriptor */
-struct efa_io_rx_cdesc_wide {
+struct efa_io_rx_cdesc_ex {
 	/* Base RX completion info */
 	struct efa_io_rx_cdesc rx_cdesc_base;
 
 	/*
-	 * Word 0 of remote (source) address, needed only for in-band
-	 * ad-hoc AH support
+	 * Valid only in case of unknown AH (0xFFFF) and CQ set_src_addr is
+	 * enabled.
 	 */
-	uint32_t src_addr_0;
-
-	/*
-	 * Word 1 of remote (source) address, needed only for in-band
-	 * ad-hoc AH support
-	 */
-	uint32_t src_addr_1;
-
-	/*
-	 * Word 2 of remote (source) address, needed only for in-band
-	 * ad-hoc AH support
-	 */
-	uint32_t src_addr_2;
-
-	/*
-	 * Word 3 of remote (source) address, needed only for in-band
-	 * ad-hoc AH support
-	 */
-	uint32_t src_addr_3;
+	uint8_t src_addr[16];
 };
 
 /* tx_meta_desc */
@@ -305,6 +285,5 @@ struct efa_io_rx_cdesc_wide {
 #define EFA_IO_CDESC_COMMON_PHASE_MASK                      BIT(0)
 #define EFA_IO_CDESC_COMMON_Q_TYPE_MASK                     GENMASK(2, 1)
 #define EFA_IO_CDESC_COMMON_HAS_IMM_MASK                    BIT(3)
-#define EFA_IO_CDESC_COMMON_WIDE_COMPLETION_MASK            BIT(4)
 
 #endif /* _EFA_IO_H_ */

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef __EFADV_H__
@@ -64,6 +64,22 @@ struct efadv_ah_attr {
 
 int efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr,
 		   uint32_t inlen);
+
+struct efadv_cq {
+	uint64_t comp_mask;
+};
+
+struct efadv_cq_init_attr {
+	uint64_t comp_mask;
+	uint64_t wc_flags;
+};
+
+struct ibv_cq_ex *efadv_create_cq(struct ibv_context *ibvctx,
+				  struct ibv_cq_init_attr_ex *attr_ex,
+				  struct efadv_cq_init_attr *efa_attr,
+				  uint32_t inlen);
+
+struct efadv_cq *efadv_cq_from_ibv_cq_ex(struct ibv_cq_ex *ibvcqx);
 
 #ifdef __cplusplus
 }

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -38,6 +38,7 @@ struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
 enum {
 	EFADV_DEVICE_ATTR_CAPS_RDMA_READ = 1 << 0,
 	EFADV_DEVICE_ATTR_CAPS_RNR_RETRY = 1 << 1,
+	EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID = 1 << 2,
 };
 
 struct efadv_device_attr {
@@ -67,6 +68,11 @@ int efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr,
 
 struct efadv_cq {
 	uint64_t comp_mask;
+	int (*wc_read_sgid)(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
+};
+
+enum {
+	EFADV_WC_EX_WITH_SGID = 1 << 0,
 };
 
 struct efadv_cq_init_attr {
@@ -80,6 +86,12 @@ struct ibv_cq_ex *efadv_create_cq(struct ibv_context *ibvctx,
 				  uint32_t inlen);
 
 struct efadv_cq *efadv_cq_from_ibv_cq_ex(struct ibv_cq_ex *ibvcqx);
+
+static inline int efadv_wc_read_sgid(struct efadv_cq *efadv_cq,
+				     union ibv_gid *sgid)
+{
+	return efadv_cq->wc_read_sgid(efadv_cq, sgid);
+}
 
 #ifdef __cplusplus
 }

--- a/providers/efa/libefa.map
+++ b/providers/efa/libefa.map
@@ -12,3 +12,9 @@ EFA_1.1 {
 		efadv_query_ah;
 		efadv_query_device;
 } EFA_1.0;
+
+EFA_1.2 {
+	global:
+		efadv_cq_from_ibv_cq_ex;
+		efadv_create_cq;
+} EFA_1.1;

--- a/providers/efa/libefa.map
+++ b/providers/efa/libefa.map
@@ -17,4 +17,5 @@ EFA_1.2 {
 	global:
 		efadv_cq_from_ibv_cq_ex;
 		efadv_create_cq;
+		efadv_wc_read_sgid;
 } EFA_1.1;

--- a/providers/efa/man/efadv_create_cq.3.md
+++ b/providers/efa/man/efadv_create_cq.3.md
@@ -21,6 +21,9 @@ struct ibv_cq_ex *efadv_create_cq(struct ibv_context *context,
 				  struct ibv_cq_init_attr_ex *attr_ex,
 				  struct efadv_cq_init_attr *efa_attr,
 				  uint32_t inlen);
+
+static inline int efadv_wc_read_sgid(struct efadv_cq *efadv_cq,
+				     union ibv_gid *sgid);
 ```
 
 # DESCRIPTION
@@ -54,7 +57,17 @@ struct efadv_cq_init_attr {
 :	Compatibility mask.
 
 *wc_flags*
-:	Required WC fields.
+:       A bitwise OR of the various values described below.
+
+	EFADV_WC_EX_WITH_SGID:
+		if source AH is unknown, require sgid in WC.
+
+
+# Completion iterator functions
+
+*efadv_wc_read_sgid*
+:	Get the source GID field from the current completion.
+	If the AH is known, a negative error value is returned.
 
 
 # RETURN VALUE

--- a/providers/efa/man/efadv_create_cq.3.md
+++ b/providers/efa/man/efadv_create_cq.3.md
@@ -1,0 +1,71 @@
+---
+layout: page
+title: EFADV_CREATE_CQ
+section: 3
+tagline: Verbs
+date: 2021-01-04
+header: "EFA Direct Verbs Manual"
+footer: efa
+---
+
+# NAME
+
+efadv_create_cq - Create EFA specific Completion Queue (CQ)
+
+# SYNOPSIS
+
+```c
+#include <infiniband/efadv.h>
+
+struct ibv_cq_ex *efadv_create_cq(struct ibv_context *context,
+				  struct ibv_cq_init_attr_ex *attr_ex,
+				  struct efadv_cq_init_attr *efa_attr,
+				  uint32_t inlen);
+```
+
+# DESCRIPTION
+
+**efadv_create_cq()** creates a Completion Queue (CQ) with specific driver
+properties.
+
+The argument attr_ex is an ibv_cq_init_attr_ex struct,
+as defined in <infiniband/verbs.h>.
+
+The EFADV work completions APIs (efadv_wc_\*) is an extension for IBV work
+completions API (ibv_wc_\*) with efa specific features for polling fields in
+the completion. This may be used together with or without ibv_wc_* calls.
+
+Use efadv_cq_from_ibv_cq_ex() to get the efadv_cq for accessing the work
+completion interface.
+
+Compatibility is handled using the comp_mask and inlen fields.
+
+```c
+struct efadv_cq_init_attr {
+	uint64_t comp_mask;
+	uint64_t wc_flags;
+};
+```
+
+*inlen*
+:	In: Size of struct efadv_cq_init_attr.
+
+*comp_mask*
+:	Compatibility mask.
+
+*wc_flags*
+:	Required WC fields.
+
+
+# RETURN VALUE
+
+efadv_create_cq() returns a pointer to the created extended CQ, or NULL if the
+request fails.
+
+# SEE ALSO
+
+**efadv**(7), **ibv_create_cq_ex**(3)
+
+# AUTHORS
+
+Daniel Kranzdorf <dkkranzd@amazon.com>

--- a/providers/efa/man/efadv_query_device.3.md
+++ b/providers/efa/man/efadv_query_device.3.md
@@ -72,6 +72,10 @@ struct efadv_device_attr {
 	EFADV_DEVICE_ATTR_CAPS_RNR_RETRY:
 		RNR retry is supported for SRD QPs.
 
+	EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID:
+		Reading source address (SGID) from receive completion descriptors is supported.
+		Valid only for unknown AH.
+
 *max_rdma_size*
 :	Maximum RDMA transfer size in bytes.
 

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -165,14 +165,16 @@ int efadv_query_device(struct ibv_context *ibvctx,
 	attr->max_rq_sge = ctx->max_rq_sge;
 	attr->inline_buf_size = ctx->inline_buf_size;
 
+	if (vext_field_avail(typeof(*attr), device_caps, inlen)) {
+		if (EFA_DEV_CAP(ctx, RNR_RETRY))
+			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
+	}
+
 	if (vext_field_avail(typeof(*attr), max_rdma_size, inlen)) {
 		attr->max_rdma_size = ctx->max_rdma_size;
 
 		if (EFA_DEV_CAP(ctx, RDMA_READ))
 			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RDMA_READ;
-
-		if (EFA_DEV_CAP(ctx, RNR_RETRY))
-			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
 	}
 
 	attr->comp_mask = comp_mask_out;

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -168,6 +168,9 @@ int efadv_query_device(struct ibv_context *ibvctx,
 	if (vext_field_avail(typeof(*attr), device_caps, inlen)) {
 		if (EFA_DEV_CAP(ctx, RNR_RETRY))
 			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_RNR_RETRY;
+
+		if (EFA_DEV_CAP(ctx, CQ_WITH_SGID))
+			attr->device_caps |= EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID;
 	}
 
 	if (vext_field_avail(typeof(*attr), max_rdma_size, inlen)) {
@@ -691,9 +694,28 @@ static uint8_t efa_wc_read_dlid_path_bits(struct ibv_cq_ex *ibvcqx)
 	return 0;
 }
 
-static void efa_cq_fill_pfns(struct ibv_cq_ex *ibvcqx,
-			     struct ibv_cq_init_attr_ex *attr)
+static int efa_wc_read_sgid(struct efadv_cq *efadv_cq, union ibv_gid *sgid)
 {
+	struct efa_cq *cq = efadv_cq_to_efa_cq(efadv_cq);
+	struct efa_io_rx_cdesc_ex *rcqex;
+
+	rcqex = container_of(cq->cur_cqe, struct efa_io_rx_cdesc_ex,
+			     rx_cdesc_base.common);
+	if (rcqex->rx_cdesc_base.ah != 0xFFFF) {
+		/* SGID is only available if AH is unknown. */
+		return -ENOENT;
+	}
+	memcpy(sgid->raw, rcqex->src_addr, sizeof(sgid->raw));
+
+	return 0;
+}
+
+static void efa_cq_fill_pfns(struct efa_cq *cq,
+			     struct ibv_cq_init_attr_ex *attr,
+			     struct efadv_cq_init_attr *efa_attr)
+{
+	struct ibv_cq_ex *ibvcqx = &cq->verbs_cq.cq_ex;
+
 	ibvcqx->start_poll = efa_start_poll;
 	ibvcqx->end_poll = efa_end_poll;
 	ibvcqx->next_poll = efa_next_poll;
@@ -716,6 +738,9 @@ static void efa_cq_fill_pfns(struct ibv_cq_ex *ibvcqx,
 		ibvcqx->read_sl = efa_wc_read_sl;
 	if (attr->wc_flags & IBV_WC_EX_WITH_DLID_PATH_BITS)
 		ibvcqx->read_dlid_path_bits = efa_wc_read_dlid_path_bits;
+
+	if (efa_attr && (efa_attr->wc_flags & EFADV_WC_EX_WITH_SGID))
+		cq->dv_cq.wc_read_sgid = efa_wc_read_sgid;
 }
 
 static void efa_sub_cq_initialize(struct efa_sub_cq *sub_cq, uint8_t *buf,
@@ -730,10 +755,12 @@ static void efa_sub_cq_initialize(struct efa_sub_cq *sub_cq, uint8_t *buf,
 }
 
 static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
-				   struct ibv_cq_init_attr_ex *attr)
+				   struct ibv_cq_init_attr_ex *attr,
+				   struct efadv_cq_init_attr *efa_attr)
 {
 	struct efa_context *ctx = to_efa_context(ibvctx);
 	struct efa_create_cq_resp resp = {};
+	uint16_t cqe_size = ctx->cqe_size;
 	struct efa_create_cq cmd = {};
 	uint16_t num_sub_cqs;
 	struct efa_cq *cq;
@@ -762,9 +789,14 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
 	if (!cq)
 		return NULL;
 
+	if (efa_attr && (efa_attr->wc_flags & EFADV_WC_EX_WITH_SGID)) {
+		cmd.flags |= EFA_CREATE_CQ_WITH_SGID;
+		cqe_size = ctx->ex_cqe_size;
+	}
+
 	num_sub_cqs = ctx->sub_cqs_per_cq;
 	cmd.num_sub_cqs = num_sub_cqs;
-	cmd.cq_entry_size = ctx->cqe_size;
+	cmd.cq_entry_size = cqe_size;
 	if (attr->channel)
 		cmd.flags |= EFA_CREATE_CQ_WITH_COMPLETION_CHANNEL;
 
@@ -781,7 +813,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
 	cq->cqn = resp.cq_idx;
 	cq->buf_size = resp.q_mmap_size;
 	cq->num_sub_cqs = num_sub_cqs;
-	cq->cqe_size = ctx->cqe_size;
+	cq->cqe_size = cqe_size;
 
 	cq->buf = mmap(NULL, cq->buf_size, PROT_READ, MAP_SHARED,
 		       ibvctx->cmd_fd, resp.q_mmap_key);
@@ -806,7 +838,7 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
 		cq->db = (uint32_t *)((uint8_t *)cq->db + resp.db_off);
 	}
 
-	efa_cq_fill_pfns(&cq->verbs_cq.cq_ex, attr);
+	efa_cq_fill_pfns(cq, attr, efa_attr);
 	pthread_spin_init(&cq->lock, PTHREAD_PROCESS_PRIVATE);
 
 	return &cq->verbs_cq.cq_ex;
@@ -831,7 +863,7 @@ struct ibv_cq *efa_create_cq(struct ibv_context *ibvctx, int ncqe,
 	};
 	struct ibv_cq_ex *ibvcqx;
 
-	ibvcqx = create_cq(ibvctx, &attr_ex);
+	ibvcqx = create_cq(ibvctx, &attr_ex, NULL);
 
 	return ibvcqx ? ibv_cq_ex_to_cq(ibvcqx) : NULL;
 }
@@ -839,7 +871,7 @@ struct ibv_cq *efa_create_cq(struct ibv_context *ibvctx, int ncqe,
 struct ibv_cq_ex *efa_create_cq_ex(struct ibv_context *ibvctx,
 				   struct ibv_cq_init_attr_ex *attr_ex)
 {
-	return create_cq(ibvctx, attr_ex);
+	return create_cq(ibvctx, attr_ex, NULL);
 }
 
 struct ibv_cq_ex *efadv_create_cq(struct ibv_context *ibvctx,
@@ -847,6 +879,9 @@ struct ibv_cq_ex *efadv_create_cq(struct ibv_context *ibvctx,
 				  struct efadv_cq_init_attr *efa_attr,
 				  uint32_t inlen)
 {
+	struct efa_context *ctx;
+	uint64_t supp_wc_flags;
+
 	if (!is_efa_dev(ibvctx->device)) {
 		verbs_err(verbs_get_ctx(ibvctx), "Not an EFA device\n");
 		errno = EOPNOTSUPP;
@@ -861,14 +896,16 @@ struct ibv_cq_ex *efadv_create_cq(struct ibv_context *ibvctx,
 		return NULL;
 	}
 
-	if (efa_attr->wc_flags) {
+	ctx = to_efa_context(ibvctx);
+	supp_wc_flags = EFA_DEV_CAP(ctx, CQ_WITH_SGID) ? EFADV_WC_EX_WITH_SGID : 0;
+	if (!check_comp_mask(efa_attr->wc_flags, supp_wc_flags)) {
 		verbs_err(verbs_get_ctx(ibvctx),
 			  "Invalid EFA wc_flags[%#x]\n", efa_attr->wc_flags);
 		errno = EOPNOTSUPP;
 		return NULL;
 	}
 
-	return create_cq(ibvctx, attr_ex);
+	return create_cq(ibvctx, attr_ex, efa_attr);
 }
 
 struct efadv_cq *efadv_cq_from_ibv_cq_ex(struct ibv_cq_ex *ibvcqx)

--- a/pyverbs/providers/efa/efa_enums.pyx
+++ b/pyverbs/providers/efa/efa_enums.pyx
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 #cython: language_level=3
 
@@ -7,6 +7,7 @@ cdef extern from 'infiniband/efadv.h':
 
     cpdef enum:
         EFADV_DEVICE_ATTR_CAPS_RDMA_READ
+        EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID
 
     cpdef enum:
         EFADV_QP_DRIVER_TYPE_SRD

--- a/pyverbs/providers/efa/efa_enums.pyx
+++ b/pyverbs/providers/efa/efa_enums.pyx
@@ -11,3 +11,6 @@ cdef extern from 'infiniband/efadv.h':
 
     cpdef enum:
         EFADV_QP_DRIVER_TYPE_SRD
+
+    cpdef enum:
+        EFADV_WC_EX_WITH_SGID

--- a/pyverbs/providers/efa/efadv.pxd
+++ b/pyverbs/providers/efa/efadv.pxd
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 #cython: language_level=3
 
@@ -7,6 +7,7 @@ cimport pyverbs.providers.efa.libefa as dv
 
 from pyverbs.addr cimport AH
 from pyverbs.base cimport PyverbsObject
+from pyverbs.cq cimport CQEX
 from pyverbs.device cimport Context
 from pyverbs.qp cimport QP, QPEx
 
@@ -37,3 +38,11 @@ cdef class SRDQPEx(QPEx):
 
 cdef class EfaQPInitAttr(PyverbsObject):
     cdef dv.efadv_qp_init_attr qp_init_attr
+
+
+cdef class EfaCQ(CQEX):
+    cdef dv.efadv_cq *dv_cq
+
+
+cdef class EfaDVCQInitAttr(PyverbsObject):
+    cdef dv.efadv_cq_init_attr cq_init_attr

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -4,8 +4,11 @@
 cimport pyverbs.providers.efa.efadv_enums as dve
 cimport pyverbs.providers.efa.libefa as dv
 
+from pyverbs.addr cimport GID
 from pyverbs.base import PyverbsRDMAErrno, PyverbsRDMAError
+from pyverbs.cq cimport CQEX, CqInitAttrEx
 import pyverbs.enums as e
+cimport pyverbs.libibverbs as v
 from pyverbs.pd cimport PD
 from pyverbs.qp cimport QP, QPEx, QPInitAttr, QPInitAttrEx
 
@@ -194,3 +197,55 @@ cdef class SRDQPEx(QPEx):
                     'RTR': 0,
                     'RTS': e.IBV_QP_SQ_PSN}
         return srd_mask [dst] | e.IBV_QP_STATE
+
+
+cdef class EfaDVCQInitAttr(PyverbsObject):
+    """
+    Represents efadv_cq_init_attr struct.
+    """
+    def __init__(self, wc_flags=0):
+        super().__init__()
+        self.cq_init_attr.wc_flags = wc_flags
+
+    @property
+    def comp_mask(self):
+        return self.cq_init_attr.comp_mask
+
+    @property
+    def wc_flags(self):
+        return self.cq_init_attr.wc_flags
+
+    @wc_flags.setter
+    def wc_flags(self, val):
+        self.cq_init_attr.wc_flags = val
+
+
+cdef class EfaCQ(CQEX):
+    """
+    Initializes an Efa CQ according to the user-provided data.
+    :param ctx: Context object
+    :param attr_ex: CQInitAttrEx object
+    :param efa_init_attr: EfaDVCQInitAttr object
+    :return: An initialized EfaCQ
+    """
+    def __init__(self, Context ctx not None, CqInitAttrEx attr_ex not None, EfaDVCQInitAttr efa_init_attr):
+        if efa_init_attr is None:
+            efa_init_attr = EfaDVCQInitAttr()
+        self.cq = dv.efadv_create_cq(ctx.context, &attr_ex.attr, &efa_init_attr.cq_init_attr, sizeof(efa_init_attr.cq_init_attr))
+        if self.cq == NULL:
+            raise PyverbsRDMAErrno('Failed to create EFA CQ')
+        self.ibv_cq = v.ibv_cq_ex_to_cq(self.cq)
+        self.dv_cq = dv.efadv_cq_from_ibv_cq_ex(self.cq)
+        self.context = ctx
+        ctx.add_ref(self)
+        super().__init__(ctx, attr_ex)
+
+    def read_sgid(self):
+        """
+        Read SGID from last work completion, if AH is unknown.
+        """
+        sgid = GID()
+        err = dv.efadv_wc_read_sgid(self.dv_cq, &sgid.gid)
+        if err:
+            return None
+        return sgid

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 cimport pyverbs.providers.efa.efadv_enums as dve
 cimport pyverbs.providers.efa.libefa as dv
@@ -14,6 +14,7 @@ def dev_cap_to_str(flags):
     l = {
             dve.EFADV_DEVICE_ATTR_CAPS_RDMA_READ: 'RDMA Read',
             dve.EFADV_DEVICE_ATTR_CAPS_RNR_RETRY: 'RNR Retry',
+            dve.EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID: 'CQ entries with source GID',
     }
     return bitmask_to_str(flags, l)
 

--- a/pyverbs/providers/efa/efadv_enums.pxd
+++ b/pyverbs/providers/efa/efadv_enums.pxd
@@ -12,3 +12,6 @@ cdef extern from 'infiniband/efadv.h':
 
     cpdef enum:
         EFADV_QP_DRIVER_TYPE_SRD
+
+    cpdef enum:
+        EFADV_WC_EX_WITH_SGID

--- a/pyverbs/providers/efa/efadv_enums.pxd
+++ b/pyverbs/providers/efa/efadv_enums.pxd
@@ -8,6 +8,7 @@ cdef extern from 'infiniband/efadv.h':
     cpdef enum:
         EFADV_DEVICE_ATTR_CAPS_RDMA_READ
         EFADV_DEVICE_ATTR_CAPS_RNR_RETRY
+        EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID
 
     cpdef enum:
         EFADV_QP_DRIVER_TYPE_SRD

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
 cimport pyverbs.libibverbs as v
@@ -28,6 +28,13 @@ cdef extern from 'infiniband/efadv.h':
         uint32_t driver_qp_type;
         uint8_t reserved[4];
 
+    cdef struct efadv_cq_init_attr:
+        uint64_t comp_mask;
+        uint64_t wc_flags;
+
+    cdef struct efadv_cq:
+        uint64_t comp_mask;
+
     int efadv_query_device(v.ibv_context *ibvctx, efadv_device_attr *attrs,
                            uint32_t inlen)
     int efadv_query_ah(v.ibv_ah *ibvah, efadv_ah_attr *attr,
@@ -38,3 +45,9 @@ cdef extern from 'infiniband/efadv.h':
                                  v.ibv_qp_init_attr_ex *attr_ex,
                                  efadv_qp_init_attr *efa_attr,
                                  uint32_t inlen)
+    v.ibv_cq_ex *efadv_create_cq(v.ibv_context *ibvctx,
+                                 v.ibv_cq_init_attr_ex *attr_ex,
+                                 efadv_cq_init_attr *efa_attr,
+                                 uint32_t inlen)
+    efadv_cq *efadv_cq_from_ibv_cq_ex(v.ibv_cq_ex *ibvcqx)
+    int efadv_wc_read_sgid(efadv_cq *efadv_cq, v.ibv_gid *sgid)

--- a/tests/efa_base.py
+++ b/tests/efa_base.py
@@ -1,11 +1,12 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 import unittest
 import random
 import errno
 
 from pyverbs.pyverbs_error import PyverbsRDMAError
+from pyverbs.cq import CqInitAttrEx
 from pyverbs.qp import QPAttr, QPCap, QPInitAttrEx
 import pyverbs.providers.efa.efa_enums as efa_e
 import pyverbs.providers.efa.efadv as efa
@@ -96,3 +97,35 @@ class SRDResources(TrafficResources):
             self.mr = tests.utils.create_custom_mr(self, e.IBV_ACCESS_REMOTE_READ)
         else:
             self.mr = tests.utils.create_custom_mr(self)
+
+
+class EfaCQRes(SRDResources):
+    def __init__(self, dev_name, ib_port, gid_index, send_ops_flags,
+                 qp_count=1, requested_dev_cap=None, wc_flags=None):
+        """
+        Initialize EFA DV CQ based on SRD resources.
+        :param requested_dev_cap: A necessary device cap. If it's not supported
+                                  by the device, the test will be skipped.
+        :param wc_flags: WC flags for EFA DV CQ.
+        """
+        self.requested_dev_cap = requested_dev_cap
+        self.efa_wc_flags = wc_flags
+        super().__init__(dev_name, ib_port, gid_index, send_ops_flags, qp_count=qp_count)
+
+    def create_context(self):
+        super().create_context()
+        if self.requested_dev_cap:
+            with efa.EfaContext(name=self.ctx.name) as efa_ctx:
+                if not efa_ctx.query_efa_device().device_caps & self.requested_dev_cap:
+                    miss_caps = efa.dev_cap_to_str(self.requested_dev_cap)
+                    raise unittest.SkipTest(f'Device caps doesn\'t support {miss_caps}')
+
+    def create_cq(self):
+        cia = CqInitAttrEx(wc_flags=e.IBV_WC_STANDARD_FLAGS)
+        efa_cia = efa.EfaDVCQInitAttr(self.efa_wc_flags)
+        try:
+            self.cq = efa.EfaCQ(self.ctx, cia, efa_cia)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest('Create EFA DV CQ is not supported')
+            raise ex


### PR DESCRIPTION
This PR adds support for EFA extended CQ with a new capability to get source GID through EFA DV.
It consists of EFA provider changes, updated EFA kernel module ABI, EFA pyverbs, and a corresponding test.

Matching kernel patch:
[https://lore.kernel.org/linux-rdma/20220809151636.788-1-mrgolin@amazon.com/T/#u](https://lore.kernel.org/linux-rdma/20220809151636.788-1-mrgolin@amazon.com/T/#u)