### PR TITLE
tests: Remove code duplication

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -680,12 +680,19 @@ class TrafficResources(BaseResources):
 
     def pre_run(self, rpsns, rqps_num):
         """
-        Modify the QP's states to RTS and fill receive queue with <num_msgs> work
-        requests.
-        This method is not implemented in this class.
-        :param rpsns: Remote PSNs
+        Configure resources before running traffic and modifies the QP to RTS
+        if required.
+        :param rpsns: Remote PSNs (packet serial numbers)
         :param rqps_num: Remote QPs Number
-        :return: None
+        """
+        self.rpsns = rpsns
+        self.rqps_num = rqps_num
+        self.to_rts()
+
+    def to_rts(self):
+        """
+        Modify the QP's states to RTS and initialize it to be ready for traffic.
+        If not required, can be "passed" but must be implemented.
         """
         raise NotImplementedError()
 
@@ -720,17 +727,6 @@ class RCResources(RoCETrafficResources):
             attr.sq_psn = self.rpsns[i]
             self.qps[i].to_rts(attr)
 
-    def pre_run(self, rpsns, rqps_num):
-        """
-        Configure Resources before running traffic
-        :param rpsns: Remote PSNs (packet serial number)
-        :param rqps_num: Remote QPs number
-        :return: None
-        """
-        self.rpsns = rpsns
-        self.rqps_num = rqps_num
-        self.to_rts()
-
 
 class UDResources(RoCETrafficResources):
     UD_QKEY = 0x11111111
@@ -761,9 +757,8 @@ class UDResources(RoCETrafficResources):
                     raise unittest.SkipTest(f'Create QP type {qp_init_attr.qp_type} is not supported')
                 raise ex
 
-    def pre_run(self, rpsns, rqps_num):
-        self.rpsns = rpsns
-        self.rqps_num = rqps_num
+    def to_rts(self):
+        pass
 
 
 class RawResources(TrafficResources):
@@ -878,8 +873,3 @@ class XRCResources(RoCETrafficResources):
         self.create_xrcd()
         super(XRCResources, self).init_resources()
         self.create_srq()
-
-    def pre_run(self, rpsns, rqps_num):
-        self.rqps_num = rqps_num
-        self.rpsns = rpsns
-        self.to_rts()

--- a/tests/efa_base.py
+++ b/tests/efa_base.py
@@ -52,11 +52,6 @@ class SRDResources(TrafficResources):
         self.send_ops_flags = send_ops_flags
         super().__init__(dev_name, ib_port, gid_index, qp_count=qp_count)
 
-    def pre_run(self, rpsns, rqps_num):
-        self.rpsns = rpsns
-        self.rqps_num = rqps_num
-        self.to_rts()
-
     def create_qp_attr(self):
         attr = QPAttr(port_num=self.ib_port)
         attr.qkey = self.SRD_QKEY

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -128,11 +128,6 @@ class Mlx5DcResources(RoCETrafficResources):
             self.qps[i].to_rts(attr)
         self.dct_qp.to_rtr(attr)
 
-    def pre_run(self, rpsns, rqps_num):
-        self.rpsns = rpsns
-        self.rqps_num = rqps_num
-        self.to_rts()
-
     def create_context(self):
         mlx5dv_attr = Mlx5DVContextAttr()
         try:

--- a/tests/test_atomic.py
+++ b/tests/test_atomic.py
@@ -79,32 +79,6 @@ class AtomicTest(RDMATestCase):
         if ctx.query_device().atomic_caps == e.IBV_ATOMIC_NONE:
             raise unittest.SkipTest('Atomic operations are not supported')
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Atomic tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-        attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-        self.sync_remote_attr()
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
-
-    def sync_remote_attr(self):
-        """
-        Sync the MR remote attributes between the server and the client.
-        """
-        self.server.rkey = self.client.mr.rkey
-        self.server.raddr = self.client.mr.buf
-        self.client.rkey = self.server.mr.rkey
-        self.client.raddr = self.server.mr.buf
-
     def test_atomic_cmp_and_swap(self):
         self.create_players(RCAtomic)
         u.atomic_traffic(**self.traffic_args, send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)

