### PR TITLE
tests: ODP testcases for RDMA Write/Read and Atomic operations

### DIFF
--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -85,13 +85,14 @@ class OdpTestCase(RDMATestCase):
                          BaseResources.
         :param resource_arg: Dict of args that specify the resource specific
                              attributes.
-        :return: The (client, server) resources.
         """
-        client = resource(**self.dev_info, **resource_arg)
-        server = resource(**self.dev_info, **resource_arg)
-        client.pre_run(server.psns, server.qps_num)
-        server.pre_run(client.psns, client.qps_num)
-        return client, server
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
 
     def tearDown(self):
         if self.user_addr:
@@ -99,83 +100,81 @@ class OdpTestCase(RDMATestCase):
         super(OdpTestCase, self).tearDown()
 
     def test_odp_rc_traffic(self):
-        client, server = self.create_players(OdpRC)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC)
+        u.traffic(**self.traffic_args)
 
     def test_odp_implicit_rc_traffic(self):
-        client, server = self.create_players(OdpRC, is_implicit=True)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, is_implicit=True)
+        u.traffic(**self.traffic_args)
 
     def test_odp_ud_traffic(self):
-        client, server = self.create_players(OdpUD)
+        self.create_players(OdpUD)
         # Implement the traffic here because OdpUD uses two different MRs for
         # send and recv.
-        ah_client = u.get_global_ah(client, self.gid_index, self.ib_port)
-        recv_sge = SGE(server.recv_mr.buf, server.msg_size + u.GRH_SIZE,
-                       server.recv_mr.lkey)
+        ah_client = u.get_global_ah(self.client, self.gid_index, self.ib_port)
+        recv_sge = SGE(self.server.recv_mr.buf, self.server.msg_size +
+                       u.GRH_SIZE, self.server.recv_mr.lkey)
         server_recv_wr = RecvWR(sg=[recv_sge], num_sge=1)
-        send_sge = SGE(client.send_mr.buf + u.GRH_SIZE, client.msg_size,
-                       client.send_mr.lkey)
+        send_sge = SGE(self.client.send_mr.buf + u.GRH_SIZE,
+                       self.client.msg_size, self.client.send_mr.lkey)
         client_send_wr = SendWR(num_sge=1, sg=[send_sge])
         for i in range(self.iters):
-            server.qp.post_recv(server_recv_wr)
-            u.post_send(client, client_send_wr, ah=ah_client)
-            u.poll_cq(client.cq)
-            u.poll_cq(server.cq)
+            self.server.qp.post_recv(server_recv_wr)
+            u.post_send(self.client, client_send_wr, ah=ah_client)
+            u.poll_cq(self.client.cq)
+            u.poll_cq(self.server.cq)
 
     def test_odp_xrc_traffic(self):
-        client, server = self.create_players(OdpXRC)
-        u.xrc_traffic(client, server)
+        self.create_players(OdpXRC)
+        u.xrc_traffic(self.client, self.server)
 
     def test_odp_rc_srq_traffic(self):
-        client, server = self.create_players(OdpSrqRc, qp_count=2)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpSrqRc, qp_count=2)
+        u.traffic(**self.traffic_args)
 
     @u.requires_huge_pages()
     def test_odp_rc_huge_traffic(self):
-        client, server = self.create_players(OdpRC, is_huge=True)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, is_huge=True)
+        u.traffic(**self.traffic_args)
 
     @u.requires_huge_pages()
     def test_odp_rc_huge_user_addr_traffic(self):
         self.user_addr = mmap(length=HUGE_PAGE_SIZE,
                               flags=MAP_ANONYMOUS_| MAP_PRIVATE_| MAP_HUGETLB_)
-        client, server = self.create_players(OdpRC, is_huge=True,
-                                              user_addr=self.user_addr)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, is_huge=True,
+                            user_addr=self.user_addr)
+        u.traffic(**self.traffic_args)
 
     def test_odp_sync_prefetch_rc_traffic(self):
         for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
                        e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
-            client, server = self.create_players(OdpRC, use_mr_prefetch='sync',
-                                                 prefetch_advice=advice)
-            u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+            self.create_players(OdpRC, use_mr_prefetch='sync',
+                                prefetch_advice=advice)
+            u.traffic(**self.traffic_args)
 
     def test_odp_async_prefetch_rc_traffic(self):
         for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
                        e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
-            client, server = self.create_players(OdpRC, use_mr_prefetch='async',
-                                                 prefetch_advice=advice)
-            u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+            self.create_players(OdpRC, use_mr_prefetch='async',
+                                prefetch_advice=advice)
+            u.traffic(**self.traffic_args)
 
     def test_odp_implicit_sync_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch='sync', is_implicit=True)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, use_mr_prefetch='sync', is_implicit=True)
+        u.traffic(**self.traffic_args)
 
     def test_odp_implicit_async_prefetch_rc_traffic(self):
-        client, server = self.create_players(OdpRC, use_mr_prefetch='async', is_implicit=True)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, use_mr_prefetch='async', is_implicit=True)
+        u.traffic(**self.traffic_args)
 
     def test_odp_prefetch_sync_no_page_fault_rc_traffic(self):
         prefetch_advice = e._IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT
-        client, server = self.create_players(OdpRC,
-                                             use_mr_prefetch='sync',
-                                             prefetch_advice=prefetch_advice)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, use_mr_prefetch='sync',
+                            prefetch_advice=prefetch_advice)
+        u.traffic(**self.traffic_args)
 
     def test_odp_prefetch_async_no_page_fault_rc_traffic(self):
         prefetch_advice = e._IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT
-        client, server = self.create_players(OdpRC,
-                                             use_mr_prefetch='async',
-                                             prefetch_advice=prefetch_advice)
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(OdpRC, use_mr_prefetch='async',
+                            prefetch_advice=prefetch_advice)
+        u.traffic(**self.traffic_args)

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -68,7 +68,8 @@ class OdpRdmaRC(RCResources):
         :param odp_caps: ODP capabilities required for the operation
         """
         self.access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND | \
