### PR TITLE
Adds resize cq support for bnxt_re devices

### DIFF
--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -96,6 +96,10 @@ struct bnxt_re_cq_resp {
 	__u32 rsvd;
 };
 
+struct bnxt_re_resize_cq_req {
+	__aligned_u64 cq_va;
+};
+
 struct bnxt_re_qp_req {
 	__aligned_u64 qpsva;
 	__aligned_u64 qprva;

--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright 2018-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef EFA_ABI_USER_H
@@ -120,6 +120,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_RNR_RETRY = 1 << 1,
 	EFA_QUERY_DEVICE_CAPS_CQ_NOTIFICATIONS = 1 << 2,
 	EFA_QUERY_DEVICE_CAPS_CQ_WITH_SGID     = 1 << 3,
+	EFA_QUERY_DEVICE_CAPS_DATA_POLLING_128 = 1 << 4,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -49,6 +49,8 @@ DECLARE_DRV_CMD(ubnxt_re_pd, IB_USER_VERBS_CMD_ALLOC_PD,
 		empty, bnxt_re_pd_resp);
 DECLARE_DRV_CMD(ubnxt_re_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		bnxt_re_cq_req, bnxt_re_cq_resp);
+DECLARE_DRV_CMD(ubnxt_re_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		bnxt_re_resize_cq_req, empty);
 DECLARE_DRV_CMD(ubnxt_re_qp, IB_USER_VERBS_CMD_CREATE_QP,
 		bnxt_re_qp_req, bnxt_re_qp_resp);
 DECLARE_DRV_CMD(ubnxt_re_cntx, IB_USER_VERBS_CMD_GET_CONTEXT,

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -100,6 +100,7 @@ static const struct verbs_context_ops bnxt_re_cntx_ops = {
 	.create_cq     = bnxt_re_create_cq,
 	.poll_cq       = bnxt_re_poll_cq,
 	.req_notify_cq = bnxt_re_arm_cq,
+	.resize_cq     = bnxt_re_resize_cq,
 	.destroy_cq    = bnxt_re_destroy_cq,
 	.create_srq    = bnxt_re_create_srq,
 	.modify_srq    = bnxt_re_modify_srq,

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -81,9 +81,11 @@ struct bnxt_re_cq {
 	struct ibv_cq ibvcq;
 	uint32_t cqid;
 	struct bnxt_re_queue cqq;
+	struct bnxt_re_queue resize_cqq;
 	struct bnxt_re_dpi *udpi;
 	struct list_head sfhead;
 	struct list_head rfhead;
+	struct list_head prev_cq_head;
 	uint32_t cqe_size;
 	uint8_t  phase;
 	int deferred_arm_flags;

--- a/providers/bnxt_re/verbs.h
+++ b/providers/bnxt_re/verbs.h
@@ -50,9 +50,15 @@
 #include <sys/mman.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <ccan/list.h>
 
 #include <infiniband/driver.h>
 #include <infiniband/verbs.h>
+
+struct bnxt_re_work_compl {
+	struct list_node list;
+	struct ibv_wc wc;
+};
 
 int bnxt_re_query_device(struct ibv_context *context,
 			 const struct ibv_query_device_ex_input *input,
@@ -67,6 +73,7 @@ int bnxt_re_dereg_mr(struct verbs_mr *vmr);
 
 struct ibv_cq *bnxt_re_create_cq(struct ibv_context *uctx, int ncqe,
 				 struct ibv_comp_channel *ch, int vec);
+int bnxt_re_resize_cq(struct ibv_cq *ibvcq, int ncqe);
 int bnxt_re_destroy_cq(struct ibv_cq *ibvcq);
 int bnxt_re_poll_cq(struct ibv_cq *ibvcq, int nwc, struct ibv_wc *wc);
 int bnxt_re_arm_cq(struct ibv_cq *ibvcq, int flags);


### PR DESCRIPTION
Adds resize CQ support.
After issuing the resize_cq cmd, library reaps all the
existing completions in the CQ and store it in a list.
The reaping continues till the final CQE is seen. Once
final CQE is seen, lib issues an ibv_cmd_poll_cq so that
the poll_cq context in the kernel is invoked and driver
frees up the resources of the previous CQ.

During a poll CQ from application, the pending completions in
the list is completed first before polling completions from the
new CQ.