--- a/tests/test_cq.py
+++ b/tests/test_cq.py
@@ -89,15 +89,6 @@ class CQTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
-
     def test_resize_cq(self):
         """
         Test resize CQ, start with specific value and then increase and decrease

--- a/tests/test_cq_events.py
+++ b/tests/test_cq_events.py
@@ -29,26 +29,11 @@ class CqEventsTestCase(RDMATestCase):
     def setUp(self):
         super().setUp()
         self.iters = 100
-        self.qp_dict = {'ud': CqEventsUD, 'rc': CqEventsRC}
-
-    def create_players(self, qp_type):
-        try:
-            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create qp with attrs {} is not supported'.format(qp_type))
-            raise ex
-        client.pre_run(server.psns, server.qps_num)
-        server.pre_run(client.psns, client.qps_num)
-        return client, server
 
     def test_cq_events_ud(self):
-        client, server = self.create_players('ud')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(CqEventsUD)
+        traffic(**self.traffic_args)
 
     def test_cq_events_rc(self):
-        client, server = self.create_players('rc')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(CqEventsRC)
+        traffic(**self.traffic_args)

--- a/tests/test_cqex.py
+++ b/tests/test_cqex.py
@@ -52,30 +52,18 @@ class CqExTestCase(RDMATestCase):
     def setUp(self):
         super().setUp()
         self.iters = 100
-        self.qp_dict = {'ud': CqExUD, 'rc': CqExRC, 'xrc': CqExXRC}
-
-    def create_players(self, qp_type):
-        client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
-        server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                       self.gid_index)
-        client.pre_run(server.psns, server.qps_num)
-        server.pre_run(client.psns, client.qps_num)
-        return client, server
 
     def test_ud_traffic_cq_ex(self):
-        client, server = self.create_players('ud')
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  is_cq_ex=True)
+        self.create_players(CqExUD)
+        u.traffic(**self.traffic_args, is_cq_ex=True)
 
     def test_rc_traffic_cq_ex(self):
-        client, server = self.create_players('rc')
-        u.traffic(client, server, self.iters, self.gid_index, self.ib_port,
-                  is_cq_ex=True)
+        self.create_players(CqExRC)
+        u.traffic(**self.traffic_args, is_cq_ex=True)
 
     def test_xrc_traffic_cq_ex(self):
-        client, server = self.create_players('xrc')
-        u.xrc_traffic(client, server, is_cq_ex=True)
+        self.create_players(CqExXRC)
+        u.xrc_traffic(self.client, self.server, is_cq_ex=True)
 
 
 class CQEXAPITest(PyverbsAPITestCase):

--- a/tests/test_cuda_dmabuf.py
+++ b/tests/test_cuda_dmabuf.py
@@ -71,31 +71,6 @@ class DmabufCudaTest(RDMATestCase):
     """
     Test RDMA traffic over CUDA memory
     """
-    def create_players(self, resource, **resource_arg):
-        """
-        Init CUDA tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-        attributes.
-        :return: Non
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-        self.sync_remote_attr()
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
-
-    def sync_remote_attr(self):
-        """
-        Exchange the MR remote attributes between the server and the client.
-        """
-        self.server.rkey = self.client.mr.rkey
-        self.server.raddr = self.client.mr.buf
-        self.client.rkey = self.server.mr.rkey
-        self.client.raddr = self.server.mr.buf
 
     def test_cuda_dmabuf_rdma_write_traffic(self):
         """

--- a/tests/test_efadv.py
+++ b/tests/test_efadv.py
@@ -137,17 +137,8 @@ class EfaCqTest(EfaRDMATestCase):
         self.client = None
 
     def create_players(self, dev_cap, wc_flags, send_ops_flags, qp_count=8):
-        try:
-            self.client = EfaCQRes(self.dev_name, self.ib_port, self.gid_index, send_ops_flags, qp_count,
-                                   dev_cap, wc_flags)
-            self.server = EfaCQRes(self.dev_name, self.ib_port, self.gid_index, send_ops_flags, qp_count,
-                                   dev_cap, wc_flags)
-        except PyverbsRDMAError as ex:
-            if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create EfaCQ Resources is not supported')
-            raise ex
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
+        super().create_players(EfaCQRes, send_ops_flags=send_ops_flags, qp_count=qp_count,
+                               requested_dev_cap=dev_cap, wc_flags=wc_flags)
         self.server.remote_gid = self.client.ctx.query_gid(self.client.ib_port, self.client.gid_index)
 
     def test_dv_cq_ex_with_sgid(self):

--- a/tests/test_flow.py
+++ b/tests/test_flow.py
@@ -102,17 +102,6 @@ class FlowTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Flow tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-        attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-
     def flow_traffic(self, specs, l3=PacketConsts.IP_V4,
                      l4=PacketConsts.UDP_PROTO):
         """

