### PR TITLE
Multiple fixes for traffic util functions and tests for SRD RDMA write

### DIFF
--- a/tests/efa_base.py
+++ b/tests/efa_base.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 import unittest
 import random
@@ -93,10 +93,12 @@ class SRDResources(TrafficResources):
             raise ex
 
     def create_mr(self):
+        additional_access_flags = 0
         if self.send_ops_flags == e.IBV_QP_EX_WITH_RDMA_READ:
-            self.mr = tests.utils.create_custom_mr(self, e.IBV_ACCESS_REMOTE_READ)
-        else:
-            self.mr = tests.utils.create_custom_mr(self)
+            additional_access_flags = e.IBV_ACCESS_REMOTE_READ
+        elif self.send_ops_flags in [e.IBV_QP_EX_WITH_RDMA_WRITE, e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM]:
+            additional_access_flags = e.IBV_ACCESS_REMOTE_WRITE
+        self.mr = tests.utils.create_custom_mr(self, additional_access_flags)
 
 
 class EfaCQRes(SRDResources):

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -398,7 +398,7 @@ class Mlx5DcStreamsRes(Mlx5DcResources):
         :return: None
         """
         import tests.utils as u
-        send_op = e.IBV_QP_EX_WITH_SEND
+        send_op = e.IBV_WR_SEND
         ah_client = u.get_global_ah(client, gid_idx, port)
         s_recv_wr = u.get_recv_wr(server)
         c_recv_wr = u.get_recv_wr(client)

--- a/tests/test_cuda_dmabuf.py
+++ b/tests/test_cuda_dmabuf.py
@@ -93,9 +93,9 @@ class DmabufCudaTest(RDMATestCase):
         Exchange the MR remote attributes between the server and the client.
         """
         self.server.rkey = self.client.mr.rkey
-        self.server.remote_addr = self.client.mr.buf
+        self.server.raddr = self.client.mr.buf
         self.client.rkey = self.server.mr.rkey
-        self.client.remote_addr = self.server.mr.buf
+        self.client.raddr = self.server.mr.buf
 
     def test_cuda_dmabuf_rdma_write_traffic(self):
         """

--- a/tests/test_efa_srd.py
+++ b/tests/test_efa_srd.py
@@ -68,6 +68,24 @@ class QPSRDTestCase(EfaRDMATestCase):
         u.rdma_traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
                        new_send=True, send_op=e.IBV_WR_RDMA_READ)
 
+    def test_qp_ex_srd_rdma_write(self):
+        self.create_players(e.IBV_QP_EX_WITH_RDMA_WRITE)
+        self.client.rkey = self.server.mr.rkey
+        self.server.rkey = self.client.mr.rkey
+        self.client.raddr = self.server.mr.buf
+        self.server.raddr = self.client.mr.buf
+        u.rdma_traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
+                       new_send=True, send_op=e.IBV_WR_RDMA_WRITE)
+
+    def test_qp_ex_srd_rdma_write_with_imm(self):
+        self.create_players(e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM)
+        self.client.rkey = self.server.mr.rkey
+        self.server.rkey = self.client.mr.rkey
+        self.client.raddr = self.server.mr.buf
+        self.server.raddr = self.client.mr.buf
+        u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
+                  new_send=True, send_op=e.IBV_WR_RDMA_WRITE_WITH_IMM)
+
     def test_qp_ex_srd_old_send(self):
         self.create_players()
         u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,

--- a/tests/test_efa_srd.py
+++ b/tests/test_efa_srd.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020-2021 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
 
 import unittest
 import errno
@@ -38,7 +38,7 @@ class QPSRDTestCase(EfaRDMATestCase):
         - Fill the qp with work requests until overflow
         """
         qp_idx = 0
-        send_op = e.IBV_QP_EX_WITH_SEND
+        send_op = e.IBV_WR_SEND
         ah = u.get_global_ah(self.client, self.gid_index, self.ib_port)
         qp_attr, _ = self.client.qps[qp_idx].query(e.IBV_QP_CAP)
         max_send_wr = qp_attr.cap.max_send_wr
@@ -49,27 +49,24 @@ class QPSRDTestCase(EfaRDMATestCase):
         self.assertEqual(ex.exception.error_code, errno.ENOMEM)
 
     def test_qp_ex_srd_send(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op)
