### PR TITLE
.gitignore: Add generated files during Debian package build

### DIFF
--- a/debian/.gitignore
+++ b/debian/.gitignore
@@ -1,0 +1,14 @@
+/*.debhelper
+/*.log
+/*.substvars
+/files
+/ibacm/
+/ibverbs-providers/
+/ibverbs-utils/
+/infiniband-diags/
+/lib*/
+/python3-pyverbs/
+/rdma-core/
+/rdmacm-utils/
+/srptools/
+/tmp/


### PR DESCRIPTION
When building a Debian package in place, several files will be created in `debian/`. Add them to `.gitignore`.