### PR TITLE
providers/erdma: Add non-4K page size support

### DIFF
--- a/kernel-headers/rdma/erdma-abi.h
+++ b/kernel-headers/rdma/erdma-abi.h
@@ -40,10 +40,13 @@ struct erdma_uresp_alloc_ctx {
 	__u32 dev_id;
 	__u32 pad;
 	__u32 sdb_type;
-	__u32 sdb_offset;
+	__u32 sdb_entid;
 	__aligned_u64 sdb;
 	__aligned_u64 rdb;
 	__aligned_u64 cdb;
+	__u32 sdb_off;
+	__u32 rdb_off;
+	__u32 cdb_off;
 };
 
 #endif

--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -87,10 +87,14 @@ struct hns_roce_ib_create_qp_resp {
 
 enum {
 	HNS_ROCE_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 enum {
 	HNS_ROCE_RSP_EXSGE_FLAGS = 1 << 0,
+	HNS_ROCE_RSP_RQ_INLINE_FLAGS = 1 << 1,
+	HNS_ROCE_RSP_CQE_INLINE_FLAGS = 1 << 2,
 };
 
 struct hns_roce_ib_alloc_ucontext_resp {

--- a/providers/erdma/erdma.h
+++ b/providers/erdma/erdma.h
@@ -23,6 +23,7 @@
 
 struct erdma_device {
 	struct verbs_device ibv_dev;
+	uint32_t page_size;
 };
 
 #define ERDMA_QP_TABLE_SIZE 4096
@@ -40,7 +41,7 @@ struct erdma_context {
 	pthread_mutex_t qp_table_mutex;
 
 	uint8_t sdb_type;
-	uint32_t sdb_offset;
+	uint32_t sdb_entid;
 
 	void *sdb;
 	void *rdb;
@@ -54,6 +55,11 @@ struct erdma_context {
 static inline struct erdma_context *to_ectx(struct ibv_context *base)
 {
 	return container_of(base, struct erdma_context, ibv_ctx.context);
+}
+
+static inline struct erdma_device *to_edev(struct ibv_device *ibv_dev)
+{
+	return container_of(ibv_dev, struct erdma_device, ibv_dev.device);
 }
 
 #endif

--- a/providers/erdma/erdma_verbs.c
+++ b/providers/erdma/erdma_verbs.c
@@ -277,7 +277,7 @@ static void __erdma_alloc_dbs(struct erdma_qp *qp, struct erdma_context *ctx)
 	uint32_t db_offset;
 
 	if (ctx->sdb_type == ERDMA_SDB_ENTRY)
-		db_offset = ctx->sdb_offset * ERDMA_NSDB_PER_ENTRY *
+		db_offset = ctx->sdb_entid * ERDMA_NSDB_PER_ENTRY *
 			    ERDMA_SQDB_SIZE;
 	else
 		db_offset = (qpn & ERDMA_SDB_ALLOC_QPN_MASK) * ERDMA_SQDB_SIZE;
@@ -1018,9 +1018,12 @@ void erdma_free_context(struct ibv_context *ibv_ctx)
 	struct erdma_context *ctx = to_ectx(ibv_ctx);
 	int i;
 
-	munmap(ctx->sdb, ERDMA_PAGE_SIZE);
-	munmap(ctx->rdb, ERDMA_PAGE_SIZE);
-	munmap(ctx->cdb, ERDMA_PAGE_SIZE);
+	munmap((void *)align_down((uintptr_t)ctx->sdb, ctx->page_size),
+	       ctx->page_size);
+	munmap((void *)align_down((uintptr_t)ctx->rdb, ctx->page_size),
+	       ctx->page_size);
+	munmap((void *)align_down((uintptr_t)ctx->cdb, ctx->page_size),
+	       ctx->page_size);
 
 	pthread_mutex_lock(&ctx->qp_table_mutex);
 	for (i = 0; i < ERDMA_QP_TABLE_SIZE; ++i) {


### PR DESCRIPTION
Hello,

This PR adds the non-4K page size support. For some aarch64 distributions, the default page size is 64K, not 4K. ERDMA will not work correctly in these systems. The main reason is that we use the wrong doorbell page and page offset. We fix it in this PR. This PR needs kernel patch.

Thanks,
Cheng Xu