+        self.create_players(e.IBV_QP_EX_WITH_SEND)
         u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=send_op)
+                  new_send=True, send_op=e.IBV_WR_SEND)
 
     def test_qp_ex_srd_send_imm(self):
-        send_op = e.IBV_QP_EX_WITH_SEND_WITH_IMM
-        self.create_players(send_op)
+        self.create_players(e.IBV_QP_EX_WITH_SEND_WITH_IMM)
         u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=send_op)
+                  new_send=True, send_op=e.IBV_WR_SEND_WITH_IMM)
 
     def test_qp_ex_srd_rdma_read(self):
-        send_op = e.IBV_QP_EX_WITH_RDMA_READ
-        self.create_players(send_op)
+        self.create_players(e.IBV_QP_EX_WITH_RDMA_READ)
         self.client.rkey = self.server.mr.rkey
         self.server.rkey = self.client.mr.rkey
         self.client.raddr = self.server.mr.buf
         self.server.raddr = self.client.mr.buf
         self.server.mr.write('s' * self.server.msg_size, self.server.msg_size)
         u.rdma_traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=send_op)
+                       new_send=True, send_op=e.IBV_WR_RDMA_READ)
 
     def test_qp_ex_srd_old_send(self):
         self.create_players()
@@ -79,37 +76,31 @@ class QPSRDTestCase(EfaRDMATestCase):
     def test_qp_ex_srd_old_send_imm(self):
         self.create_players()
         u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
-                  new_send=False, is_imm=True)
+                  new_send=False, send_op=e.IBV_WR_SEND_WITH_IMM)
 
     def test_qp_ex_srd_zero_size(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op)
+        self.create_players(e.IBV_QP_EX_WITH_SEND)
         self.client.msg_size = 0
         self.server.msg_size = 0
         u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=send_op)
+                  new_send=True, send_op=e.IBV_WR_SEND)
 
     def test_post_receive_qp_state_bad_flow(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op, qp_count=1)
+        self.create_players(e.IBV_QP_EX_WITH_SEND, qp_count=1)
         u.post_rq_state_bad_flow(self)
 
     def test_post_send_qp_state_bad_flow(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op, qp_count=1)
+        self.create_players(e.IBV_QP_EX_WITH_SEND, qp_count=1)
         u.post_sq_state_bad_flow(self)
 
     def test_full_rq_bad_flow(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op, qp_count=1)
+        self.create_players(e.IBV_QP_EX_WITH_SEND, qp_count=1)
         u.full_rq_bad_flow(self)
 
     def test_full_sq_bad_flow(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op, qp_count=1)
+        self.create_players(e.IBV_QP_EX_WITH_SEND, qp_count=1)
         self.full_sq_bad_flow()
 
     def test_rq_with_larger_sgl_bad_flow(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
-        self.create_players(send_op, qp_count=1)
+        self.create_players(e.IBV_QP_EX_WITH_SEND, qp_count=1)
         u.create_rq_with_larger_sgl_bad_flow(self)

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
-# Copyright 2020-2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright 2020-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
 """
 Test module for efa direct-verbs.
 """
@@ -149,14 +149,13 @@ class EfaCqTest(EfaRDMATestCase):
         self.server.remote_gid = self.client.ctx.query_gid(self.client.ib_port, self.client.gid_index)
 
     def test_dv_cq_ex_with_sgid(self):
-        send_op = e.IBV_QP_EX_WITH_SEND
         wc_flag = efa_e.EFADV_WC_EX_WITH_SGID
         dev_cap = efa_e.EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID
-        self.create_players(dev_cap, wc_flag, send_op, qp_count=1)
+        self.create_players(dev_cap, wc_flag, e.IBV_QP_EX_WITH_SEND, qp_count=1)
         recv_wr = u.get_recv_wr(self.server)
         self.server.qps[0].post_recv(recv_wr)
         ah_client = u.get_global_ah(self.client, self.gid_index, self.ib_port)
         _ , sg = u.get_send_elements(self.client, False)
-        u.send(self.client, sg, send_op, new_send=True, qp_idx=0, ah=ah_client)
+        u.send(self.client, sg, e.IBV_WR_SEND, new_send=True, qp_idx=0, ah=ah_client)
         u.poll_cq_ex(self.client.cq)
         u.poll_cq_ex(self.server.cq, sgid=self.server.remote_gid)

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -107,7 +107,9 @@ class EfaQPExTest(EfaAPITestCase):
 def get_random_send_op_flags():
     send_ops_flags = [e.IBV_QP_EX_WITH_SEND,
                       e.IBV_QP_EX_WITH_SEND_WITH_IMM,
-                      e.IBV_QP_EX_WITH_RDMA_READ]
+                      e.IBV_QP_EX_WITH_RDMA_READ,
+                      e.IBV_QP_EX_WITH_RDMA_WRITE,
+                      e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM]
     selected = u.sample(send_ops_flags)
     selected_ops_flags = 0
     for s in selected:

