### PR TITLE
Fix grammar mistake of "allow doing"

### DIFF
--- a/providers/mlx5/man/mlx5dv_create_steering_anchor.3.md
+++ b/providers/mlx5/man/mlx5dv_create_steering_anchor.3.md
@@ -32,8 +32,8 @@ the packet.
 A steering anchor allows the user to reinject the packet back into the kernel
 for additional processing.
 
-**mlx5dv_create_steering_anchor()** Creates an anchor which will allow to
-inject the packet back into the kernel steering pipeline.
+**mlx5dv_create_steering_anchor()** Creates an anchor which will allow
+injecting the packet back into the kernel steering pipeline.
 
 **mlx5dv_destroy_steering_anchor()** Destroys a steering anchor.
 


### PR DESCRIPTION
`allow to do` is wrong. It should be `allow one to do` or `allow doing`.

lintian found this typo.