### PR TITLE
srp_daemon fixes

### DIFF
--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -1883,7 +1883,6 @@ static void umad_resources_init(struct umad_resources *umad_res)
 {
 	umad_res->portid = -1;
 	umad_res->agent = -1;
-	umad_res->agent = -1;
 	umad_res->port_sysfs_path = NULL;
 }
 

--- a/srp_daemon/srp_daemon.c
+++ b/srp_daemon/srp_daemon.c
@@ -42,7 +42,6 @@
 #include <assert.h>
 #include <stdarg.h>
 #include <stddef.h>
-#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/srp_daemon/srp_daemon.h
+++ b/srp_daemon/srp_daemon.h
@@ -270,7 +270,6 @@ struct resources {
 	pthread_t trap_thread;
 	pthread_t async_ev_thread;
 	pthread_t reconnect_thread;
-	pthread_t timer_thread;
 };
 
 struct srp_ib_user_mad {

--- a/srp_daemon/srp_daemon.h
+++ b/srp_daemon/srp_daemon.h
@@ -37,6 +37,7 @@
 #define SRP_DM_H
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <signal.h>
 #include <endian.h>
 #include <util/util.h>
@@ -247,6 +248,7 @@ enum {
 
 struct sync_resources {
 	int stop_threads;
+	bool error;
 	int next_task;
 	struct timespec next_recalc_time;
 	struct {
@@ -315,6 +317,7 @@ int pop_from_list(struct sync_resources *res, uint16_t *lid,
 		  union umad_gid *gid, uint16_t *pkey);
 int sync_resources_init(struct sync_resources *res);
 void sync_resources_cleanup(struct sync_resources *res);
+bool sync_resources_error(struct sync_resources *res);
 int modify_qp_to_err(struct ibv_qp *qp);
 void srp_sleep(time_t sec, time_t usec);
 void wake_up_main_loop(char ch);
@@ -322,5 +325,6 @@ void __schedule_rescan(struct sync_resources *res, int when);
 void schedule_rescan(struct sync_resources *res, int when);
 int __rescan_scheduled(struct sync_resources *res);
 int rescan_scheduled(struct sync_resources *res);
+void raise_catastrophic_error(struct sync_resources *res);
 
 #endif /* SRP_DM_H */

--- a/srp_daemon/srp_handle_traps.c
+++ b/srp_daemon/srp_handle_traps.c
@@ -744,8 +744,10 @@ static int get_trap_notices(struct resources *res)
 
 		ret = poll_cq(res->sync_res, res->ud_res->recv_cq, &wc,
 			      res->ud_res->channel);
-		if (ret < 0)
+		if (ret < 0) {
+			srp_sleep(0, 1);
 			continue;
+		}
 
 		pr_debug("get_trap_notices: Got CQE wc.wr_id=%lld\n", (long long int) wc.wr_id);
 		cur_receive = wc.wr_id;

--- a/srp_daemon/srp_handle_traps.c
+++ b/srp_daemon/srp_handle_traps.c
@@ -567,9 +567,14 @@ static int poll_cq(struct sync_resources *sync_res, struct ibv_cq *cq,
 		if (ret < 0)
 			return ret;
 
-		if (ret == 0 && channel) {
-			pr_err("Weird poll returned no cqe after CQ event\n");
-			return -1;
+		if (ret == 0) {
+			if (channel) {
+				pr_err("Weird poll returned no cqe after CQ event\n");
+				return -1;
+			}
+
+			if (sync_resources_error(sync_res))
+				return -1;
 		}
 	} while (ret == 0);
 
@@ -862,7 +867,7 @@ void *run_thread_listen_to_events(void *res_in)
 		  /* clean and restart */
 			pr_err("Critical event %d, raising catastrophic "
 			       "error signal\n", event.event_type);
-			raise(SRP_CATAS_ERR);
+			raise_catastrophic_error(res->sync_res);
 			break;
 
  	      	 /*

--- a/srp_daemon/srp_sync.c
+++ b/srp_daemon/srp_sync.c
@@ -84,11 +84,31 @@ int rescan_scheduled(struct sync_resources *res)
 	return ret;
 }
 
+void raise_catastrophic_error(struct sync_resources *res)
+{
+	pthread_mutex_lock(&res->mutex);
+	res->error = true;
+	pthread_mutex_unlock(&res->mutex);
+	raise(SRP_CATAS_ERR);
+}
+
+bool sync_resources_error(struct sync_resources *res)
+{
+	bool ret;
+
+	pthread_mutex_lock(&res->mutex);
+	ret = res->error;
+	pthread_mutex_unlock(&res->mutex);
+
+	return ret;
+}
+
 int sync_resources_init(struct sync_resources *res)
 {
 	int ret;
 
 	res->stop_threads = 0;
+	res->error = false;
 	__schedule_rescan(res, 0);
 	res->next_task = 0;
 	ret = pthread_mutex_init(&res->mutex, NULL);


### PR DESCRIPTION
The patch set includes mix fixes and minor code cleanup for srp_daemon.
The first patch is the most important. It fixes a bug in handling RDMA
device removal. The second patch prevents printing many repeating
messages to the log. The last one removes a couple of lines of unused code.