--- a/tests/test_mlx5_cq.py
+++ b/tests/test_mlx5_cq.py
@@ -241,4 +241,4 @@ class DvCqTest(Mlx5RDMATestCase):
                 self.set_env_variable('MLX5_SCATTER_TO_CQE', s2c_env_val)
                 self.create_players(Mlx5DvCqDcRes, create_flags=qp_s2c_value)
                 u.traffic(**self.traffic_args, new_send=True,
-                          send_op=e.IBV_QP_EX_WITH_SEND, is_cq_ex=True)
+                          send_op=e.IBV_WR_SEND, is_cq_ex=True)

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -67,13 +67,13 @@ class DCTest(Mlx5RDMATestCase):
         self.create_players(Mlx5DcResources, qp_count=2,
                             send_ops_flags=e.IBV_QP_EX_WITH_RDMA_WRITE)
         u.rdma_traffic(**self.traffic_args, new_send=True,
-                       send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+                       send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_dc_send(self):
         self.create_players(Mlx5DcResources, qp_count=2,
                             send_ops_flags=e.IBV_QP_EX_WITH_SEND)
         u.traffic(**self.traffic_args, new_send=True,
-                  send_op=e.IBV_QP_EX_WITH_SEND)
+                  send_op=e.IBV_WR_SEND)
 
     def test_dc_ah_to_qp_mapping(self):
         self.create_players(Mlx5DcResources, qp_count=2,
@@ -86,7 +86,7 @@ class DCTest(Mlx5RDMATestCase):
                 raise unittest.SkipTest('Mapping AH to QP is not supported')
             raise ex
         u.traffic(**self.traffic_args, new_send=True,
-                  send_op=e.IBV_QP_EX_WITH_SEND)
+                  send_op=e.IBV_WR_SEND)
 
     def check_odp_dc_support(self):
         """
@@ -103,7 +103,7 @@ class DCTest(Mlx5RDMATestCase):
         self.create_players(OdpDc, qp_count=2, send_ops_flags=send_ops_flag)
         self.check_odp_dc_support()
         u.traffic(**self.traffic_args, new_send=True,
-                  send_op=e.IBV_QP_EX_WITH_SEND)
+                  send_op=e.IBV_WR_SEND)
 
     def test_dc_rdma_write_stream(self):
         """
