### PR TITLE
mlx5: DR, Fixes and improvements 

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -742,13 +742,20 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				dr_dbg(dmn, "Root decap L3 action cannot be used on current table\n");
 				goto out_invalid_arg;
 			}
-			attr.decap_index = action->rewrite.param.index;
-			attr.decap_actions = action->rewrite.param.num_of_actions;
-			attr.decap_with_vlan =
-				attr.decap_actions == WITH_VLAN_NUM_HW_ACTIONS;
-			if (action->rewrite.ptrn_arg.ptrn &&
-			    action->rewrite.ptrn_arg.arg)
-				attr.args_index = dr_arg_get_object_id(action->rewrite.ptrn_arg.arg);
+			if (action->rewrite.ptrn_arg.ptrn && action->rewrite.ptrn_arg.arg) {
+				attr.decap_index =
+					dr_arg_get_object_id(action->rewrite.ptrn_arg.arg);
+				attr.decap_actions =
+				     action->rewrite.ptrn_arg.ptrn->rewrite_param.num_of_actions;
+				attr.decap_pat_idx =
+					action->rewrite.ptrn_arg.ptrn->rewrite_param.index;
+			} else {
+				attr.decap_index = action->rewrite.param.index;
+				attr.decap_actions = action->rewrite.param.num_of_actions;
+				attr.decap_with_vlan =
+					attr.decap_actions == WITH_VLAN_NUM_HW_ACTIONS;
+				attr.decap_pat_idx = DR_INVALID_PATTERN_INDEX;
+			}
 			break;
 		case DR_ACTION_TYP_MODIFY_HDR:
 			if (action->rewrite.is_root_level) {
@@ -760,14 +767,18 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				attr.modify_actions = action->rewrite.param.num_of_actions;
 				attr.single_modify_action = action->rewrite.param.data;
 			} else {
-				if (action->rewrite.ptrn_arg.ptrn &&
-				    action->rewrite.ptrn_arg.arg) {
-					attr.args_index = dr_arg_get_object_id(action->rewrite.ptrn_arg.arg);
-					attr.modify_index = action->rewrite.ptrn_arg.ptrn->rewrite_param.index;
-					attr.modify_actions = action->rewrite.ptrn_arg.ptrn->rewrite_param.num_of_actions;
+				if (action->rewrite.ptrn_arg.ptrn && action->rewrite.ptrn_arg.arg) {
+					attr.modify_index =
+						dr_arg_get_object_id(action->rewrite.ptrn_arg.arg);
+					attr.modify_pat_idx =
+						action->rewrite.ptrn_arg.ptrn->rewrite_param.index;
+					attr.modify_actions =
+						action->rewrite.ptrn_arg.ptrn->rewrite_param.
+										num_of_actions;
 				} else {
 					attr.modify_actions = action->rewrite.param.num_of_actions;
 					attr.modify_index = action->rewrite.param.index;
+					attr.modify_pat_idx = DR_INVALID_PATTERN_INDEX;
 				}
 			}
 			break;

--- a/providers/mlx5/dr_arg.c
+++ b/providers/mlx5/dr_arg.c
@@ -120,7 +120,6 @@ static void dr_arg_pool_put_arg_obj(struct dr_arg_pool *pool,
 				    struct dr_arg_obj *arg_obj)
 {
 	pthread_mutex_lock(&pool->mutex);
-	list_del(&arg_obj->list_node);
 	list_add(&pool->free_list, &arg_obj->list_node);
 	pthread_mutex_unlock(&pool->mutex);
 }

--- a/providers/mlx5/dr_arg.c
+++ b/providers/mlx5/dr_arg.c
@@ -250,7 +250,7 @@ dr_arg_mngr_create(struct mlx5dv_dr_domain *dmn)
 
 	pool_mngr->dmn = dmn;
 
-	for (i = 0; i <= DR_ARG_CHUNK_SIZE_MAX - 1; i++) {
+	for (i = 0; i < DR_ARG_CHUNK_SIZE_MAX; i++) {
 		pool_mngr->pools[i] = dr_arg_pool_create(dmn, i);
 		if (!pool_mngr->pools[i])
 			goto clean_pools;
@@ -275,7 +275,7 @@ void dr_arg_mngr_destroy(struct dr_arg_mngr *mngr)
 		return;
 
 	pools = mngr->pools;
-	for (i = 0; i < DR_ARG_CHUNK_SIZE_MAX - 1; i++)
+	for (i = 0; i < DR_ARG_CHUNK_SIZE_MAX; i++)
 		dr_arg_pool_destroy(pools[i]);
 
 	free(mngr);

--- a/providers/mlx5/dr_arg.c
+++ b/providers/mlx5/dr_arg.c
@@ -10,6 +10,8 @@ enum dr_arg_chunk_size {
 	DR_ARG_CHUNK_SIZE_1,
 	DR_ARG_CHUNK_SIZE_MIN = DR_ARG_CHUNK_SIZE_1, /* keep updated when changing */
 	DR_ARG_CHUNK_SIZE_2,
+	DR_ARG_CHUNK_SIZE_3,
+	DR_ARG_CHUNK_SIZE_4,
 	DR_ARG_CHUNK_SIZE_MAX,
 };
 
@@ -179,6 +181,12 @@ dr_arg_get_chunk_size(uint16_t num_of_actions)
 		return DR_ARG_CHUNK_SIZE_1;
 	if (num_of_actions <= 16)
 		return DR_ARG_CHUNK_SIZE_2;
+	if (num_of_actions <= 32)
+		return DR_ARG_CHUNK_SIZE_3;
+	if (num_of_actions <= 64)
+		return DR_ARG_CHUNK_SIZE_4;
+
+	errno = EINVAL;
 	return DR_ARG_CHUNK_SIZE_MAX;
 }
 

--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -735,15 +735,18 @@ static int dr_dump_domain(FILE *f, struct mlx5dv_dr_domain *dmn)
 	int ret, i;
 
 	domain_id = dr_domain_id_calc(dmn_type);
-
-	ret = fprintf(f, "%d,0x%" PRIx64 ",%d,0%x,%d,%s,%s\n",
+	ret = fprintf(f, "%d,0x%" PRIx64 ",%d,0%x,%d,%s,%s,%u,%u,%u,%u\n",
 		      DR_DUMP_REC_TYPE_DOMAIN,
 		      domain_id,
 		      dmn_type,
 		      dmn->info.caps.gvmi,
 		      dmn->info.supp_sw_steering,
 		      PACKAGE_VERSION,
-		      dev_name);
+		      dev_name,
+		      dmn->flags,
+		      dmn->num_buddies[DR_ICM_TYPE_STE],
+		      dmn->num_buddies[DR_ICM_TYPE_MODIFY_ACTION],
+		      dmn->num_buddies[DR_ICM_TYPE_MODIFY_HDR_PTRN]);
 	if (ret < 0)
 		return ret;
 

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -182,6 +182,9 @@ static void dr_domain_vports_uninit(struct mlx5dv_dr_domain *dmn)
 		vports->vports = NULL;
 	}
 	pthread_spin_destroy(&vports->lock);
+
+	if (vports->ib_ports)
+		free(vports->ib_ports);
 }
 
 static int dr_domain_query_esw_mgr(struct mlx5dv_dr_domain *dmn,
@@ -360,7 +363,7 @@ static int dr_domain_caps_init(struct ibv_context *ctx,
 	default:
 		dr_dbg(dmn, "Invalid domain\n");
 		ret = EINVAL;
-		break;
+		goto uninit_vports;
 	}
 
 	return ret;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -43,7 +43,7 @@ enum {
 
 bool dr_domain_is_support_modify_hdr_cache(struct mlx5dv_dr_domain *dmn)
 {
-	return dmn->info.caps.sw_format_ver == MLX5_HW_CONNECTX_6DX &&
+	return dmn->info.caps.sw_format_ver >= MLX5_HW_CONNECTX_6DX &&
 	       dmn->info.caps.support_modify_argument;
 }
 
@@ -433,7 +433,7 @@ static int dr_domain_check_icm_memory_caps(struct mlx5dv_dr_domain *dmn)
 	dmn->info.max_log_sw_icm_sz =
 		min_t(uint32_t, DR_CHUNK_SIZE_1024K, max_req_chunks_log);
 
-	if (dmn->info.caps.sw_format_ver == MLX5_HW_CONNECTX_6DX) {
+	if (dmn->info.caps.sw_format_ver >= MLX5_HW_CONNECTX_6DX) {
 		if (dmn->info.caps.log_modify_pattern_icm_size < DR_CHUNK_SIZE_4K +
 		    DR_MODIFY_ACTION_LOG_SIZE) {
 			errno = ENOMEM;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -49,6 +49,8 @@ bool dr_domain_is_support_modify_hdr_cache(struct mlx5dv_dr_domain *dmn)
 
 static int dr_domain_init_resources(struct mlx5dv_dr_domain *dmn)
 {
+	struct mlx5dv_pd mlx5_pd = {};
+	struct mlx5dv_obj obj;
 	int ret = -1;
 
 	dmn->ste_ctx = dr_ste_get_ctx(dmn->info.caps.sw_format_ver);
@@ -62,6 +64,14 @@ static int dr_domain_init_resources(struct mlx5dv_dr_domain *dmn)
 		dr_dbg(dmn, "Couldn't allocate PD\n");
 		return ret;
 	}
+
+	obj.pd.in = dmn->pd;
+	obj.pd.out = &mlx5_pd;
+	ret = mlx5dv_init_obj(&obj, MLX5DV_OBJ_PD);
+	if (ret)
+		goto clean_pd;
+
+	dmn->pd_num = mlx5_pd.pdn;
 
 	dmn->uar = mlx5dv_devx_alloc_uar(dmn->ctx,
 					 MLX5_IB_UAPI_UAR_ALLOC_TYPE_NC);

--- a/providers/mlx5/dr_icm_pool.c
+++ b/providers/mlx5/dr_icm_pool.c
@@ -283,6 +283,8 @@ static int dr_icm_buddy_create(struct dr_icm_pool *pool)
 	/* add it to the -start- of the list in order to search in it first */
 	list_add(&pool->buddy_mem_list, &buddy->list_node);
 
+	pool->dmn->num_buddies[pool->icm_type]++;
+
 	return 0;
 
 err_cleanup_buddy:
@@ -307,6 +309,8 @@ static void dr_icm_buddy_destroy(struct dr_icm_buddy_mem *buddy)
 	dr_icm_pool_mr_destroy(buddy->icm_mr);
 
 	dr_buddy_cleanup(buddy);
+
+	buddy->pool->dmn->num_buddies[buddy->pool->icm_type]--;
 
 	if (buddy->pool->icm_type == DR_ICM_TYPE_STE)
 		dr_icm_buddy_cleanup_ste_cache(buddy);

--- a/providers/mlx5/dr_ptrn.c
+++ b/providers/mlx5/dr_ptrn.c
@@ -184,7 +184,7 @@ dr_ptrn_cache_get_pattern(struct dr_ptrn_mngr *mngr,
 		}
 
 		if (dr_send_postsend_pattern(mngr->dmn, chunk, num_of_actions,
-					     data))
+					     pattern->rewrite_param.data))
 			goto put_pattern;
 	}
 	atomic_fetch_add(&pattern->refcount, 1);

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -690,6 +690,8 @@ static void dr_fill_write_args_segs(struct dr_send_ring *send_ring,
 
 	if (send_ring->pending_wqe % send_ring->signal_th == 0)
 		send_info->write.send_flags |= IBV_SEND_SIGNALED;
+	else
+		send_info->write.send_flags = 0;
 }
 
 static void dr_fill_write_icm_segs(struct mlx5dv_dr_domain *dmn,

--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -1135,7 +1135,6 @@ static int dr_send_ring_alloc_one(struct mlx5dv_dr_domain *dmn,
 {
 	struct dr_qp_init_attr init_attr = {};
 	struct dr_send_ring *send_ring;
-	struct mlx5dv_pd mlx5_pd = {};
 	struct mlx5dv_cq mlx5_cq = {};
 	int cq_size, page_size;
 	struct mlx5dv_obj obj;
@@ -1178,15 +1177,8 @@ static int dr_send_ring_alloc_one(struct mlx5dv_dr_domain *dmn,
 	send_ring->cq.ncqe = mlx5_cq.cqe_cnt;
 	send_ring->cq.cqe_sz = mlx5_cq.cqe_size;
 
-	obj.pd.in = dmn->pd;
-	obj.pd.out = &mlx5_pd;
-
-	ret = mlx5dv_init_obj(&obj, MLX5DV_OBJ_PD);
-	if (ret)
-		goto clean_cq;
-
 	init_attr.cqn			= mlx5_cq.cqn;
-	init_attr.pdn			= mlx5_pd.pdn;
+	init_attr.pdn			= dmn->pd_num;
 	init_attr.uar			= dmn->uar;
 	init_attr.cap.max_send_wr	= QUEUE_SIZE;
 	init_attr.cap.max_recv_wr	= 1;

--- a/providers/mlx5/dr_ste_v0.c
+++ b/providers/mlx5/dr_ste_v0.c
@@ -764,11 +764,9 @@ static void dr_ste_v0_build_eth_l2_src_dst_bit_mask(struct dr_match_param *value
 	DR_STE_SET_TAG(eth_l2_src_dst, bit_mask, first_priority, mask, first_prio);
 	DR_STE_SET_ONES(eth_l2_src_dst, bit_mask, l3_type, mask, ip_version);
 
-	if (mask->cvlan_tag) {
+	if (mask->cvlan_tag || mask->svlan_tag) {
 		DR_STE_SET(eth_l2_src_dst, bit_mask, first_vlan_qualifier, -1);
 		mask->cvlan_tag = 0;
-	} else if (mask->svlan_tag) {
-		DR_STE_SET(eth_l2_src_dst, bit_mask, first_vlan_qualifier, -1);
 		mask->svlan_tag = 0;
 	}
 }

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -1243,11 +1243,9 @@ static void dr_ste_v1_build_eth_l2_src_dst_bit_mask(struct dr_match_param *value
 	DR_STE_SET_TAG(eth_l2_src_dst_v1, bit_mask, first_priority, mask, first_prio);
 	DR_STE_SET_ONES(eth_l2_src_dst_v1, bit_mask, l3_type, mask, ip_version);
 
-	if (mask->cvlan_tag) {
+	if (mask->cvlan_tag || mask->svlan_tag) {
 		DR_STE_SET(eth_l2_src_dst_v1, bit_mask, first_vlan_qualifier, -1);
 		mask->cvlan_tag = 0;
-	} else if (mask->svlan_tag) {
-		DR_STE_SET(eth_l2_src_dst_v1, bit_mask, first_vlan_qualifier, -1);
 		mask->svlan_tag = 0;
 	}
 }

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1905,7 +1905,7 @@ struct mlx5_ifc_ste_double_action_insert_with_ptr_v1_bits {
 	u8         pointer[0x20];
 };
 
-struct mlx5_ifc_ste_double_action_modify_action_list_v1_bits {
+struct mlx5_ifc_ste_double_action_accelerated_modify_action_list_v1_bits {
 	u8         action_id[0x8];
 	u8         modify_actions_pattern_pointer[0x18];
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -378,12 +378,15 @@ struct dr_action_aso {
 	};
 };
 
+#define DR_INVALID_PATTERN_INDEX 0xffffffff
+
 struct dr_ste_actions_attr {
 	uint32_t	modify_index;
+	uint32_t	modify_pat_idx;
 	uint16_t	modify_actions;
 	uint8_t		*single_modify_action;
-	uint32_t	args_index;
 	uint32_t	decap_index;
+	uint32_t	decap_pat_idx;
 	uint16_t	decap_actions;
 	bool		decap_with_vlan;
 	uint64_t	final_icm_addr;

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -95,6 +95,7 @@ enum dr_icm_type {
 	DR_ICM_TYPE_STE,
 	DR_ICM_TYPE_MODIFY_ACTION,
 	DR_ICM_TYPE_MODIFY_HDR_PTRN,
+	DR_ICM_TYPE_MAX,
 };
 
 static inline enum dr_icm_chunk_size
@@ -1066,6 +1067,8 @@ struct mlx5dv_dr_domain {
 	uint32_t			flags;
 	/* protect debug lists of all tracked objects */
 	pthread_spinlock_t		debug_lock;
+	/* statistcs */
+	uint32_t num_buddies[DR_ICM_TYPE_MAX];
 };
 
 static inline int dr_domain_nic_lock_init(struct dr_domain_rx_tx *nic_dmn)


### PR DESCRIPTION
This series includes fixes and improvements in the DR area, mainly in the pattern and arguments area.

Specifically,
- Fixes an issue causing fallback from pattern/args to legacy modify header mode and some following issues in this area.
- Fixes an issue when both svlan and cvlan matches are provided.
- Improve to adds memory statistics for domain object.
- Improve to calculate the threshold of each pool according to its type.
- Improve to enable up to 64 modifications in modify-header action.


