### PR TITLE
tests: add and improve some tests

### DIFF
--- a/pyverbs/mem_alloc.pyx
+++ b/pyverbs/mem_alloc.pyx
@@ -5,14 +5,19 @@
 
 from posix.stdlib cimport posix_memalign as c_posix_memalign
 from libc.stdlib cimport malloc as c_malloc, free as c_free
-from posix.mman cimport mmap as c_mmap, munmap as c_munmap
+from posix.mman cimport mmap as c_mmap, munmap as c_munmap, madvise as c_madvise
+
 from libc.stdint cimport uintptr_t, uint32_t, uint64_t
+from pyverbs.base import PyverbsRDMAErrno
 from libc.string cimport memcpy
 from libc.string cimport memset
 cimport posix.mman as mm
 
 cdef extern from 'sys/mman.h':
     cdef void* MAP_FAILED
+
+cdef extern from 'bits/mman-linux.h':
+    cdef int MADV_DONTNEED
 
 cdef extern from 'endian.h':
     unsigned long htobe32(unsigned long host_32bits)
@@ -37,6 +42,18 @@ def mmap(addr=0, length=100, prot=mm.PROT_READ | mm.PROT_WRITE,
     if <void *>ptr == MAP_FAILED:
         raise MemoryError('Failed to mmap memory')
     return <uintptr_t> ptr
+
+
+def madvise(addr, length, flags=MADV_DONTNEED):
+    """
+    Python wrapper for sys madvise function
+    :param addr: Address of the memory to be advised about
+    :param length: The length of the requested memory in bytes
+    :param flags: Specify speicific flags to this memory
+    """
+    rc = c_madvise(<void*><uintptr_t>addr, length, flags)
+    if rc:
+        raise PyverbsRDMAErrno('Failed to madvise memory')
 
 
 def munmap(addr, length):

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -1326,7 +1326,7 @@ class FlowTableEntryMatchSetMisc(Packet):
         BitField('gre_key_h', 0, 24),
         ByteField('gre_key_l', 0),
         BitField('vxlan_vni', 0, 24),
-        ByteField('reserved3', 0),
+        ByteField('bth_opcode', 0),
         BitField('geneve_vni', 0, 24),
         BitField('reserved4', 0, 7),
         BitField('geneve_oam', 0, 1),

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -88,22 +88,6 @@ class OdpRC(RCResources):
         return qp_attr
 
 
-class OdpSrqRc(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index, qp_count=1, request_user_addr=False):
-        self.request_user_addr = request_user_addr
-        self.user_addr = None
-        super(OdpSrqRc, self).__init__(dev_name=dev_name, ib_port=ib_port,
-                                       gid_index=gid_index, with_srq=True,
-                                       qp_count=qp_count)
-
-    @u.requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
-    def create_mr(self):
-        if self.request_user_addr:
-            self.user_addr = mmap(length=self.msg_size,
-                                  flags=MAP_ANONYMOUS_| MAP_PRIVATE_)
-        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND, user_addr=self.user_addr)
-
-
 class OdpXRC(XRCResources):
     def __init__(self, request_user_addr=False, **kwargs):
         self.request_user_addr = request_user_addr
@@ -215,10 +199,6 @@ class OdpTestCase(RDMATestCase):
     def test_odp_xrc_traffic(self):
         self.create_players(OdpXRC)
         u.xrc_traffic(self.client, self.server)
-
-    def test_odp_rc_srq_traffic(self):
-        self.create_players(OdpSrqRc, qp_count=2)
-        u.traffic(**self.traffic_args)
 
     @u.requires_huge_pages()
     def test_odp_rc_huge_traffic(self):

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -1,4 +1,4 @@
-from pyverbs.mem_alloc import mmap, munmap, MAP_ANONYMOUS_, MAP_PRIVATE_, \
+from pyverbs.mem_alloc import mmap, munmap, madvise, MAP_ANONYMOUS_, MAP_PRIVATE_, \
     MAP_HUGETLB_
 from tests.base import RCResources, UDResources, XRCResources
 from pyverbs.wr import SGE, SendWR, RecvWR
