### PR TITLE
tests: poll_cq: Don't pass wc.status to PyverbsRDMAError

### DIFF
--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -6,6 +6,7 @@ from pyverbs.qp import QPCap, QPInitAttrEx, QPAttr, QPEx, QP
 from pyverbs.pyverbs_error import PyverbsRDMAError
 from pyverbs.mr import MW, MWBindInfo
 from pyverbs.base import inc_rkey
+from tests.utils import wc_status_to_str
 import pyverbs.enums as e
 
 from tests.base import UDResources, RCResources, RDMATestCase, XRCResources
@@ -311,11 +312,9 @@ class QpExTestCase(RDMATestCase):
         client.qp.wr_rdma_write(new_key, server.mr.buf)
         client.qp.wr_set_sge(client_sge)
         client.qp.wr_complete()
-        try:
-            u.poll_cq(client.cq)
-        except PyverbsRDMAError as ex:
-            if ex.error_code != e.IBV_WC_REM_ACCESS_ERR:
-                raise ex
+        wcs = u._poll_cq(client.cq)
+        if wcs[0].status != e.IBV_WC_REM_ACCESS_ERR:
+            raise PyverbsRDMAError(f'Completion status is {wc_status_to_str(wcs[0].status)}')
 
     def test_post_receive_qp_state_bad_flow(self):
         self.create_players(qp_type='ud_send')


### PR DESCRIPTION
When testing fails, we got below confusing error message due to the wrong errno:
    u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
  File "rdma-core/tests/utils.py", line 1013, in rdma_traffic
    poll_cq(client.cq)
  File "rdma-core/tests/utils.py", line 577, in poll_cq
    raise PyverbsRDMAError('Completion status is {s}'.
pyverbs.pyverbs_error.PyverbsRDMAError: Completion status is local QP operation error. Errno: 2, No such file or directory

That's because PyverbsRDMAError(msg, errno) accept the 2nd parameter as errno.

Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>