@@ -117,7 +117,7 @@ class DCTest(Mlx5RDMATestCase):
         self.create_players(Mlx5DcStreamsRes, qp_count=2,
                             send_ops_flags=e.IBV_QP_EX_WITH_RDMA_WRITE)
         u.rdma_traffic(**self.traffic_args, new_send=True,
-                       send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+                       send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_dc_send_stream_bad_flow(self):
         """

--- a/tests/test_mlx5_rdmacm.py
+++ b/tests/test_mlx5_rdmacm.py
@@ -49,7 +49,7 @@ class DcCMConnection(CMAsyncConnection):
         self.syncer.wait()
         for send_idx in range(self.cm_res.num_msgs):
             dci_idx = send_idx % len(self.cm_res.qps)
-            u.post_send_ex(self.cm_res, send_wr, e.IBV_QP_EX_WITH_SEND, ah=ah,
+            u.post_send_ex(self.cm_res, send_wr, e.IBV_WR_SEND, ah=ah,
                            qp_idx=dci_idx)
             u.poll_cq(self.cm_res.cq)
 

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -97,9 +97,9 @@ class MRTest(RDMATestCase):
         Exchange the MR remote attributes between the server and the client.
         """
         self.server.rkey = self.client.mr.rkey
-        self.server.remote_addr = self.client.mr.buf
+        self.server.raddr = self.client.mr.buf
         self.client.rkey = self.server.mr.rkey
-        self.client.remote_addr = self.server.mr.buf
+        self.client.raddr = self.server.mr.buf
 
     def restate_qps(self):
         """
@@ -261,9 +261,9 @@ class MWTest(RDMATestCase):
         u.poll_cq(self.server.cq)
         u.poll_cq(self.client.cq)
         self.server.rkey = self.client.mw.rkey
-        self.server.remote_addr = self.client.mr.buf
+        self.server.raddr = self.client.mr.buf
         self.client.rkey = self.server.mw.rkey
-        self.client.remote_addr = self.server.mr.buf
+        self.client.raddr = self.server.mr.buf
 
     def bind_mw_type_2(self):
         client_send_wr = SendWR(opcode=e.IBV_WR_BIND_MW)
@@ -276,9 +276,9 @@ class MWTest(RDMATestCase):
         u.poll_cq(self.server.cq)
         u.poll_cq(self.client.cq)
         self.server.rkey = client_send_wr.rkey
-        self.server.remote_addr = self.client.mr.buf
+        self.server.raddr = self.client.mr.buf
         self.client.rkey = server_send_wr.rkey
-        self.client.remote_addr = self.server.mr.buf
+        self.client.raddr = self.server.mr.buf
 
     def invalidate_mw_type1(self):
         """
@@ -686,9 +686,9 @@ class DmaBufTestCase(RDMATestCase):
         client, server = self.create_players(DmaBufRC, gpu=self.gpu,
                                              gtt=self.gtt)
         server.rkey = client.mr.rkey
-        server.remote_addr = client.mr.offset
+        server.raddr = client.mr.offset
         client.rkey = server.mr.rkey
-        client.remote_addr = server.mr.offset
+        client.raddr = server.mr.offset
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
                        send_op=e.IBV_WR_RDMA_WRITE)
 
@@ -767,9 +767,9 @@ class DeviceMemoryTest(RDMATestCase):
         Exchange the MR remote attributes between the server and the client.
         """
         self.server.rkey = self.client.mr.rkey
-        self.server.remote_addr = self.client.mr.buf
+        self.server.raddr = self.client.mr.buf
         self.client.rkey = self.server.mr.rkey
-        self.client.remote_addr = self.server.mr.buf
+        self.client.raddr = self.server.mr.buf
 
     def test_dm_traffic(self):
         self.create_players(DeviceMemoryRes)

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -134,9 +134,9 @@ class OdpTestCase(RDMATestCase):
         Sync the MR remote attributes between the server and the client.
         """
         self.server.rkey = self.client.mr.rkey
-        self.server.remote_addr = self.server.raddr = self.client.mr.buf
+        self.server.raddr = self.server.raddr = self.client.mr.buf
         self.client.rkey = self.server.mr.rkey
-        self.client.remote_addr = self.client.raddr = self.server.mr.buf
+        self.client.raddr = self.client.raddr = self.server.mr.buf
 
     def tearDown(self):
         if self.server and self.server.user_addr:

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -217,37 +217,37 @@ class QpExTestCase(RDMATestCase):
     def test_qp_ex_ud_send(self):
         client, server = self.create_players('ud_send')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_SEND)
+                  new_send=True, send_op=e.IBV_WR_SEND)
 
     def test_qp_ex_ud_zero_size(self):
         client, server = self.create_players('ud_send')
         client.msg_size = 0
         server.msg_size = 0
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_SEND)
+                  new_send=True, send_op=e.IBV_WR_SEND)
 
     def test_qp_ex_rc_send(self):
         client, server = self.create_players('rc_send')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_SEND)
+                  new_send=True, send_op=e.IBV_WR_SEND)
 
     def test_qp_ex_xrc_send(self):
         client, server = self.create_players('xrc_send')
-        u.xrc_traffic(client, server, send_op=e.IBV_QP_EX_WITH_SEND)
+        u.xrc_traffic(client, server, send_op=e.IBV_WR_SEND)
 
     def test_qp_ex_ud_send_imm(self):
         client, server = self.create_players('ud_send_imm')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_SEND_WITH_IMM)
+                  new_send=True, send_op=e.IBV_WR_SEND_WITH_IMM)
 
     def test_qp_ex_rc_send_imm(self):
         client, server = self.create_players('rc_send_imm')
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_SEND_WITH_IMM)
+                  new_send=True, send_op=e.IBV_WR_SEND_WITH_IMM)
 
     def test_qp_ex_xrc_send_imm(self):
         client, server = self.create_players('xrc_send_imm')
