### PR TITLE
bnxt_re/lib: Doorbell Drop Prevention

### DIFF
--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -53,6 +53,7 @@ enum {
 	BNXT_RE_UCNTX_CMASK_HAVE_CCTX = 0x1ULL,
 	BNXT_RE_UCNTX_CMASK_HAVE_MODE = 0x02ULL,
 	BNXT_RE_UCNTX_CMASK_WC_DPI_ENABLED = 0x04ULL,
+	BNXT_RE_UCNTX_CMASK_DBR_PACING_ENABLED = 0x08ULL,
 };
 
 enum bnxt_re_wqe_mode {
@@ -131,10 +132,13 @@ enum bnxt_re_shpg_offt {
 
 enum bnxt_re_objects {
 	BNXT_RE_OBJECT_ALLOC_PAGE = (1U << UVERBS_ID_NS_SHIFT),
+	BNXT_RE_OBJECT_NOTIFY_DRV,
 };
 
 enum bnxt_re_alloc_page_type {
 	BNXT_RE_ALLOC_WC_PAGE = 0,
+	BNXT_RE_ALLOC_DBR_BAR_PAGE,
+	BNXT_RE_ALLOC_DBR_PAGE,
 };
 
 enum bnxt_re_var_alloc_page_attrs {
@@ -154,4 +158,7 @@ enum bnxt_re_alloc_page_methods {
 	BNXT_RE_METHOD_DESTROY_PAGE,
 };
 
+enum bnxt_re_notify_drv_methods {
+	BNXT_RE_METHOD_NOTIFY_DRV = (1U << UVERBS_ID_NS_SHIFT),
+};
 #endif /* __BNXT_RE_UVERBS_ABI_H__*/

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -211,6 +211,7 @@ enum bnxt_re_ud_cqe_mask {
 
 enum {
 	BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED = 0x01,
+	BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED = 0x02,
 };
 
 enum bnxt_re_modes {

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -126,6 +126,44 @@ static bool bnxt_re_is_chip_gen_p5(struct bnxt_re_chip_ctx *cctx)
 		cctx->chip_num == CHIP_NUM_57502);
 }
 
+static int bnxt_re_alloc_map_dbr_page(struct ibv_context *ibvctx)
+{
+	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
+	struct bnxt_re_mmap_info minfo = {};
+	int ret;
+
+	minfo.type = BNXT_RE_ALLOC_DBR_PAGE;
+	ret = bnxt_re_alloc_page(ibvctx, &minfo, NULL);
+	if (ret)
+		return ret;
+
+	cntx->dbr_page = mmap(NULL, minfo.alloc_size, PROT_READ,
+			      MAP_SHARED, ibvctx->cmd_fd, minfo.alloc_offset);
+	if (cntx->dbr_page == MAP_FAILED)
+		return -ENOMEM;
+
+	return 0;
+}
+
+static int bnxt_re_alloc_map_dbr_bar_page(struct ibv_context *ibvctx)
+{
+	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
+	struct bnxt_re_mmap_info minfo = {};
+	int ret;
+
+	minfo.type = BNXT_RE_ALLOC_DBR_BAR_PAGE;
+	ret = bnxt_re_alloc_page(ibvctx, &minfo, NULL);
+	if (ret)
+		return ret;
+
+	cntx->bar_map = mmap(NULL, minfo.alloc_size, PROT_WRITE,
+			     MAP_SHARED, ibvctx->cmd_fd, minfo.alloc_offset);
+	if (cntx->bar_map == MAP_FAILED)
+		return -ENOMEM;
+
+	return 0;
+}
+
 /* Context Init functions */
 static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 						   int cmd_fd,
@@ -166,6 +204,8 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 		cntx->wqe_mode = resp.mode;
 	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_WC_DPI_ENABLED)
 		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED;
+	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_DBR_PACING_ENABLED)
+		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED;
 
 	pthread_spin_init(&cntx->fqlock, PTHREAD_PROCESS_PRIVATE);
 	/* mmap shared page. */
@@ -175,6 +215,23 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 		cntx->shpg = NULL;
 		goto failed;
 	}
+
+	if (cntx->comp_mask & BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED) {
+		if (bnxt_re_alloc_map_dbr_page(&cntx->ibvctx.context)) {
+			munmap(cntx->shpg, rdev->pg_size);
+			cntx->shpg = NULL;
+			goto failed;
+		}
+
+		if (bnxt_re_alloc_map_dbr_bar_page(&cntx->ibvctx.context)) {
+			munmap(cntx->shpg, rdev->pg_size);
+			cntx->shpg = NULL;
+			munmap(cntx->dbr_page, rdev->pg_size);
+			cntx->dbr_page = NULL;
+			goto failed;
+		}
+	}
+
 	pthread_mutex_init(&cntx->shlock, NULL);
 
 	verbs_set_ops(&cntx->ibvctx, &bnxt_re_cntx_ops);