@@ -12,26 +12,35 @@ HUGE_PAGE_SIZE = 0x200000
 
 
 class OdpUD(UDResources):
+    def __init__(self, request_user_addr=False, **kwargs):
+        self.request_user_addr = request_user_addr
+        self.user_addr = None
+        super(OdpUD, self).__init__(**kwargs)
+
     @u.requires_odp('ud', e.IBV_ODP_SUPPORT_SEND)
     def create_mr(self):
+        if self.request_user_addr:
+            self.user_addr = mmap(length=self.msg_size,
+                                  flags=MAP_ANONYMOUS_ | MAP_PRIVATE_)
         self.send_mr = MR(self.pd, self.msg_size + u.GRH_SIZE,
-                          e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND)
+                          e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND, address=self.user_addr)
         self.recv_mr = MR(self.pd, self.msg_size + u.GRH_SIZE,
                           e.IBV_ACCESS_LOCAL_WRITE)
 
 
 class OdpRC(RCResources):
     def __init__(self, dev_name, ib_port, gid_index, is_huge=False,
-                 user_addr=None, use_mr_prefetch=None, is_implicit=False,
-                 prefetch_advice=e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE):
+                 request_user_addr=False, use_mr_prefetch=None, is_implicit=False,
+                 prefetch_advice=e._IBV_ADVISE_MR_ADVICE_PREFETCH_WRITE,
+                 msg_size=1024, odp_caps=e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV):
         """
         Initialize an OdpRC object.
         :param dev_name: Device name to be used
         :param ib_port: IB port of the device to use
         :param gid_index: Which GID index to use
         :param is_huge: If True, use huge pages for MR registration
-        :param user_addr: The MR's buffer address. If None, the buffer will be
-                          allocated by pyverbs.
+        :param request_user_addr: Request to provide the MR's buffer address.
+                                  If False, the buffer will be allocated by pyverbs.
         :param use_mr_prefetch: Describes the properties of the prefetch
                                 operation. The options are 'sync', 'async'
                                 and None to skip the prefetch operation.
@@ -40,45 +49,34 @@ class OdpRC(RCResources):
                                 if use_mr_prefetch is None).
         """
         self.is_huge = is_huge
-        self.user_addr = user_addr
+        self.request_user_addr = request_user_addr
         self.is_implicit = is_implicit
+        self.odp_caps = odp_caps
+        self.access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND | \
+            e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ | \
+            e.IBV_ACCESS_REMOTE_WRITE
+        self.user_addr = None
         super(OdpRC, self).__init__(dev_name=dev_name, ib_port=ib_port,
                                     gid_index=gid_index)
         self.use_mr_prefetch = use_mr_prefetch
         self.prefetch_advice = prefetch_advice
+        self.msg_size = msg_size
 
