### PR TITLE
[PATCH rdma-core 0/8] Fix sge num bug, refactor rq inline, support cqe inline

### DIFF
--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -87,10 +87,14 @@ struct hns_roce_ib_create_qp_resp {
 
 enum {
 	HNS_ROCE_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 enum {
 	HNS_ROCE_RSP_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RSP_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_RSP_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 struct hns_roce_ib_alloc_ucontext_resp {

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -113,7 +113,7 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	if (!context)
 		return NULL;
 
-	cmd.config |= HNS_ROCE_EXSGE_FLAGS;
+	cmd.config |= HNS_ROCE_EXSGE_FLAGS | HNS_ROCE_RQ_INLINE_FLAGS;
 	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto err_free;

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -103,9 +103,9 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 {
 	struct hns_roce_device *hr_dev = to_hr_dev(ibdev);
 	struct hns_roce_alloc_ucontext_resp resp = {};
+	struct hns_roce_alloc_ucontext cmd = {};
 	struct ibv_device_attr dev_attrs;
 	struct hns_roce_context *context;
-	struct ibv_get_context cmd;
 	int i;
 
 	context = verbs_init_and_alloc_context(ibdev, cmd_fd, context, ibv_ctx,
@@ -113,7 +113,8 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	if (!context)
 		return NULL;
 
-	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd, sizeof(cmd),
+	cmd.config |= HNS_ROCE_EXSGE_FLAGS;
+	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto err_free;
 
@@ -123,6 +124,10 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 		context->cqe_size = resp.cqe_size;
 	else
 		context->cqe_size = HNS_ROCE_V3_CQE_SIZE;
+
+	context->config = resp.config;
+	if (resp.config & HNS_ROCE_RSP_EXSGE_FLAGS)
+		context->max_inline_data = resp.max_inline_data;
 
 	context->qp_table_shift = calc_table_shift(resp.qp_tab_size,
 						   HNS_ROCE_QP_TABLE_BITS);

--- a/providers/hns/hns_roce_u.c
+++ b/providers/hns/hns_roce_u.c
@@ -113,7 +113,8 @@ static struct verbs_context *hns_roce_alloc_context(struct ibv_device *ibdev,
 	if (!context)
 		return NULL;
 
-	cmd.config |= HNS_ROCE_EXSGE_FLAGS | HNS_ROCE_RQ_INLINE_FLAGS;
+	cmd.config |= HNS_ROCE_EXSGE_FLAGS | HNS_ROCE_RQ_INLINE_FLAGS |
+		      HNS_ROCE_CQE_INLINE_FLAGS;
 	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd.ibv_cmd, sizeof(cmd),
 				&resp.ibv_resp, sizeof(resp)))
 		goto err_free;

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -213,6 +213,8 @@ struct hns_roce_context {
 	unsigned int			max_srq_sge;
 	int				max_cqe;
 	unsigned int			cqe_size;
+	uint32_t			config;
+	unsigned int			max_inline_data;
 };
 
 struct hns_roce_pd {
@@ -267,6 +269,7 @@ struct hns_roce_wq {
 	unsigned int			head;
 	unsigned int			tail;
 	unsigned int			max_gs;
+	unsigned int			ext_sge_cnt;
 	unsigned int			rsv_sge;
 	unsigned int			wqe_shift;
 	unsigned int			shift; /* wq size is 2^shift */

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -246,10 +246,21 @@ struct hns_roce_idx_que {
 	unsigned int			tail;
 };
 
+struct hns_roce_rinl_wqe {
+	struct ibv_sge			*sg_list;
+	unsigned int			sge_cnt;
+};
+
+struct hns_roce_rinl_buf {
+	struct hns_roce_rinl_wqe	*wqe_list;
+	unsigned int			wqe_cnt;
+};
+
 struct hns_roce_srq {
 	struct verbs_srq		verbs_srq;
 	struct hns_roce_idx_que		idx_que;
 	struct hns_roce_buf		wqe_buf;
+	struct hns_roce_rinl_buf	srq_rinl_buf;
 	pthread_spinlock_t		lock;
 	unsigned long			*wrid;
 	unsigned int			srqn;
@@ -288,16 +299,6 @@ struct hns_roce_sge_ex {
 	int				offset;
 	unsigned int			sge_cnt;
 	unsigned int			sge_shift;
-};
-
-struct hns_roce_rinl_wqe {
-	struct ibv_sge			*sg_list;
-	unsigned int			sge_cnt;
-};
-
-struct hns_roce_rinl_buf {
-	struct hns_roce_rinl_wqe	*wqe_list;
-	unsigned int			wqe_cnt;
 };
 
 struct hns_roce_qp {

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -290,13 +290,8 @@ struct hns_roce_sge_ex {
 	unsigned int			sge_shift;
 };
 
-struct hns_roce_rinl_sge {
-	void				*addr;
-	unsigned int			len;
-};
-
 struct hns_roce_rinl_wqe {
-	struct hns_roce_rinl_sge	*sg_list;
+	struct ibv_sge			*sg_list;
 	unsigned int			sge_cnt;
 };
 

--- a/providers/hns/hns_roce_u_abi.h
+++ b/providers/hns/hns_roce_u_abi.h
@@ -47,7 +47,7 @@ DECLARE_DRV_CMD(hns_roce_create_cq_ex, IB_USER_VERBS_EX_CMD_CREATE_CQ,
 		hns_roce_ib_create_cq, hns_roce_ib_create_cq_resp);
 
 DECLARE_DRV_CMD(hns_roce_alloc_ucontext, IB_USER_VERBS_CMD_GET_CONTEXT,
-		empty, hns_roce_ib_alloc_ucontext_resp);
+		hns_roce_ib_alloc_ucontext, hns_roce_ib_alloc_ucontext_resp);
 
 DECLARE_DRV_CMD(hns_roce_create_qp, IB_USER_VERBS_CMD_CREATE_QP,
 		hns_roce_ib_create_qp, hns_roce_ib_create_qp_resp);

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -839,6 +839,14 @@ static void get_src_buf_info(void **src_addr, uint32_t *src_len,
 	}
 }
 
+static unsigned int get_std_sge_num(struct hns_roce_qp *qp)
+{
+	if (qp->verbs_qp.qp.qp_type == IBV_QPT_UD)
+		return 0;
+
+	return HNS_ROCE_SGE_IN_WQE;
+}
+
 static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 				 struct hns_roce_sge_info *sge_info,
 				 const void *buf_list,
@@ -848,9 +856,12 @@ static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 	unsigned int sge_mask = qp->ex_sge.sge_cnt - 1;
 	void *dst_addr, *src_addr, *tail_bound_addr;
 	uint32_t src_len, tail_len;
+	unsigned int std_sge_num;
 	int i;
 
-	if (sge_info->total_len > qp->sq.max_gs * HNS_ROCE_SGE_SIZE)
+	std_sge_num = get_std_sge_num(qp);
+	if (sge_info->total_len >
+	    (qp->sq.max_gs - std_sge_num) * HNS_ROCE_SGE_SIZE)
 		return EINVAL;
 
 	dst_addr = get_send_sge_ex(qp, sge_info->start_idx & sge_mask);

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -845,13 +845,12 @@ static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 				 uint32_t num_buf,
 				 enum hns_roce_wr_buf_type buf_type)
 {
-	unsigned int sge_sz = sizeof(struct hns_roce_v2_wqe_data_seg);
 	unsigned int sge_mask = qp->ex_sge.sge_cnt - 1;
 	void *dst_addr, *src_addr, *tail_bound_addr;
 	uint32_t src_len, tail_len;
 	int i;
 
-	if (sge_info->total_len > qp->sq.max_gs * sge_sz)
+	if (sge_info->total_len > qp->sq.max_gs * HNS_ROCE_SGE_SIZE)
 		return EINVAL;
 
 	dst_addr = get_send_sge_ex(qp, sge_info->start_idx & sge_mask);
@@ -878,7 +877,7 @@ static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 		}
 	}
 
-	sge_info->valid_num = DIV_ROUND_UP(sge_info->total_len, sge_sz);
+	sge_info->valid_num = DIV_ROUND_UP(sge_info->total_len, HNS_ROCE_SGE_SIZE);
 	sge_info->start_idx += sge_info->valid_num;
 
 	return 0;

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -34,6 +34,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mman.h>
+#include <ccan/minmax.h>
 #include "hns_roce_u.h"
 #include "hns_roce_u_db.h"
 #include "hns_roce_u_hw_v2.h"
@@ -416,46 +417,41 @@ static void get_opcode_for_resp(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 	wc->opcode = wc_rcv_op_map[opcode];
 }
 
-static int handle_recv_inl_wqe(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
-			       struct hns_roce_qp **cur_qp, uint32_t opcode)
+static void handle_recv_inl_data(struct hns_roce_v2_cqe *cqe,
+				 struct hns_roce_rinl_buf *rinl_buf,
+				 uint32_t wr_cnt, uint8_t *buf)
 {
-	if (((*cur_qp)->verbs_qp.qp.qp_type == IBV_QPT_RC) &&
-	    (opcode == HNS_ROCE_RECV_OP_SEND ||
-	     opcode == HNS_ROCE_RECV_OP_SEND_WITH_IMM ||
-	     opcode == HNS_ROCE_RECV_OP_SEND_WITH_INV) &&
-	     hr_reg_read(cqe, CQE_RQ_INLINE)) {
-		struct hns_roce_rinl_sge *sge_list;
-		uint32_t wr_num, wr_cnt, sge_num, data_len;
-		uint8_t *wqe_buf;
-		uint32_t sge_cnt, size;
+	struct ibv_sge *sge_list;
+	uint32_t sge_num, data_len;
+	uint32_t sge_cnt, size;
 
-		wr_num = hr_reg_read(cqe, CQE_WQE_IDX);
-		wr_cnt = wr_num & ((*cur_qp)->rq.wqe_cnt - 1);
+	sge_list = rinl_buf->wqe_list[wr_cnt].sg_list;
+	sge_num = rinl_buf->wqe_list[wr_cnt].sge_cnt;
 
-		sge_list = (*cur_qp)->rq_rinl_buf.wqe_list[wr_cnt].sg_list;
-		sge_num = (*cur_qp)->rq_rinl_buf.wqe_list[wr_cnt].sge_cnt;
-		wqe_buf = (uint8_t *)get_recv_wqe_v2(*cur_qp, wr_cnt);
+	data_len = le32toh(cqe->byte_cnt);
 
-		data_len = wc->byte_len;
+	for (sge_cnt = 0; (sge_cnt < sge_num) && (data_len); sge_cnt++) {
+		size = min(sge_list[sge_cnt].length, data_len);
 
-		for (sge_cnt = 0; (sge_cnt < sge_num) && (data_len);
-		     sge_cnt++) {
-			size = sge_list[sge_cnt].len < data_len ?
-			       sge_list[sge_cnt].len : data_len;
-
-			memcpy((void *)sge_list[sge_cnt].addr,
-				(void *)wqe_buf, size);
-			data_len -= size;
-			wqe_buf += size;
-		}
-
-		if (data_len) {
-			wc->status = IBV_WC_LOC_LEN_ERR;
-			return V2_CQ_POLL_ERR;
-		}
+		memcpy((void *)(uintptr_t)sge_list[sge_cnt].addr, (void *)buf, size);
+		data_len -= size;
+		buf += size;
 	}
 
-	return V2_CQ_OK;
+	if (data_len)
+		hr_reg_write(cqe, CQE_STATUS, HNS_ROCE_V2_CQE_LOCAL_LENGTH_ERR);
+}
+
+static void handle_recv_rq_inl(struct hns_roce_v2_cqe *cqe,
+			       struct hns_roce_qp *cur_qp)
+{
+	uint8_t *wqe_buf;
+	uint32_t wr_num;
+
+	wr_num = hr_reg_read(cqe, CQE_WQE_IDX) & (cur_qp->rq.wqe_cnt - 1);
+
+	wqe_buf = (uint8_t *)get_recv_wqe_v2(cur_qp, wr_num);
+	handle_recv_inl_data(cqe, &cur_qp->rq_rinl_buf, wr_num, wqe_buf);
 }
 
 static void parse_for_ud_qp(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc)
@@ -478,10 +474,9 @@ static void parse_cqe_for_srq(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 }
 
 static int parse_cqe_for_resp(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
-			       struct hns_roce_qp *hr_qp, uint8_t opcode)
+			       struct hns_roce_qp *hr_qp)
 {
 	struct hns_roce_wq *wq;
-	int ret;
 
 	wq = &hr_qp->rq;
 	wc->wr_id = wq->wrid[wq->tail & (wq->wqe_cnt - 1)];
@@ -490,12 +485,8 @@ static int parse_cqe_for_resp(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 	if (hr_qp->verbs_qp.qp.qp_type == IBV_QPT_UD)
 		parse_for_ud_qp(cqe, wc);
 
-	ret = handle_recv_inl_wqe(cqe, wc, &hr_qp, opcode);
-	if (ret) {
-		verbs_err(verbs_get_ctx(hr_qp->verbs_qp.qp.context),
-			  PFX "failed to handle recv inline wqe!\n");
-		return ret;
-	}
+	if (hr_reg_read(cqe, CQE_RQ_INLINE))
+		handle_recv_rq_inl(cqe, hr_qp);
 
 	return 0;
 }
@@ -624,7 +615,7 @@ static int parse_cqe_for_cq(struct hns_roce_context *ctx, struct hns_roce_cq *cq
 		if (srq)
 			parse_cqe_for_srq(cqe, wc, srq);
 		else
-			parse_cqe_for_resp(cqe, wc, cur_qp, opcode);
+			parse_cqe_for_resp(cqe, wc, cur_qp);
 	}
 
 	return 0;
@@ -1353,26 +1344,31 @@ static void fill_recv_sge_to_wqe(struct ibv_recv_wr *wr, void *wqe,
 	}
 }
 
+static void fill_recv_inl_buf(struct hns_roce_rinl_buf *rinl_buf,
+			      unsigned int wqe_idx, struct ibv_recv_wr *wr)
+{
+	struct ibv_sge *sge_list;
+	unsigned int i;
+
+	if (!rinl_buf->wqe_cnt)
+		return;
+
+	sge_list = rinl_buf->wqe_list[wqe_idx].sg_list;
+	rinl_buf->wqe_list[wqe_idx].sge_cnt = (unsigned int)wr->num_sge;
+	for (i = 0; i < wr->num_sge; i++)
+		memcpy((void *)&sge_list[i], (void *)&wr->sg_list[i],
+		       sizeof(struct ibv_sge));
+}
+
 static void fill_rq_wqe(struct hns_roce_qp *qp, struct ibv_recv_wr *wr,
 			unsigned int wqe_idx, unsigned int max_sge)
 {
-	struct hns_roce_rinl_sge *sge_list;
-	unsigned int i;
 	void *wqe;
 
 	wqe = get_recv_wqe_v2(qp, wqe_idx);
 	fill_recv_sge_to_wqe(wr, wqe, max_sge, qp->rq.rsv_sge);
 
-	if (!qp->rq_rinl_buf.wqe_cnt)
-		return;
-
-	/* QP support receive inline wqe */
-	sge_list = qp->rq_rinl_buf.wqe_list[wqe_idx].sg_list;
-	qp->rq_rinl_buf.wqe_list[wqe_idx].sge_cnt = (unsigned int)wr->num_sge;
-	for (i = 0; i < wr->num_sge; i++) {
-		sge_list[i].addr = (void *)(uintptr_t)wr->sg_list[i].addr;
-		sge_list[i].len = wr->sg_list[i].length;
-	}
+	fill_recv_inl_buf(&qp->rq_rinl_buf, wqe_idx, wr);
 }
 
 static int hns_roce_u_v2_post_recv(struct ibv_qp *ibvqp, struct ibv_recv_wr *wr,

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -839,14 +839,6 @@ static void get_src_buf_info(void **src_addr, uint32_t *src_len,
 	}
 }
 
-static unsigned int get_std_sge_num(struct hns_roce_qp *qp)
-{
-	if (qp->verbs_qp.qp.qp_type == IBV_QPT_UD)
-		return 0;
-
-	return HNS_ROCE_SGE_IN_WQE;
-}
-
 static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 				 struct hns_roce_sge_info *sge_info,
 				 const void *buf_list,
@@ -856,12 +848,9 @@ static int fill_ext_sge_inl_data(struct hns_roce_qp *qp,
 	unsigned int sge_mask = qp->ex_sge.sge_cnt - 1;
 	void *dst_addr, *src_addr, *tail_bound_addr;
 	uint32_t src_len, tail_len;
-	unsigned int std_sge_num;
 	int i;
 
-	std_sge_num = get_std_sge_num(qp);
-	if (sge_info->total_len >
-	    (qp->sq.max_gs - std_sge_num) * HNS_ROCE_SGE_SIZE)
+	if (sge_info->total_len > qp->sq.ext_sge_cnt * HNS_ROCE_SGE_SIZE)
 		return EINVAL;
 
 	dst_addr = get_send_sge_ex(qp, sge_info->start_idx & sge_mask);

--- a/providers/hns/hns_roce_u_hw_v2.h
+++ b/providers/hns/hns_roce_u_hw_v2.h
@@ -157,7 +157,7 @@ struct hns_roce_v2_cqe {
 	__le32	smac;
 	__le32	byte_28;
 	__le32	byte_32;
-	__le32	rsv[8];
+	__le32	payload[8];
 };
 
 #define CQE_FIELD_LOC(h, l) FIELD_LOC(struct hns_roce_v2_cqe, h, l)
@@ -170,7 +170,7 @@ struct hns_roce_v2_cqe {
 #define CQE_WQE_IDX CQE_FIELD_LOC(31, 16)
 #define CQE_RKEY_IMMTDATA CQE_FIELD_LOC(63, 32)
 #define CQE_XRC_SRQN CQE_FIELD_LOC(87, 64)
-#define CQE_RSV0 CQE_FIELD_LOC(95, 88)
+#define CQE_CQE_INLINE CQE_FIELD_LOC(89, 88)
 #define CQE_LCL_QPN CQE_FIELD_LOC(119, 96)
 #define CQE_SUB_STATUS CQE_FIELD_LOC(127, 120)
 #define CQE_BYTE_CNT CQE_FIELD_LOC(159, 128)

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -1078,7 +1078,9 @@ static void hns_roce_set_qp_params(struct ibv_qp_init_attr_ex *attr,
 		cnt = roundup_pow_of_two(attr->cap.max_recv_wr);
 		qp->rq.wqe_cnt = cnt;
 		qp->rq.shift = hr_ilog32(cnt);
-		qp->rq_rinl_buf.wqe_cnt = cnt;
+
+		if (ctx->config & HNS_ROCE_RSP_RQ_INLINE_FLAGS)
+			qp->rq_rinl_buf.wqe_cnt = cnt;
 
 		attr->cap.max_recv_wr = qp->rq.wqe_cnt;
 		attr->cap.max_recv_sge = qp->rq.max_gs;

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -522,6 +522,8 @@ static int verify_srq_create_attr(struct hns_roce_context *context,
 static void set_srq_param(struct ibv_context *context, struct hns_roce_srq *srq,
 			  struct ibv_srq_init_attr_ex *attr)
 {
+	struct hns_roce_context *ctx = to_hr_ctx(context);
+
 	if (to_hr_dev(context->device)->hw_version == HNS_ROCE_HW_VER2)
 		srq->rsv_sge = 1;
 
@@ -531,6 +533,10 @@ static void set_srq_param(struct ibv_context *context, struct hns_roce_srq *srq,
 						      srq->max_gs));
 	attr->attr.max_sge = srq->max_gs;
 	attr->attr.srq_limit = 0;
+
+	srq->srq_rinl_buf.wqe_cnt = 0;
+	if (ctx->config & HNS_ROCE_RSP_CQE_INLINE_FLAGS)
+		srq->srq_rinl_buf.wqe_cnt = srq->wqe_cnt;
 }
 
 static int alloc_srq_idx_que(struct hns_roce_srq *srq)
@@ -570,6 +576,11 @@ static int alloc_srq_wqe_buf(struct hns_roce_srq *srq)
 	return hns_roce_alloc_buf(&srq->wqe_buf, buf_size, HNS_HW_PAGE_SIZE);
 }
 
+static int alloc_recv_rinl_buf(uint32_t max_sge,
+			       struct hns_roce_rinl_buf *rinl_buf);
+
+static void free_recv_rinl_buf(struct hns_roce_rinl_buf *rinl_buf);
+
 static int alloc_srq_buf(struct hns_roce_srq *srq)
 {
 	int ret;
@@ -582,14 +593,22 @@ static int alloc_srq_buf(struct hns_roce_srq *srq)
 	if (ret)
 		goto err_idx_que;
 
+	if (srq->srq_rinl_buf.wqe_cnt) {
+		ret = alloc_recv_rinl_buf(srq->max_gs, &srq->srq_rinl_buf);
+		if (ret)
+			goto err_wqe_buf;
+	}
+
 	srq->wrid = calloc(srq->wqe_cnt, sizeof(*srq->wrid));
 	if (!srq->wrid) {
 		ret = -ENOMEM;
-		goto err_wqe_buf;
+		goto err_inl_buf;
 	}
 
 	return 0;
 
+err_inl_buf:
+	free_recv_rinl_buf(&srq->srq_rinl_buf);
 err_wqe_buf:
 	hns_roce_free_buf(&srq->wqe_buf);
 err_idx_que:
@@ -603,6 +622,7 @@ static void free_srq_buf(struct hns_roce_srq *srq)
 {
 	free(srq->wrid);
 	hns_roce_free_buf(&srq->wqe_buf);
+	free_recv_rinl_buf(&srq->srq_rinl_buf);
 	hns_roce_free_buf(&srq->idx_que.buf);
 	free(srq->idx_que.bitmap);
 }
@@ -1079,8 +1099,8 @@ static void hns_roce_set_qp_params(struct ibv_qp_init_attr_ex *attr,
 		cnt = roundup_pow_of_two(attr->cap.max_recv_wr);
 		qp->rq.wqe_cnt = cnt;
 		qp->rq.shift = hr_ilog32(cnt);
-
-		if (ctx->config & HNS_ROCE_RSP_RQ_INLINE_FLAGS)
+		if (ctx->config & (HNS_ROCE_RSP_RQ_INLINE_FLAGS |
+				   HNS_ROCE_RSP_CQE_INLINE_FLAGS))
 			qp->rq_rinl_buf.wqe_cnt = cnt;
 
 		attr->cap.max_recv_wr = qp->rq.wqe_cnt;


### PR DESCRIPTION
The patchset mainly fixes and refactors the code relate to inline
features and supports cqe inline in user space.
1.#1-3: Fix the problem of sge
2.#4-7: rq inline related patches(handle compatibility, refactor
rq inline, add new interface to support rq inline)
3.#8: support cqe inline

The kernal space part is named "[PATCH for-next 0/3] Refactor rq inline and add cqe inline".
https://lore.kernel.org/lkml/Y6w2aRPSXAv4s5Pp@unreal/T/

Haoyue Xu (1):
  Update kernel headers

Luoyouming (7):
  libhns: Use a constant instead of sizeof operation
  libhns: Fix ext_sge num error when post send
  libhns: Fix the problem of sge nums
  libhns: Add compatibility handling for rq inline
  libhns: Refactor rq inline
  libhns: Add RQ inline support for ibv_wc_*()
  libhns: Support cqe inline

 kernel-headers/rdma/hns-abi.h    |   4 +
 providers/hns/hns_roce_u.c       |  10 +-
 providers/hns/hns_roce_u.h       |  29 +++---
 providers/hns/hns_roce_u_abi.h   |   2 +-
 providers/hns/hns_roce_u_hw_v2.c | 152 ++++++++++++++++++------------
 providers/hns/hns_roce_u_hw_v2.h |   4 +-
 providers/hns/hns_roce_u_verbs.c | 156 ++++++++++++++++++++++---------
 7 files changed, 236 insertions(+), 121 deletions(-)
-- 
2.30.0