### PR TITLE
debian: Add 64-bit MIPS architectures to COHERENT_DMA_ARCHS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ include /usr/share/dpkg/architecture.mk
 
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
-COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
+COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 mips64 mips64el mips64r6 mips64r6el powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
 
 dh_params = --with python3,systemd --builddirectory=build-deb
 


### PR DESCRIPTION
Commit b7c428344ea96d446f6ffe31c620a238a7f25c9e ("util: Add barriers support for MIPS") added support for coherent DMA support for MIPS. Therefore add the 64-bit MIPS architectures `mips64`, `mips64el`, `mips64r6`, and `mips64r6el` to `COHERENT_DMA_ARCHS`.

Bug-Debian: https://bugs.debian.org/1026088