### PR TITLE
examples: Include alloca.h for strdupa

### DIFF
--- a/libibverbs/examples/asyncwatch.c
+++ b/libibverbs/examples/asyncwatch.c
@@ -36,6 +36,7 @@
 #include <endian.h>
 #include <getopt.h>
 #include <string.h>
+#include <alloca.h>
 
 #include <util/compiler.h>
 #include <infiniband/verbs.h>


### PR DESCRIPTION
musl defines strdupa via a macro which uses alloca() therefore include
the header to get the prototype

Signed-off-by: Khem Raj <raj.khem@gmail.com>