### PR TITLE
debian: Remove /etc/udev/rules.d/70-persistent-ipoib.rules on upgrade

### DIFF
--- a/debian/rdma-core.maintscript
+++ b/debian/rdma-core.maintscript
@@ -1,0 +1,1 @@
+rm_conffile /etc/udev/rules.d/70-persistent-ipoib.rules 43.0 rdma-core


### PR DESCRIPTION
Commit b9ddb7f8013b274e55727ec390960960b95ae7fa installed `70-persistent-ipoib.rules` into docs instead of `/etc`. Remove `/etc/udev/rules.d/70-persistent-ipoib.rules` on upgrade if it was not modified by the user.