### PR TITLE
verbs: Allow aligned address & size only for fork init

### DIFF
--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -113,6 +113,9 @@ as the rkey field of struct ibv_send_wr passed to the ibv_post_send function.
 .B ibv_dereg_mr()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).
 .SH "NOTES"
+.B ibv_reg_mr() / ibv_reg_mr_iova()
+fails if the address (\fBaddr\fR) or the length (\fBlength\fR) is not aligned to page size once ibv_fork_init() is called.
+.PP
 .B ibv_dereg_mr()
 fails if any memory window is still bound to this MR.
 .SH "SEE ALSO"


### PR DESCRIPTION
Run the following sample code and reproduce segfault:
```
struct memstruct {
	char local[2048];
	char remote[2048];
};

int main()
{
	struct rdma_addrinfo hints = {0}, *rai;
	struct ibv_qp_init_attr init_attr;
	struct rdma_event_channel *channel;
	struct rdma_cm_id *cm_id;
	struct ibv_pd *pd;
	struct memstruct *mem;

	ibv_fork_init();
	hints.ai_flags = RAI_PASSIVE;
	hints.ai_port_space = RDMA_PS_TCP;
	assert(!rdma_getaddrinfo("10.2.16.102", "7471", &hints, &rai));
	assert(channel = rdma_create_event_channel());
	assert(!rdma_create_id(channel, &cm_id, NULL, RDMA_PS_TCP));
	assert(!rdma_bind_addr(cm_id, rai->ai_src_addr));
	assert(pd = ibv_alloc_pd(cm_id->verbs));

	mem = mmap(NULL, sizeof(*mem), PROT_READ | PROT_WRITE,
			MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
	assert(mem != MAP_FAILED);
	assert(ibv_reg_mr(pd, mem->remote, sizeof(mem->remote), IBV_ACCESS_LOCAL_WRITE));
	if (fork() == 0)
		mem->local[0] = 0; /* unexpected segfault */

	return 0;
}
```
Because madvise(addr, length, advise) needs page size aligned value, unexpected memory is marked as DONTFORK too,this leads segment fault.

In the real scenario, a user process usually uses malloc/free, and the random segfault in the child process is quite difficult to trouble shoot. Rather than random segfault in the child process, return error as soos as ibv_reg_mr().

Signed-off-by: zhenwei pi <pizhenwei@bytedance.com>