-        u.xrc_traffic(client, server, send_op=e.IBV_QP_EX_WITH_SEND_WITH_IMM)
+        u.xrc_traffic(client, server, send_op=e.IBV_WR_SEND_WITH_IMM)
 
     def test_qp_ex_rc_flush(self):
         client, server = self.create_players('rc_flush')
@@ -258,14 +258,14 @@ class QpExTestCase(RDMATestCase):
         server.raddr = client.mr.buf
         wcs = u.flush_traffic(client, server, self.iters, self.gid_index,
                               self.ib_port, new_send=True,
-                              send_op=e.IBV_QP_EX_WITH_FLUSH)
+                              send_op=e.IBV_WR_FLUSH)
         if wcs[0].status != e.IBV_WC_SUCCESS:
             raise PyverbsError(f'Unexpected {wc_status_to_str(wcs[0].status)}')
 
         client.level = e.IBV_FLUSH_MR
         wcs = u.flush_traffic(client, server, self.iters, self.gid_index,
                               self.ib_port, new_send=True,
-                              send_op=e.IBV_QP_EX_WITH_FLUSH)
+                              send_op=e.IBV_WR_FLUSH)
         if wcs[0].status != e.IBV_WC_SUCCESS:
             raise PyverbsError(f'Unexpected {wc_status_to_str(wcs[0].status)}')
 
@@ -279,7 +279,7 @@ class QpExTestCase(RDMATestCase):
         client.ptype = e.IBV_FLUSH_PERSISTENT
         wcs = u.flush_traffic(client, server, self.iters, self.gid_index,
                               self.ib_port, new_send=True,
-                              send_op=e.IBV_QP_EX_WITH_FLUSH)
+                              send_op=e.IBV_WR_FLUSH)
         if wcs[0].status != e.IBV_WC_REM_ACCESS_ERR:
             raise PyverbsError(f'Expected errors {wc_status_to_str(e.IBV_WC_REM_ACCESS_ERR)} - got {wc_status_to_str(wcs[0].status)}')
 
@@ -292,7 +292,7 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_ATOMIC_WRITE)
+                       new_send=True, send_op=e.IBV_WR_ATOMIC_WRITE)
 
     def test_qp_ex_rc_rdma_write(self):
         client, server = self.create_players('rc_write')
@@ -301,7 +301,7 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+                       new_send=True, send_op=e.IBV_WR_ATOMIC_WRITE)
 
     def test_qp_ex_rc_rdma_write_imm(self):
         client, server = self.create_players('rc_write_imm')
@@ -310,7 +310,7 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM)
+                  new_send=True, send_op=e.IBV_WR_RDMA_WRITE_WITH_IMM)
 
     def test_qp_ex_rc_rdma_write_zero_length(self):
         client, server = self.create_players('rc_write')
@@ -321,7 +321,7 @@ class QpExTestCase(RDMATestCase):
         client.raddr = server.mr.buf
         server.raddr = client.mr.buf
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE)
+                       new_send=True, send_op=e.IBV_WR_RDMA_WRITE)
 
     def test_qp_ex_rc_rdma_read(self):
         client, server = self.create_players('rc_read')
@@ -331,7 +331,7 @@ class QpExTestCase(RDMATestCase):
         server.raddr = client.mr.buf
         server.mr.write('s' * server.msg_size, server.msg_size)
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_READ)
+                       new_send=True, send_op=e.IBV_WR_RDMA_READ)
 
     def test_qp_ex_rc_rdma_read_zero_size(self):
         client, server = self.create_players('rc_read')
@@ -343,7 +343,7 @@ class QpExTestCase(RDMATestCase):
         server.msg_size = 0
         server.mr.write('s' * server.msg_size, server.msg_size)
         u.rdma_traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                       new_send=True, send_op=e.IBV_QP_EX_WITH_RDMA_READ)
+                       new_send=True, send_op=e.IBV_WR_RDMA_READ)
 
     def test_qp_ex_rc_atomic_cmp_swp(self):
         client, server = self.create_players('rc_cmp_swp')
