### PR TITLE
Revert "verbs: Allow aligned address & size only for fork init"

### DIFF
--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -113,9 +113,6 @@ as the rkey field of struct ibv_send_wr passed to the ibv_post_send function.
 .B ibv_dereg_mr()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).
 .SH "NOTES"
-.B ibv_reg_mr() / ibv_reg_mr_iova()
-fails if the address (\fBaddr\fR) or the length (\fBlength\fR) is not aligned to page size once ibv_fork_init() is called.
-.PP
 .B ibv_dereg_mr()
 fails if any memory window is still bound to this MR.
 .SH "SEE ALSO"

--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -635,18 +635,6 @@ static int ibv_madvise_range(void *base, size_t size, int advice)
 	else
 		range_page_size = page_size;
 
-	if (mm_root) {
-		/* 0x7f2764ac5000      -      0x7f2764ac7000
-		 * |ptr0 128| ... |ptr1 4096| ... |ptr2 512|
-		 * After ibv_reg_mr(pd, ptr1, 4096, access), the full 8K range
-		 * becomes DONTFORK. And the child process will hit a segment
-		 * fault during access ptr0/ptr2.
-		 */
-		unsigned long page_mask = range_page_size - 1;
-		if ((unsigned long)base & page_mask || (unsigned long)size & page_mask)
-			return -1;
-	}
-
 	start = (uintptr_t) base & ~(range_page_size - 1);
 	end   = ((uintptr_t) (base + size + range_page_size - 1) &
 		 ~(range_page_size - 1)) - 1;


### PR DESCRIPTION
Unfortunately, this change broke HW steering in DPDK. The reason to it that length can be unaligned on newer kernel.

This reverts commit 561cbce90cf4ef097d80efdcd68d619fa0ddb266.

Signed-off-by: Leon Romanovsky <leonro@nvidia.com>