### PR TITLE
util: Add barriers support for MIPS

### DIFF
--- a/util/udma_barrier.h
+++ b/util/udma_barrier.h
@@ -100,6 +100,8 @@
 #define udma_to_device_barrier() asm volatile("dbar 0" ::: "memory")
 #elif defined(__riscv)
 #define udma_to_device_barrier() asm volatile("fence ow,ow" ::: "memory")
+#elif defined(__mips__)
+#define udma_to_device_barrier() asm volatile("sync 0" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif
@@ -136,6 +138,8 @@
 #define udma_from_device_barrier() asm volatile("dbar 0" ::: "memory")
 #elif defined(__riscv)
 #define udma_from_device_barrier() asm volatile("fence ir,ir" ::: "memory")
+#elif defined(__mips__)
+#define udma_from_device_barrier() asm volatile("sync 0" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif
@@ -207,6 +211,8 @@
 #elif defined(__s390x__)
 #include "s390_mmio_insn.h"
 #define mmio_flush_writes() s390_pciwb()
+#elif defined(__mips__)
+#define mmio_flush_writes() asm volatile("sync 0" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif


### PR DESCRIPTION
MIPS has the capability to issue memory barriers.  Implement this using a full (heavy) barrier.  This is the only variant that is guaranteed to exist on all hardware.  Other barriers are only available on mipsr6 or some special earlier implementations.  However even on the former the kernel uses a full barrier for safety due to not yet trusting their reliability.

See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=881731
See: https://s3-eu-west-1.amazonaws.com/downloads-mips/documents/MD00605-2B-CMPCOHERE-AFP-01.01.pdf
See: https://github.com/torvalds/linux/blob/master/arch/mips/include/asm/sync.h