### PR TITLE
pyverbs: Expose UAR C pointer

### DIFF
--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1394,6 +1394,10 @@ cdef class Mlx5UAR(PyverbsObject):
     def comp_mask(self):
         return self.uar.comp_mask
 
+    @property
+    def uar(self):
+        return <uintptr_t>self.uar
+
 
 cdef class Mlx5DmOpAddr(PyverbsCM):
     def __init__(self, DM dm not None, op=0):


### PR DESCRIPTION
Expose the UAR C object pointer from its pyverbs class for external python usage.