### PR TITLE
Update umad.c

### DIFF
--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -360,8 +360,11 @@ static int resolve_ca_name(const char *ca_in, int *best_port,
 
 	/* Get the list of CA names */
 	device_list = umad_get_ca_device_list();
-	if (!device_list)
+	if (!device_list) {
+		if (*ca_name)
+			free(*ca_name);
 		return -1;
+	}
 
 	/* Find the first existing CA with an active port */
 	for (node = device_list; node; node = node->next) {


### PR DESCRIPTION
libibumad/umad.c: minor cleanups in error path

The strdup() function returns a pointer to a new string which is a duplicate of the string s. Memory for the new string is obtained with malloc, and can be freed with free. Therefore, *ca_name should be freed in error path.

Signed-off-by: CaiZhongS <119937696+CaiZhongS@users.noreply.github.com>