@@ -356,7 +356,7 @@ class QpExTestCase(RDMATestCase):
         server.mr.write('s' * 8, 8)
         u.atomic_traffic(client, server, self.iters, self.gid_index,
                          self.ib_port, new_send=True,
-                         send_op=e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP)
+                         send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
 
     def test_qp_ex_rc_atomic_fetch_add(self):
         client, server = self.create_players('rc_fetch_add')
@@ -369,7 +369,7 @@ class QpExTestCase(RDMATestCase):
         server.mr.write('s' * 8, 8)
         u.atomic_traffic(client, server, self.iters, self.gid_index,
                          self.ib_port, new_send=True,
-                         send_op=e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
+                         send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD)
 
     def test_qp_ex_rc_bind_mw(self):
         """

--- a/tests/test_shared_pd.py
+++ b/tests/test_shared_pd.py
@@ -92,4 +92,4 @@ class SharedPDTestCase(RDMATestCase):
         client.raddr = server_import.mr.buf
         server_import.raddr = client.mr.buf
         u.rdma_traffic(client, server_import, self.iters, self.gid_index,
-                       self.ib_port, send_op=e.IBV_QP_EX_WITH_RDMA_WRITE, new_send=True)
+                       self.ib_port, send_op=e.IBV_WR_RDMA_WRITE, new_send=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -745,10 +745,7 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=e.IBV_
             if force_page_faults:
                 madvise(client.mr.buf, client.msg_size)
                 madvise(server.mr.buf, server.msg_size)
-            if imm_data:
-                c_send_wr, c_sg = get_send_elements(client, False, opcode=e.IBV_WR_SEND_WITH_IMM)
-            else:
-                c_send_wr, c_sg = get_send_elements(client, False)
+            c_send_wr, c_sg = get_send_elements(client, False, send_op)
             if client.use_mr_prefetch:
                 flags = e._IBV_ADVISE_MR_FLAG_FLUSH
                 if client.use_mr_prefetch == 'async':
@@ -763,10 +760,7 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=e.IBV_
             post_recv(server, s_recv_wr, qp_idx=qp_idx)
             msg_received = server.mr.read(server.msg_size, read_offset)
             validate(msg_received, True, server.msg_size)
-            if imm_data:
-                s_send_wr, s_sg = get_send_elements(server, True, opcode=e.IBV_WR_SEND_WITH_IMM)
-            else:
-                s_send_wr, s_sg = get_send_elements(server, True)
+            s_send_wr, s_sg = get_send_elements(server, True, send_op)
             if server.use_mr_prefetch:
                 flags = e._IBV_ADVISE_MR_FLAG_FLUSH
                 if server.use_mr_prefetch == 'async':

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -405,7 +405,7 @@ def get_send_elements(agr_obj, is_server, opcode=e.IBV_WR_SEND):
     :param is_server: Indicates whether this is server or client side
     :return: send wr and its SGE
     """
-    if opcode == e.IBV_QP_EX_WITH_ATOMIC_WRITE:
+    if opcode == e.IBV_WR_ATOMIC_WRITE:
         atomic_wr = agr_obj.msg_size * (b's' if is_server else b'c')
         return None, atomic_wr
 
@@ -474,28 +474,28 @@ def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
     qp.wr_start()
     qp.wr_id = 0x123
     qp.wr_flags = e.IBV_SEND_SIGNALED
-    if send_op == e.IBV_QP_EX_WITH_SEND:
+    if send_op == e.IBV_WR_SEND:
         qp.wr_send()
-    elif send_op == e.IBV_QP_EX_WITH_RDMA_WRITE:
+    elif send_op == e.IBV_WR_RDMA_WRITE:
         qp.wr_rdma_write(agr_obj.rkey, agr_obj.raddr)
-    elif send_op == e.IBV_QP_EX_WITH_SEND_WITH_IMM:
+    elif send_op == e.IBV_WR_SEND_WITH_IMM:
         qp.wr_send_imm(IMM_DATA)
-    elif send_op == e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM:
+    elif send_op == e.IBV_WR_RDMA_WRITE_WITH_IMM:
         qp.wr_rdma_write_imm(agr_obj.rkey, agr_obj.raddr, IMM_DATA)
-    elif send_op == e.IBV_QP_EX_WITH_ATOMIC_WRITE:
+    elif send_op == e.IBV_WR_ATOMIC_WRITE:
         qp.wr_atomic_write(agr_obj.rkey, agr_obj.raddr, send_object)
