### PR TITLE
 bnxt_re/lib: Enable low latency push support

### DIFF
--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -41,6 +41,7 @@
 #define __BNXT_RE_UVERBS_ABI_H__
 
 #include <linux/types.h>
+#include <rdma/ib_user_ioctl_cmds.h>
 
 #define BNXT_RE_ABI_VERSION	1
 
@@ -51,6 +52,7 @@
 enum {
 	BNXT_RE_UCNTX_CMASK_HAVE_CCTX = 0x1ULL,
 	BNXT_RE_UCNTX_CMASK_HAVE_MODE = 0x02ULL,
+	BNXT_RE_UCNTX_CMASK_WC_DPI_ENABLED = 0x04ULL,
 };
 
 enum bnxt_re_wqe_mode {
@@ -125,6 +127,31 @@ enum bnxt_re_shpg_offt {
 	BNXT_RE_AVID_OFFT	= 0x10,
 	BNXT_RE_AVID_SIZE	= 0x04,
 	BNXT_RE_END_RESV_OFFT	= 0xFF0
+};
+
+enum bnxt_re_objects {
+	BNXT_RE_OBJECT_ALLOC_PAGE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum bnxt_re_alloc_page_type {
+	BNXT_RE_ALLOC_WC_PAGE = 0,
+};
+
+enum bnxt_re_var_alloc_page_attrs {
+	BNXT_RE_ALLOC_PAGE_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+	BNXT_RE_ALLOC_PAGE_TYPE,
+	BNXT_RE_ALLOC_PAGE_DPI,
+	BNXT_RE_ALLOC_PAGE_MMAP_OFFSET,
+	BNXT_RE_ALLOC_PAGE_MMAP_LENGTH,
+};
+
+enum bnxt_re_alloc_page_attrs {
+	BNXT_RE_DESTROY_PAGE_HANDLE = (1U << UVERBS_ID_NS_SHIFT),
+};
+
+enum bnxt_re_alloc_page_methods {
+	BNXT_RE_METHOD_ALLOC_PAGE = (1U << UVERBS_ID_NS_SHIFT),
+	BNXT_RE_METHOD_DESTROY_PAGE,
 };
 
 #endif /* __BNXT_RE_UVERBS_ABI_H__*/

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -139,14 +139,22 @@ enum bnxt_re_db_que_type {
 	BNXT_RE_QUE_TYPE_CQ_ARMENA	= 0x07,
 	BNXT_RE_QUE_TYPE_SRQ_ARMENA	= 0x08,
 	BNXT_RE_QUE_TYPE_CQ_CUT_ACK	= 0x09,
+	BNXT_RE_PUSH_TYPE_START		= 0x0C,
+	BNXT_RE_PUSH_TYPE_END		= 0x0D,
 	BNXT_RE_QUE_TYPE_NULL		= 0x0F
 };
 
 enum bnxt_re_db_mask {
 	BNXT_RE_DB_INDX_MASK		= 0xFFFFFUL,
+	BNXT_RE_DB_PILO_MASK		= 0x0FFUL,
+	BNXT_RE_DB_PILO_SHIFT		= 0x18,
 	BNXT_RE_DB_QID_MASK		= 0xFFFFFUL,
-	BNXT_RE_DB_TYP_MASK		= 0x0FUL,
-	BNXT_RE_DB_TYP_SHIFT		= 0x1C
+	BNXT_RE_DB_PIHI_MASK            = 0xF00UL,
+	BNXT_RE_DB_PIHI_SHIFT           = 0x0C, /* Because mask is 0xF00 */
+	BNXT_RE_DB_TYP_MASK             = 0x0FUL,
+	BNXT_RE_DB_TYP_SHIFT            = 0x1C,
+	BNXT_RE_DB_VALID_SHIFT          = 0x1A,
+	BNXT_RE_DB_EPOCH_SHIFT          = 0x18
 };
 
 enum bnxt_re_psns_mask {
@@ -199,6 +207,10 @@ enum bnxt_re_ud_cqe_mask {
 	BNXT_RE_UD_CQE_SRCQPLO_MASK	= 0xFFFF,
 	BNXT_RE_UD_CQE_SRCQPLO_SHIFT	= 0x30,
 	BNXT_RE_UD_CQE_LEN_MASK         = 0x3FFFU,
+};
+
+enum {
+	BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED = 0x01,
 };
 
 enum bnxt_re_modes {
@@ -326,5 +338,9 @@ struct bnxt_re_rqe {
 
 struct bnxt_re_srqe {
 	__le64 rsvd[2];
+};
+
+struct bnxt_re_push_wqe {
+	__u64 addr[32];
 };
 #endif

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -164,6 +164,8 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 
 	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_HAVE_MODE)
 		cntx->wqe_mode = resp.mode;
+	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_WC_DPI_ENABLED)
+		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED;
 
 	pthread_spin_init(&cntx->fqlock, PTHREAD_PROCESS_PRIVATE);
 	/* mmap shared page. */
@@ -203,6 +205,10 @@ static void bnxt_re_free_context(struct ibv_context *ibvctx)
 	/* Un-map DPI only for the first PD that was
 	 * allocated in this context.
 	 */
+	if (cntx->udpi.wcdbpg && cntx->udpi.wcdbpg != MAP_FAILED) {
+		munmap(cntx->udpi.wcdbpg, rdev->pg_size);
+		cntx->udpi.wcdbpg = NULL;
+	}
 	if (cntx->udpi.dbpage && cntx->udpi.dbpage != MAP_FAILED) {
 		munmap(cntx->udpi.dbpage, rdev->pg_size);
 		cntx->udpi.dbpage = NULL;

--- a/providers/bnxt_re/memory.h
+++ b/providers/bnxt_re/memory.h
@@ -44,6 +44,7 @@
 
 struct bnxt_re_queue {
 	void *va;
+	uint32_t *dbtail;
 	uint32_t bytes; /* for munmap */
 	uint32_t depth; /* no. of entries */
 	uint32_t head;

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -83,14 +83,80 @@ int bnxt_re_query_port(struct ibv_context *ibvctx, uint8_t port,
 	return ibv_cmd_query_port(ibvctx, port, port_attr, &cmd, sizeof(cmd));
 }
 
+static inline bool bnxt_re_is_wcdpi_enabled(struct bnxt_re_context *cntx)
+{
+	return cntx->comp_mask & BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED;
+}
+
+static int bnxt_re_map_db_page(struct ibv_context *ibvctx,
+			       uint64_t dbr, uint32_t dpi)
+{
+	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
+	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
+
+	cntx->udpi.dpindx = dpi;
+	cntx->udpi.dbpage = mmap(NULL, dev->pg_size, PROT_WRITE,
+				 MAP_SHARED, ibvctx->cmd_fd, dbr);
+	if (cntx->udpi.dbpage == MAP_FAILED)
+		return -ENOMEM;
+	return 0;
+}
+
+static int bnxt_re_alloc_page(struct ibv_context *ibvctx,
+			      struct bnxt_re_mmap_info *minfo,
+			      uint32_t *page_handle)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       BNXT_RE_OBJECT_ALLOC_PAGE,
+			       BNXT_RE_METHOD_ALLOC_PAGE,
+			       4);
+	struct ib_uverbs_attr *handle;
+	int ret;
+
+	handle = fill_attr_out_obj(cmd, BNXT_RE_ALLOC_PAGE_HANDLE);
+	fill_attr_const_in(cmd, BNXT_RE_ALLOC_PAGE_TYPE, minfo->type);
+	fill_attr_out_ptr(cmd, BNXT_RE_ALLOC_PAGE_MMAP_OFFSET,
+			  &minfo->alloc_offset);
+	fill_attr_out_ptr(cmd, BNXT_RE_ALLOC_PAGE_MMAP_LENGTH, &minfo->alloc_size);
+	fill_attr_out_ptr(cmd, BNXT_RE_ALLOC_PAGE_DPI, &minfo->dpi);
+
+	ret = execute_ioctl(ibvctx, cmd);
+
+	if (ret)
+		return ret;
+	*page_handle = read_attr_obj(BNXT_RE_ALLOC_PAGE_HANDLE, handle);
+	return 0;
+}
+
+static int bnxt_re_alloc_map_push_page(struct ibv_context *ibvctx)
+{
+	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
+	struct bnxt_re_mmap_info minfo = {};
+	int ret;
+
+	minfo.type = BNXT_RE_ALLOC_WC_PAGE;
+	ret = bnxt_re_alloc_page(ibvctx, &minfo, &cntx->wc_handle);
+	if (ret)
+		return ret;
+
+	cntx->udpi.wcdbpg = mmap(NULL, minfo.alloc_size, PROT_WRITE,
+				 MAP_SHARED, ibvctx->cmd_fd, minfo.alloc_offset);
+	if (cntx->udpi.wcdbpg == MAP_FAILED)
+		return -ENOMEM;
+
+	cntx->udpi.wcdpi = minfo.dpi;
+	return 0;
+}
+
+
+
 struct ibv_pd *bnxt_re_alloc_pd(struct ibv_context *ibvctx)
 {
 	struct ibv_alloc_pd cmd;
 	struct ubnxt_re_pd_resp resp;
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
-	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
 	struct bnxt_re_pd *pd;
-	uint64_t dbr;
+	uint64_t dbr = 0;
 
 	pd = calloc(1, sizeof(*pd));
 	if (!pd)
@@ -108,16 +174,18 @@ struct ibv_pd *bnxt_re_alloc_pd(struct ibv_context *ibvctx)
 
 	/* Map DB page now. */
 	if (!cntx->udpi.dbpage) {
-		cntx->udpi.dpindx = resp.dpi;
-		cntx->udpi.dbpage = mmap(NULL, dev->pg_size, PROT_WRITE,
-					 MAP_SHARED, ibvctx->cmd_fd, dbr);
-		if (cntx->udpi.dbpage == MAP_FAILED) {
-			(void)ibv_cmd_dealloc_pd(&pd->ibvpd);
-			goto out;
+		if (bnxt_re_map_db_page(ibvctx, dbr, resp.dpi))
+			goto fail;
+		if (bnxt_re_is_wcdpi_enabled(cntx)) {
+			bnxt_re_alloc_map_push_page(ibvctx);
+			if (cntx->cctx.gen_p5 && cntx->udpi.wcdpi)
+				bnxt_re_init_pbuf_list(cntx);
 		}
         }
 
 	return &pd->ibvpd;
+fail:
+	(void)ibv_cmd_dealloc_pd(&pd->ibvpd);
 out:
 	free(pd);
 	return NULL;
@@ -1151,6 +1219,9 @@ static int bnxt_re_alloc_queues(struct bnxt_re_dev *dev,
 	qp->cap.max_swr = nswr;
 	pthread_spin_init(&que->qlock, PTHREAD_PROCESS_PRIVATE);
 
+	que->dbtail = (qp->qpmode == BNXT_RE_WQE_MODE_VARIABLE) ?
+		       &que->tail : &qp->jsqq->start_idx;
+
 	if (qp->jrqq) {
 		que = qp->jrqq->hwque;
 		nswr = roundup_pow_of_two(attr->cap.max_recv_wr + 1);
@@ -1165,6 +1236,7 @@ static int bnxt_re_alloc_queues(struct bnxt_re_dev *dev,
 		que->stride = sizeof(struct bnxt_re_sge);
 		que->depth = nslots;
 		que->diff = 0;
+		que->dbtail = &qp->jrqq->start_idx;
 
 		ret = bnxt_re_alloc_aligned(que, pg_size);
 		if (ret)
@@ -1206,6 +1278,7 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 	/* alloc queues */
 	qp->cctx = &cntx->cctx;
 	qp->qpmode = cntx->wqe_mode & BNXT_RE_WQE_MODE_VARIABLE;
+	qp->cntx = cntx;
 	if (bnxt_re_alloc_queues(dev, qp, attr, dev->pg_size))
 		goto failq;
 	/* Fill ibv_cmd */
@@ -1234,6 +1307,11 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 	cap->sqsig = attr->sq_sig_all;
 	fque_init_node(&qp->snode);
 	fque_init_node(&qp->rnode);
+
+	if (qp->cctx->gen_p5 && cntx->udpi.wcdpi) {
+		qp->push_st_en = 1;
+		qp->max_push_sz = BNXT_RE_MAX_INLINE_SIZE;
+	}
 
 	return &qp->ibvqp;
 failcmd:
@@ -1346,6 +1424,7 @@ static inline int bnxt_re_calc_inline_len(struct ibv_send_wr *swr)
 }
 
 static int bnxt_re_put_inline(struct bnxt_re_queue *que, uint32_t *idx,
+			      struct bnxt_re_push_buffer *pbuf,
 			      struct ibv_sge *sgl, uint32_t nsg,
 			      uint16_t max_ils)
 {
@@ -1371,6 +1450,9 @@ static int bnxt_re_put_inline(struct bnxt_re_queue *que, uint32_t *idx,
 			if (pull_dst) {
 				pull_dst = false;
 				il_dst = bnxt_re_get_hwqe(que, (*idx)++);
+				if (pbuf)
+					pbuf->wqe[*idx - 1] =
+					(uintptr_t)il_dst;
 				t_cplen = 0;
 				offt = 0;
 			}
@@ -1393,7 +1475,7 @@ bad:
 }
 
 static int bnxt_re_required_slots(struct bnxt_re_qp *qp, struct ibv_send_wr *wr,
-				  uint32_t *wqe_sz)
+				  uint32_t *wqe_sz, bool *push)
 {
 	uint32_t wqe_byte;
 	int ilsize;
@@ -1402,6 +1484,8 @@ static int bnxt_re_required_slots(struct bnxt_re_qp *qp, struct ibv_send_wr *wr,
 		ilsize = bnxt_re_calc_inline_len(wr);
 		if (ilsize > qp->cap.max_inline)
 			return -EINVAL;
+		if (qp->push_st_en && ilsize <= qp->max_push_sz)
+			*push = true;
 		wqe_byte = (ilsize + bnxt_re_get_sqe_hdr_sz());
 	} else {
 		wqe_byte = bnxt_re_calc_wqe_sz(wr->num_sge);
@@ -1445,11 +1529,12 @@ static inline void bnxt_re_set_hdr_flags(struct bnxt_re_bsqe *hdr,
 }
 
 static int bnxt_re_build_sge(struct bnxt_re_queue *que, uint32_t *idx,
+			     struct bnxt_re_push_buffer *pbuf,
 			     struct ibv_send_wr *wr,
 			     uint16_t max_il)
 {
 	if (wr->send_flags & IBV_SEND_INLINE)
-		return bnxt_re_put_inline(que, idx, wr->sg_list, wr->num_sge, max_il);
+		return bnxt_re_put_inline(que, idx, pbuf, wr->sg_list, wr->num_sge, max_il);
 
 	return bnxt_re_put_sge(que, idx, wr->sg_list, wr->num_sge);
 }
@@ -1546,6 +1631,7 @@ int bnxt_re_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 {
 	struct bnxt_re_qp *qp = to_bnxt_re_qp(ibvqp);
 	struct bnxt_re_queue *sq = qp->jsqq->hwque;
+	struct bnxt_re_push_buffer *pbuf = NULL;
 	struct bnxt_re_wrid *wrid;
 	struct bnxt_re_rdma *rsqe;
 	struct bnxt_re_send *sqe;
@@ -1555,12 +1641,15 @@ int bnxt_re_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 	uint32_t wqe_size = 0;
 	bool ring_db = false;
 	uint8_t sig = 0;
+	bool try_push;
 	uint32_t idx;
 
 	pthread_spin_lock(&sq->qlock);
 	while (wr) {
 
-		slots = bnxt_re_required_slots(qp, wr, &wqe_size);
+		try_push = false;
+		pbuf = NULL;
+		slots = bnxt_re_required_slots(qp, wr, &wqe_size, &try_push);
 		if (bnxt_re_is_que_full(sq, slots) ||
 		    wr->num_sge > qp->cap.max_ssge) {
 			*bad = wr;
@@ -1571,8 +1660,17 @@ int bnxt_re_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 		idx = 0;
 		hdr = bnxt_re_get_hwqe(sq, idx++);
 		sqe = bnxt_re_get_hwqe(sq, idx++);
+		if (try_push) {
+			pbuf = bnxt_re_get_pbuf(&qp->push_st_en, qp->cntx);
+			if (pbuf) {
+				pbuf->qpid = qp->qpid;
+				pbuf->wqe[0] = (uintptr_t)hdr;
+				pbuf->wqe[1] = (uintptr_t)sqe;
+				pbuf->st_idx = *sq->dbtail;
+			}
+		}
 		if (wr->num_sge) {
-			bytes = bnxt_re_build_sge(sq, &idx, wr, qp->cap.max_inline);
+			bytes = bnxt_re_build_sge(sq, &idx, pbuf, wr, qp->cap.max_inline);
 			if (unlikely(bytes < 0)) {
 				ret = ENOMEM;
 				*bad = wr;
@@ -1628,9 +1726,17 @@ int bnxt_re_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 		bnxt_re_fill_psns(qp, wrid, wr->opcode, bytes);
 		bnxt_re_jqq_mod_start(qp->jsqq, swq_idx);
 		bnxt_re_incr_tail(sq, slots);
+		ring_db = true;
+
+		if (pbuf) {
+			ring_db = false;
+			pbuf->tail = *sq->dbtail;
+			bnxt_re_fill_push_wcb(qp, pbuf, idx);
+			bnxt_re_put_pbuf(qp->cntx, pbuf);
+		}
+
 		qp->wqe_cnt++;
 		wr = wr->next;
-		ring_db = true;
 
 		if (qp->wqe_cnt == BNXT_RE_UD_QP_HW_STALL &&
 		    qp->qptyp == IBV_QPT_UD) {


### PR DESCRIPTION
Enable Low latency push support for Broadcom Adapters.