### PR TITLE
Changes from Debian upload 44.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,25 @@ rdma-core (45.0-1) unstable; urgency=medium
 
   * New upstream release.
 
- -- Jason Gunthorpe <jgg@obsidianresearch.com>  Thu, 18 Aug 2022 16:02:54 +0200
+ -- Jason Gunthorpe <jgg@obsidianresearch.com>  Tue, 03 Jan 2023 17:46:57 +0100
+
+rdma-core (44.0-1) unstable; urgency=medium
+
+  * New upstream release.
+    - Add Microsoft Azure Network Adapter (MANA) RDMA provider
+    - util: mmio: fix build on MIPS with binutils >= 2.35
+  * Add 64-bit MIPS architectures to COHERENT_DMA_ARCHS (Closes: #1026088)
+  * debian/watch: Query api.github.com for release tarballs
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Tue, 03 Jan 2023 17:29:32 +0100
+
+rdma-core (43.0-1) unstable; urgency=medium
+
+  * New upstream release.
+    - Install 70-persistent-ipoib.rules into docs instead of /etc
+      (Closes: #958385)
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 24 Oct 2022 18:21:42 +0200
 
 rdma-core (42.0-1) unstable; urgency=medium
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -12,7 +12,7 @@ Files: debian/*
 Copyright: 2008, Genome Research Ltd
            2014, Ana Beatriz Guerrero Lopez <ana@debian.org>
            2015-2016, Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
-           2016-2022, Benjamin Drung <bdrung@ubuntu.com>
+           2016-2023, Benjamin Drung <bdrung@ubuntu.com>
            2016-2017, Talat Batheesh <talatb@mellanox.com>
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify

--- a/debian/ibverbs-providers.install
+++ b/debian/ibverbs-providers.install
@@ -1,6 +1,6 @@
 etc/libibverbs.d/
 usr/lib/*/libefa.so.*
 usr/lib/*/libibverbs/lib*-rdmav*.so
-usr/lib/*/libmana.so*
+usr/lib/*/libmana.so.*
 usr/lib/*/libmlx4.so.*
 usr/lib/*/libmlx5.so.*

--- a/debian/watch
+++ b/debian/watch
@@ -1,2 +1,4 @@
-version=3
-https://github.com/linux-rdma/rdma-core/releases (?:.*?/)?(?:rdma-core-|v)?(\d[\d.]*)\.tar\.gz
+version=4
+opts="searchmode=plain" \
+  https://api.github.com/repos/linux-rdma/rdma-core/releases?per_page=100 \
+  https://github.com/linux-rdma/rdma-core/releases/download/v[^/]+/rdma-core-@ANY_VERSION@@ARCHIVE_EXT@


### PR DESCRIPTION
* debian: Query api.github.com for release tarballs
* debian: Exclude libmana.so from ibverbs-providers
* debian: Update year in copyright
* debian: Add Debian uploads up to version 44.0-1

See individual commits for details.