-    elif send_op == e.IBV_QP_EX_WITH_FLUSH:
+    elif send_op == e.IBV_WR_FLUSH:
         qp.wr_flush(agr_obj.rkey, agr_obj.raddr, agr_obj.msg_size,
                     agr_obj.ptype, agr_obj.level)
-    elif send_op == e.IBV_QP_EX_WITH_RDMA_READ:
+    elif send_op == e.IBV_WR_RDMA_READ:
         qp.wr_rdma_read(agr_obj.rkey, agr_obj.raddr)
-    elif send_op == e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP:
+    elif send_op == e.IBV_WR_ATOMIC_CMP_AND_SWP:
         qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr,
                              int8b_from_int(2), int8b_from_int(0))
-    elif send_op == e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD:
+    elif send_op == e.IBV_WR_ATOMIC_FETCH_AND_ADD:
         qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr,
                                int8b_from_int(2))
-    elif send_op == e.IBV_QP_EX_WITH_BIND_MW:
+    elif send_op == e.IBV_WR_BIND_MW:
         bind_info = MWBindInfo(agr_obj.mr, agr_obj.mr.buf, agr_obj.mr.rkey,
                                e.IBV_ACCESS_REMOTE_WRITE)
         mw = MW(agr_obj.pd, mw_type=e.IBV_MW_TYPE_2)
@@ -516,8 +516,8 @@ def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
                                      stream_id)
         else:
             qp.wr_set_dc_addr(ah, agr_obj.remote_dct_num, DCT_KEY)
-    if send_op != e.IBV_QP_EX_WITH_ATOMIC_WRITE and \
-            send_op != e.IBV_QP_EX_WITH_FLUSH:
+    if send_op != e.IBV_WR_ATOMIC_WRITE and \
+            send_op != e.IBV_WR_FLUSH:
         qp.wr_set_sge(send_object)
     qp.wr_complete()
 
@@ -705,8 +705,8 @@ def send(agr_obj, send_object, send_op=None, new_send=False, qp_idx=0, ah=None, 
     return post_send(agr_obj, send_object, qp_idx, ah, is_imm)
 
 
-def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
-            new_send=False, is_imm=False, force_page_faults=False):
+def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=e.IBV_WR_SEND,
+            new_send=False, force_page_faults=False):
     """
     Runs basic traffic between two sides
     :param client: client side, clients base class is BaseTraffic
@@ -717,7 +717,6 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
     :param is_cq_ex: If True, use poll_cq_ex() rather than poll_cq()
     :param send_op: The send_wr opcode.
     :param new_send: If True use new post send API.
-    :param is_imm: If True, send with imm_data, relevant for old post send API.
     :param force_page_faults: If True, use madvise to hint that we don't need the MR's buffer to
                               force page faults (useful for ODP testing).
     :return:
@@ -729,12 +728,11 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
         ah_client = None
         ah_server = None
     poll = poll_cq_ex if is_cq_ex else poll_cq
-    if send_op == e.IBV_QP_EX_WITH_SEND_WITH_IMM or \
-       send_op == e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM or \
-       is_imm:
+
+    imm_data = None
+    if send_op in [e.IBV_WR_SEND_WITH_IMM, e.IBV_WR_RDMA_WRITE_WITH_IMM]:
         imm_data = IMM_DATA
-    else:
-        imm_data = None
+
     s_recv_wr = get_recv_wr(server)
     c_recv_wr = get_recv_wr(client)
     for qp_idx in range(server.qp_count):
@@ -757,9 +755,9 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
                     flags = 0
                 prefetch_mrs(client, [c_sg], advice=client.prefetch_advice,
                              flags=flags)
-            c_send_object = c_sg if send_op else c_send_wr
+            c_send_object = c_sg if new_send else c_send_wr
             send(client, c_send_object, send_op, new_send, qp_idx,
-                 ah_client, is_imm=is_imm)
+                 ah_client, is_imm=(imm_data != None))
             poll(client.cq)
             poll(server.cq, data=imm_data)
             post_recv(server, s_recv_wr, qp_idx=qp_idx)
@@ -775,9 +773,9 @@ def traffic(client, server, iters, gid_idx, port, is_cq_ex=False, send_op=None,
                     flags = 0
                 prefetch_mrs(server, [s_sg], advice=server.prefetch_advice,
                              flags=flags)
-            s_send_object = s_sg if send_op else s_send_wr
+            s_send_object = s_sg if new_send else s_send_wr
             send(server, s_send_object, send_op, new_send, qp_idx,
-                 ah_server, is_imm=is_imm)
+                 ah_server, is_imm=(imm_data != None))
             poll(server.cq)
             poll(client.cq, data=imm_data)
             post_recv(client, c_recv_wr, qp_idx=qp_idx)
@@ -1096,7 +1094,7 @@ def flush_traffic(client, server, iters, gid_idx, port, new_send=False,
     :param send_op: The send_wr opcode.
     :return:
     """
