### PR TITLE
tests: Add a test of RDMA zero-byte Write

### DIFF
--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -240,6 +240,17 @@ class QpExTestCase(RDMATestCase):
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
                   new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM)
 
+    def test_qp_ex_rc_rdma_write_zero_length(self):
+        client, server = self.create_players('rc_write')
+        client.msg_size = 0
+        server.msg_size = 0
+        client.rkey = server.mr.rkey
+        server.rkey = client.mr.rkey
+        client.raddr = server.mr.buf
+        server.raddr = client.mr.buf
+        u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
+                       new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+
     def test_qp_ex_rc_rdma_read(self):
         client, server = self.create_players('rc_read')
         client.rkey = server.mr.rkey


### PR DESCRIPTION
Zero bytes messages can be used for keep alive check in the RC mode, but there is no test to check the behaviour. This patch adds the test of RDMA zero-byte Write to the qpex testcases.

Signed-off-by: Daisuke Matsuda <matsuda-daisuke@fujitsu.com>