### PR TITLE
verbs: Make integer conversions explicit

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2547,7 +2547,7 @@ __ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, unsigned int access,
 	     int is_access_const)
 {
 	if (is_access_const && (access & IBV_ACCESS_OPTIONAL_RANGE) == 0)
-		return ibv_reg_mr(pd, addr, length, access);
+		return ibv_reg_mr(pd, addr, length, (int)access);
 	else
 		return ibv_reg_mr_iova2(pd, addr, length, (uintptr_t)addr,
 					access);
@@ -2570,7 +2570,7 @@ __ibv_reg_mr_iova(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova,
 		  unsigned int access, int is_access_const)
 {
 	if (is_access_const && (access & IBV_ACCESS_OPTIONAL_RANGE) == 0)
-		return ibv_reg_mr_iova(pd, addr, length, iova, access);
+		return ibv_reg_mr_iova(pd, addr, length, iova, (int)access);
 	else
 		return ibv_reg_mr_iova2(pd, addr, length, iova, access);
 }
@@ -2932,7 +2932,7 @@ ibv_create_srq_ex(struct ibv_context *context,
 	struct verbs_context *vctx;
 	uint32_t mask = srq_init_attr_ex->comp_mask;
 
-	if (!(mask & ~(IBV_SRQ_INIT_ATTR_PD | IBV_SRQ_INIT_ATTR_TYPE)) &&
+	if (!(mask & ~(uint32_t)(IBV_SRQ_INIT_ATTR_PD | IBV_SRQ_INIT_ATTR_TYPE)) &&
 	    (mask & IBV_SRQ_INIT_ATTR_PD) &&
 	    (!(mask & IBV_SRQ_INIT_ATTR_TYPE) ||
 	     (srq_init_attr_ex->srq_type == IBV_SRQT_BASIC)))


### PR DESCRIPTION
Make integer conversions explicit to silent the following warnings/errors:
```
./build/include/infiniband/verbs.h: In function ‘__ibv_reg_mr’: 
./build/include/infiniband/verbs.h:2550:53: error: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Werror=sign-conversion]
 2550 | return ibv_reg_mr(pd, addr, length, access);
      |                                     ^~~~~~
./build/include/infiniband/verbs.h: In function ‘__ibv_reg_mr_iova’:
./build/include/infiniband/verbs.h:2573:64: error: conversion to ‘int’ from ‘unsigned int’ may change the sign of the result [-Werror=sign-conversion]
 2573 | return ibv_reg_mr_iova(pd, addr, length, iova, access);
      |                                                ^~~~~~
./build/include/infiniband/verbs.h: In function ‘ibv_create_srq_ex’:
./build/include/infiniband/verbs.h:2935:20: error: unsigned conversion from ‘int’ to ‘uint32_t’ {aka ‘unsigned int’} changes value from ‘-4’ to ‘4294967292’ [-Werror=sign-conversion]
 2935 | if (!(mask & ~(IBV_SRQ_INIT_ATTR_PD | IBV_SRQ_INIT_ATTR_TYPE)) &&
      |            ^
cc1: all warnings being treated as errors
```

Signed-off-by: Lukasz Dorau <lukasz.dorau@intel.com>