### PR TITLE
stable: Tune stable branch creation process

### DIFF
--- a/Documentation/stable.md
+++ b/Documentation/stable.md
@@ -80,7 +80,10 @@ To do that, the creator of the branch should run
 mkdir ABI
 touch ABI/.gitignore
 git add ABI/.gitignore
-git commit -m "ABI Files"
+echo "              changeLogCompareToRelease: lastNonDraftReleaseByTag" >> buildlib/azure-pipelines-release.yml
+echo "              changeLogCompareToReleaseTag: $(git describe HEAD --match="v*.0"  --abbrev=0 | sed 's/0$/*/')" >> buildlib/azure-pipelines-release.yml
+git add buildlib/azure-pipelines-release.yml
+git commit -s -m "stable branch creation" -m "Add ABI files and tune Azure pipeline for changelog generation"
 ./buildlib/cbuild pkg azp
 git add ABI/*
 git commit --amend


### PR DESCRIPTION
Currently Azure generates release changelogs by diffing the new tag and the overall latest github release ( git log new_tag ^latest_release). This means that the changelog usually contains all the commits from the stable branch (vXX.0..vXX.N) and not just the one added from the latest release in this branch (vXX.N-1..vXX.N).

This commits changes the stable branch creation process so that azure-pipelines-release.yml will create the changelog using the latest github release in this stable branch.