### PR TITLE
Update srq_pingpong.c

### DIFF
--- a/libibverbs/examples/srq_pingpong.c
+++ b/libibverbs/examples/srq_pingpong.c
@@ -947,8 +947,8 @@ int main(int argc, char *argv[])
 
 			for (i = 0; i < ne; ++i) {
 				if (wc[i].status != IBV_WC_SUCCESS) {
-					fprintf(stderr, "Failed status %s (%d) for wr_id %d\n",
-						ibv_wc_status_str(wc[i].status),
+					fprintf(stderr, "%d WCs polled, the %d wc failed status %s (%d) for wr_id %d\n",
+						ne, i, ibv_wc_status_str(wc[i].status),
 						wc[i].status, (int) wc[i].wr_id);
 					return 1;
 				}


### PR DESCRIPTION
libibverbs/example: optimization of the debug log for srq_pingpong.c

The error branch returned once a wc status failed, but we actually need to known more error information, i.e. the total polled wc numbers, and the first one which failed, under the condition of all wc's stauts cannot be printed.

Signed-off-by: yuwei (O) <yuwei139@huawei.com>
Reviewed-by: zhaofei (K) <zhaofei82@huawei.com>