### PR TITLE
tests: Make the client and server members of the TestCase

### DIFF
--- a/tests/test_cq_events.py
+++ b/tests/test_cq_events.py
@@ -30,25 +30,26 @@ class CqEventsTestCase(RDMATestCase):
         super().setUp()
         self.iters = 100
         self.qp_dict = {'ud': CqEventsUD, 'rc': CqEventsRC}
+        self.client = None
+        self.server = None
 
     def create_players(self, qp_type):
         try:
-            client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
-            server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
-                                           self.gid_index)
+            self.client = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                                self.gid_index)
+            self.server = self.qp_dict[qp_type](self.dev_name, self.ib_port,
+                                                self.gid_index)
         except PyverbsRDMAError as ex:
             if ex.error_code == errno.EOPNOTSUPP:
                 raise unittest.SkipTest('Create qp with attrs {} is not supported'.format(qp_type))
             raise ex
-        client.pre_run(server.psns, server.qps_num)
-        server.pre_run(client.psns, client.qps_num)
-        return client, server
+        self.client.pre_run(self.server.psns, self.server.qps_num)
+        self.server.pre_run(self.client.psns, self.client.qps_num)
 
     def test_cq_events_ud(self):
-        client, server = self.create_players('ud')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players('ud')
+        traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)
 
     def test_cq_events_rc(self):
-        client, server = self.create_players('rc')
-        traffic(client, server, self.iters, self.gid_index, self.ib_port)
+        self.create_players('rc')
+        traffic(self.client, self.server, self.iters, self.gid_index, self.ib_port)


### PR DESCRIPTION
Issue is that tests fail to deregister the MR because it is busy with pending receive requests that never get released.

This change enforces destruction order of the client+server prior to base class, which makes sure the pending receives are aborted before trying to free the MR.  Previous solution was at the mercy of garbage collection and therefore flaky.

This makes the presented changes in line with other test suites.