@@ -212,6 +269,12 @@ static void bnxt_re_free_context(struct ibv_context *ibvctx)
 	if (cntx->udpi.dbpage && cntx->udpi.dbpage != MAP_FAILED) {
 		munmap(cntx->udpi.dbpage, rdev->pg_size);
 		cntx->udpi.dbpage = NULL;
+	}
+	if (cntx->comp_mask & BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED) {
+		munmap(cntx->dbr_page, rdev->pg_size);
+		cntx->dbr_page = NULL;
+		munmap(cntx->bar_map, rdev->pg_size);
+		cntx->bar_map = NULL;
 	}
 
 	verbs_uninit_context(&cntx->ibvctx);

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -258,6 +258,8 @@ void bnxt_re_put_pbuf(struct bnxt_re_context *cntx,
 int bnxt_re_alloc_page(struct ibv_context *ibvctx,
 		       struct bnxt_re_mmap_info *minfo,
 		       uint32_t *page_handle);
+int bnxt_re_notify_drv(struct ibv_context *ibvctx);
+
 /* pointer conversion functions*/
 static inline struct bnxt_re_dev *to_bnxt_re_dev(struct ibv_device *ibvdev)
 {

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -222,6 +222,8 @@ struct bnxt_re_context {
 	pthread_spinlock_t fqlock;
 	struct bnxt_re_push_rec *pbrec;
 	uint32_t wc_handle;
+	void *dbr_page;
+	void *bar_map;
 };
 
 struct bnxt_re_mmap_info {
@@ -253,6 +255,9 @@ struct bnxt_re_push_buffer *bnxt_re_get_pbuf(uint8_t *push_st_en,
 					     struct bnxt_re_context *cntx);
 void bnxt_re_put_pbuf(struct bnxt_re_context *cntx,
 		      struct bnxt_re_push_buffer *pbuf);
+int bnxt_re_alloc_page(struct ibv_context *ibvctx,
+		       struct bnxt_re_mmap_info *minfo,
+		       uint32_t *page_handle);
 /* pointer conversion functions*/
 static inline struct bnxt_re_dev *to_bnxt_re_dev(struct ibv_device *ibvdev)
 {

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -47,6 +47,7 @@
 #include <sys/param.h>
 
 #include <util/mmio.h>
+#include <util/util.h>
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>
 
@@ -61,6 +62,9 @@
 #define CHIP_NUM_57508		0x1750
 #define CHIP_NUM_57504		0x1751
 #define CHIP_NUM_57502		0x1752
+#define BNXT_RE_MAX_DO_PACING	0xFFFF
+#define BNXT_NSEC_PER_SEC	1000000000UL
+#define BNXT_RE_PAGE_MASK(pg_size) (~((__u64)(pg_size) - 1))
 
 struct bnxt_re_chip_ctx {
 	__u16 chip_num;
@@ -84,6 +88,7 @@ struct bnxt_re_pd {
 struct bnxt_re_cq {
 	struct ibv_cq ibvcq;
 	uint32_t cqid;
+	struct bnxt_re_context *cntx;
 	struct bnxt_re_queue cqq;
 	struct bnxt_re_queue resize_cqq;
 	struct bnxt_re_dpi *udpi;
@@ -92,6 +97,7 @@ struct bnxt_re_cq {
 	struct list_head prev_cq_head;
 	uint32_t cqe_size;
 	uint8_t  phase;
+	struct xorshift32_state rand;
 };
 
 struct bnxt_re_push_buffer {
@@ -145,9 +151,11 @@ struct bnxt_re_qpcap {
 struct bnxt_re_srq {
 	struct ibv_srq ibvsrq;
 	struct ibv_srq_attr cap;
+	struct bnxt_re_context *cntx;
 	struct bnxt_re_queue *srqq;
 	struct bnxt_re_wrid *srwrid;
 	struct bnxt_re_dpi *udpi;
+	struct xorshift32_state rand;
 	uint32_t srqid;
 	int start_idx;
 	int last_idx;
@@ -165,6 +173,7 @@ struct bnxt_re_qp {
 	struct ibv_qp ibvqp;
 	struct bnxt_re_chip_ctx *cctx;
 	struct bnxt_re_context *cntx;
+	struct xorshift32_state rand;
 	struct bnxt_re_joint_queue *jsqq;
 	struct bnxt_re_joint_queue *jrqq;
 	struct bnxt_re_srq *srq;
@@ -224,6 +233,16 @@ struct bnxt_re_context {
 	uint32_t wc_handle;
 	void *dbr_page;
 	void *bar_map;
+};
+
+struct bnxt_re_pacing_data {
+	uint32_t do_pacing;
+	uint32_t pacing_th;
+	uint32_t alarm_th;
+	uint32_t fifo_max_depth;
+	uint32_t fifo_room_mask;
+	uint32_t fifo_room_shift;
+	uint32_t grc_reg_offset;
 };
 
 struct bnxt_re_mmap_info {
@@ -536,6 +555,40 @@ static inline void bnxt_re_copy_data_to_pb(struct bnxt_re_push_buffer *pbuf,
 		dst++;
 		src++;
 		mmio_write64(dst, *src);
+	}
+}
+
+static void timespec_sub(const struct timespec *a, const struct timespec *b,
+			 struct timespec *res)
+{
+	res->tv_sec = a->tv_sec - b->tv_sec;
+	res->tv_nsec = a->tv_nsec - b->tv_nsec;
+	if (res->tv_nsec < 0) {
+		res->tv_sec--;
+		res->tv_nsec += BNXT_NSEC_PER_SEC;
+	}
+}
+
+/*
+ * Function waits in a busy loop for a given nano seconds
+ * The maximum wait period allowed is less than one second
+ */
+static inline void bnxt_re_sub_sec_busy_wait(uint32_t nsec)
+{
+	struct timespec start, cur, res;
+
+	if (nsec >= BNXT_NSEC_PER_SEC)
+		return;
+
+	if (clock_gettime(CLOCK_REALTIME, &start))
+		return;
+
+	while (1) {
+		if (clock_gettime(CLOCK_REALTIME, &cur))
+			return;
+		timespec_sub(&cur, &start, &res);
+		if (res.tv_nsec >= nsec)
+			break;
 	}
 }
 #endif

--- a/providers/bnxt_re/memory.c
+++ b/providers/bnxt_re/memory.c
@@ -39,6 +39,7 @@
 
 #include <string.h>
 #include <sys/mman.h>
+#include <util/util.h>
 
 #include "main.h"
 
@@ -47,7 +48,7 @@ int bnxt_re_alloc_aligned(struct bnxt_re_queue *que, uint32_t pg_size)
 	int ret, bytes;
 
 	bytes = (que->depth * que->stride);
-	que->bytes = get_aligned(bytes, pg_size);
+	que->bytes = align(bytes, pg_size);
 	que->va = mmap(NULL, que->bytes, PROT_READ | PROT_WRITE,
 		       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
 	if (que->va == MAP_FAILED) {

--- a/providers/bnxt_re/memory.h
+++ b/providers/bnxt_re/memory.h
@@ -63,24 +63,6 @@ struct bnxt_re_queue {
 	pthread_spinlock_t qlock;
 };
 
-static inline unsigned long get_aligned(uint32_t size, uint32_t al_size)
-{
-	return (unsigned long)(size + al_size - 1) & ~(al_size - 1);
-}
-
-static inline unsigned long roundup_pow_of_two(unsigned long val)
-{
-	unsigned long roundup = 1;
-
-	if (val == 1)
-		return (roundup << 1);
-
-	while (roundup < val)
-		roundup <<= 1;
-
-	return roundup;
-}
-
 int bnxt_re_alloc_aligned(struct bnxt_re_queue *que, uint32_t pg_size);
 void bnxt_re_free_aligned(struct bnxt_re_queue *que);
 

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -102,6 +102,16 @@ static int bnxt_re_map_db_page(struct ibv_context *ibvctx,
 	return 0;
 }
 
+int bnxt_re_notify_drv(struct ibv_context *ibvctx)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       BNXT_RE_OBJECT_NOTIFY_DRV,
+			       BNXT_RE_METHOD_NOTIFY_DRV,
+			       0);
+
+	return execute_ioctl(ibvctx, cmd);
+}
+
 int bnxt_re_alloc_page(struct ibv_context *ibvctx,
 		       struct bnxt_re_mmap_info *minfo,
 		       uint32_t *page_handle)

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -291,6 +291,8 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 	cq->phase = resp.phase;
 	cq->cqq.tail = resp.tail;
 	cq->udpi = &cntx->udpi;
+	cq->cntx = cntx;
+	cq->rand.seed = cq->cqid;
 
 	list_head_init(&cq->sfhead);
 	list_head_init(&cq->rfhead);
@@ -1053,7 +1055,6 @@ static int bnxt_re_alloc_queue_ptr(struct bnxt_re_qp *qp,
 		if (!qp->jrqq->hwque)
 			goto fail;
 	}
-
 	return 0;
 fail:
 	bnxt_re_free_queue_ptr(qp);
@@ -1312,6 +1313,7 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 	if (attr->srq)
 		qp->srq = to_bnxt_re_srq(attr->srq);
 	qp->udpi = &cntx->udpi;
+	qp->rand.seed = qp->qpid;
 	/* Save/return the altered Caps. */
 	cap->max_ssge = attr->cap.max_send_sge;
 	cap->max_rsge = attr->cap.max_recv_sge;
@@ -1932,7 +1934,10 @@ struct ibv_srq *bnxt_re_create_srq(struct ibv_pd *ibvpd,
 		goto fail;
 
 	srq->srqid = resp.srqid;
+	srq->cntx = cntx;
 	srq->udpi = &cntx->udpi;
+	srq->rand.seed = srq->srqid;
+
 	srq->cap.max_wr = srq->srqq->depth;
 	srq->cap.max_sge = attr->attr.max_sge;
 	srq->cap.srq_limit = attr->attr.srq_limit;

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -49,6 +49,7 @@
 #include <unistd.h>
 
 #include <util/compiler.h>
+#include <util/util.h>
 
 #include "main.h"
 #include "verbs.h"
@@ -1138,13 +1139,13 @@ static int bnxt_re_get_sq_slots(struct bnxt_re_dev *rdev,
 	hdr_sz = bnxt_re_get_sqe_hdr_sz();
 	stride = sizeof(struct bnxt_re_sge);
 	max_wqesz = bnxt_re_calc_wqe_sz(rdev->devattr.max_sge);
-	ilsize = get_aligned(*ils, hdr_sz);
+	ilsize = align(*ils, hdr_sz);
 
 	wqe_size = bnxt_re_calc_wqe_sz(nsge);
 	if (ilsize) {
 		cal_ils = hdr_sz + ilsize;
 		wqe_size = MAX(cal_ils, wqe_size);
-		wqe_size = get_aligned(wqe_size, hdr_sz);
+		wqe_size = align(wqe_size, hdr_sz);
 	}
 	if (wqe_size > max_wqesz)
 		return -EINVAL;
@@ -1431,7 +1432,7 @@ static inline int bnxt_re_calc_inline_len(struct ibv_send_wr *swr)
 	illen = 0;
 	for (indx = 0; indx < swr->num_sge; indx++)
 		illen += swr->sg_list[indx].length;
-	return get_aligned(illen, sizeof(struct bnxt_re_sge));
+	return align(illen, sizeof(struct bnxt_re_sge));
 }
 
 static int bnxt_re_put_inline(struct bnxt_re_queue *que, uint32_t *idx,

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -102,9 +102,9 @@ static int bnxt_re_map_db_page(struct ibv_context *ibvctx,
 	return 0;
 }
 
-static int bnxt_re_alloc_page(struct ibv_context *ibvctx,
-			      struct bnxt_re_mmap_info *minfo,
-			      uint32_t *page_handle)
+int bnxt_re_alloc_page(struct ibv_context *ibvctx,
+		       struct bnxt_re_mmap_info *minfo,
+		       uint32_t *page_handle)
 {
 	DECLARE_COMMAND_BUFFER(cmd,
 			       BNXT_RE_OBJECT_ALLOC_PAGE,
@@ -124,7 +124,8 @@ static int bnxt_re_alloc_page(struct ibv_context *ibvctx,
 
 	if (ret)
 		return ret;
-	*page_handle = read_attr_obj(BNXT_RE_ALLOC_PAGE_HANDLE, handle);
+	if (page_handle)
+		*page_handle = read_attr_obj(BNXT_RE_ALLOC_PAGE_HANDLE, handle);
 	return 0;
 }
 

--- a/util/util.c
+++ b/util/util.c
@@ -53,3 +53,15 @@ bool check_env(const char *var)
 
 	return env_value && (strcmp(env_value, "0") != 0);
 }
+
+/* Xorshift random number generator */
+uint32_t xorshift32(struct xorshift32_state *state)
+{
+	/* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
+	uint32_t x = state->seed;;
+
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	return state->seed = x;
+}

--- a/util/util.h
+++ b/util/util.h
@@ -86,6 +86,13 @@ static inline unsigned long DIV_ROUND_UP(unsigned long n, unsigned long d)
 	return (n + d - 1) / d;
 }
 
+struct xorshift32_state {
+	/* The state word must be initialized to non-zero */
+	uint32_t seed;
+};
+
+uint32_t xorshift32(struct xorshift32_state *state);
+
 int set_fd_nonblock(int fd, bool nonblock);
 
 int open_cdev(const char *devname_hint, dev_t cdev);


### PR DESCRIPTION
The idea behind this series is to prevent Doorbell drops
on some of the Broadcom adapters that require Doorbell
moderation. This is achieved by pacing the doorbell writes
into the hardware FIFO. The rate at which individual doorbells
are written needs to be dynamically adjusted, because
it depends on the ability of the hardware to drain the
FIFO and on the number and behavior of individual
doorbell writers. When congestion is detected by the user
library, it notifies the driver and driver adjust the
pacing parameters dynamically in a shared page, which will
be used for pacing the Doorbells.