### PR TITLE
mlx5: Misc. fixes

### DIFF
--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -3549,7 +3549,7 @@ mlx5dv_get_vfio_device_list(struct mlx5dv_vfio_context_attr *attr)
 		return NULL;
 	}
 
-	list = calloc(1, sizeof(struct ibv_device *));
+	list = calloc(2, sizeof(struct ibv_device *));
 	if (!list) {
 		errno = ENOMEM;
 		return NULL;

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -2395,7 +2395,7 @@ static struct ibv_mr *mlx5_vfio_reg_mr(struct ibv_pd *pd, void *addr, size_t len
 		goto end;
 
 	aligned_va = (void *)(uintptr_t)((unsigned long)addr & ~(ctx->iova_min_page_size - 1));
-	page_shift = ilog32(mr->iova_page_size - 1);
+	page_shift = ilog64(mr->iova_page_size - 1);
 	iova_min_page_shift = ilog32(ctx->iova_min_page_size - 1);
 	if (page_shift > iova_min_page_shift)
 		/* Ensure the low bis of the mkey VA match the low bits of the IOVA because the mkc
@@ -2429,7 +2429,13 @@ static struct ibv_mr *mlx5_vfio_reg_mr(struct ibv_pd *pd, void *addr, size_t len
 	}
 
 	pas = (__be64 *)DEVX_ADDR_OF(create_mkey_in, in, klm_pas_mtt);
-	mlx5_vfio_populate_pas(mr->iova, num_pas, (1ULL << page_shift), pas, MLX5_MTT_PRESENT);
+	/* if page_shift was greater than MLX5_MAX_PAGE_SHIFT then limiting it
+	 * will cause the starting IOVA to be incorrect, adjust it.
+	 */
+	mlx5_vfio_populate_pas(align_down(mr->iova + mr->iova_aligned_offset,
+					  1ULL << page_shift),
+			       num_pas, (1ULL << page_shift),
+			       pas, MLX5_MTT_PRESENT);
 
 	DEVX_SET(create_mkey_in, in, opcode, MLX5_CMD_OP_CREATE_MKEY);
 	DEVX_SET(create_mkey_in, in, pg_access, 1);

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -2670,9 +2670,14 @@ static void crypto_umr_wqe_finalize(struct mlx5_qp *mqp)
 		return;
 	}
 
+	/*
+	 * Handle the case when the size of the previously written data segment
+	 * was bigger than MLX5_SEND_WQE_BB and it overlapped the end of the SQ.
+	 * The BSF segment needs to come just after it for this UMR WQE.
+	 */
 	seg = mqp->cur_data + cur_data_size;
 	if (unlikely(seg >= qend))
-		seg = qend - seg + mlx5_get_send_wqe(mqp, 0);
+		seg = seg - qend + mlx5_get_send_wqe(mqp, 0);
 
 	if (mkey->sig) {
 		/* If sig and crypto are enabled, sig BSF must be set */
@@ -2776,9 +2781,14 @@ static void umr_wqe_finalize(struct mlx5_qp *mqp)
 		return;
 	}
 
+	/*
+	 * Handle the case when the size of the previously written data segment
+	 * was bigger than MLX5_SEND_WQE_BB and it overlapped the end of the SQ.
+	 * The BSF segment needs to come just after it for this UMR WQE.
+	 */
 	seg = mqp->cur_data + cur_data_size;
 	if (unlikely(seg >= qend))
-		seg = qend - seg + mlx5_get_send_wqe(mqp, 0);
+		seg = seg - qend + mlx5_get_send_wqe(mqp, 0);
 
 	ret = mlx5_umr_fill_sig_bsf(seg, &mkey->sig->block, false);
 	if (ret) {


### PR DESCRIPTION
This series includes a few fixes in mlx5 driver as of below:
- Handle properly BSF segment when a UMR WQE overlaps the end of the SQ.
- Fix some issues when creating a mkey over vfio.
- Fix mlx5dv_get_vfio_device_list() based on valgrind memcheck report.