### PR TITLE
Add general support for LTTng tracing and traces for EFA provider

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,8 @@
 #      Disable man pages. Allows rdma-core to be built and installed
 #      (without man pages) when neither pandoc/rst2man nor the pandoc-prebuilt
 #      directory are available.
+#   -DENABLE_LTTNG (default, no tracing support)
+#      Enable LTTng tracing.
 
 if (${CMAKE_VERSION} VERSION_LESS "3.18.1")
 	# Centos 7 support
@@ -555,6 +557,12 @@ if (DRM_INCLUDE_DIRS)
   else()
     unset(DRM_INCLUDE_DIRS CACHE)
   endif()
+endif()
+
+# LTTng Tracer support
+if (DEFINED ENABLE_LTTNG)
+  include(FindLTTngUST REQUIRED)
+  add_definitions(-DLTTNG_ENABLED)
 endif()
 
 #-------------------------

--- a/buildlib/FindLTTngUST.cmake
+++ b/buildlib/FindLTTngUST.cmake
@@ -1,0 +1,116 @@
+#.rst:
+# FindLTTngUST
+# ------------
+#
+# This module finds the `LTTng-UST <http://lttng.org/>`__ library.
+#
+# Imported target
+# ^^^^^^^^^^^^^^^
+#
+# This module defines the following :prop_tgt:`IMPORTED` target:
+#
+# ``LTTng::UST``
+#   The LTTng-UST library, if found
+#
+# Result variables
+# ^^^^^^^^^^^^^^^^
+#
+# This module sets the following
+#
+# ``LTTNGUST_FOUND``
+#   ``TRUE`` if system has LTTng-UST
+# ``LTTNGUST_INCLUDE_DIRS``
+#   The LTTng-UST include directories
+# ``LTTNGUST_LIBRARIES``
+#   The libraries needed to use LTTng-UST
+# ``LTTNGUST_VERSION_STRING``
+#   The LTTng-UST version
+# ``LTTNGUST_HAS_TRACEF``
+#   ``TRUE`` if the ``tracef()`` API is available in the system's LTTng-UST
+# ``LTTNGUST_HAS_TRACELOG``
+#   ``TRUE`` if the ``tracelog()`` API is available in the system's LTTng-UST
+
+#=============================================================================
+# Copyright 2016 Kitware, Inc.
+# Copyright 2016 Philippe Proulx <pproulx@efficios.com>
+#
+# Distributed under the OSI-approved BSD License (the "License");
+# see accompanying file Copyright.txt for details.
+#
+# This software is distributed WITHOUT ANY WARRANTY; without even the
+# implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the License for more information.
+#=============================================================================
+# (To distribute this file outside of CMake, substitute the full
+#  License text for the above reference.)
+
+find_path(LTTNGUST_INCLUDE_DIRS NAMES lttng/tracepoint.h)
+# Must also check for the path of generated header files since out-of-tree
+# build is a possibility (Yocto).
+find_path(LTTNGUST_INCLUDE_DIRS_GENERATED NAMES lttng/ust-config.h)
+find_library(LTTNGUST_LIBRARIES NAMES lttng-ust)
+
+if(LTTNGUST_INCLUDE_DIRS AND LTTNGUST_INCLUDE_DIRS_GENERATED AND LTTNGUST_LIBRARIES)
+  # find tracef() and tracelog() support
+  set(LTTNGUST_HAS_TRACEF 0)
+  set(LTTNGUST_HAS_TRACELOG 0)
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracef.h")
+    set(LTTNGUST_HAS_TRACEF TRUE)
+  endif()
+
+  if(EXISTS "${LTTNGUST_INCLUDE_DIRS}/lttng/tracelog.h")
+    set(LTTNGUST_HAS_TRACELOG TRUE)
+  endif()
+
+  # get version
+  set(lttngust_version_file "${LTTNGUST_INCLUDE_DIRS_GENERATED}/lttng/ust-version.h")
+
+  if(EXISTS "${lttngust_version_file}")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_major_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MAJOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_minor_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_MINOR_VERSION[\t ]+[0-9]+[\t ]*$")
+    file(STRINGS "${lttngust_version_file}" lttngust_version_patch_string
+         REGEX "^[\t ]*#define[\t ]+LTTNG_UST_PATCHLEVEL_VERSION[\t ]+[0-9]+[\t ]*$")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_major "${lttngust_version_major_string}")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_minor "${lttngust_version_minor_string}")
+    string(REGEX REPLACE ".*([0-9]+).*" "\\1"
+           lttngust_v_patch "${lttngust_version_patch_string}")
+    set(LTTNGUST_VERSION_STRING
+        "${lttngust_v_major}.${lttngust_v_minor}.${lttngust_v_patch}")
+    unset(lttngust_version_major_string)
+    unset(lttngust_version_minor_string)
+    unset(lttngust_version_patch_string)
+    unset(lttngust_v_major)
+    unset(lttngust_v_minor)
+    unset(lttngust_v_patch)
+  else()
+    message(FATAL_ERROR "Missing version header")
+  endif()
+
+  unset(lttngust_version_file)
+
+  if(NOT TARGET LTTng::UST)
+    add_library(LTTng::UST UNKNOWN IMPORTED)
+    set_target_properties(LTTng::UST PROPERTIES
+      INTERFACE_INCLUDE_DIRECTORIES "${LTTNGUST_INCLUDE_DIRS};${LTTNGUST_INCLUDE_DIRS_GENERATED}"
+      INTERFACE_LINK_LIBRARIES ${CMAKE_DL_LIBS}
+      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+      IMPORTED_LOCATION "${LTTNGUST_LIBRARIES}")
+  endif()
+
+  # add libdl to required libraries
+  set(LTTNGUST_LIBRARIES ${LTTNGUST_LIBRARIES} ${CMAKE_DL_LIBS})
+endif()
+
+# handle the QUIETLY and REQUIRED arguments and set LTTNGUST_FOUND to
+# TRUE if all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(LTTngUST FOUND_VAR LTTNGUST_FOUND
+  REQUIRED_VARS LTTNGUST_LIBRARIES
+  LTTNGUST_INCLUDE_DIRS
+  VERSION_VAR LTTNGUST_VERSION_STRING)
+mark_as_advanced(LTTNGUST_LIBRARIES LTTNGUST_INCLUDE_DIRS)

