### PR TITLE
redhat: Update source filename in spec file

### DIFF
--- a/redhat/rdma-core.spec
+++ b/redhat/rdma-core.spec
@@ -9,7 +9,7 @@ Summary: RDMA core userspace libraries and daemons
 #  providers/hfi1verbs Uses the 3 Clause BSD license
 License: GPLv2 or BSD
 Url: https://github.com/linux-rdma/rdma-core
-Source: rdma-core-%{version}.tgz
+Source: rdma-core-%{version}.tar.gz
 # Do not build static libs by default.
 %define with_static %{?_with_static: 1} %{?!_with_static: 0}
 


### PR DESCRIPTION
rdma-core release uses .tar.gz
suse/rdma-core.spec also uses .tar.gz