### PR TITLE
suse: fix package name for libmana

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -48,7 +48,7 @@ Group:          Productivity/Networking/Other
 %define  verbs_lname  libibverbs%{verbs_so_major}
 %define  rdmacm_lname librdmacm%{rdmacm_so_major}
 %define  umad_lname   libibumad%{umad_so_major}
-%define  mana_lname   libmana-%{mana_so_major}
+%define  mana_lname   libmana%{mana_so_major}
 %define  mlx4_lname   libmlx4-%{mlx4_so_major}
 %define  mlx5_lname   libmlx5-%{mlx5_so_major}
 


### PR DESCRIPTION
SUSE policy is that shared lib packages are named %{libname}%{lib_major_version} unless the libname ends with a digit (ie libmlx4, libmlx5) in which case the package should be %{libname}-%{lib_major_version}

Fixes: 443f196deee0 ("mana: Microsoft Azure Network Adapter (MANA) RDMA provider")