--- a/providers/efa/CMakeLists.txt
+++ b/providers/efa/CMakeLists.txt
@@ -1,5 +1,10 @@
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+  set(TRACE_FILE efa_trace.c)
+endif()
+
 rdma_shared_provider(efa libefa.map
 	1 1.2.${PACKAGE_VERSION}
+	${TRACE_FILE}
 	efa.c
 	verbs.c
 )
@@ -9,3 +14,8 @@ publish_headers(infiniband
 )
 
 rdma_pkg_config("efa" "libibverbs" "${CMAKE_THREAD_LIBS_INIT}")
+
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+	target_include_directories(efa PUBLIC ".")
+	target_link_libraries(efa LINK_PRIVATE LTTng::UST)
+endif()

--- a/providers/efa/efa_trace.c
+++ b/providers/efa/efa_trace.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "efa_trace.h"

--- a/providers/efa/efa_trace.h
+++ b/providers/efa/efa_trace.h
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#if defined(LTTNG_ENABLED)
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER rdma_core_efa
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "efa_trace.h"
+
+#if !defined(__EFA_TRACE_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __EFA_TRACE_H__
+
+#include <lttng/tracepoint.h>
+#include <infiniband/verbs.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	rdma_core_efa,
+
+	/* Tracepoint name */
+	post_recv,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		uint64_t, wr_id,
+		uint32_t, qp_num,
+		int, num_sge
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
+		lttng_ust_field_integer(uint32_t, qp_num, qp_num)
+		lttng_ust_field_integer(int, num_sge, num_sge)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	rdma_core_efa,
+
+	/* Tracepoint name */
+	post_send,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		uint64_t, wr_id,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_integer(uint32_t, dst_qp_num, dst_qp_num)
+		lttng_ust_field_integer(uint16_t, ah_num, ah_num)
+	)
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	rdma_core_efa,
+
+	/* Tracepoint name */
+	process_completion,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		uint64_t, wr_id,
+		int, status,
+		uint32_t, qp_num,
+		int, opcode,
+		uint32_t, length
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
+		lttng_ust_field_integer(int, status, status)
+		lttng_ust_field_integer(uint32_t, qp_num, qp_num)
+		lttng_ust_field_integer(int, opcode, opcode)
+		lttng_ust_field_integer(uint32_t, length, length)
+	)
+)
+
+#define rdma_tracepoint(arg...) lttng_ust_tracepoint(arg)
+
+#endif /* __EFA_TRACE_H__*/
+
+#include <lttng/tracepoint-event.h>
+
+#else
+
+#ifndef __EFA_TRACE_H__
+#define __EFA_TRACE_H__
+
+#define rdma_tracepoint(arg...)
+
+#endif /* __EFA_TRACE_H__*/
+
+#endif /* defined(LTTNG_ENABLED) */


### PR DESCRIPTION
Add support for LTTng: The LTTng User Space Tracing (LTTng-UST) library allows any C/C++ application to be instrumented for and traced by LTTng.

Add CMake flag to compile in LTTng support for providers who added LTTng traces, without suppling this flags the tracing code will be compiled out without any influence on other code.

Also add initial support for EFA tracing: post receive, send and completion.