### PR TITLE
Add ibv_query_qp_data_in_order flags

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef EFA_ABI_USER_H
@@ -120,6 +120,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_RNR_RETRY = 1 << 1,
 	EFA_QUERY_DEVICE_CAPS_CQ_NOTIFICATIONS = 1 << 2,
 	EFA_QUERY_DEVICE_CAPS_CQ_WITH_SGID     = 1 << 3,
+	EFA_QUERY_DEVICE_CAPS_DATA_POLLING_128 = 1 << 4,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -87,10 +87,14 @@ struct hns_roce_ib_create_qp_resp {
 
 enum {
 	HNS_ROCE_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 enum {
 	HNS_ROCE_RSP_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RSP_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_RSP_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 struct hns_roce_ib_alloc_ucontext_resp {

--- a/libibverbs/man/ibv_query_qp_data_in_order.3.md
+++ b/libibverbs/man/ibv_query_qp_data_in_order.3.md
@@ -41,11 +41,22 @@ This function describes ordering at the receiving side of the QP, not the sendin
 	This function should not be used to determine ordering of other operation types.
 
 *flags*
-:	Extra field for future input. For now must be 0.
+:	Flags are used to select a query type. Supported values:
+
+IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS - Query for supported capabilities and return a capabilities vector.
+
+Passing 0 is equivalent to using IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS and checking for IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG support.
 
 # RETURN VALUE
 
-**ibv_query_qp_data_in_order()** Returns 1 if the data is guaranteed to be written in-order, 0 otherwise.
+**ibv_query_qp_data_in_order()** Return value is determined by flags. For each capability bit, 1 is returned if the data is guaranteed to be written in-order for selected operation and type, 0 otherwise.
+If IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS flag is used, return value can consist of following capabilities:
+
+IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG - All data is being written in order.
+
+IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES - Each 128 bytes aligned block is being written in order.
+
+If flags is 0, the function will return 1 if IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG is supported and 0 otherwise.
 
 # NOTES
 

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -701,7 +701,16 @@ int ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
 	 */
 	return 0;
 #else
-	return get_ops(qp->context)->query_qp_data_in_order(qp, op, flags);
+	int result;
+
+	if (!check_comp_mask(flags, IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS))
+		return 0;
+
+	result = get_ops(qp->context)->query_qp_data_in_order(qp, op, flags);
+	if (result & IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG)
+		result |= IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
+
+	return flags ? result : !!(result & IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG);
 #endif
 }
 

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1036,6 +1036,15 @@ enum ibv_qp_attr_mask {
 	IBV_QP_RATE_LIMIT		= 1 << 25,
 };
 
+enum ibv_query_qp_data_in_order_flags {
+	IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS = 1 << 0,
+};
+
+enum ibv_query_qp_data_in_order_caps {
+	IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG = 1 << 0,
+	IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES = 1 << 1,
+};
+
 enum ibv_qp_state {
 	IBV_QPS_RESET,
 	IBV_QPS_INIT,
@@ -3205,11 +3214,15 @@ ibv_modify_qp_rate_limit(struct ibv_qp *qp,
  *   written in-order.
  * @qp: The QP to query.
  * @op: Operation type.
- * @flags: Extra field for future input. For now must be 0.
+ * @flags: Flags are used to select a query type.
+ * For IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS, the function will return a
+ * capabilities vector. If 0, will query for IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG
+ * support and return 0/1 result.
  *
  * Return Value
- * ibv_query_qp_data_in_order() returns 1 if the data is guaranteed to be
- *   written in-order, 0 otherwise.
+ * ibv_query_qp_data_in_order() return value is determined by flags.
+ * For each capability bit, 1 is returned if the data is guaranteed to be
+ * written in-order for selected operation and type, 0 otherwise.
  */
 int ibv_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
 			       uint32_t flags);

--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 /*
- * Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #include <stdio.h>
@@ -45,6 +45,7 @@ static const struct verbs_context_ops efa_ctx_ops = {
 	.query_device_ex = efa_query_device_ex,
 	.query_port = efa_query_port,
 	.query_qp = efa_query_qp,
+	.query_qp_data_in_order = efa_query_qp_data_in_order,
 	.reg_dmabuf_mr = efa_reg_dmabuf_mr,
 	.reg_mr = efa_reg_mr,
 	.req_notify_cq = efa_arm_cq,

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 /*
- * Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #include <assert.h>
@@ -1522,6 +1522,18 @@ int efa_query_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr,
 
 	return ibv_cmd_query_qp(ibvqp, attr, attr_mask, init_attr,
 				&cmd, sizeof(cmd));
+}
+
+int efa_query_qp_data_in_order(struct ibv_qp *ibvqp, enum ibv_wr_opcode op,
+			       uint32_t flags)
+{
+	struct efa_context *ctx = to_efa_context(ibvqp->context);
+	int caps = 0;
+
+	if (EFA_DEV_CAP(ctx, DATA_POLLING_128))
+		caps |= IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES;
+
+	return caps;
 }
 
 int efa_destroy_qp(struct ibv_qp *ibvqp)

--- a/providers/efa/verbs.h
+++ b/providers/efa/verbs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2019-2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef __EFA_VERBS_H__
@@ -40,6 +40,8 @@ int efa_modify_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr,
 		  int ibv_qp_attr_mask);
 int efa_query_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr, int attr_mask,
 		 struct ibv_qp_init_attr *init_attr);
+int efa_query_qp_data_in_order(struct ibv_qp *ibvqp, enum ibv_wr_opcode op,
+			       uint32_t flags);
 int efa_destroy_qp(struct ibv_qp *ibvqp);
 int efa_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 		  struct ibv_send_wr **bad);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -2839,11 +2839,12 @@ int mlx5_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
 	struct mlx5_qp *mqp = to_mqp(qp);
 	int ret;
 
-	if (flags || !mctx->qp_data_in_order_cap)
+	if (!mctx->qp_data_in_order_cap)
 		return 0;
 
 	if (mqp->dc_type == MLX5DV_DCTYPE_DCT)
-		return query_dct_in_order(qp);
+		return query_dct_in_order(qp) ?
+		       IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG : 0;
 
 	if (qp->state != IBV_QPS_RTS)
 		return 0;
@@ -2855,7 +2856,8 @@ int mlx5_query_qp_data_in_order(struct ibv_qp *qp, enum ibv_wr_opcode op,
 	if (ret)
 		return 0;
 
-	return DEVX_GET(query_qp_out, out_qp, qpc.data_in_order);
+	return DEVX_GET(query_qp_out, out_qp, qpc.data_in_order) ?
+	       IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG : 0;
 }
 
 int mlx5_query_qp(struct ibv_qp *ibqp, struct ibv_qp_attr *attr,

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -318,6 +318,13 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_QP_DEST_QPN
         IBV_QP_RATE_LIMIT
 
+    cpdef enum ibv_query_qp_data_in_order_flags:
+        IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS
+
+    cpdef enum ibv_query_qp_data_in_order_caps:
+        IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG
+        IBV_QUERY_QP_DATA_IN_ORDER_ALIGNED_128_BYTES
+
     cpdef enum ibv_wq_type:
         IBV_WQT_RQ
 

--- a/pyverbs/qp.pyx
+++ b/pyverbs/qp.pyx
@@ -1241,8 +1241,15 @@ cdef class QP(PyverbsCM):
         """
         Query if QP data is guaranteed to be in order.
         :param op: Operation type.
-        :param flags: Extra field for future input. For now must be 0.
-        :return: 1 in case the data is guaranteed to be in order, 0 otherwise.
+        :param flags: Flags are used to select a query type.
+                      For IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS, the function
+                      will return a capabilities vector. If 0, will query for
+                      IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG support and return
+                      0/1 result. (see enum ibv_query_qp_data_in_order_flags)
+        :return: Return value is determined by flags. For each capability bit,
+                 1 is returned if the data is guaranteed to be written in-order
+                 for selected operation and type, 0 otherwise.
+                 (see enum ibv_query_qp_data_in_order_caps)
         """
         return v.ibv_query_qp_data_in_order(self.qp, op, flags)
 


### PR DESCRIPTION
Add definition for ibv_query_qp_data_in_order flags to allow querying for specific capabilities related to data polling support, currently adding 128 bytes in order flag (LL128).
Adopt existing code and add support in EFA provider.