### PR TITLE
ibdiags: Fix max length of node description (dump_fst/ibroute/ibtracert)

### DIFF
--- a/infiniband-diags/dump_fts.c
+++ b/infiniband-diags/dump_fts.c
@@ -109,7 +109,7 @@ static void dump_multicast_tables(ibnd_node_t *node, unsigned startl,
 				  unsigned endl, struct ibmad_port *mad_port)
 {
 	ib_portid_t *portid = &node->path_portid;
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	char str[512];
 	char *s;
 	uint64_t nodeguid;
@@ -224,7 +224,7 @@ static int dump_lid(char *str, int str_len, int lid, int valid,
 		    ibnd_fabric_t *fabric, int *last_port_lid,
 		    int *base_port_lid, uint64_t *portguid)
 {
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 
 	ibnd_port_t *port = NULL;
 
@@ -302,7 +302,7 @@ static void dump_unicast_tables(ibnd_node_t *node, int startl, int endl,
 {
 	ib_portid_t * portid = &node->path_portid;
 	char lft[IB_SMP_DATA_SIZE] = { 0 };
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	char str[200];
 	uint64_t nodeguid;
 	int block, i, e, top;

--- a/infiniband-diags/ibroute.c
+++ b/infiniband-diags/ibroute.c
@@ -133,7 +133,7 @@ static __be16 mft[16][IB_MLIDS_IN_BLOCK];
 static const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
 					 unsigned endlid)
 {
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	uint8_t sw[IB_SMP_DATA_SIZE] = { 0 };
 	char str[512], *s;
 	const char *err;
@@ -245,7 +245,7 @@ static const char *dump_multicast_tables(ib_portid_t *portid, unsigned startlid,
 
 static int dump_lid(char *str, int strlen, int lid, int valid)
 {
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 	uint8_t pi[IB_SMP_DATA_SIZE] = { 0 };
 	ib_portid_t lidport = { 0 };
@@ -322,7 +322,7 @@ static const char *dump_unicast_tables(ib_portid_t *portid, int startlid,
 				       int endlid)
 {
 	uint8_t lft[IB_SMP_DATA_SIZE] = { 0 };
-	char nd[IB_SMP_DATA_SIZE] = { 0 };
+	char nd[IB_SMP_DATA_SIZE + 1] = { 0 };
 	uint8_t sw[IB_SMP_DATA_SIZE] = { 0 };
 	char str[200];
 	const char *s;

--- a/infiniband-diags/ibtracert.c
+++ b/infiniband-diags/ibtracert.c
@@ -105,7 +105,7 @@ struct Node {
 	int upport;
 	Node *upnode;
 	uint64_t nodeguid;	/* also portguid */
-	char nodedesc[64];
+	char nodedesc[IB_SMP_DATA_SIZE + 1];
 	char nodeinfo[64];
 };
 


### PR DESCRIPTION
This fix related to the previous commit d974c4e398d281ce2993c44f865f5161480307f2 / PR(#1237)

dump_fst/ibroute/ibtracert truncate node description up to 63 bytes instead 64 bytes. 
Node description field declared as char array of IB_SMP_DATA_SIZE bytes. 
Last character for compatibility with c-string set to zero. 
In this case node description will be truncated from 64 bytes to 63 bytes. 
Size of node description fields was enlarged to the IB_SMP_DATA_SIZE + 1 bytes 
for using last character for zero char without truncated node description

Signed-off-by: Gregory Linschitz <gregoryl@nvidia.com>