### PR TITLE
buildlib: Fix build errors in old debian

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,12 @@
 #      (without man pages) when neither pandoc/rst2man nor the pandoc-prebuilt
 #      directory are available.
 
-cmake_minimum_required(VERSION 3.18.1 FATAL_ERROR)
+if (${CMAKE_VERSION} VERSION_LESS "3.18.1")
+	# Centos 7 support
+	cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+else()
+	cmake_minimum_required(VERSION 3.18.1 FATAL_ERROR)
+endif()
 project(rdma-core C)
 
 # CMake likes to use -rdynamic too much, they fixed it in 3.4.

--- a/libibnetdisc/CMakeLists.txt
+++ b/libibnetdisc/CMakeLists.txt
@@ -20,5 +20,6 @@ rdma_pkg_config("ibnetdisc" "libibumad libibmad" "")
 rdma_test_executable(testleaks tests/testleaks.c)
 target_link_libraries(testleaks LINK_PRIVATE
   ibmad
+  ibumad
   ibnetdisc
 )


### PR DESCRIPTION
This specific error from Ubuntu 20.4:

2023-01-26T08:15:31.4858000Z make[2]: Entering directory '/__w/1/s/rdma-core-45.0' 2023-01-26T08:15:31.4859279Z if [ -e /usr/bin/python3 ]; then \ 2023-01-26T08:15:31.4861846Z 	dh_auto_configure "--" "-GNinja" "-DDISTRO_FLAVOUR=Debian" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc" "-DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system" "-DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d" "-DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib" "-DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib" "-DCMAKE_INSTALL_RUNDIR:PATH=/run" "-DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d" "-DCMAKE_INSTALL_PERLDIR:PATH=/usr/share/perl5" "-DENABLE_STATIC=1"  \ 2023-01-26T08:15:31.4865385Z 			-DPYTHON_EXECUTABLE:PATH=/usr/bin/python3 \ 2023-01-26T08:15:31.4866510Z 			-DCMAKE_INSTALL_PYTHON_ARCH_LIB:PATH=/usr/lib/python3/dist-packages; \ 2023-01-26T08:15:31.4867348Z else \
2023-01-26T08:15:31.4869708Z 	dh_auto_configure "--" "-GNinja" "-DDISTRO_FLAVOUR=Debian" "-DCMAKE_BUILD_TYPE=Release" "-DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc" "-DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system" "-DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d" "-DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib" "-DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib" "-DCMAKE_INSTALL_RUNDIR:PATH=/run" "-DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d" "-DCMAKE_INSTALL_PERLDIR:PATH=/usr/share/perl5" "-DENABLE_STATIC=1"  \
2023-01-26T08:15:31.4871685Z 		        -DNO_PYVERBS=1; \
2023-01-26T08:15:31.4872252Z fi
2023-01-26T08:15:31.5754387Z 	cd build-deb && cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=None -DCMAKE_INSTALL_SYSCONFDIR=/etc -DCMAKE_INSTALL_LOCALSTATEDIR=/var -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY=ON "-GUnix Makefiles" -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_AUTOGEN_VERBOSE=ON -DCMAKE_INSTALL_LIBDIR=lib/x86_64-linux-gnu -GNinja -DDISTRO_FLAVOUR=Debian -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc -DCMAKE_INSTALL_SYSTEMD_SERVICEDIR:PATH=/lib/systemd/system -DCMAKE_INSTALL_INITDDIR:PATH=/etc/init.d -DCMAKE_INSTALL_LIBEXECDIR:PATH=/usr/lib -DCMAKE_INSTALL_SHAREDSTATEDIR:PATH=/var/lib -DCMAKE_INSTALL_RUNDIR:PATH=/run -DCMAKE_INSTALL_UDEV_RULESDIR:PATH=/lib/udev/rules.d -DCMAKE_INSTALL_PERLDIR:PATH=/usr/share/perl5 -DENABLE_STATIC=1 -DPYTHON_EXECUTABLE:PATH=/usr/bin/python3 -DCMAKE_INSTALL_PYTHON_ARCH_LIB:PATH=/usr/lib/python3/dist-packages ..
2023-01-26T08:15:31.5939369Z CMake Error at CMakeLists.txt:56 (cmake_minimum_required):
2023-01-26T08:15:31.5941381Z   CMake 3.18.1 or higher is required.  You are running version 3.16.3
2023-01-26T08:15:31.5942504Z
2023-01-26T08:15:31.5943504Z
2023-01-26T08:15:31.5949003Z -- Configuring incomplete, errors occurred!

Fixes: 2b229d09d552 ("buildlib: Remove centos6 era distros")
Signed-off-by: Leon Romanovsky <leon@kernel.org>