### PR TITLE
bnxt_re/lib: QP error and reuse handling

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1259,9 +1259,11 @@ int bnxt_re_modify_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr,
 			if (qp->qpst == IBV_QPS_RESET) {
 				qp->jsqq->hwque->head = 0;
 				qp->jsqq->hwque->tail = 0;
+				bnxt_re_cleanup_cq(qp, qp->scq);
 				if (qp->jrqq) {
 					qp->jrqq->hwque->head = 0;
 					qp->jrqq->hwque->tail = 0;
+					bnxt_re_cleanup_cq(qp, qp->rcq);
 				}
 			}
 		}

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1260,10 +1260,14 @@ int bnxt_re_modify_qp(struct ibv_qp *ibvqp, struct ibv_qp_attr *attr,
 				qp->jsqq->hwque->head = 0;
 				qp->jsqq->hwque->tail = 0;
 				bnxt_re_cleanup_cq(qp, qp->scq);
+				qp->jsqq->start_idx = 0;
+				qp->jsqq->last_idx = 0;
 				if (qp->jrqq) {
 					qp->jrqq->hwque->head = 0;
 					qp->jrqq->hwque->tail = 0;
 					bnxt_re_cleanup_cq(qp, qp->rcq);
+					qp->jrqq->start_idx = 0;
+					qp->jrqq->last_idx = 0;
 				}
 			}
 		}


### PR DESCRIPTION
This series includes 3 patches that fixes issues when qp is re-used  and destroyed.