### PR TITLE
libibverbs: Fix ibv_devinfo help message

### DIFF
--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -675,7 +675,7 @@ static void usage(const char *argv0)
 	printf("Usage: %s             print the ca attributes\n", argv0);
 	printf("\n");
 	printf("Options:\n");
-	printf("  -d, --ib-dev=<dev>     use IB device <dev> (default first device found)\n");
+	printf("  -d, --ib-dev=<dev>     use IB device <dev> (default all devices)\n");
 	printf("  -i, --ib-port=<port>   use port <port> of IB device (default all ports)\n");
 	printf("  -l, --list             print only the IB devices names\n");
 	printf("  -v, --verbose          print all the attributes of the IB device(s)\n");

--- a/libibverbs/man/ibv_devinfo.1
+++ b/libibverbs/man/ibv_devinfo.1
@@ -17,7 +17,7 @@ Print information about RDMA devices available for use from userspace.
 .PP
 .TP
 \fB\-d\fR, \fB\-\-ib\-dev\fR=\fIDEVICE\fR
-use IB device \fIDEVICE\fR (default first device found)
+use IB device \fIDEVICE\fR (default all devices)
 
 \fB\-i\fR, \fB\-\-ib\-port\fR=\fIPORT\fR
 query port \fIPORT\fR (default all ports)


### PR DESCRIPTION
By default, ibv_devinfo will list all the RDMA devices in the system.