### PR TITLE
srq_pingpong.c: optimization of the debug log

### DIFF
--- a/libibverbs/examples/srq_pingpong.c
+++ b/libibverbs/examples/srq_pingpong.c
@@ -947,8 +947,8 @@ int main(int argc, char *argv[])
 
 			for (i = 0; i < ne; ++i) {
 				if (wc[i].status != IBV_WC_SUCCESS) {
-					fprintf(stderr, "Failed status %s (%d) for wr_id %d\n",
-						ibv_wc_status_str(wc[i].status),
+					fprintf(stderr, "%d WCs were polled, wc[%d] status %s (%d) for wr_id %d\n",
+						ne, i, ibv_wc_status_str(wc[i].status),
 						wc[i].status, (int) wc[i].wr_id);
 					return 1;
 				}


### PR DESCRIPTION
The error branch is returned when the wc status fails, but we actually need to know more error information, that is, the total number of polled wc, and the first failed wc, in the case that the status of all wc cannot be printed.

Signed-off-by: Wevistar <yuwei139@huawei.com>