### PR TITLE
providers/irdma: Use s/g array in post send only when its valid

### DIFF
--- a/providers/irdma/uk.c
+++ b/providers/irdma/uk.c
@@ -476,7 +476,8 @@ enum irdma_status_code irdma_uk_send(struct irdma_qp_uk *qp,
 			      FIELD_PREP(IRDMAQPSQ_IMMDATA, info->imm_data));
 		i = 0;
 	} else {
-		qp->wqe_ops.iw_set_fragment(wqe, 0, op_info->sg_list,
+		qp->wqe_ops.iw_set_fragment(wqe, 0,
+					    frag_cnt ? op_info->sg_list : NULL,
 					    qp->swqe_polarity);
 		i = 1;
 	}


### PR DESCRIPTION
Send with invalidate verb call can pass in an
uninitialized s/g array with 0 sge's which is
filled into irdma WQE and causes a HW asynchronous event.

Fix this by using the s/g array in irdma post send only when its valid.

Fixes: 3bebdf5 ("rdma-core/irdma: Add user/kernel shared libraries")
Signed-off-by: Tatyana Nikolova tatyana.e.nikolova@intel.com
Signed-off-by: Sindhu-Devale <sindhu.devale@intel.com>