### PR TITLE
debian: Update debhelper to 10

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -6,8 +6,7 @@ Section: net
 Priority: optional
 Build-Depends: cmake (>= 2.8.11),
                cython3,
-               debhelper (>= 9),
-               debhelper (>= 9.20160709) | dh-systemd,
+               debhelper (>= 10),
                dh-python,
                dpkg-dev (>= 1.17),
                libnl-3-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -6,7 +6,7 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
 COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 mips64 mips64el mips64r6 mips64r6el powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
 
-dh_params = --with python3,systemd --builddirectory=build-deb
+dh_params = --with python3 --builddirectory=build-deb
 
 %:
 	dh $@ $(dh_params)


### PR DESCRIPTION
Commit 698f40ecc32bf59fb87691c3437302f63bec3cc4 updated the compat level to version 10, but did not increase the minimum debhelper version.

The systemd sequence is now enabled by default since compat level 10.

Fixes: 698f40ecc32bf59fb87691c3437302f63bec3cc4 ("debian: Update compat to 10")