### PR TITLE
mlx5: DR, Few improvements

### DIFF
--- a/providers/mlx5/dr_dbg.c
+++ b/providers/mlx5/dr_dbg.c
@@ -761,7 +761,7 @@ static int dr_dump_domain(FILE *f, struct mlx5dv_dr_domain *dmn)
 	int ret, i;
 
 	domain_id = dr_domain_id_calc(dmn_type);
-	ret = fprintf(f, "%d,0x%" PRIx64 ",%d,0%x,%d,%s,%s,%u,%u,%u,%u\n",
+	ret = fprintf(f, "%d,0x%" PRIx64 ",%d,0%x,%d,%s,%s,%u,%u,%u,%u,%u\n",
 		      DR_DUMP_REC_TYPE_DOMAIN,
 		      domain_id,
 		      dmn_type,
@@ -772,7 +772,8 @@ static int dr_dump_domain(FILE *f, struct mlx5dv_dr_domain *dmn)
 		      dmn->flags,
 		      dmn->num_buddies[DR_ICM_TYPE_STE],
 		      dmn->num_buddies[DR_ICM_TYPE_MODIFY_ACTION],
-		      dmn->num_buddies[DR_ICM_TYPE_MODIFY_HDR_PTRN]);
+		      dmn->num_buddies[DR_ICM_TYPE_MODIFY_HDR_PTRN],
+		      dmn->info.caps.sw_format_ver);
 	if (ret < 0)
 		return ret;
 

--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -240,6 +240,9 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 			capability.cmd_hca_cap.general_obj_types) &
 			(1LL << MLX5_OBJ_TYPE_HEADER_MODIFY_ARGUMENT);
 
+	caps->roce_caps.fl_rc_qp_when_roce_disabled = DEVX_GET(query_hca_cap_out, out,
+					capability.cmd_hca_cap.fl_rc_qp_when_roce_disabled);
+
 	if (caps->support_modify_argument) {
 		caps->log_header_modify_argument_granularity =
 			DEVX_GET(query_hca_cap_out, out,
@@ -444,7 +447,7 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 			dr_dbg_ctx(ctx, "Query RoCE capabilities failed %d\n", err);
 			return err;
 		}
-		caps->roce_caps.fl_rc_qp_when_roce_disabled = DEVX_GET(query_hca_cap_out, out,
+		caps->roce_caps.fl_rc_qp_when_roce_disabled |= DEVX_GET(query_hca_cap_out, out,
 					      capability.roce_caps.fl_rc_qp_when_roce_disabled);
 		caps->roce_caps.fl_rc_qp_when_roce_enabled = DEVX_GET(query_hca_cap_out, out,
 					      capability.roce_caps.fl_rc_qp_when_roce_enabled);

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -175,6 +175,11 @@ static bool dr_mask_is_tnl_geneve_set(struct dr_match_misc *misc)
 	       misc->geneve_opt_len;
 }
 
+static bool dr_mask_is_ib_l4_set(struct dr_match_misc *misc)
+{
+	return misc->bth_opcode || misc->bth_dst_qp;
+}
+
 static int dr_matcher_supp_geneve_tlv_option(struct dr_devx_caps *caps)
 {
 	return caps->flex_protocols & MLX5_FLEX_PARSER_GENEVE_OPT_0_ENABLED;
@@ -991,6 +996,12 @@ static int dr_matcher_set_ste_builders(struct mlx5dv_dr_matcher *matcher,
 		if (dr_mask_is_flex_parser_4_7_set(&mask.misc4))
 			dr_ste_build_flex_parser_1(ste_ctx, &sb[idx++],
 						   &mask, false, rx);
+	}
+
+	if (matcher->match_criteria & DR_MATCHER_CRITERIA_MISC) {
+		if (dr_mask_is_ib_l4_set(&mask.misc))
+			dr_ste_build_ib_l4(ste_ctx, &sb[idx++], &mask,
+					   inner, rx);
 	}
 
 	/* Empty matcher, takes all */

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -851,6 +851,7 @@ static void dr_ste_copy_mask_misc(char *mask, struct dr_match_misc *spec, bool c
 	spec->gre_key_l = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_key_l, clear);
 
 	spec->vxlan_vni = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, vxlan_vni, clear);
+	spec->bth_opcode = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, bth_opcode, clear);
 
 	spec->geneve_vni = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_vni, clear);
 	spec->geneve_oam = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_oam, clear);
