### PR TITLE
debian: Add 32-bit MIPS architectures to COHERENT_DMA_ARCHS

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,7 +4,7 @@ include /usr/share/dpkg/architecture.mk
 
 export DEB_BUILD_MAINT_OPTIONS=hardening=+all
 
-COHERENT_DMA_ARCHS = amd64 arm64 i386 ia64 mips64 mips64el mips64r6 mips64r6el powerpc powerpcspe ppc64 ppc64el riscv64 s390x sparc64 x32
+NON_COHERENT_DMA_ARCHS = alpha arc armel armhf hppa m68k sh4
 
 dh_params = --with python3 --builddirectory=build-deb
 
@@ -58,7 +58,7 @@ override_dh_auto_test:
 
 override_dh_auto_install:
 # Some providers are disabled on architectures that are not able to do coherent DMA
-ifneq (,$(filter-out $(COHERENT_DMA_ARCHS),$(DEB_HOST_ARCH)))
+ifeq (,$(filter-out $(NON_COHERENT_DMA_ARCHS),$(DEB_HOST_ARCH)))
 	for package in ibverbs-providers libibverbs-dev rdma-core; do \
 		test -e debian/$$package.install.backup || cp debian/$$package.install debian/$$package.install.backup; \
 	done


### PR DESCRIPTION
Commit b7c428344ea96d446f6ffe31c620a238a7f25c9e ("util: Add barriers support for MIPS") added support for coherent DMA support for MIPS. All MIPS architectures needs to be added to `COHERENT_DMA_ARCHS` (not just the 64-bit variants).

The list of architectures that support coherent DMA gets very long, because most architectures support it. So inverse the list to make it easier to read.

Bug-Debian: https://bugs.debian.org/1026088