### PR TITLE
providers/irdma: Report correct WC errors

### DIFF
--- a/providers/irdma/user.h
+++ b/providers/irdma/user.h
@@ -106,6 +106,7 @@ enum irdma_flush_opcode {
 	FLUSH_FATAL_ERR,
 	FLUSH_RETRY_EXC_ERR,
 	FLUSH_MW_BIND_ERR,
+	FLUSH_REM_INV_REQ_ERR,
 };
 
 enum irdma_cmpl_status {

--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -560,6 +560,8 @@ static enum ibv_wc_status irdma_flush_err_to_ib_wc_status(enum irdma_flush_opcod
 		return IBV_WC_RETRY_EXC_ERR;
 	case FLUSH_MW_BIND_ERR:
 		return IBV_WC_MW_BIND_ERR;
+	case FLUSH_REM_INV_REQ_ERR:
+		return IBV_WC_REM_INV_REQ_ERR;
 	case FLUSH_FATAL_ERR:
 	default:
 		return IBV_WC_FATAL_ERR;


### PR DESCRIPTION
Return specific WC errors for certain type of error events.

In particular,

Return IBV_WC_REM_INV_REQ_ERR for an invalid
request related asynchronous event.

Fixes: 14a0fc8 ("rdma-core/irdma: Implement device supported verb APIs")
Signed-off-by: Tatyana Nikolova <tatyana.e.nikolova@intel.com>
Signed-off-by: Sindhu-Devale <sindhu.devale@intel.com>