### PR TITLE
util: mmio: fix build on MIPS with binutils >= 2.35

### DIFF
--- a/util/mmio.c
+++ b/util/mmio.c
@@ -123,8 +123,6 @@ static bool have_sse(void)
 	return dx & bit_SSE;
 }
 
-#endif /* defined(__i386__) */
-
 typedef void (*write64_fn_t)(void *, __be64);
 
 /* This uses the STT_GNU_IFUNC extension to have the dynamic linker select the
@@ -140,11 +138,18 @@ write64_fn_t resolve_mmio_write64_be(void) __asm__("mmio_write64_be");
 
 write64_fn_t resolve_mmio_write64_be(void)
 {
-#if defined(__i386__)
 	if (have_sse())
 		return &sse_mmio_write64_be;
-#endif
 	return &pthread_mmio_write64_be;
 }
+
+#else
+
+void mmio_write64_be(void *addr, __be64 val)
+{
+	return pthread_mmio_write64_be(addr, val);
+}
+
+#endif /* defined(__i386__) */
 
 #endif /* SIZEOF_LONG != 8 */


### PR DESCRIPTION
rdma-core added udma_barrier support for MIPS in:
https://github.com/linux-rdma/rdma-core/commit/b7c428344ea96d446f6ffe31c620a238a7f25c9e This commit is present in rdma-core version >= 43.0. See also: https://github.com/linux-rdma/rdma-core/pull/1225 Before this commit, coherent dma support was disabled for MIPS.

util/mmio.c functions are compiled when coherent dma support is enabled. They are always using indirect functions, to select at runtime the best function implementation. It is currently used for x86 sse_mmio_write64_be(), and s390x mmio_memcpy_x64_mio(). In the MIPS case, there is ifunc used to always resolve the same function (namely, resolve_mmio_write64_be() will always select and return pthread_mmio_write64_be().

rdma-core includes a detection of the compiler support for the ifunc attribute. See RDMA_Check_C_Compiles(HAVE_FUNC_ATTRIBUTE_IFUNC ...) in CMakeLists.txt. When the compiler does not support this attribute, rdma-core uses an assembler directive instead. This construct assumes that the toolchain and target architecture always support indirect functions. This is no longer the case with MIPS.

Binutils, on its side, stopped accepting ifunc for MIPS, in commit: https://sourceware.org/git/?p=binutils-gdb.git;a=commit;h=8e4979ac1ea78147ecbcbf81af5e946873dda079 This commit is present in binutils version >= 2.35. See also: https://sourceware.org/bugzilla/show_bug.cgi?id=25803 We end up in a case where both the compiler and the assembler are not accepting indirect functions.

Compiling rdma-core is such configuration (MIPS, rdma-core >= 43, binutils >= 2.35) fails with output:

    /tmp/ccXXXXXX.s: Assembler messages:
    /tmp/ccXXXXXX.s:10: Error: symbol type "gnu_indirect_function" is not supported by MIPS targets

This patch adds a special case for MIPS in which mmio_write64_be() always uses pthread_mmio_write64_be(). It fixes the build issue to have DMA coherent primitives on MIPS while being compiled with binutils >= 2.35.

Note: this issue was found while testing the rdma-core package with Buildroot https://buildroot.org/ proposed in: https://patchwork.ozlabs.org/project/buildroot/patch/20221127110358.495420-1-ju.o@free.fr/ This was found with the Buildroot test command:

    ./utils/test-pkg -a -p rdma-core

Signed-off-by: Julien Olivain <ju.o@free.fr>