### PR TITLE
mlx5: Expose max outstanding RDMA read/atomic per DC QP

### DIFF
--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -62,6 +62,8 @@ void		*hca_core_clock; /* points to a memory location that is mapped to the HCA'
 struct mlx5dv_sig_caps sig_caps;
 size_t max_wr_memcpy_length; /* max length that is supported by the DMA memcpy WR */
 struct mlx5dv_crypto_caps crypto_caps;
+uint64_t max_dc_rd_atom; /* Maximum number of outstanding RDMA read/atomic per DC QP as a requester */
+uint64_t max_dc_init_rd_atom; /* Maximum number of outstanding RDMA read/atomic per DC QP as a responder */
 .in -8
 };
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -965,6 +965,12 @@ static int _mlx5dv_query_device(struct ibv_context *ctx_in,
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD;
 	}
 
+	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM) {
+		attrs_out->max_dc_rd_atom = mctx->max_dc_rd_atom;
+		attrs_out->max_dc_init_rd_atom = mctx->max_dc_init_rd_atom;
+		comp_mask_out |= MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM;
+	}
+
 	attrs_out->comp_mask = comp_mask_out;
 
 	return 0;

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -420,6 +420,8 @@ struct mlx5_context {
 	struct mlx5_dv_context_ops	*dv_ctx_ops;
 	struct mlx5dv_devx_obj		*crypto_login;
 	pthread_mutex_t			crypto_login_mutex;
+	uint64_t			max_dc_rd_atom;
+	uint64_t			max_dc_init_rd_atom;
 };
 
 struct mlx5_hugetlb_mem {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -86,6 +86,7 @@ enum mlx5dv_context_comp_mask {
 	MLX5DV_CONTEXT_MASK_DCI_STREAMS		= 1 << 11,
 	MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH	= 1 << 12,
 	MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD	= 1 << 13,
+	MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM	= 1 << 14,
 };
 
 struct mlx5dv_cqe_comp_caps {
@@ -232,6 +233,8 @@ struct mlx5dv_context {
 	struct mlx5dv_dci_streams_caps dci_streams_caps;
 	size_t max_wr_memcpy_length;
 	struct mlx5dv_crypto_caps crypto_caps;
+	uint64_t max_dc_rd_atom;
+	uint64_t max_dc_init_rd_atom;
 };
 
 enum mlx5dv_context_flags {

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -3850,6 +3850,14 @@ static void get_hca_general_caps(struct mlx5_context *mctx)
 		DEVX_GET64(query_hca_cap_out, out,
 			   capability.cmd_hca_cap.general_obj_types);
 
+	mctx->max_dc_rd_atom =
+		1 << DEVX_GET(query_hca_cap_out, out,
+				capability.cmd_hca_cap.log_max_ra_req_dc);
+
+	mctx->max_dc_init_rd_atom =
+		1 << DEVX_GET(query_hca_cap_out, out,
+				capability.cmd_hca_cap.log_max_ra_res_dc);
+
 	get_hca_sig_caps(out, mctx);
 
 	if (DEVX_GET(query_hca_cap_out, out, capability.cmd_hca_cap.crypto))

--- a/pyverbs/providers/mlx5/libmlx5.pxd
+++ b/pyverbs/providers/mlx5/libmlx5.pxd
@@ -59,6 +59,9 @@ cdef extern from 'infiniband/mlx5dv.h':
         uint8_t                 num_lag_ports
         mlx5dv_crypto_caps      crypto_caps
         size_t                  max_wr_memcpy_length
+        uint64_t                max_dc_rd_atom
+        uint64_t                max_dc_init_rd_atom
+
 
     cdef struct mlx5dv_dci_streams:
         uint8_t       log_num_concurent

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -312,7 +312,8 @@ cdef class Mlx5Context(Context):
                 dve.MLX5DV_CONTEXT_MASK_FLOW_ACTION_FLAGS |\
                 dve.MLX5DV_CONTEXT_MASK_DCI_STREAMS |\
                 dve.MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH |\
-                dve.MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD
+                dve.MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD |\
+                dve.MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM
         else:
             dv_attr.comp_mask = comp_mask
         rc = dv.mlx5dv_query_device(self.context, &dv_attr.dv)
@@ -534,6 +535,14 @@ cdef class Mlx5DVContext(PyverbsObject):
     def max_wr_memcpy_length(self):
         return self.dv.max_wr_memcpy_length
 
+    @property
+    def max_dc_rd_atom(self):
+        return self.dv.max_dc_rd_atom
+
+    @property
+    def max_dc_init_rd_atom(self):
+        return self.dv.max_dc_init_rd_atom
+
     def __str__(self):
         print_format = '{:20}: {:<20}\n'
         ident_format = '  {:20}: {:<20}\n'
@@ -579,7 +588,9 @@ cdef class Mlx5DVContext(PyverbsObject):
                                    self.dv.flow_action_flags) +\
                print_format.format('DC ODP caps', self.dv.dc_odp_caps) +\
                print_format.format('Num LAG ports', self.dv.num_lag_ports) +\
-               print_format.format('Max WR memcpy length', self.dv.max_wr_memcpy_length)
+               print_format.format('Max WR memcpy length', self.dv.max_wr_memcpy_length) +\
+               print_format.format('Max DC Read Atomic', self.dv.max_dc_rd_atomic) +\
+               print_format.format('Max DC Init Read Atomic', self.dv.max_dc_init_rd_atomic)
 
 
 cdef class Mlx5DCIStreamInitAttr(PyverbsObject):

--- a/pyverbs/providers/mlx5/mlx5dv_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5dv_enums.pxd
@@ -48,6 +48,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_MASK_DCI_STREAMS         = 1 << 11
         MLX5DV_CONTEXT_MASK_WR_MEMCPY_LENGTH    = 1 << 12
         MLX5DV_CONTEXT_MASK_CRYPTO_OFFLOAD      = 1 << 13
+        MLX5DV_CONTEXT_MASK_MAX_DC_RD_ATOM      = 1 << 14
 
     cpdef enum mlx5dv_context_flags:
         MLX5DV_CONTEXT_FLAGS_CQE_V1                     = 1 << 0

--- a/tests/mlx5_base.py
+++ b/tests/mlx5_base.py
@@ -143,7 +143,8 @@ class Mlx5DcResources(RoCETrafficResources):
             raise unittest.SkipTest('Opening mlx5 context is not supported')
 
     def create_mr(self):
-        access = e.IBV_ACCESS_REMOTE_WRITE | e.IBV_ACCESS_LOCAL_WRITE
+        access = e.IBV_ACCESS_REMOTE_WRITE | e.IBV_ACCESS_LOCAL_WRITE | \
+                 e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ
         self.mr = MR(self.pd, self.msg_size, access)
 
     def create_qp_cap(self):
@@ -152,7 +153,8 @@ class Mlx5DcResources(RoCETrafficResources):
     def create_qp_attr(self):
         qp_attr = QPAttr(port_num=self.ib_port)
         set_rnr_attributes(qp_attr)
-        qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE
+        qp_access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_WRITE | \
+                    e.IBV_ACCESS_REMOTE_ATOMIC | e.IBV_ACCESS_REMOTE_READ
         qp_attr.qp_access_flags = qp_access
         gr = GlobalRoute(dgid=self.ctx.query_gid(self.ib_port, self.gid_index),
                          sgid_index=self.gid_index)

--- a/tests/test_mlx5_dc.py
+++ b/tests/test_mlx5_dc.py
@@ -75,6 +75,15 @@ class DCTest(Mlx5RDMATestCase):
         u.traffic(**self.traffic_args, new_send=True,
                   send_op=e.IBV_WR_SEND)
 
+    def test_dc_atomic(self):
+        self.create_players(Mlx5DcResources, qp_count=2,
+                            send_ops_flags=e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
+        client_max_log = self.client.ctx.query_mlx5_device().max_dc_rd_atom
+        server_max_log = self.server.ctx.query_mlx5_device().max_dc_rd_atom
+        u.atomic_traffic(**self.traffic_args, new_send=True,
+                         send_op=e.IBV_WR_ATOMIC_FETCH_AND_ADD,
+                         client_wr=client_max_log, server_wr=server_max_log)
+
     def test_dc_ah_to_qp_mapping(self):
         self.create_players(Mlx5DcResources, qp_count=2,
                             send_ops_flags=e.IBV_QP_EX_WITH_SEND)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -468,7 +468,7 @@ def xrc_post_send(agr_obj, qp_num, send_object, send_op=None):
         post_send(agr_obj, send_object)
 
 
-def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
+def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None, **kwargs):
     qp = agr_obj.qps[qp_idx]
     qp_type = qp.qp_type
     qp.wr_start()
@@ -490,11 +490,14 @@ def post_send_ex(agr_obj, send_object, send_op=None, qp_idx=0, ah=None):
     elif send_op == e.IBV_WR_RDMA_READ:
         qp.wr_rdma_read(agr_obj.rkey, agr_obj.raddr)
     elif send_op == e.IBV_WR_ATOMIC_CMP_AND_SWP:
+        cmp_add = kwargs.get('cmp_add')
+        swp = kwargs.get('swap')
         qp.wr_atomic_cmp_swp(agr_obj.rkey, agr_obj.raddr,
-                             int8b_from_int(2), int8b_from_int(0))
+                             int8b_from_int(cmp_add), int8b_from_int(swp))
     elif send_op == e.IBV_WR_ATOMIC_FETCH_AND_ADD:
+        cmp_add = kwargs.get('cmp_add')
         qp.wr_atomic_fetch_add(agr_obj.rkey, agr_obj.raddr,
-                               int8b_from_int(2))
+                               int8b_from_int(cmp_add))
     elif send_op == e.IBV_WR_BIND_MW:
         bind_info = MWBindInfo(agr_obj.mr, agr_obj.mr.buf, agr_obj.mr.rkey,
                                e.IBV_ACCESS_REMOTE_WRITE)
