### PR TITLE
Changes from Debian upload 42.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,26 @@ rdma-core (43.0-1) unstable; urgency=medium
 
   * New upstream release.
 
- -- Jason Gunthorpe <jgg@obsidianresearch.com>  Thu, 27 Jan 2022 20:08:33 +0100
+ -- Jason Gunthorpe <jgg@obsidianresearch.com>  Thu, 18 Aug 2022 16:02:54 +0200
+
+rdma-core (42.0-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Update overrides for lintian 2.115.2
+  * Bump Standards-Version to 4.6.1
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Thu, 18 Aug 2022 15:24:14 +0200
+
+rdma-core (40.0-1) unstable; urgency=medium
+
+  [ Benjamin Drung ]
+  * New upstream release.
+  * Update my email address to @ubuntu.com
+
+  [ Heinrich Schuchardt ]
+  * Add riscv64 to COHERENT_DMA_ARCHS
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 16 May 2022 13:55:12 +0200
 
 rdma-core (39.0-1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -21,7 +21,7 @@ Build-Depends: cmake (>= 2.8.11),
                python3-docutils,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Rules-Requires-Root: no
-Standards-Version: 4.6.0
+Standards-Version: 4.6.1
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
 Homepage: https://github.com/linux-rdma/rdma-core

--- a/debian/infiniband-diags.lintian-overrides
+++ b/debian/infiniband-diags.lintian-overrides
@@ -1,2 +1,4 @@
 # The infiniband-diags man page gives an overview of the available commands.
+infiniband-diags: spare-manual-page [usr/share/man/man8/infiniband-diags.8.gz]
+# For lintian < 2.115.2
 infiniband-diags: spare-manual-page usr/share/man/man8/infiniband-diags.8.gz

--- a/debian/rdma-core.lintian-overrides
+++ b/debian/rdma-core.lintian-overrides
@@ -1,7 +1,10 @@
 # "module -i ib_qib" will executes code. This cannot be replaced by the softdep command.
-rdma-core: obsolete-command-in-modprobe.d-file etc/modprobe.d/truescale.conf install
+rdma-core: obsolete-command-in-modprobe.d-file install [etc/modprobe.d/truescale.conf]
 # The rdma-ndd service is started by udev.
 rdma-core: systemd-service-file-missing-install-key [lib/systemd/system/iwpmd.service]
 rdma-core: systemd-service-file-missing-install-key [lib/systemd/system/rdma-ndd.service]
 # Example/documentary udev rules file
+rdma-core: udev-rule-in-etc [etc/udev/rules.d/70-persistent-ipoib.rules]
+# For lintian < 2.115.2
+rdma-core: obsolete-command-in-modprobe.d-file etc/modprobe.d/truescale.conf install
 rdma-core: udev-rule-in-etc etc/udev/rules.d/70-persistent-ipoib.rules


### PR DESCRIPTION
* Update overrides for lintian 2.115.2
* Bump Standards-Version to 4.6.1

This is a follow-up merge request to #1206. Change to #1026: Keep the old lintian overrides for the CI pipeline (which uses lintian on Ubuntu 20.04).
 

