### PR TITLE
tests: Pass the specified gid index to u.get_global_route()

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -76,6 +76,7 @@ class PyverbsAPITestCase(unittest.TestCase):
         self.ctx = None
         self.attr = None
         self.attr_ex = None
+        self.gid_index = 0
 
     def setUp(self):
         """
@@ -92,6 +93,9 @@ class PyverbsAPITestCase(unittest.TestCase):
             if not dev_list:
                 raise unittest.SkipTest('No IB devices found')
             self.dev_name = dev_list[0].name.decode()
+
+        if self.config['gid']:
+            self.gid_index = self.config['gid']
 
         self.create_context()
         self.attr = self.ctx.query_device()

--- a/tests/test_addr.py
+++ b/tests/test_addr.py
@@ -38,7 +38,7 @@ class AHTest(PyverbsAPITestCase):
         Test ibv_create_ah.
         """
         self.verify_state(self.ctx)
-        gr = u.get_global_route(self.ctx, port_num=self.ib_port)
+        gr = u.get_global_route(self.ctx, gid_index=self.gid_index, port_num=self.ib_port)
         port_attrs = self.ctx.query_port(self.ib_port)
         dlid = port_attrs.lid if port_attrs.link_layer == e.IBV_LINK_LAYER_INFINIBAND else 0
         ah_attr = AHAttr(dlid=dlid, gr=gr, is_global=1, port_num=self.ib_port)
@@ -72,7 +72,7 @@ class AHTest(PyverbsAPITestCase):
         Test ibv_destroy_ah.
         """
         self.verify_state(self.ctx)
-        gr = u.get_global_route(self.ctx, port_num=self.ib_port)
+        gr = u.get_global_route(self.ctx, gid_index=self.gid_index, port_num=self.ib_port)
         port_attrs = self.ctx.query_port(self.ib_port)
         dlid = port_attrs.lid if port_attrs.link_layer == e.IBV_LINK_LAYER_INFINIBAND else 0
         ah_attr = AHAttr(dlid=dlid, gr=gr, is_global=1, port_num=self.ib_port)


### PR DESCRIPTION
test_create_ah() or test_destroy_ah() always triggered the following
error on SoftRoCE because the specified gid index didn't work.

$ bin/run_tests.py --dev rxe_enp0s5 --gid 1 -v tests.test_addr.AHTest.test_create_ah
test_create_ah (tests.test_addr.AHTest)
Test ibv_create_ah. ... ERROR

======================================================================
ERROR: test_create_ah (tests.test_addr.AHTest)
Test ibv_create_ah.
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/root/rdma-core/tests/test_addr.py", line 51, in test_create_ah
    raise ex
  File "/root/rdma-core/tests/test_addr.py", line 47, in test_create_ah
    AH(pd, attr=ah_attr)
  File "addr.pyx", line 410, in pyverbs.addr.AH.__init__
pyverbs.pyverbs_error.PyverbsRDMAError: Failed to create AH. Errno: 110, Connection timed out

----------------------------------------------------------------------
Ran 1 test in 1.271s

FAILED (errors=1)

Try to fix the issue by passing the specified gid index to u.get_global_route().

Signed-off-by: Xiao Yang <yangx.jy@fujitsu.com>
Link: https://lore.kernel.org/r/20220901073836.1573-1-yangx.jy@fujitsu.com
Signed-off-by: Leon Romanovsky <leonro@nvidia.com>