### PR TITLE
Bugfixes

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -119,7 +119,7 @@ static int set_atomic_seg(struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 	}
 
 	if (!is_ext_atomic(data_len))
-		return -EINVAL;
+		return EINVAL;
 
 	buf_sge_num = data_len >> HNS_ROCE_SGE_SHIFT;
 	aseg->fetchadd_swap_data = 0;
@@ -127,7 +127,7 @@ static int set_atomic_seg(struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 
 	/* both ext CAS and ext FAA need 2 bufs */
 	if ((buf_sge_num << 1) + HNS_ROCE_SGE_IN_WQE > qp->sq.max_gs)
-		return -EINVAL;
+		return EINVAL;
 
 	if (wr->opcode == IBV_WR_ATOMIC_CMP_AND_SWP) {
 		buf[0] = (void *)(uintptr_t)wr->wr.atomic.swap;
@@ -138,7 +138,7 @@ static int set_atomic_seg(struct hns_roce_qp *qp, struct ibv_send_wr *wr,
 	}
 
 	if (!buf[0] || !buf[1])
-		return -EINVAL;
+		return EINVAL;
 
 	set_extend_atomic_seg(qp, buf_sge_num, sge_info, buf[0]);
 	set_extend_atomic_seg(qp, buf_sge_num, sge_info, buf[1]);
@@ -248,7 +248,7 @@ static int get_srq_from_cqe(struct hns_roce_v2_cqe *cqe,
 
 		*srq = hns_roce_find_srq(ctx, srqn);
 		if (!*srq)
-			return -EINVAL;
+			return EINVAL;
 	} else if (hr_qp->verbs_qp.qp.srq) {
 		*srq = to_hr_srq(hr_qp->verbs_qp.qp.srq);
 	}
@@ -740,12 +740,12 @@ static int check_qp_send(struct ibv_qp *qp, struct hns_roce_context *ctx)
 	if (unlikely(qp->qp_type != IBV_QPT_RC &&
 		     qp->qp_type != IBV_QPT_UD) &&
 		     qp->qp_type != IBV_QPT_XRC_SEND)
-		return -EINVAL;
+		return EINVAL;
 
 	if (unlikely(qp->state == IBV_QPS_RESET ||
 		     qp->state == IBV_QPS_INIT ||
 		     qp->state == IBV_QPS_RTR))
-		return -EINVAL;
+		return EINVAL;
 
 	return 0;
 }
@@ -933,7 +933,7 @@ static int set_ud_inl(struct hns_roce_qp *qp, const struct ibv_send_wr *wr,
 	int ret;
 
 	if (!check_inl_data_len(qp, sge_info->total_len))
-		return -EINVAL;
+		return EINVAL;
 
 	if (sge_info->total_len <= HNS_ROCE_MAX_UD_INL_INN_SZ) {
 		hr_reg_clear(ud_sq_wqe, UDWQE_INLINE_TYPE);
@@ -1320,10 +1320,10 @@ static int check_qp_recv(struct ibv_qp *qp, struct hns_roce_context *ctx)
 {
 	if (unlikely(qp->qp_type != IBV_QPT_RC &&
 		     qp->qp_type != IBV_QPT_UD))
-		return -EINVAL;
+		return EINVAL;
 
 	if (qp->state == IBV_QPS_RESET || qp->srq)
-		return -EINVAL;
+		return EINVAL;
 
 	return 0;
 }
@@ -1640,10 +1640,10 @@ static int check_post_srq_valid(struct hns_roce_srq *srq,
 				struct ibv_recv_wr *wr, unsigned int max_sge)
 {
 	if (hns_roce_v2_srqwq_overflow(srq))
-		return -ENOMEM;
+		return ENOMEM;
 
 	if (wr->num_sge > max_sge)
-		return -EINVAL;
+		return EINVAL;
 
 	return 0;
 }
@@ -1658,7 +1658,7 @@ static int get_wqe_idx(struct hns_roce_srq *srq, unsigned int *wqe_idx)
 	for (i = 0; i < idx_que->bitmap_cnt && idx_que->bitmap[i] == 0; ++i)
 		;
 	if (i == idx_que->bitmap_cnt)
-		return -ENOMEM;
+		return ENOMEM;
 
 	bit_num = ffsl(idx_que->bitmap[i]);
 	idx_que->bitmap[i] &= ~(1ULL << (bit_num - 1));
@@ -1669,7 +1669,7 @@ static int get_wqe_idx(struct hns_roce_srq *srq, unsigned int *wqe_idx)
 	 * than wqe_cnt.
 	 */
 	if (*wqe_idx >= srq->wqe_cnt)
-		return -ENOMEM;
+		return ENOMEM;
 
 	return 0;
 }

--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -410,7 +410,6 @@ static void get_opcode_for_resp(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 		wc->imm_data = htobe32(le32toh(cqe->immtdata));
 		break;
 	default:
-		wc->status = IBV_WC_GENERAL_ERR;
 		return;
 	}
 
@@ -542,7 +541,6 @@ static void parse_cqe_for_req(struct hns_roce_v2_cqe *cqe, struct ibv_wc *wc,
 		wc->byte_len  = le32toh(cqe->byte_cnt);
 		break;
 	default:
-		wc->status = IBV_WC_GENERAL_ERR;
 		wc->wc_flags = 0;
 		return;
 	}

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -774,24 +774,24 @@ static int check_qp_create_mask(struct hns_roce_context *ctx,
 	struct hns_roce_device *hr_dev = to_hr_dev(ctx->ibv_ctx.context.device);
 
 	if (!check_comp_mask(attr->comp_mask, CREATE_QP_SUP_COMP_MASK))
-		return -EOPNOTSUPP;
+		return EOPNOTSUPP;
 
 	switch (attr->qp_type) {
 	case IBV_QPT_UD:
 		if (hr_dev->hw_version == HNS_ROCE_HW_VER2)
-			return -EINVAL;
+			return EINVAL;
 		SWITCH_FALLTHROUGH;
 	case IBV_QPT_RC:
 	case IBV_QPT_XRC_SEND:
 		if (!(attr->comp_mask & IBV_QP_INIT_ATTR_PD))
-			return -EINVAL;
+			return EINVAL;
 		break;
 	case IBV_QPT_XRC_RECV:
 		if (!(attr->comp_mask & IBV_QP_INIT_ATTR_XRCD))
-			return -EINVAL;
+			return EINVAL;
 		break;
 	default:
-		return -EINVAL;
+		return EOPNOTSUPP;
 	}
 
 	return 0;

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -284,13 +284,13 @@ static int verify_cq_create_attr(struct ibv_cq_init_attr_ex *attr,
 				 struct hns_roce_context *context)
 {
 	if (!attr->cqe || attr->cqe > context->max_cqe)
-		return -EINVAL;
+		return EINVAL;
 
 	if (attr->comp_mask)
-		return -EOPNOTSUPP;
+		return EOPNOTSUPP;
 
 	if (!check_comp_mask(attr->wc_flags, CREATE_CQ_SUPPORTED_WC_FLAGS))
-		return -EOPNOTSUPP;
+		return EOPNOTSUPP;
 
 	attr->cqe = max_t(uint32_t, HNS_ROCE_MIN_CQE_NUM,
 			  roundup_pow_of_two(attr->cqe));


### PR DESCRIPTION
The four patches fix minor errors found while running
the rdma-core tests. It is generally all about the return value.

Chengchang Tang (4):
  libhns: Fix return value when creating unsupported QP types
  libhns: Fix immediately error sign type in data path.
  libhns: Fix return value when creating unsupported CQ flags
  libhns: Fix multiple assignment of WC status

 providers/hns/hns_roce_u_hw_v2.c | 28 +++++++++++++---------------
 providers/hns/hns_roce_u_verbs.c | 16 ++++++++--------
 2 files changed, 21 insertions(+), 23 deletions(-)