### PR TITLE
providers/mthca: The db_tab memory can be used only after it is not empty.

### DIFF
--- a/providers/mthca/memfree.c
+++ b/providers/mthca/memfree.c
@@ -175,7 +175,7 @@ struct mthca_db_table *mthca_alloc_db_tab(int uarc_size)
 	npages = uarc_size / MTHCA_DB_REC_PAGE_SIZE;
 	db_tab = malloc(sizeof (struct mthca_db_table) +
 			npages * sizeof (struct mthca_db_page));
-	if (!db_tal) {
+	if (!db_tab) {
 		return NULL;
 	}
 

--- a/providers/mthca/memfree.c
+++ b/providers/mthca/memfree.c
@@ -175,6 +175,9 @@ struct mthca_db_table *mthca_alloc_db_tab(int uarc_size)
 	npages = uarc_size / MTHCA_DB_REC_PAGE_SIZE;
 	db_tab = malloc(sizeof (struct mthca_db_table) +
 			npages * sizeof (struct mthca_db_page));
+	if (!db_tal) {
+		return NULL;
+	}
 
 	pthread_mutex_init(&db_tab->mutex, NULL);
 


### PR DESCRIPTION
In the mthca_alloc_db_tab function, the db_tab memory applied for by using malloc must be checked before being used.
Signed-off-by: ZhuqingKuang kuangzhuqing@huawei.com