### PR TITLE
Install xprtrdma/svcrdma kmods in redhat/suse dracut modules

### DIFF
--- a/redhat/rdma.modules-setup.sh
+++ b/redhat/rdma.modules-setup.sh
@@ -29,5 +29,5 @@ install() {
 
 installkernel() {
 	hostonly='' instmods =drivers/infiniband =drivers/net/ethernet/mellanox =drivers/net/ethernet/chelsio =drivers/net/ethernet/cisco =drivers/net/ethernet/emulex =drivers/target
-	hostonly='' instmods crc-t10dif crct10dif_common
+	hostonly='' instmods crc-t10dif crct10dif_common xprtrdma svcrdma
 }

--- a/suse/module-setup.sh
+++ b/suse/module-setup.sh
@@ -27,5 +27,5 @@ install() {
 
 installkernel() {
 	hostonly='' instmods =drivers/infiniband =drivers/net/ethernet/mellanox =drivers/net/ethernet/chelsio =drivers/net/ethernet/cisco =drivers/net/ethernet/emulex =drivers/target
-	hostonly='' instmods crc-t10dif crct10dif_common
+	hostonly='' instmods crc-t10dif crct10dif_common xprtrdma svcrdma
 }


### PR DESCRIPTION
The `rdma` dracut module installs udev rules that can cause `rdma-load-modules@rdma.service` to load kernel modules listed in `rdma.conf`.  That file mentions the `xprtrdma` and `svcrdma` modules (both of which are aliases for `rpcrdma` in kernel 5.18) but the dracut module doesn't install them in the initrd.  If they're not installed by other means, this causes warnings in the journal:

    systemd-modules-load[...]: Failed to find module 'xprtrdma'
    systemd-modules-load[...]: Failed to find module 'svcrdma'

Before systemd 244, it also causes `rdma-load-modules@rdma.service` to fail entirely.

Fix by explicitly installing those modules in the initrd.

See also https://bugzilla.redhat.com/show_bug.cgi?id=2117375.

Fixes: 8bb38f6cb1b2 ("redhat: update dracut setting")
Fixes: 775241089e26 ("suse: fix dracut support")
Signed-off-by: Benjamin Gilbert &lt;bgilbert@redhat.com&gt;