@@ -1476,6 +1477,19 @@ void dr_ste_build_tunnel_header(struct dr_ste_ctx *ste_ctx,
 	sb->caps = caps;
 
 	ste_ctx->build_tunnel_header_init(sb, mask);
+}
+
+void dr_ste_build_ib_l4(struct dr_ste_ctx *ste_ctx,
+			struct dr_ste_build *sb,
+			struct dr_match_param *mask,
+			bool inner, bool rx)
+{
+	if (!ste_ctx->build_ib_l4_init)
+		return;
+
+	sb->rx = rx;
+	sb->inner = inner;
+	ste_ctx->build_ib_l4_init(sb, mask);
 }
 
 int dr_ste_build_def0(struct dr_ste_ctx *ste_ctx,

--- a/providers/mlx5/dr_ste.h
+++ b/providers/mlx5/dr_ste.h
@@ -183,6 +183,7 @@ struct dr_ste_ctx {
 	dr_ste_builder_void_init build_flex_parser_0_init;
 	dr_ste_builder_void_init build_flex_parser_1_init;
 	dr_ste_builder_void_init build_tunnel_header_init;
+	dr_ste_builder_void_init build_ib_l4_init;
 	dr_ste_builder_void_init build_def0_init;
 	dr_ste_builder_void_init build_def2_init;
 	dr_ste_builder_void_init build_def6_init;

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2397,6 +2397,27 @@ static void dr_ste_v1_build_tunnel_header_init(struct dr_ste_build *sb,
 	sb->ste_build_tag_func = &dr_ste_v1_build_tunnel_header_tag;
 }
 
+static int dr_ste_v1_build_ib_l4_tag(struct dr_match_param *value,
+				     struct dr_ste_build *sb,
+				     uint8_t *tag)
+{
+	struct  dr_match_misc *misc = &value->misc;
+
+	DR_STE_SET_TAG(ib_l4, tag, opcode, misc, bth_opcode);
+	DR_STE_SET_TAG(ib_l4, tag, qp, misc, bth_dst_qp);
+
+	return 0;
+}
+
+static void dr_ste_v1_build_ib_l4_init(struct dr_ste_build *sb,
+				       struct dr_match_param *mask)
+{
+	sb->lu_type = DR_STE_V1_LU_TYPE_IBL4;
+	dr_ste_v1_build_ib_l4_tag(mask, sb, sb->bit_mask);
+	sb->byte_mask = dr_ste_conv_bit_to_byte_mask(sb->bit_mask);
+	sb->ste_build_tag_func = &dr_ste_v1_build_ib_l4_tag;
+}
+
 static int dr_ste_v1_build_def0_tag(struct dr_match_param *value,
 				    struct dr_ste_build *sb,
 				    uint8_t *tag)
@@ -3570,6 +3591,7 @@ static struct dr_ste_ctx ste_ctx_v1 = {
 	.build_flex_parser_0_init	= &dr_ste_v1_build_flex_parser_0_init,
 	.build_flex_parser_1_init	= &dr_ste_v1_build_flex_parser_1_init,
 	.build_tunnel_header_init	= &dr_ste_v1_build_tunnel_header_init,
+	.build_ib_l4_init		= &dr_ste_v1_build_ib_l4_init,
 	.build_def0_init		= &dr_ste_v1_build_def0_init,
 	.build_def2_init		= &dr_ste_v1_build_def2_init,
 	.build_def6_init		= &dr_ste_v1_build_def6_init,

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1041,7 +1041,9 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 	u8         rc[0x1];
 
 	u8         uar_4k[0x1];
-	u8         reserved_at_241[0x9];
+	u8         reserved_at_241[0x7];
+	u8	   fl_rc_qp_when_roce_disabled[0x1];
+	u8	   reserved_at_249[0x1];
 	u8         uar_sz[0x6];
 	u8         reserved_at_250[0x2];
 	u8         umem_uid_0[0x1];

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -574,7 +574,7 @@ struct mlx5_ifc_dr_match_set_misc_bits {
 	u8         gre_key_l[0x8];
 
 	u8         vxlan_vni[0x18];
-	u8         reserved_at_b8[0x8];
+	u8         bth_opcode[0x8];
 
 	u8         geneve_vni[0x18];
 	u8         reserved_at_e4[0x6];
@@ -2670,6 +2670,29 @@ struct mlx5_ifc_ste_icmp_v1_bits {
 	u8         icmp_type[0x8];
 	u8         icmp_code[0x8];
 	u8         reserved_at_50[0x10];
+
+	u8         reserved_at_60[0x20];
+};
+
+struct mlx5_ifc_ste_ib_l4_bits {
+	u8         opcode[0x8];
+	u8         qp[0x18];
+
+	u8         se[0x1];
+	u8         migreg[0x1];
+	u8         ackreq[0x1];
+	u8         fecn[0x1];
+	u8         becn[0x1];
+	u8         bth[0x1];
+	u8         deth[0x1];
+	u8         dcceth[0x1];
+	u8         reserved_at_28[0x2];
+	u8         pad_count[0x2];
+	u8         tver[0x4];
+	u8         pkey[0x10];
+
+	u8         reserved_at_40[0x8];
+	u8         deth_source_qp[0x18];
 
 	u8         reserved_at_60[0x20];
 };

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -620,6 +620,10 @@ void dr_ste_build_tunnel_header(struct dr_ste_ctx *ste_ctx,
 				struct dr_match_param *mask,
 				struct dr_devx_caps *caps,
 				bool inner, bool rx);
+void dr_ste_build_ib_l4(struct dr_ste_ctx *ste_ctx,
+			struct dr_ste_build *sb,
+			struct dr_match_param *mask,
+			bool inner, bool rx);
 int dr_ste_build_def0(struct dr_ste_ctx *ste_ctx,
 		      struct dr_ste_build *sb,
 		      struct dr_match_param *mask,
@@ -742,7 +746,7 @@ struct dr_match_misc {
 	uint32_t gre_key_h:24;			/* GRE Key[31:8] (outer) */
 	uint32_t gre_key_l:8;			/* GRE Key [7:0] (outer) */
 	uint32_t vxlan_vni:24;			/* VXLAN VNI (outer) */
-	uint32_t reserved_at_b8:8;
+	uint32_t bth_opcode:8;			/* Opcode field from BTH header */
 	uint32_t geneve_vni:24;			/* GENEVE VNI field (outer) */
 	uint32_t reserved_at_e4:6;
 	uint32_t geneve_tlv_option_0_exist:1;


### PR DESCRIPTION
This series includes a few improvements in the DR area, it includes:
- Add support to match on IB layer 4 header layout in ste_v1 format.
- Add the ability to dump some extra information.
- Use an additional capability for RC QP FL support when RoCE capability is disabled.