### PR TITLE
tests: Skip CUDA tests if there is no CUDA device

### DIFF
--- a/tests/cuda_utils.py
+++ b/tests/cuda_utils.py
@@ -20,6 +20,9 @@ def requires_cuda(func):
         if not CUDA_FOUND:
             raise unittest.SkipTest(
                 'cuda-python 12.0+ must be installed to run CUDA tests')
+        res = cudart.cudaGetDeviceCount()
+        if res[0].value == cuda.CUresult.CUDA_ERROR_NO_DEVICE or res[1] == 0:
+            raise unittest.SkipTest('No CUDA-capable devices were detected')
         return func(instance)
     return inner
 


### PR DESCRIPTION
Skip CUDA tests in case cuda-python package is installed but no CUDA-cappable device is found.