--- a/tests/test_mlx5_cq.py
+++ b/tests/test_mlx5_cq.py
@@ -123,16 +123,10 @@ class DvCqTest(Mlx5RDMATestCase):
         attributes.
         :return: None
         """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
+        super().create_players(resource, **resource_arg)
         if resource == Mlx5DvCqDcRes:
             self.client.remote_dct_num = self.server.dct_qp.qp_num
             self.server.remote_dct_num = self.client.dct_qp.qp_num
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
 
     def test_dv_cq_traffic(self):
         """

--- a/tests/test_mlx5_crypto.py
+++ b/tests/test_mlx5_crypto.py
@@ -255,19 +255,6 @@ class Mlx5CryptoTrafficTest(Mlx5RDMATestCase):
         self.msg_size = 1024
         self.key_size = dve.MLX5DV_CRYPTO_KEY_SIZE_128
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Mlx5CryptoTest test resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-
     def create_client_dek(self):
         """
         Create DEK using the client resources.

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -151,17 +151,6 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         if self.client:
             self.client.ctx.close()
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Dr test resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-
     @skip_unsupported
     def create_rx_recv_rules_based_on_match_params(self, mask_param, val_param, actions,
                                                    match_criteria=u.MatchCriteriaEnable.OUTER,

--- a/tests/test_mlx5_flow.py
+++ b/tests/test_mlx5_flow.py
@@ -110,17 +110,6 @@ class Mlx5MatcherTest(Mlx5RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Flow tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-
     @u.skip_unsupported
     def test_create_empty_matcher(self):
         """

--- a/tests/test_mlx5_lag_affinity.py
+++ b/tests/test_mlx5_lag_affinity.py
@@ -67,17 +67,14 @@ class LagPortTestCase(Mlx5RDMATestCase):
                              specific attributes.
         :return: None
         """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
+        super().create_players(resource, **resource_arg)
         self.modify_lag(self.client)
         self.modify_lag(self.server)
 
     def test_rc_modify_lag_port(self):
         self.create_players(RCResources)
-        u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(**self.traffic_args)
 
     def test_ud_modify_lag_port(self):
         self.create_players(UDResources)
-        u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(**self.traffic_args)

--- a/tests/test_mlx5_mkey.py
+++ b/tests/test_mlx5_mkey.py
@@ -104,19 +104,6 @@ class Mlx5MkeyTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Mkey test resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-
     def reg_mr_list(self, configure_mkey=False):
         """
         Register a list of SGEs using the player's mkeys.