@@ -697,11 +700,12 @@ def validate(received_str, is_server, msg_size):
                 format(exp=expected_str, rcv=received_str))
 
 
-def send(agr_obj, send_object, send_op=None, new_send=False, qp_idx=0, ah=None, is_imm=False):
+def send(agr_obj, send_object, send_op=None, new_send=False, qp_idx=0, ah=None, is_imm=False,
+         **kwargs):
     if isinstance(agr_obj, XRCResources):
         agr_obj.qps = agr_obj.sqp_lst
     if new_send:
-        return post_send_ex(agr_obj, send_object, send_op, qp_idx, ah)
+        return post_send_ex(agr_obj, send_object, send_op, qp_idx, ah, **kwargs)
     return post_send(agr_obj, send_object, qp_idx, ah, is_imm)
 
 
@@ -1161,7 +1165,7 @@ def rdma_traffic(client, server, iters, gid_idx, port, new_send=False,
 
 
 def atomic_traffic(client, server, iters, gid_idx, port, new_send=False,
-                   send_op=None, receiver_val=1, sender_val=2, **kwargs):
+                   send_op=None, receiver_val=1, sender_val=2, swap=0, **kwargs):
     """
     Runs atomic traffic between two sides.
     :param client: Client side, clients base class is BaseTraffic
@@ -1181,24 +1185,24 @@ def atomic_traffic(client, server, iters, gid_idx, port, new_send=False,
         server.mr.write(int.to_bytes(receiver_val, 1, byteorder='big') * 8, 8)
         c_send_wr = get_atomic_send_elements(client, send_op,
                                              cmp_add=sender_val,
-                                             swap=0)[send_element_idx]
+                                             swap=swap)[send_element_idx]
         if isinstance(server, XRCResources):
             c_send_wr.set_qp_type_xrc(server.srq.get_srq_num())
-        send(client, c_send_wr, send_op, new_send)
+        send(client, c_send_wr, send_op, new_send, cmp_add=sender_val, swap=swap)
         poll_cq(client.cq)
         validate_atomic(send_op, server, client, receiver_val=receiver_val,
-                        send_cmp_add=sender_val, send_swp=0)
+                        send_cmp_add=sender_val, send_swp=swap)
         server.mr.write(int.to_bytes(sender_val, 1, byteorder='big') * 8, 8)
         client.mr.write(int.to_bytes(receiver_val, 1, byteorder='big') * 8, 8)
         s_send_wr = get_atomic_send_elements(server, send_op,
                                              cmp_add=sender_val,
-                                             swap=0)[send_element_idx]
+                                             swap=swap)[send_element_idx]
         if isinstance(client, XRCResources):
             s_send_wr.set_qp_type_xrc(client.srq.get_srq_num())
-        send(server, s_send_wr, send_op, new_send)
+        send(server, s_send_wr, send_op, new_send, cmp_add=sender_val, swap=swap)
         poll_cq(server.cq)
         validate_atomic(send_op, client, server, receiver_val=receiver_val,
-                        send_cmp_add=sender_val, send_swp=0)
+                        send_cmp_add=sender_val, send_swp=swap)
 
 
 def validate_atomic(opcode, recv_player, send_player, receiver_val,


### PR DESCRIPTION
This series exposes the maximum number of outstanding RDMA read/atomic per DC QP as a requester or a responder.

In addition, it includes some pyverbs stuff that uses those new capabilities.