### PR TITLE
Install 70-persistent-ipoib.rules into docs instead of /etc

### DIFF
--- a/buildlib/centos6.spec
+++ b/buildlib/centos6.spec
@@ -103,7 +103,6 @@ rm -rf %{buildroot}/%{my_unitdir}/
 %config %{_sysconfdir}/libibverbs.d/*
 %config %{_sysconfdir}/rdma/modules/*
 %{perl_vendorlib}/IBswcountlimits.pm
-%config(noreplace) %{_sysconfdir}/udev/rules.d/*
 %config(noreplace) %{_sysconfdir}/infiniband-diags/error_thresholds
 %config(noreplace) %{_sysconfdir}/infiniband-diags/ibdiag.conf
 %{_sysconfdir}/modprobe.d/*

--- a/debian/rdma-core.install
+++ b/debian/rdma-core.install
@@ -8,7 +8,6 @@ etc/rdma/modules/iwpmd.conf
 etc/rdma/modules/opa.conf
 etc/rdma/modules/rdma.conf
 etc/rdma/modules/roce.conf
-etc/udev/rules.d/70-persistent-ipoib.rules
 lib/systemd/system/iwpmd.service
 lib/systemd/system/rdma-hw.target
 lib/systemd/system/rdma-load-modules@.service
@@ -24,6 +23,7 @@ lib/udev/rules.d/90-rdma-umad.rules
 usr/lib/truescale-serdes.cmds
 usr/sbin/iwpmd
 usr/sbin/rdma-ndd
+usr/share/doc/rdma-core/70-persistent-ipoib.rules
 usr/share/doc/rdma-core/MAINTAINERS
 usr/share/doc/rdma-core/README.md
 usr/share/doc/rdma-core/rxe.md

--- a/debian/rdma-core.lintian-overrides
+++ b/debian/rdma-core.lintian-overrides
@@ -3,8 +3,5 @@ rdma-core: obsolete-command-in-modprobe.d-file install [etc/modprobe.d/truescale
 # The rdma-ndd service is started by udev.
 rdma-core: systemd-service-file-missing-install-key [lib/systemd/system/iwpmd.service]
 rdma-core: systemd-service-file-missing-install-key [lib/systemd/system/rdma-ndd.service]
-# Example/documentary udev rules file
-rdma-core: udev-rule-in-etc [etc/udev/rules.d/70-persistent-ipoib.rules]
 # For lintian < 2.115.2
 rdma-core: obsolete-command-in-modprobe.d-file etc/modprobe.d/truescale.conf install
-rdma-core: udev-rule-in-etc etc/udev/rules.d/70-persistent-ipoib.rules

--- a/kernel-boot/CMakeLists.txt
+++ b/kernel-boot/CMakeLists.txt
@@ -36,11 +36,10 @@ install(FILES "rdma-umad.rules"
   RENAME "90-rdma-umad.rules"
   DESTINATION "${CMAKE_INSTALL_UDEV_RULESDIR}")
 
-# This file is intended to be customized by the user, so it is installed in
-# /etc/
-install(FILES "persistent-ipoib.rules"
+rdma_subst_install(FILES "persistent-ipoib.rules.in"
   RENAME "70-persistent-ipoib.rules"
-  DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/udev/rules.d")
+  DESTINATION "${CMAKE_INSTALL_DOCDIR}"
+  PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
 

--- a/kernel-boot/persistent-ipoib.rules.in
+++ b/kernel-boot/persistent-ipoib.rules.in
@@ -1,6 +1,7 @@
 # This is a sample udev rules file that demonstrates how to get udev to
-# set the name of IPoIB interfaces to whatever you wish.  There is a
-# 16 character limit on network device names.
+# set the name of IPoIB interfaces to whatever you wish.  Copy this file
+# into @CMAKE_INSTALL_SYSCONFDIR@/udev/rules.d before editing it!  There is a 16 character limit
+# on network device names.
 #
 # Important items to note: ATTR{type}=="32" is IPoIB interfaces, and the
 # ATTR{address} match must start with ?* and only reference the last 8

--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -326,7 +326,6 @@ mkdir -p %{buildroot}/%{_sysconfdir}/rdma
 # Red Hat specific glue
 %global dracutlibdir %{_prefix}/lib/dracut
 %global sysmodprobedir %{_prefix}/lib/modprobe.d
-mkdir -p %{buildroot}%{_sysconfdir}/udev/rules.d
 mkdir -p %{buildroot}%{_libexecdir}
 mkdir -p %{buildroot}%{_udevrulesdir}
 mkdir -p %{buildroot}%{dracutlibdir}/modules.d/05rdma
@@ -390,6 +389,7 @@ fi
 %files
 %dir %{_sysconfdir}/rdma
 %dir %{_docdir}/%{name}
+%doc %{_docdir}/%{name}/70-persistent-ipoib.rules
 %doc %{_docdir}/%{name}/README.md
 %doc %{_docdir}/%{name}/rxe.md
 %doc %{_docdir}/%{name}/udev.md
@@ -400,7 +400,6 @@ fi
 %config(noreplace) %{_sysconfdir}/rdma/modules/opa.conf
 %config(noreplace) %{_sysconfdir}/rdma/modules/rdma.conf
 %config(noreplace) %{_sysconfdir}/rdma/modules/roce.conf
-%config(noreplace) %{_sysconfdir}/udev/rules.d/*
 %dir %{_sysconfdir}/modprobe.d
 %config(noreplace) %{_sysconfdir}/modprobe.d/mlx4.conf
 %config(noreplace) %{_sysconfdir}/modprobe.d/truescale.conf

--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -600,9 +600,8 @@ done
 %dir %{_sysconfdir}/rdma/modules
 %dir %{_docdir}/%{name}-%{version}
 %dir %{_udevrulesdir}
-%dir %{_sysconfdir}/udev
-%dir %{_sysconfdir}/udev/rules.d
 %dir %{_modprobedir}
+%doc %{_docdir}/%{name}-%{version}/70-persistent-ipoib.rules
 %doc %{_docdir}/%{name}-%{version}/README.md
 %doc %{_docdir}/%{name}-%{version}/udev.md
 %config(noreplace) %{_sysconfdir}/rdma/mlx4.conf
@@ -615,7 +614,6 @@ done
 %{_modprobedir}/mlx4.conf
 %endif
 %{_modprobedir}/truescale.conf
-%config(noreplace) %{_sysconfdir}/udev/rules.d/70-persistent-ipoib.rules
 %{_unitdir}/rdma-hw.target
 %{_unitdir}/rdma-load-modules@.service
 %dir %{dracutlibdir}


### PR DESCRIPTION
This rdma-core Debian package ships the udev rule `70-persistent-ipoib.rules` and installs it under `/etc/udev/rules.d`, which is reserved for user-installed files.

Install `70-persistent-ipoib.rules` into `/usr/share/doc/rdma-core` instead of `/etc/udev/rules.d` and document to copy this file into `/etc/udev/rules.d` before editing.

Bug-Debian: https://bugs.debian.org/958385