### PR TITLE
Fix max length of node description (ibtracert)

### DIFF
--- a/infiniband-diags/ibtracert.c
+++ b/infiniband-diags/ibtracert.c
@@ -105,7 +105,7 @@ struct Node {
 	int upport;
 	Node *upnode;
 	uint64_t nodeguid;	/* also portguid */
-	char nodedesc[64];
+	char nodedesc[IB_SMP_DATA_SIZE + 1];
 	char nodeinfo[64];
 };
 


### PR DESCRIPTION
This fix releted to the previous commit d974c4e398d281ce2993c44f865f5161480307f2 / PR(#1237)

ibtracert truncate node description up to 63 bytes instead 64 bytes. Node description field declared as char array of IB_SMP_DATA_SIZE bytes. Last character for compatibility with c-string set to zero. In this case node description will be truncated from 64 bytes to 63 bytes. Size of node description fields was enlarged to the IB_SMP_DATA_SIZE + 1 bytes for using last character for zero char without truncated node description

Signed-off-by: Gregory Linschitz <gregoryl@nvidia.com>