### PR TITLE
rdma-ndd: disable systemd ProtectHostName feature

### DIFF
--- a/rdma-ndd/rdma-ndd.service.in
+++ b/rdma-ndd/rdma-ndd.service.in
@@ -22,7 +22,6 @@ Restart=always
 ExecStart=@CMAKE_INSTALL_FULL_SBINDIR@/rdma-ndd --systemd
 ProtectSystem=full
 ProtectHome=true
-ProtectHostname=true
 ProtectKernelLogs=true
 
 # rdma-ndd is automatically wanted by udev when an RDMA device with a node description is present


### PR DESCRIPTION
ProtectHostName prevents dynamic name changes to be noticed by the service. This means that on a system with no static hostname, rdma-ndd is started with a hostname 'localhost' and is not aware of new hostname retreived through a DHCP lease.
Fixes: 384b75b5f624 ("rdma-ndd: systemd hardening")

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>