-    @u.requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
+    @u.requires_odp('rc', e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
     def create_mr(self):
-        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND
+        u.odp_supported(self.ctx, 'rc', self.odp_caps)
+        if self.request_user_addr:
+            mmap_flags = MAP_ANONYMOUS_| MAP_PRIVATE_
+            length = self.msg_size
+            if self.is_huge:
+                mmap_flags |= MAP_HUGETLB_
+                length = HUGE_PAGE_SIZE
+            self.user_addr = mmap(length=length, flags=mmap_flags)
+        access = self.access
         if self.is_huge:
             access |= e.IBV_ACCESS_HUGETLB
         self.mr = MR(self.pd, self.msg_size, access, address=self.user_addr,
                      implicit=self.is_implicit)
-
-class OdpRdmaRC(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index, msg_size=512, odp_caps=0):
-        """
-        Initialize an OdpRdmaRC Resource object. This is intended to be
-        used with RDMA Write, RDMA Read, and Atomic operations.
-        :param dev_name: Device name to be used
-        :param ib_port: IB port of the device to use
-        :param gid_index: Which GID index to use
-        :param msg_size: Message size for RDMA operations. Ignored for
-                         Atomic operations (always '8' in that case).
-        :param odp_caps: ODP capabilities required for the operation
-        """
-        self.access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_ON_DEMAND | \
-            e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ | \
-            e.IBV_ACCESS_REMOTE_WRITE
-        self.odp_caps = odp_caps
-        super().__init__(dev_name=dev_name, ib_port=ib_port,
-                         gid_index=gid_index)
-        self.msg_size = msg_size
-        self.new_mr_lkey = None
-
-    def create_mr(self):
-        u.odp_supported(self.ctx, 'rc', self.odp_caps)
-        self.mr = MR(self.pd, self.msg_size, self.access)
 
     def create_qp_init_attr(self):
         return QPInitAttr(qp_type=e.IBV_QPT_RC, scq=self.cq, sq_sig_all=0,
@@ -91,27 +89,41 @@ class OdpRdmaRC(RCResources):
 
 
 class OdpSrqRc(RCResources):
-    def __init__(self, dev_name, ib_port, gid_index, qp_count=1):
+    def __init__(self, dev_name, ib_port, gid_index, qp_count=1, request_user_addr=False):
+        self.request_user_addr = request_user_addr
+        self.user_addr = None
         super(OdpSrqRc, self).__init__(dev_name=dev_name, ib_port=ib_port,
                                        gid_index=gid_index, with_srq=True,
                                        qp_count=qp_count)
 
     @u.requires_odp('rc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
     def create_mr(self):
-        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+        if self.request_user_addr:
+            self.user_addr = mmap(length=self.msg_size,
+                                  flags=MAP_ANONYMOUS_| MAP_PRIVATE_)
+        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND, user_addr=self.user_addr)
 
 
 class OdpXRC(XRCResources):
+    def __init__(self, request_user_addr=False, **kwargs):
+        self.request_user_addr = request_user_addr
+        self.user_addr = None
+        super(OdpXRC, self).__init__(**kwargs)
+
     @u.requires_odp('xrc',  e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_SRQ_RECV)
     def create_mr(self):
-        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND)
+        if self.request_user_addr:
+            self.user_addr = mmap(length=self.msg_size,
+                                  flags=MAP_ANONYMOUS_| MAP_PRIVATE_)
+        self.mr = u.create_custom_mr(self, e.IBV_ACCESS_ON_DEMAND, user_addr=self.user_addr)
 
 
 class OdpTestCase(RDMATestCase):
     def setUp(self):
         super(OdpTestCase, self).setUp()
         self.iters = 100
-        self.user_addr = None
+        self.force_page_faults = True
+        self.is_huge = False
 
     def create_players(self, resource, **resource_arg):
         """
@@ -121,15 +133,17 @@ class OdpTestCase(RDMATestCase):
         :param resource_arg: Dict of args that specify the resource specific
                              attributes.
         """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
+        self.client = resource(**self.dev_info, **resource_arg,
+                               request_user_addr=self.force_page_faults)
+        self.server = resource(**self.dev_info, **resource_arg,
+                               request_user_addr=self.force_page_faults)
         self.client.pre_run(self.server.psns, self.server.qps_num)
         self.server.pre_run(self.client.psns, self.client.qps_num)
-        if resource == OdpRdmaRC:
+        if resource != OdpUD:
             self.sync_remote_attr()
         self.traffic_args = {'client': self.client, 'server': self.server,
                              'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
+                             'port': self.ib_port, 'force_page_faults': self.force_page_faults}
 
     def sync_remote_attr(self):
         """
@@ -141,8 +155,12 @@ class OdpTestCase(RDMATestCase):
         self.client.remote_addr = self.client.raddr = self.server.mr.buf
 
     def tearDown(self):
-        if self.user_addr:
-            munmap(self.user_addr, HUGE_PAGE_SIZE)
+        if self.server and self.server.user_addr:
+            length = HUGE_PAGE_SIZE if self.is_huge else self.server.msg_size
+            munmap(self.server.user_addr, length)
+        if self.client and self.client.user_addr:
+            length = HUGE_PAGE_SIZE if self.is_huge else self.client.msg_size
+            munmap(self.client.user_addr, length)
         super(OdpTestCase, self).tearDown()
 
     def test_odp_rc_traffic(self):
@@ -150,24 +168,26 @@ class OdpTestCase(RDMATestCase):
         u.traffic(**self.traffic_args)
 
     def test_odp_rc_atomic_cmp_and_swp(self):
-        self.create_players(OdpRdmaRC, msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
+        self.force_page_faults = False
+        self.create_players(OdpRC, msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
         u.atomic_traffic(**self.traffic_args,
                          send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
         u.atomic_traffic(**self.traffic_args, receiver_val=1, sender_val=1,
                          send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
 
     def test_odp_rc_atomic_fetch_and_add(self):
-        self.create_players(OdpRdmaRC, msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
+        self.force_page_faults = False
+        self.create_players(OdpRC, msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
         u.atomic_traffic(**self.traffic_args,
                          send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
 
     def test_odp_rc_rdma_read(self):
-        self.create_players(OdpRdmaRC, odp_caps=e.IBV_ODP_SUPPORT_READ)
+        self.create_players(OdpRC, odp_caps=e.IBV_ODP_SUPPORT_READ)
         self.server.mr.write('s' * self.server.msg_size, self.server.msg_size)
         u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_READ)
 
     def test_odp_rc_rdma_write(self):
-        self.create_players(OdpRdmaRC, odp_caps=e.IBV_ODP_SUPPORT_WRITE)
+        self.create_players(OdpRC, odp_caps=e.IBV_ODP_SUPPORT_WRITE)
         u.rdma_traffic(**self.traffic_args, send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_odp_implicit_rc_traffic(self):
@@ -186,6 +206,7 @@ class OdpTestCase(RDMATestCase):
                        self.client.msg_size, self.client.send_mr.lkey)
         client_send_wr = SendWR(num_sge=1, sg=[send_sge])
         for i in range(self.iters):
+            madvise(self.client.send_mr.buf, self.client.msg_size)
             self.server.qp.post_recv(server_recv_wr)
             u.post_send(self.client, client_send_wr, ah=ah_client)
             u.poll_cq(self.client.cq)
@@ -201,15 +222,14 @@ class OdpTestCase(RDMATestCase):
 
     @u.requires_huge_pages()
     def test_odp_rc_huge_traffic(self):
+        self.force_page_faults = False
         self.create_players(OdpRC, is_huge=True)
         u.traffic(**self.traffic_args)
 
     @u.requires_huge_pages()
     def test_odp_rc_huge_user_addr_traffic(self):
-        self.user_addr = mmap(length=HUGE_PAGE_SIZE,
-                              flags=MAP_ANONYMOUS_| MAP_PRIVATE_| MAP_HUGETLB_)
-        self.create_players(OdpRC, is_huge=True,
-                            user_addr=self.user_addr)
+        self.is_huge = True
+        self.create_players(OdpRC, is_huge=True)
         u.traffic(**self.traffic_args)
 
     def test_odp_sync_prefetch_rc_traffic(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,21 +16,21 @@ import glob
 import time
 import os
 
+from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx, QPAttr, QPEx, QP
 from pyverbs.pyverbs_error import PyverbsError, PyverbsRDMAError
-from pyverbs.addr import AHAttr, AH, GlobalRoute
+from tests.mlx5_base import Mlx5DcResources, Mlx5DcStreamsRes
 from tests.base import XRCResources, DCT_KEY, MLNX_VENDOR_ID
-from tests.efa_base import SRDResources
+from pyverbs.addr import AHAttr, AH, GlobalRoute
 from pyverbs.providers.efa.efadv import EfaCQ
 from pyverbs.wr import SGE, SendWR, RecvWR
-from pyverbs.qp import QPCap, QPInitAttr, QPInitAttrEx, QPAttr, QPEx, QP
-from tests.mlx5_base import Mlx5DcResources, Mlx5DcStreamsRes
 from pyverbs.base import PyverbsRDMAErrno
+from tests.efa_base import SRDResources
 from pyverbs.cq import PollCqAttr, CQEX
 from pyverbs.mr import MW, MWBindInfo
+from pyverbs.mem_alloc import madvise
 import pyverbs.device as d
 import pyverbs.enums as e
 from pyverbs.mr import MR
-import pyverbs.providers.mlx5.mlx5_enums as me
 
 
 MAX_MR_SIZE = 4194304
@@ -370,7 +370,7 @@ def wc_status_to_str(status):
         return 'Unknown WC status ({s})'.format(s=status)
 
 
-def create_custom_mr(agr_obj, additional_access_flags=0, size=None):
+def create_custom_mr(agr_obj, additional_access_flags=0, size=None, user_addr=None):
     """
     Creates a memory region using the aggregation object's PD.
     If size is None, the agr_obj's message size is used to set the MR's size.
@@ -378,11 +378,12 @@ def create_custom_mr(agr_obj, additional_access_flags=0, size=None):
     :param agr_obj: The aggregation object that creates the MR
     :param additional_access_flags: Addition access flags to set in the MR
     :param size: MR's length. If None, agr_obj.msg_size is used.
+    :param user_addr: The MR's buffer address. If None, the buffer will be allocated by pyverbs.
     """
     mr_length = size if size else agr_obj.msg_size
     try:
         return MR(agr_obj.pd, mr_length,
-                  e.IBV_ACCESS_LOCAL_WRITE | additional_access_flags)
+                  e.IBV_ACCESS_LOCAL_WRITE | additional_access_flags, address=user_addr)
     except PyverbsRDMAError as ex:
         if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest(f'Create custom mr with additional access flags {additional_access_flags} is not supported')
@@ -699,7 +700,7 @@ def send(agr_obj, send_object, send_op=None, new_send=False, qp_idx=0, ah=None, 
 
 
 def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
-            new_send=False, is_imm=False):
+            new_send=False, is_imm=False, force_page_faults=False):
     """
     Runs basic traffic between two sides
     :param client: client side, clients base class is BaseTraffic
@@ -711,6 +712,8 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
     :param send_op: The send_wr opcode.
     :param new_send: If True use new post send API.
     :param is_imm: If True, send with imm_data, relevant for old post send API.
+    :param force_page_faults: If True, use madvise to hint that we don't need the MR's buffer to
+                              force page faults (useful for ODP testing).
     :return:
     """
     if is_datagram_qp(client):
@@ -735,6 +738,9 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
     read_offset = GRH_SIZE if client.qp.qp_type == e.IBV_QPT_UD else 0
     for _ in range(iters):
         for qp_idx in range(server.qp_count):
+            if force_page_faults:
+                madvise(client.mr.buf, client.msg_size)
+                madvise(server.mr.buf, server.msg_size)
             if imm_data:
                 c_send_wr, c_sg = get_send_elements(client, False, opcode=e.IBV_WR_SEND_WITH_IMM)
             else:
@@ -1085,8 +1091,15 @@ def flush_traffic(client, server, iters, gid_idx, port, new_send=False,
     return wcs
 
 
+def prepare_validate_data(client=None, server=None):
+    if server:
+        server.mem_write('s' * server.msg_size, server.msg_size)
+    if client:
+        client.mem_write('c' * client.msg_size, client.msg_size)
+
+
 def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
-                 send_op=None):
+                 send_op=None, force_page_faults=False):
     """
     Runs basic RDMA traffic between two sides. No receive WQEs are posted. For
     RDMA send with immediate, use traffic().
@@ -1097,6 +1110,8 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
     :param port: IB port
     :param new_send: If True use new post send API.
     :param send_op: The send_wr opcode.
+    :param force_page_faults: If True, use madvise to hint that we don't need the MR's buffer to
+                              force page faults (useful for ODP testing).
     :return:
     """
     # Using the new post send API, we need the SGE, not the SendWR
@@ -1113,6 +1128,10 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
                                    e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD,
                                    e.IBV_WR_RDMA_READ]
     for _ in range(iters):
+        if force_page_faults:
+            madvise(client.mr.buf, client.msg_size)
+            madvise(server.mr.buf, server.msg_size)
+        prepare_validate_data(client=client, server=server)
         c_send_wr = get_send_elements(client, False, send_op)[send_element_idx]
         send(client, c_send_wr, send_op, new_send, ah=ah_client)
         poll_cq(client.cq)
@@ -1123,8 +1142,7 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
         validate(msg_received, False if same_side_check else True,
                  server.msg_size)
         s_send_wr = get_send_elements(server, True, send_op)[send_element_idx]
-        if same_side_check:
-            client.mem_write('c' * client.msg_size, client.msg_size)
+        prepare_validate_data(client=client, server=server)
         send(server, s_send_wr, send_op, new_send, ah=ah_server)
         poll_cq(server.cq)
         if same_side_check:
@@ -1133,12 +1151,10 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
             msg_received = client.mem_read(server.msg_size)
         validate(msg_received, True if same_side_check else False,
                  client.msg_size)
-        if same_side_check:
-            server.mem_write('s' * server.msg_size, server.msg_size)
 
 
 def atomic_traffic(client, server, iters, gid_idx, port, new_send=False,
-                   send_op=None, receiver_val=1, sender_val=2):
+                   send_op=None, receiver_val=1, sender_val=2, **kwargs):
     """
     Runs atomic traffic between two sides.
     :param client: Client side, clients base class is BaseTraffic
@@ -1150,6 +1166,7 @@ def atomic_traffic(client, server, iters, gid_idx, port, new_send=False,
     :param send_op: The send_wr opcode.
     :param receiver_val: The requested value on the reciver MR.
     :param sender_val: The requested value on the sender SendWR.
+    :param kwargs: General arguments (shared with other traffic functions).
     """
     send_element_idx = 1 if new_send else 0
     for _ in range(iters):
@@ -1241,7 +1258,7 @@ def get_atomic_send_elements(agr_obj, opcode, cmp_add=0, swap=0):
     return send_wr, sge
 
 
-def xrc_traffic(client, server, is_cq_ex=False, send_op=None):
+def xrc_traffic(client, server, is_cq_ex=False, send_op=None, force_page_faults=False):
     """
     Runs basic xrc traffic, this function assumes that number of QPs, which
     server and client have are equal, server.send_qp[i] is connected to
@@ -1254,6 +1271,8 @@ def xrc_traffic(client, server, is_cq_ex=False, send_op=None):
     of XRCResources class
     :param is_cq_ex: If True, use poll_cq_ex() rather than poll_cq()
     :param send_op: If not None, new post send API is assumed.
+    :param force_page_faults: If True, use madvise to hint that we don't need the MR's buffer to
+                              force page faults (useful for ODP testing).
     :return: None
     """
     poll = poll_cq_ex if is_cq_ex else poll_cq
@@ -1267,6 +1286,9 @@ def xrc_traffic(client, server, is_cq_ex=False, send_op=None):
     send_element_idx = 1 if send_op else 0
     for _ in range(client.num_msgs):
         for i in range(server.qp_count):
+            if force_page_faults:
+                madvise(client.mr.buf, client.msg_size)
+                madvise(server.mr.buf, server.msg_size)
             c_send_wr = get_send_elements(client, False)[send_element_idx]
             if send_op is None:
                 c_send_wr.set_qp_type_xrc(client.remote_srqn)


### PR DESCRIPTION
This series adds a new SW Steering test and improve ODP tests by explicitly invalidating the MRs to make sure a page fault occurs.
In addition, adjusts the way we get the net-interface to be dependent on both the device name and port.