### PR TITLE
Fix max length of node description (ibnetdiscover and smpquery)

### DIFF
--- a/infiniband-diags/smpquery.c
+++ b/infiniband-diags/smpquery.c
@@ -75,7 +75,7 @@ static const char *node_desc(ib_portid_t *dest, char **argv, int argc)
 {
 	int node_type, l;
 	uint64_t node_guid;
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	uint8_t data[IB_SMP_DATA_SIZE] = { 0 };
 	char dots[128];
 	char *nodename = NULL;

--- a/libibnetdisc/ibnetdisc.h
+++ b/libibnetdisc/ibnetdisc.h
@@ -72,7 +72,7 @@ typedef struct ibnd_node {
 	/* use libibmad decoder functions for info */
 	uint8_t info[IB_SMP_DATA_SIZE];
 
-	char nodedesc[IB_SMP_DATA_SIZE];
+	char nodedesc[IB_SMP_DATA_SIZE + 1];
 
 	struct ibnd_port **ports;	/* array of ports, indexed by port number
 					   ports[1] == port 1,

--- a/util/node_name_map.c
+++ b/util/node_name_map.c
@@ -41,6 +41,8 @@
 #include <ctype.h>
 #include <errno.h>
 
+#include <infiniband/mad.h>
+
 #include <ccan/minmax.h>
 
 #include <util/node_name_map.h>
@@ -115,7 +117,7 @@ char *clean_nodedesc(char *nodedesc)
 {
 	int i = 0;
 
-	nodedesc[63] = '\0';
+	nodedesc[IB_SMP_DATA_SIZE] = '\0';
 	while (nodedesc[i]) {
 		if (!isprint(nodedesc[i]))
 			nodedesc[i] = ' ';


### PR DESCRIPTION
Both utilities truncate node description up to 63 bytes instead 64 bytes. 
Node description fields declared as char array of IB_SMP_DATA_SIZE bytes. 
Last character for compatibility with c-string set to zero. 
In this case node description will be truncated from 64 bytes to 63 bytes. 
Size of node description fields was enlarged to the IB_SMP_DATA_SIZE + 1 bytes for using last character for zero char without truncated node description

Signed-off-by: Gregory Linschitz <gregoryl@nvidia.com>