### PR TITLE
redhat/spec: Drop pandoc requirement for RHEL 9.0 build

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -80,7 +80,7 @@ BuildRequires: make
 %define cmake_install DESTDIR=%{buildroot} make install
 %endif
 
-%if 0%{?fedora} >= 25 || 0%{?rhel} >= 8
+%if 0%{?fedora} >= 25 || 0%{?rhel} == 8
 # pandoc was introduced in FC25, Centos8
 BuildRequires: pandoc
 %endif


### PR DESCRIPTION
Pandoc is removed in RHEL 9.0 and no longer a build requirement.

Reflect this in the spec file.

Signed-off-by: Shiraz Saleem <shiraz.saleem@intel.com>
Signed-off-by: Tatyana Nikolova <tatyana.e.nikolova@intel.com>
Signed-off-by: Sindhu-Devale <sindhu.devale@intel.com>