### PR TITLE
debian: Add 32-bit MIPS architectures to COHERENT_DMA_ARCHS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ include /usr/share/dpkg/architecture.mk
 
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
-COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 mips64 mips64el mips64r6 mips64r6el powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
+COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 mips mipsel mipsr6 mipsr6el mips64 mips64el mips64r6 mips64r6el powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
 
 dh_params = --with python3 --builddirectory=build-deb
 


### PR DESCRIPTION
Commit b7c428344ea96d446f6ffe31c620a238a7f25c9e ("util: Add barriers support for MIPS") added support for coherent DMA support for MIPS, including 32-bit MIPS.

Bug-Debian: https://bugs.debian.org/1026088
Signed-off-by: Adrian Bunk <bunk@debian.org>

@bdrung This adds the suggested change from https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1026088#10 fixing https://buildd.debian.org/status/fetch.php?pkg=rdma-core&arch=mipsel&ver=44.0-1&stamp=1672980469&raw=0