### PR TITLE
Typo in ibv_alloc_parent_domain.3

### DIFF
--- a/libibverbs/man/ibv_alloc_parent_domain.3
+++ b/libibverbs/man/ibv_alloc_parent_domain.3
@@ -8,7 +8,7 @@ ibv_alloc_parent_domain(), ibv_dealloc_pd() \- allocate and deallocate the paren
 .nf
 .B #include <infiniband/verbs.h>
 .sp
-.BI "struct ibv_pd *ibv_alloc_parent_domain(struct ibv_context "*context" ", struct ibv_parent_domain_init_attr " "*attr");
+.BI "struct ibv_pd *ibv_alloc_parent_domain(struct ibv_context " "*context" ", struct ibv_parent_domain_init_attr " "*attr");
 .sp
 .SH "DESCRIPTION"
 .B ibv_alloc_parent_domain()


### PR DESCRIPTION
Typo in this man page can be seen here:

- https://man7.org/linux/man-pages/man3/ibv_alloc_parent_domain.3.html

There is an additional quotation mark for the `*context"` parameter. This PR corrects it. See screenshot:

Before:
<img width="1077" alt="Screenshot 2023-06-27 at 5 51 58 PM" src="https://github.com/linux-rdma/rdma-core/assets/9093579/76fb094b-d4ec-4696-b7e4-61b8d1ada223">

After:
<img width="1065" alt="Screenshot 2023-06-27 at 5 50 49 PM" src="https://github.com/linux-rdma/rdma-core/assets/9093579/e5f2fc96-0963-48fd-9c77-25b6572d8b2f">
