### PR TITLE
pyverbs: Remove include of bits/mman-linux.h

### DIFF
--- a/pyverbs/mem_alloc.pyx
+++ b/pyverbs/mem_alloc.pyx
@@ -15,8 +15,6 @@ cimport posix.mman as mm
 
 cdef extern from 'sys/mman.h':
     cdef void* MAP_FAILED
-
-cdef extern from 'bits/mman-linux.h':
     cdef int MADV_DONTNEED
 
 cdef extern from 'endian.h':


### PR DESCRIPTION
As documented in the bits/mman-linux.h header file, the header should never been included directly. sys/mman.h should be included and it will include bits/mman-linux.h. This matters because bit/mman-linux.h does not exist in some older copies of glibc-headers. sys/mman.h will pull in the correct headers for the the installed version of glibc-headers.

Fixes: 4c0d33d ("pyverbs: Add madvise python wrapper function ")
Signed-off-by: Mark Haywood mark.haywood@oracle.com