### PR TITLE
tests: add coverage for rdma cuda dmabuf

### DIFF
--- a/Documentation/testing.md
+++ b/Documentation/testing.md
@@ -128,6 +128,27 @@ Ran 14 tests in 0.152s
 OK
 ```
 
+### GPUDirect RDMA
+Part of the available tests includes GPUDirect RDMA.
+Those tests run RDMA traffic over CUDA-allocated memory.
+In order to run them successfully it's required to have a supported NVIDIA GPU,
+CUDA 11.7 and above with "Open flavor" ("-m kernel-open") Driver 515 or later
+and cuda-python 12.0 and above.
+Running the tests is similar to other tests, with the option to choose which GPU
+unit to use in case there are multiple GPUs on the setup.
+```
+$ build/bin/run_tests.py -v --gpu 0 -k cuda
+test_cuda_dmabuf_rdma_write_traffic (tests.test_cuda_dmabuf.DmabufCudaTest)
+Runs RDMA Write traffic over CUDA allocated memory using DMA BUF and ... ok
+test_mlx_devx_cuda_send_imm_traffic (tests.test_mlx5_cuda_umem.Mlx5GpuDevxRcTrafficTest)
+Creates two DevX RC QPs and runs SEND_IMM traffic over CUDA allocated ... ok
+
+----------------------------------------------------------------------
+Ran 2 tests in 3.033s
+
+OK
+```
+
 ## Writing Tests
 The following section explains how to add a new test, using tests/test_odp.py
 as an example. It's a simple test that runs ping-pong over a few different

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -255,6 +255,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         uint32_t    access
         uint64_t    pgsz_bitmap
         uint64_t    comp_mask
+        int         dmabuf_fd
 
     cdef struct mlx5dv_vfio_context_attr:
         const char  *pci_name

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1642,7 +1642,7 @@ cdef class Wqe(PyverbsCM):
 
 cdef class Mlx5UMEM(PyverbsCM):
     def __init__(self, Context context not None, size, addr=None, alignment=64,
-                 access=0, pgsz_bitmap=0, comp_mask=0):
+                 access=0, pgsz_bitmap=0, comp_mask=0, dmabuf_fd=0):
         """
         User memory object to be used by the DevX interface.
         If pgsz_bitmap or comp_mask were passed, the extended umem registration
@@ -1657,6 +1657,7 @@ cdef class Mlx5UMEM(PyverbsCM):
         :param access: The desired memory protection attributes (default: 0)
         :param pgsz_bitmap: Represents the required page sizes
         :param comp_mask: Compatibility mask
+        :param dmabuf_fd: FD of a dmabuf
         """
         super().__init__()
         cdef dv.mlx5dv_devx_umem_in umem_in
@@ -1675,6 +1676,7 @@ cdef class Mlx5UMEM(PyverbsCM):
             umem_in.access = access
             umem_in.pgsz_bitmap = pgsz_bitmap
             umem_in.comp_mask = comp_mask
+            umem_in.dmabuf_fd = dmabuf_fd
             self.umem = dv.mlx5dv_devx_umem_reg_ex(context.context, &umem_in)
         else:
             self.umem = dv.mlx5dv_devx_umem_reg(context.context, self.addr,

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -285,6 +285,9 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_DR_ACTION_DEST
         MLX5DV_DR_ACTION_DEST_REFORMAT
 
+    cpdef enum:
+        MLX5DV_UMEM_MASK_DMABUF
+
     cdef unsigned long long MLX5DV_RES_TYPE_QP
     cdef unsigned long long MLX5DV_RES_TYPE_RWQ
     cdef unsigned long long MLX5DV_RES_TYPE_DBR

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ rdma_python_test(tests
   args_parser.py
   base.py
   base_rdmacm.py
+  cuda_utils.py
   efa_base.py
   mlx5_base.py
   mlx5_prm_structs.py
@@ -15,6 +16,7 @@ rdma_python_test(tests
   test_cq.py
   test_cq_events.py
   test_cqex.py
+  test_cuda_dmabuf.py
   test_device.py
   test_efa_srd.py
   test_efadv.py

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ rdma_python_test(tests
   test_fork.py
   test_mlx5_cq.py
   test_mlx5_crypto.py
+  test_mlx5_cuda_umem.py
   test_mlx5_dc.py
   test_mlx5_devx.py
   test_mlx5_dm_ops.py

--- a/tests/base.py
+++ b/tests/base.py
@@ -486,6 +486,13 @@ class BaseResources(object):
     def create_pd(self):
         self.pd = PD(self.ctx)
 
+    def mem_write(self, data, size, offset=0):
+        self.mr.write(data, size, offset)
+
+    def mem_read(self, size=None, offset=0):
+        size_ = self.msg_size if size is None else size
+        return self.mr.read(size_, offset)
+
 
 class TrafficResources(BaseResources):
     """

--- a/tests/base_rdmacm.py
+++ b/tests/base_rdmacm.py
@@ -133,6 +133,13 @@ class CMResources(abc.ABC):
         attr, mask = cmid.init_qp_attr(e.IBV_QPS_RTS)
         self.qps[conn_idx].modify(attr, mask)
 
+    def mem_write(self, data, size, offset=0):
+        self.mr.write(data, size, offset)
+
+    def mem_read(self, size=None, offset=0):
+        size_ = self.msg_size if size is None else size
+        return self.mr.read(size_, offset)
+
     @abc.abstractmethod
     def create_child_id(self, cm_event=None):
         pass

--- a/tests/cuda_utils.py
+++ b/tests/cuda_utils.py
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2022 Nvidia Inc. All rights reserved. See COPYING file
+
+"""
+This module provides utilities and auxiliary functions for CUDA related tests
+including the initialization/tear down needed and some error handlers.
+"""
+
+import unittest
+
+try:
+    from cuda import cuda, cudart, nvrtc
+    CUDA_FOUND = True
+except ImportError:
+    CUDA_FOUND = False
+
+
+def requires_cuda(func):
+    def inner(instance):
+        if not CUDA_FOUND:
+            raise unittest.SkipTest(
+                'cuda-python 12.0+ must be installed to run CUDA tests')
+        return func(instance)
+    return inner
+
+
+def _cuda_get_error_enum(error):
+    if isinstance(error, cuda.CUresult):
+        err, name = cuda.cuGetErrorName(error)
+        return name if err == cuda.CUresult.CUDA_SUCCESS else "<unknown>"
+    elif isinstance(error, cudart.cudaError_t):
+        return cudart.cudaGetErrorName(error)[1]
+    elif isinstance(error, nvrtc.nvrtcResult):
+        return nvrtc.nvrtcGetErrorString(error)[1]
+    else:
+        raise RuntimeError(f'Unknown error type: {error}')
+
+
+def check_cuda_errors(result):
+    """
+    CUDA error handler.
+    If the CUDA result is success it returns the remaining objects that
+    originally returned by the CUDA function call (if any).
+    Otherwise and exception is raised.
+    :param result: CUDA function result (CUresult)
+    :return: The CUDA function results in case of success
+    """
+    if result[0].value:
+        raise RuntimeError(
+            f'CUDA error code = {result[0].value} ({_cuda_get_error_enum(result[0])})')
+    if len(result) == 1:
+        return None
+    elif len(result) == 2:
+        return result[1]
+    else:
+        return result[1:]
+
+
+# The following functions should not be used directly, instead they should
+# replace/extend unittest.TestCase's derived methods in CUDA tests.
+
+@requires_cuda
+def setUp(obj):
+    super(obj.__class__, obj).setUp()
+    obj.iters = 10
+    obj.traffic_args = None
+    obj.cuda_ctx = None
+    obj.init_cuda()
+
+
+def tearDown(obj):
+    if obj.server and obj.server.cuda_addr:
+        check_cuda_errors(cuda.cuMemFree(obj.server.cuda_addr))
+    if obj.client and obj.client.cuda_addr:
+        check_cuda_errors(cuda.cuMemFree(obj.client.cuda_addr))
+    if obj.cuda_ctx:
+        check_cuda_errors(cuda.cuCtxDestroy(obj.cuda_ctx))
+    super(obj.__class__, obj).tearDown()
+
+
+def init_cuda(obj):
+    cuda_dev_id = obj.config['gpu']
+    if cuda_dev_id is None:
+        raise unittest.SkipTest('GPU device ID must be passed')
+    check_cuda_errors(cuda.cuInit(0))
+    cuda_device = check_cuda_errors(cuda.cuDeviceGet(cuda_dev_id))
+    obj.cuda_ctx = check_cuda_errors(
+        cuda.cuCtxCreate(cuda.CUctx_flags.CU_CTX_MAP_HOST, cuda_device))
+    check_cuda_errors(cuda.cuCtxSetCurrent(obj.cuda_ctx))
+
+
+def set_init_cuda_methods(cls):
+    """
+    Replaces the setUp and tearDown methods of any unittest.TestCase derived
+    class. Can be useful as a decorator for CUDA related tests.
+    :param cls: Test class of unittest.TestCase
+    """
+    cls.setUp = setUp
+    cls.tearDown = tearDown
+    cls.init_cuda = init_cuda
+    cls.mem_write = mem_write
+    cls.mem_read = mem_read
+    return cls
+
+
+# The following functions should be used by CUDA resources objects
+
+def mem_write(obj, data, size, offset=0):
+    cuda_addr = cuda.CUdeviceptr(init_value=int(obj.cuda_addr) + offset)
+    check_cuda_errors(cuda.cuMemcpyHtoD(cuda_addr, data.encode(), size))
+
+
+def mem_read(obj, size=None, offset=0):
+    size_ = obj.msg_size if size is None else size
+    data_read = bytearray(size_)
+    cuda_addr = cuda.CUdeviceptr(init_value=int(obj.cuda_addr) + offset)
+    check_cuda_errors(cuda.cuMemcpyDtoH(data_read, cuda_addr, size_))
+    return data_read
+
+
+def set_mem_io_cuda_methods(cls):
+    """
+    Replaces the mem_write/mem_read methods of any class derived from
+    BaseResources.
+    :param cls: Test class of BaseResources
+    """
+    cls.mem_write = mem_write
+    cls.mem_read = mem_read
+    return cls

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -527,6 +527,9 @@ class Mlx5DevxRcResources(BaseResources):
                 mad_port_state = self.query_port_state_with_mads(ib_port)
         self.init_resources()
 
+    def get_wqe_data_segment(self):
+        return WqeDataSeg(self.mr.length, self.mr.lkey, self.mr.buf)
+
     def change_port_state_with_registers(self, state):
         from tests.mlx5_prm_structs import PaosReg
         paos_in = PaosReg(local_port=self.ib_port, admin_status=state, ase=1)
@@ -800,9 +803,9 @@ class Mlx5DevxRcResources(BaseResources):
         # Prepare WQE
         imm_be32 = struct.unpack("<I", struct.pack(">I", self.imm + self.qattr.sq.post_idx))[0]
         ctrl_seg = WqeCtrlSeg(imm=imm_be32, fm_ce_se=dve.MLX5_WQE_CTRL_CQ_UPDATE)
-        data_seg = WqeDataSeg(self.mr.length, self.mr.lkey, self.mr.buf)
+        data_seg = self.get_wqe_data_segment()
         ctrl_seg.opmod_idx_opcode = (self.qattr.sq.post_idx & 0xffff) << 8 | dve.MLX5_OPCODE_SEND_IMM
-        size_in_octowords = int((ctrl_seg.sizeof() +  data_seg.sizeof()) / 16)
+        size_in_octowords = int((ctrl_seg.sizeof() + data_seg.sizeof()) / 16)
         ctrl_seg.qpn_ds = self.qpn << 8 | size_in_octowords
         Wqe([ctrl_seg, data_seg], self.umems['qp'].umem_addr + buf_offset)
         self.qattr.sq.post_idx += int((size_in_octowords * 16 +
@@ -824,7 +827,7 @@ class Mlx5DevxRcResources(BaseResources):
         """
         buf_offset = self.qattr.rq.offset + self.qattr.rq.wqe_size * self.qattr.rq.head
         # Prepare WQE
-        data_seg = WqeDataSeg(self.mr.length, self.mr.lkey, self.mr.buf)
+        data_seg = self.get_wqe_data_segment()
         Wqe([data_seg], self.umems['qp'].umem_addr + buf_offset)
         # Update indexes
         self.qattr.rq.post_idx += 1
@@ -909,7 +912,7 @@ class Mlx5DevxTrafficBase(Mlx5RDMATestCase):
                             self.server.lid, self.mac_addr)
 
     def send_imm_traffic(self):
-        self.client.mr.write('c' * self.client.msg_size, self.client.msg_size)
+        self.client.mem_write('c' * self.client.msg_size, self.client.msg_size)
         for _ in range(self.client.num_msgs):
             cons_idx = self.client.qattr.cq.cons_idx
             self.server.post_recv()
@@ -922,7 +925,7 @@ class Mlx5DevxTrafficBase(Mlx5RDMATestCase):
             recv_cqe = self.server.poll_cq()
             self.assertEqual(recv_cqe.opcode, dve.MLX5_CQE_RESP_SEND_IMM,
                              'Unexpected CQE opcode')
-            msg_received = self.server.mr.read(self.server.msg_size, 0)
+            msg_received = self.server.mem_read()
             # Validate data (of received message and immediate value)
             tests.utils.validate(msg_received, True, self.server.msg_size)
             imm_inval_pkey = recv_cqe.imm_inval_pkey
@@ -930,8 +933,7 @@ class Mlx5DevxTrafficBase(Mlx5RDMATestCase):
                 imm_inval_pkey = int.from_bytes(
                     imm_inval_pkey.to_bytes(4, byteorder='big'), 'little')
             self.assertEqual(imm_inval_pkey, self.client.imm + cons_idx)
-            self.server.mr.write('s' * self.server.msg_size,
-                                 self.server.msg_size)
+            self.server.mem_write('s' * self.server.msg_size, self.server.msg_size)
 
 
 class Mlx5RcResources(RCResources):

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -43,6 +43,7 @@ class DevxOps:
     MLX5_CMD_OP_MAD_IFC = 0x50d
     MLX5_CMD_OP_ACCESS_REGISTER_PAOS = 0x5006
     MLX5_CMD_OP_ACCESS_REG = 0x805
+    MLX5_CMD_OP_CREATE_MKEY = 0x200
 
 
 # Common
@@ -1631,4 +1632,90 @@ class CreateTirOut(Packet):
         ByteField('icm_address_39_32', 0),
         BitField('tirn', 0, 24),
         IntField('icm_address_31_0', 0),
+    ]
+
+
+class SwMkc(Packet):
+    fields_desc = [
+        BitField('reserved1', 0, 1),
+        BitField('free', 0, 1),
+        BitField('reserved2', 0, 1),
+        BitField('access_mode_4_2', 0, 3),
+        BitField('alter_pd_to_vhca_id', 0, 1),
+        BitField('crossed_side_mkey', 0, 1),
+        BitField('reserved3', 0, 5),
+        BitField('relaxed_ordering_write', 0, 1),
+        BitField('reserved4', 0, 1),
+        BitField('small_fence_on_rdma_read_response', 0, 1),
+        BitField('umr_en', 0, 1),
+        BitField('a', 0, 1),
+        BitField('rw', 0, 1),
+        BitField('rr', 0, 1),
+        BitField('lw', 0, 1),
+        BitField('lr', 0, 1),
+        BitField('access_mode_1_0', 0, 2),
+        BitField('reserved5', 0, 1),
+        BitField('tunneled_atomic', 0, 1),
+        BitField('ma_translation_mode', 0, 2),
+        BitField('reserved6', 0, 4),
+        BitField('qpn', 0, 24),
+        ByteField('mkey_7_0', 0),
+        ByteField('reserved7', 0),
+        BitField('pasid', 0, 24),
+        BitField('length64', 0, 1),
+        BitField('bsf_en', 0, 1),
+        BitField('sync_umr', 0, 1),
+        BitField('reserved8', 0, 2),
+        BitField('expected_sigerr_count', 0, 1),
+        BitField('reserved9', 0, 1),
+        BitField('en_rinval', 0, 1),
+        BitField('pd', 0, 24),
+        LongField('start_addr', 0),
+        LongField('len', 0),
+        IntField('bsf_octword_size', 0),
+        StrFixedLenField('reserved10', None, length=12),
+        ShortField('crossing_target_vhca_id', 0),
+        ShortField('reserved11', 0),
+        IntField('translations_octword_size', 0),
+        BitField('reserved12', 0, 25),
+        BitField('relaxed_ordering_read', 0, 1),
+        BitField('reserved13', 0, 1),
+        BitField('log_entity_size', 0, 5),
+        BitField('reserved14', 0, 3),
+        BitField('crypto_en', 0, 2),
+        BitField('reserved15', 0, 27),
+    ]
+
+
+class CreateMkeyIn(Packet):
+    fields_desc = [
+        ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_MKEY),
+        ShortField('uid', 0),
+        ShortField('reserved1', 0),
+        ShortField('op_mod', 0),
+        ByteField('reserved2', 0),
+        BitField('input_mkey_index', 0, 24),
+        BitField('pg_access', 0, 1),
+        BitField('mkey_umem_valid', 0, 1),
+        BitField('reserved3', 0, 30),
+        PacketField('sw_mkc', SwMkc(), SwMkc),
+        LongField('e_mtt_pointer', 0),
+        LongField('e_bsf_pointer', 0),
+        IntField('translations_octword_actual_size', 0),
+        IntField('mkey_umem_id', 0),
+        LongField('mkey_umem_offset', 0),
+        IntField('bsf_octword_actual_size', 0),
+        StrFixedLenField('reserved4', None, length=156),
+        FieldListField('klm_pas_mtt', [0 for x in range(0)], IntField('', 0), count_from=lambda pkt:0),
+    ]
+
+
+class CreateMkeyOut(Packet):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('reserved1', 0, 24),
+        IntField('syndrome', 0),
+        ByteField('reserved2', 0),
+        BitField('mkey_index', 0, 24),
+        StrFixedLenField('reserved3', None, length=4),
     ]

--- a/tests/test_cuda_dmabuf.py
+++ b/tests/test_cuda_dmabuf.py
@@ -1,0 +1,107 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2022 Nvidia Inc. All rights reserved. See COPYING file
+
+import unittest
+import errno
+
+from pyverbs.pyverbs_error import PyverbsRDMAError
+from tests.base import RCResources, RDMATestCase
+from pyverbs.mr import DmaBufMR
+from pyverbs.qp import QPAttr
+import tests.cuda_utils as cu
+import pyverbs.enums as e
+import tests.utils as u
+
+try:
+    from cuda import cuda, cudart, nvrtc
+    cu.CUDA_FOUND = True
+except ImportError:
+    cu.CUDA_FOUND = False
+
+GPU_PAGE_SIZE = 1 << 16
+
+
+@cu.set_mem_io_cuda_methods
+class DmabufCudaRes(RCResources):
+    def __init__(self, dev_name, ib_port, gid_index,
+                 mr_access=e.IBV_ACCESS_LOCAL_WRITE):
+        """
+        Initializes MR and DMA BUF resources on top of a CUDA memory.
+        Uses RC QPs for traffic.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param mr_access: The MR access
+        """
+        self.mr_access = mr_access
+        self.cuda_addr = None
+        super().__init__(dev_name=dev_name, ib_port=ib_port, gid_index=gid_index)
+
+    def create_mr(self):
+        self.cuda_addr = cu.check_cuda_errors(cuda.cuMemAlloc(GPU_PAGE_SIZE))
+
+        attr_flag = 1
+        cu.check_cuda_errors(cuda.cuPointerSetAttribute(
+            attr_flag,
+            cuda.CUpointer_attribute.CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+            int(self.cuda_addr)))
+
+        dmabuf_fd = cu.check_cuda_errors(
+            cuda.cuMemGetHandleForAddressRange(self.cuda_addr,
+                                               GPU_PAGE_SIZE,
+                                               cuda.CUmemRangeHandleType.CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                               0))
+        try:
+            self.mr = DmaBufMR(self.pd, self.msg_size, self.mr_access, dmabuf_fd)
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.EOPNOTSUPP:
+                raise unittest.SkipTest(f'Registering DMABUF MR is not supported')
+            raise ex
+
+    def create_qp_attr(self):
+        qp_attr = QPAttr(port_num=self.ib_port)
+        qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE | \
+                    e.IBV_ACCESS_REMOTE_READ
+        qp_attr.qp_access_flags = qp_access
+        return qp_attr
+
+
+@cu.set_init_cuda_methods
+class DmabufCudaTest(RDMATestCase):
+    """
+    Test RDMA traffic over CUDA memory
+    """
+    def create_players(self, resource, **resource_arg):
+        """
+        Init CUDA tests resources.
+        :param resource: The RDMA resources to use.
+        :param resource_arg: Dict of args that specify the resource specific
+        attributes.
+        :return: Non
+        """
+        self.client = resource(**self.dev_info, **resource_arg)
+        self.server = resource(**self.dev_info, **resource_arg)
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
+        self.sync_remote_attr()
+        self.traffic_args = {'client': self.client, 'server': self.server,
+                             'iters': self.iters, 'gid_idx': self.gid_index,
+                             'port': self.ib_port}
+
+    def sync_remote_attr(self):
+        """
+        Exchange the MR remote attributes between the server and the client.
+        """
+        self.server.rkey = self.client.mr.rkey
+        self.server.remote_addr = self.client.mr.buf
+        self.client.rkey = self.server.mr.rkey
+        self.client.remote_addr = self.server.mr.buf
+
+    def test_cuda_dmabuf_rdma_write_traffic(self):
+        """
+        Runs RDMA Write traffic over CUDA allocated memory using DMA BUF and
+        RC QPs.
+        """
+        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
+        self.create_players(DmabufCudaRes, mr_access=access)
+        u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)

--- a/tests/test_mlx5_cuda_umem.py
+++ b/tests/test_mlx5_cuda_umem.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
+# Copyright (c) 2022 Nvidia Inc. All rights reserved. See COPYING file
+
+import resource
+
+from pyverbs.providers.mlx5.mlx5dv import Mlx5DevxObj, WqeDataSeg, Mlx5UMEM
+from tests.mlx5_base import Mlx5DevxRcResources, Mlx5DevxTrafficBase
+from tests.mlx5_prm_structs import SwMkc, CreateMkeyIn, CreateMkeyOut
+import pyverbs.providers.mlx5.mlx5_enums as dve
+import tests.cuda_utils as cu
+import pyverbs.enums as e
+
+try:
+    from cuda import cuda, cudart, nvrtc
+    cu.CUDA_FOUND = True
+except ImportError:
+    cu.CUDA_FOUND = False
+
+GPU_PAGE_SIZE = 1 << 16
+
+
+@cu.set_mem_io_cuda_methods
+class CudaDevxRes(Mlx5DevxRcResources):
+    def __init__(self, dev_name, ib_port, gid_index,
+                 mr_access=e.IBV_ACCESS_LOCAL_WRITE):
+        """
+        Initialize DevX resources with CUDA memory allocations.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param mr_access: The MR access
+        """
+        self.mr_access = mr_access
+        self.cuda_addr = None
+        self.dmabuf_fd = None
+        self.umem = None
+        self.mkey = None
+        self.lkey = None
+        self.lkey = None
+        super().__init__(dev_name=dev_name, ib_port=ib_port, gid_index=gid_index)
+
+    def init_resources(self):
+        self.alloc_cuda_mem()
+        super().init_resources()
+        self.create_dmabuf_umem()
+        self.create_mkey()
+
+    def get_wqe_data_segment(self):
+        return WqeDataSeg(self.msg_size, self.lkey, int(self.cuda_addr))
+
+    def alloc_cuda_mem(self):
+        """
+        Allocates CUDA memory and a DMABUF FD on that memory.
+        """
+        self.cuda_addr = cu.check_cuda_errors(cuda.cuMemAlloc(GPU_PAGE_SIZE))
+
+        # Sync between memory operations
+        attr_value = 1
+        cu.check_cuda_errors(cuda.cuPointerSetAttribute(
+            attr_value,
+            cuda.CUpointer_attribute.CU_POINTER_ATTRIBUTE_SYNC_MEMOPS,
+            int(self.cuda_addr)
+        ))
+
+        # Memory address and size must be aligned to page size to get a handle
+        assert (GPU_PAGE_SIZE % resource.getpagesize() == 0 and
+                int(self.cuda_addr) % resource.getpagesize() == 0)
+        self.dmabuf_fd = cu.check_cuda_errors(
+            cuda.cuMemGetHandleForAddressRange(self.cuda_addr,
+                                               GPU_PAGE_SIZE,
+                                               cuda.CUmemRangeHandleType.CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD,
+                                               0))
+
+    def create_mr(self):
+        pass
+
+    def create_dmabuf_umem(self):
+        umem_aligment = resource.getpagesize()
+        self.umem = Mlx5UMEM(self.ctx, GPU_PAGE_SIZE, 0,
+                             umem_aligment, self.mr_access, umem_aligment,
+                             dve.MLX5DV_UMEM_MASK_DMABUF, self.dmabuf_fd)
+
+    def create_mkey(self):
+        accesses = [e.IBV_ACCESS_LOCAL_WRITE, e.IBV_ACCESS_REMOTE_READ, e.IBV_ACCESS_REMOTE_WRITE]
+        lw, rr, rw = (list(map(lambda access: int(self.mr_access & access != 0), accesses)))
+        mkey_ctx = SwMkc(lr=1, lw=lw, rr=rr, rw=rw, access_mode_1_0=0x1,
+                         start_addr=int(self.cuda_addr),
+                         len=GPU_PAGE_SIZE, pd=self.dv_pd.pdn, qpn=0xffffff)
+        self.mkey = Mlx5DevxObj(self.ctx, CreateMkeyIn(sw_mkc=mkey_ctx,
+                                                       mkey_umem_id=self.umem.umem_id,
+                                                       mkey_umem_valid=1),
+                                len(CreateMkeyOut()))
+        self.lkey = CreateMkeyOut(self.mkey.out_view).mkey_index << 8
+
+
+@cu.set_init_cuda_methods
+class Mlx5GpuDevxRcTrafficTest(Mlx5DevxTrafficBase):
+    """
+    Test DevX traffic over CUDA memory using DMA BUF and UMEM
+    """
+
+    @cu.requires_cuda
+    def test_mlx_devx_cuda_send_imm_traffic(self):
+        """
+        Creates two DevX RC QPs and runs SEND_IMM traffic over CUDA allocated
+        memory using UMEM and DMA BUF.
+        """
+        self.create_players(CudaDevxRes)
+        # Send traffic
+        self.send_imm_traffic()


### PR DESCRIPTION
Add tests that cover RDMA traffic over MR/UMEM DMA BUF.
In both cases, the memory is a CUDA-allocated memory.