### PR TITLE
build: include the module CheckCSourceCompiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${BUILDLIB}")
 
 include(CMakeParseArguments)
 include(CheckCCompilerFlag)
+include(CheckCSourceCompiles)
 include(CheckIncludeFile)
 include(CheckTypeSize)
 include(RDMA_EnableCStd)


### PR DESCRIPTION
The macro CHECK_C_SOURCE_COMPILES that CMakeLists.txt is using is defined in the module CheckCSourceCompiles. That module is included indirectly via CheckCCompilerFlag.

It was reported in Fedora Bugzilla, that a recent cmake 3.27.0-rc1 removed the indirect inclusion of the macro, breaking the rdma-core build:
  https://bugzilla.redhat.com/show_bug.cgi?id=2214541

The build error message:
```
  -- Detecting C compile features - done
  CMake Error at buildlib/RDMA_EnableCStd.cmake:63 (CHECK_C_SOURCE_COMPILES):
    Unknown CMake command "CHECK_C_SOURCE_COMPILES".
  Call Stack (most recent call first):
    CMakeLists.txt:209 (RDMA_Check_C_Compiles)
```
The change in cmake broke the build in many more projects, so cmake restored compatibility in -rc2:
  https://gitlab.kitware.com/cmake/cmake/-/issues/24991

Still, let's be safe and include the module explicitly.