### PR TITLE
providers/rxe: Add missing flush length

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -941,6 +941,8 @@ static void wr_flush(struct ibv_qp_ex *ibqp, uint32_t rkey,
 	wqe->wr.wr.flush.rkey = rkey;
 	wqe->wr.wr.flush.type = type;
 	wqe->wr.wr.flush.level = level;
+	wqe->dma.length = length;
+	wqe->dma.resid = length;
 	wqe->iova = remote_addr;
 	wqe->ssn = qp->ssn++;
 

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -110,7 +110,7 @@ class QpExXRCSendImm(XRCResources):
 
 class QpExRCFlush(RCResources):
     ptype = e.IBV_FLUSH_GLOBAL
-    level = e.IBV_FLUSH_MR
+    level = e.IBV_FLUSH_RANGE
     def create_qps(self):
         create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_FLUSH | e.IBV_QP_EX_WITH_RDMA_WRITE)
 
@@ -251,6 +251,13 @@ class QpExTestCase(RDMATestCase):
         server.rkey = client.mr.rkey
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
+        wcs = u.flush_traffic(client, server, self.iters, self.gid_index,
+                              self.ib_port, new_send=True,
+                              send_op=e.IBV_QP_EX_WITH_FLUSH)
+        if wcs[0].status != e.IBV_WC_SUCCESS:
+            raise PyverbsError(f'Unexpected {wc_status_to_str(wcs[0].status)}')
+
+        client.level = e.IBV_FLUSH_MR
         wcs = u.flush_traffic(client, server, self.iters, self.gid_index,
                               self.ib_port, new_send=True,
                               send_op=e.IBV_QP_EX_WITH_FLUSH)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1016,7 +1016,9 @@ def flush_traffic(client, server, iters, gid_idx, port, new_send=False,
     :return:
     """
     rdma_traffic(client, server, iters, gid_idx, port, new_send, e.IBV_QP_EX_WITH_RDMA_WRITE)
-    for _ in range(iters):
+    for i in range(iters):
+        if client.level == e.IBV_FLUSH_MR:
+            client.msg_size = 0 if i == 0 else random.randint(0, 12345678)
         send(client, None, send_op, new_send)
         wcs = _poll_cq(client.cq)
         if (wcs[0].status != e.IBV_WC_SUCCESS):


### PR DESCRIPTION
this length will be set to FETH for FLUSH operation

Fixes: 20a37f32ceee ("providers/rxe: Add new API ibv_wr_flush()")
Signed-off-by: Li Zhijian <lizhijian@fujitsu.com>