-            e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ
+            e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ | \
+            e.IBV_ACCESS_REMOTE_WRITE
         self.odp_caps = odp_caps
         super().__init__(dev_name=dev_name, ib_port=ib_port,
                          gid_index=gid_index)
@@ -164,6 +165,10 @@ class OdpTestCase(RDMATestCase):
         self.create_players(OdpRdmaRC, odp_caps=e.IBV_ODP_SUPPORT_READ)
         self.server.mr.write('s' * self.server.msg_size, self.server.msg_size)
         u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_READ)
+
+    def test_odp_rc_rdma_write(self):
+        self.create_players(OdpRdmaRC, odp_caps=e.IBV_ODP_SUPPORT_WRITE)
+        u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_odp_implicit_rc_traffic(self):
         self.create_players(OdpRC, is_implicit=True)

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -1,23 +1,21 @@
 from pyverbs.mem_alloc import mmap, munmap, MAP_ANONYMOUS_, MAP_PRIVATE_, \
     MAP_HUGETLB_
-from tests.utils import requires_odp, requires_huge_pages, traffic, \
-    xrc_traffic, create_custom_mr, poll_cq, post_send, get_global_ah, GRH_SIZE
 from tests.base import RCResources, UDResources, XRCResources
 from pyverbs.wr import SGE, SendWR, RecvWR
 from tests.base import RDMATestCase
 from pyverbs.mr import MR
 import pyverbs.enums as e
-
+import tests.utils as u
 
 HUGE_PAGE_SIZE = 0x200000
 
 
 class OdpUD(UDResources):
-    @requires_odp('ud', e.IBV_ODP_SUPPORT_SEND)
+    @u.requires_odp('ud', e.IBV_ODP_SUPPORT_SEND)
     def create_mr(self):