--- a/tests/test_mlx5_raw_wqe.py
+++ b/tests/test_mlx5_raw_wqe.py
@@ -33,19 +33,6 @@ class RawWqeTest(Mlx5RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init RawWqe test resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-
     def prepare_send_elements(self):
         mr = self.client.mr
         sge_count = 2

--- a/tests/test_mlx5_sched.py
+++ b/tests/test_mlx5_sched.py
@@ -65,22 +65,6 @@ class Mlx5SchedTrafficTest(Mlx5RDMATestCase):
         self.client = None
         self.traffic_args = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init schedule elements traffic tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-                             attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
-
     def test_sched_per_qp_traffic(self):
         """
         Tests attaching a QP to a sched leaf. The test creates a sched tree

--- a/tests/test_mlx5_timestamp.py
+++ b/tests/test_mlx5_timestamp.py
@@ -96,20 +96,6 @@ class TimeStampTest(RDMATestCase):
         return {'send_ts': self.send_ts, 'recv_ts': self.recv_ts,
                 'qp_type': self.qp_type}
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init TimeStamp tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-        attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        if self.qp_type == e.IBV_QPT_RC:
-            self.client.pre_run(self.server.psns, self.server.qps_num)
-            self.server.pre_run(self.client.psns, self.client.qps_num)
-
     def test_timestamp_free_running_rc_traffic(self):
         """
         Test free running timestamp on RC traffic.

--- a/tests/test_mlx5_udp_sport.py
+++ b/tests/test_mlx5_udp_sport.py
@@ -21,19 +21,6 @@ class UdpSportTestCase(Mlx5RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Initialize tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dictionary of args that specify the resource
-                             specific attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-
     def test_rc_modify_udp_sport(self):
         """
         Create RC resources and change the server QP's UDP source port to an
@@ -47,4 +34,4 @@ class UdpSportTestCase(Mlx5RDMATestCase):
             if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Modifying a QP UDP sport is not supported')
             raise ex
-        u.traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)
+        u.traffic(**self.traffic_args)

--- a/tests/test_parent_domain.py
+++ b/tests/test_parent_domain.py
@@ -145,22 +145,6 @@ class ParentDomainTrafficTest(RDMATestCase):
         self.server = None
         self.client = None
 
-    def create_players(self, resource, **resource_arg):
-        """
-        Init Parent Domain tests resources.
-        :param resource: The RDMA resources to use.
-        :param resource_arg: Dict of args that specify the resource specific
-        attributes.
-        :return: None
-        """
-        self.client = resource(**self.dev_info, **resource_arg)
-        self.server = resource(**self.dev_info, **resource_arg)
-        self.client.pre_run(self.server.psns, self.server.qps_num)
-        self.server.pre_run(self.client.psns, self.client.qps_num)
-        self.traffic_args = {'client': self.client, 'server': self.server,
-                             'iters': self.iters, 'gid_idx': self.gid_index,
-                             'port': self.ib_port}
-
     def test_without_allocators_rc_traffic(self):
         parent_domain_rc_res = parent_domain_res_cls(RCResources)
         self.create_players(parent_domain_rc_res)

--- a/tests/test_relaxed_ordering.py
+++ b/tests/test_relaxed_ordering.py
@@ -1,12 +1,8 @@
-import unittest
-import errno
-
 from tests.base import RCResources, UDResources, XRCResources
 from tests.utils import traffic, xrc_traffic
 from tests.base import RDMATestCase
 from pyverbs.mr import MR
 import pyverbs.enums as e
-from pyverbs.pyverbs_error import PyverbsRDMAError
 
 
 class RoUD(UDResources):
@@ -31,30 +27,15 @@ class RoTestCase(RDMATestCase):
     def setUp(self):
         super(RoTestCase, self).setUp()
         self.iters = 100
-        self.qp_dict = {'rc': RoRC, 'ud': RoUD, 'xrc': RoXRC}
-
-    def create_players(self, qp_type):
-        try:
-            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-        except PyverbsRDMAError as ex:
-           if ex.error_code == errno.EOPNOTSUPP:
-                raise unittest.SkipTest('Create player with attrs {} is not supported'.format(qp_type))
-           raise ex
-        client.pre_run(server.psns, server.qps_num)
-        server.pre_run(client.psns, client.qps_num)
-        return client, server
 
     def test_ro_rc_traffic(self):
-        client, server = self.create_players('rc')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(RoRC)
+        traffic(**self.traffic_args)
 
     def test_ro_ud_traffic(self):
-        client, server = self.create_players('ud')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players(RoUD)
+        traffic(**self.traffic_args)
 
     def test_ro_xrc_traffic(self):
-        client, server = self.create_players('xrc')
-        xrc_traffic(client, server)
+        self.create_players(RoXRC)
+        xrc_traffic(self.client, self.server)


### PR DESCRIPTION
Some of the tests' common functions (such as resource creation and rkeys exchange) were massively duplicated.
This series cleans this wherever it's applicable with minimal modifications.