### PR TITLE
mlx5: fix inline send bug for DR

### DIFF
--- a/providers/mlx5/dr_send.c
+++ b/providers/mlx5/dr_send.c
@@ -701,7 +701,7 @@ static void dr_fill_write_icm_segs(struct mlx5dv_dr_domain *dmn,
 	unsigned int inline_flag;
 	uint32_t buff_offset;
 
-	if (send_info->write.length > dmn->info.max_inline_size) {
+	if (send_info->write.length > send_ring->max_inline_size) {
 		buff_offset = (send_ring->tx_head & (send_ring->signal_th - 1)) *
 			dmn->info.max_send_size;
 		/* Copy to ring mr */

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -1032,7 +1032,6 @@ struct dr_domain_rx_tx {
 
 struct dr_domain_info {
 	bool			supp_sw_steering;
-	uint32_t		max_inline_size;
 	uint32_t		max_log_sw_icm_sz;
 	uint32_t		max_log_action_icm_sz;
 	uint32_t		max_log_modify_hdr_pattern_icm_sz;


### PR DESCRIPTION
The field max_inline_size in dr_domain_info is no longer used; remove the field and a buggy reference to it.

Fixes: 2dbeaf37f460 ("mlx5: DR, Add infrastructure for multi QPs")

Signed-off-by: Josh Fried <joshuafried@gmail.com>