-        self.send_mr = MR(self.pd, self.msg_size + self.GRH_SIZE,
+        self.send_mr = MR(self.pd, self.msg_size + u.GRH_SIZE,
                           e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
-        self.recv_mr = MR(self.pd, self.msg_size + self.GRH_SIZE,
+        self.recv_mr = MR(self.pd, self.msg_size + u.GRH_SIZE,
                           e.IBV_ACCESS_LOCAL_WRITE)
 
 
@@ -48,7 +46,7 @@ class OdpRC(RCResources):
         self.use_mr_prefetch = use_mr_prefetch
         self.prefetch_advice = prefetch_advice
 
-    @requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
+    @u.requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
     def create_mr(self):
         access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND
         if self.is_huge:
@@ -63,15 +61,15 @@ class OdpSrqRc(RCResources):
                                        gid_index=gid_index, with_srq=True,
                                        qp_count=qp_count)
 
-    @requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
+    @u.requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
     def create_mr(self):
-        self.mr = create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
 
 
 class OdpXRC(XRCResources):
-    @requires_odp('xrc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
+    @u.requires_odp('xrc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
     def create_mr(self):
-        self.mr = create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
 
 
 class OdpTestCase(RDMATestCase):
@@ -102,82 +100,82 @@ class OdpTestCase(RDMATestCase):
 
     def test_odp_rc_traffic(self):
         client, server = self.create_players(OdpRC)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_implicit_rc_traffic(self):
         client, server = self.create_players(OdpRC, is_implicit=True)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_ud_traffic(self):
         client, server = self.create_players(OdpUD)
         # Implement the traffic here because OdpUD uses two different MRs for
         # send and recv.
-        ah_client = get_global_ah(client, self.gid_index, self.ib_port)
-        recv_sge = SGE(server.recv_mr.buf, server.msg_size + GRH_SIZE,
+        ah_client = u.get_global_ah(client, self.gid_index, self.ib_port)
+        recv_sge = SGE(server.recv_mr.buf, server.msg_size + u.GRH_SIZE,
                        server.recv_mr.lkey)
         server_recv_wr = RecvWR(sg=[recv_sge], num_sge=1)
-        send_sge = SGE(client.send_mr.buf + GRH_SIZE, client.msg_size,
+        send_sge = SGE(client.send_mr.buf + u.GRH_SIZE, client.msg_size,
                        client.send_mr.lkey)
         client_send_wr = SendWR(num_sge=1, sg=[send_sge])
         for i in range(self.iters):
             server.qp.post_recv(server_recv_wr)
-            post_send(client, client_send_wr, ah=ah_client)
-            poll_cq(client.cq)
-            poll_cq(server.cq)
+            u.post_send(client, client_send_wr, ah=ah_client)
+            u.poll_cq(client.cq)
+            u.poll_cq(server.cq)
 
     def test_odp_xrc_traffic(self):
         client, server = self.create_players(OdpXRC)
-        xrc_traffic(client, server)
+        u.xrc_traffic(client, server)
 
     def test_odp_rc_srq_traffic(self):
         client, server = self.create_players(OdpSrqRc, qp_count=2)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
-    @requires_huge_pages()
+    @u.requires_huge_pages()
     def test_odp_rc_huge_traffic(self):
         client, server = self.create_players(OdpRC, is_huge=True)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
-    @requires_huge_pages()
+    @u.requires_huge_pages()
     def test_odp_rc_huge_user_addr_traffic(self):
         self.user_addr = mmap(length=HUGE_PAGE_SIZE,
                               flags=MAP_ANONYMOUS_| MAP_PRIVATE_| MAP_HUGETLB_)
         client, server = self.create_players(OdpRC, is_huge=True,
                                               user_addr=self.user_addr)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_sync_prefetch_rc_traffic(self):
         for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
                        e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
             client, server = self.create_players(OdpRC, use_mr_prefetch='sync',
                                                  prefetch_advice=advice)
-            traffic(client, server, self.iters, self.gid_index, self.ib_port)
+            u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_async_prefetch_rc_traffic(self):
         for advice in [e._IBV_ADVISE_MR_ADVICE_PREFETCH,
                        e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE]:
             client, server = self.create_players(OdpRC, use_mr_prefetch='async',
                                                  prefetch_advice=advice)
-            traffic(client, server, self.iters, self.gid_index, self.ib_port)
+            u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_implicit_sync_prefetch_rc_traffic(self):
         client, server = self.create_players(OdpRC, use_mr_prefetch='sync', is_implicit=True)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_implicit_async_prefetch_rc_traffic(self):
         client, server = self.create_players(OdpRC, use_mr_prefetch='async', is_implicit=True)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_prefetch_sync_no_page_fault_rc_traffic(self):
         prefetch_advice = e._IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT
         client, server = self.create_players(OdpRC,
                                              use_mr_prefetch='sync',
                                              prefetch_advice=prefetch_advice)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)
 
     def test_odp_prefetch_async_no_page_fault_rc_traffic(self):
         prefetch_advice = e._IBV_ADVISE_MR_ADVICE_PREFETCH_NO_FAULT
         client, server = self.create_players(OdpRC,
                                              use_mr_prefetch='async',
                                              prefetch_advice=prefetch_advice)
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(client, server, self.iters, self.gid_index, self.ib_port)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1204,7 +1204,7 @@ def requires_mcast_support():
 
 def odp_supported(ctx, qp_type, required_odp_caps):
     """
-    Check device ODP capabilities, support only send/recv so far.
+    Check device ODP capabilities
     :param ctx: Device Context
     :param qp_type: QP type ('rc', 'ud' or 'uc')
     :param required_odp_caps: ODP Capability mask of specified device
@@ -1215,7 +1215,7 @@ def odp_supported(ctx, qp_type, required_odp_caps):
         raise unittest.SkipTest('ODP is not supported - No ODP caps')
     qp_odp_caps = getattr(odp_caps, '{}_odp_caps'.format(qp_type))
     if required_odp_caps & qp_odp_caps != required_odp_caps:
-        raise unittest.SkipTest('ODP is not supported - ODP recv/send is not supported')
+        raise unittest.SkipTest('ODP is unavailable - Operation not supported on this device')
 
 
 def odp_implicit_supported(ctx):


### PR DESCRIPTION
These patches add new testcases for ODP (test_odp.py).  Currently, only Send/Recv operations are checked, and other operations are not tested with ODP at all. This patchset cleans-up the ODP test code and add four new testcases. I confirmed these new testcases succeeded with RFC implementation of Explicit ODP on rxe[1].

The new testcases succeeded also with ConnectX-6, but currently the ODP Atomic tests are skipped with my device. This is because the capability for RC (rc_odp_caps) is not filled with IB_ODP_SUPPORT_ATOMIC in internal_fill_odp_caps(). However, it seems the device can actually handle Atomic operations. I am not sure if this is a bug of the device or not. If anybody from NVIDIA knows why rc_odp_caps is unfilled, please let me know
cf. https://github.com/torvalds/linux/blame/master/drivers/infiniband/hw/mlx5/odp.c#L321

The first two patches are for clean-up:
 tests: Import test.utils entirely for ODP test cases
 tests: Make ODP test consistent with other traffic tests

The latter three add new testcases:
  tests: Add tests for Atomic operations with ODP
  tests: Add a test for RDMA Read with ODP
  tests: Add a test for RDMA Write with ODP

[1] [RFC PATCH 0/7] RDMA/rxe: On-Demand Paging on SoftRoCE
https://lore.kernel.org/lkml/cover.1662461897.git.matsuda-daisuke@fujitsu.com/t/