-    rdma_traffic(client, server, iters, gid_idx, port, new_send, e.IBV_QP_EX_WITH_RDMA_WRITE)
+    rdma_traffic(client, server, iters, gid_idx, port, new_send, e.IBV_WR_RDMA_WRITE)
     for i in range(iters):
         if client.level == e.IBV_FLUSH_MR:
             client.msg_size = 0 if i == 0 else random.randint(0, 12345678)
@@ -1139,10 +1137,9 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
         ah_client = None
         ah_server = None
     send_element_idx = 1 if new_send else 0
-    same_side_check =  send_op in [e.IBV_QP_EX_WITH_RDMA_READ,
-                                   e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP,
-                                   e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD,
-                                   e.IBV_WR_RDMA_READ]
+    same_side_check =  send_op in [e.IBV_WR_RDMA_READ,
+                                   e.IBV_WR_ATOMIC_CMP_AND_SWP,
+                                   e.IBV_WR_ATOMIC_FETCH_AND_ADD]
     for _ in range(iters):
         if force_page_faults:
             madvise(client.mr.buf, client.msg_size)
@@ -1560,7 +1557,7 @@ def post_sq_state_bad_flow(test_obj):
     ah = get_global_ah(test_obj.client, test_obj.gid_index, test_obj.ib_port)
     _, sg = get_send_elements(test_obj.client, False)
     with test_obj.assertRaises(PyverbsRDMAError) as ex:
-        send(test_obj.client, sg, e.IBV_QP_EX_WITH_SEND, new_send=True,
+        send(test_obj.client, sg, e.IBV_WR_SEND, new_send=True,
              qp_idx=qp_idx, ah=ah)
     test_obj.assertEqual(ex.exception.error_code, errno.EINVAL)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -416,7 +416,7 @@ def get_send_elements(agr_obj, is_server, opcode=e.IBV_WR_SEND):
     agr_obj.mem_write(msg, agr_obj.msg_size + offset)
     sge = SGE(agr_obj.mr.buf + offset, agr_obj.msg_size, agr_obj.mr_lkey)
     send_wr = SendWR(opcode=opcode, num_sge=1, sg=[sge])
-    if opcode in [e.IBV_WR_RDMA_WRITE, e.IBV_WR_RDMA_READ]:
+    if opcode in [e.IBV_WR_RDMA_WRITE, e.IBV_WR_RDMA_WRITE_WITH_IMM, e.IBV_WR_RDMA_READ]:
         send_wr.set_wr_rdma(int(agr_obj.rkey), int(agr_obj.remote_addr))
     return send_wr, sge
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -417,7 +417,7 @@ def get_send_elements(agr_obj, is_server, opcode=e.IBV_WR_SEND):
     sge = SGE(agr_obj.mr.buf + offset, agr_obj.msg_size, agr_obj.mr_lkey)
     send_wr = SendWR(opcode=opcode, num_sge=1, sg=[sge])
     if opcode in [e.IBV_WR_RDMA_WRITE, e.IBV_WR_RDMA_WRITE_WITH_IMM, e.IBV_WR_RDMA_READ]:
-        send_wr.set_wr_rdma(int(agr_obj.rkey), int(agr_obj.remote_addr))
+        send_wr.set_wr_rdma(int(agr_obj.rkey), int(agr_obj.raddr))
     return send_wr, sge
 
 def get_recv_wr(agr_obj):


### PR DESCRIPTION
Multiple fixes for traffic util functions:
1. Add RDMA write with imm opcode to send util
2. Fix double naming of remote address in players
3. Fix ambiguous use of QP opcode in traffic functions
4. Fix wrong send opcode use in traffic util

In addition add tests for SRD RDMA write with and without imm.