### PR TITLE
providers/irdma: Fix CQ size validation

### DIFF
--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -353,7 +353,7 @@ static struct ibv_cq_ex *ucreate_cq(struct ibv_context *context,
 		return NULL;
 	}
 
-	if (attr_ex->cqe < IRDMA_MIN_CQ_SIZE || attr_ex->cqe > uk_attrs->max_hw_cq_size) {
+	if (attr_ex->cqe < IRDMA_MIN_CQ_SIZE || attr_ex->cqe > uk_attrs->max_hw_cq_size - 1) {
 		errno = EINVAL;
 		return NULL;
 	}


### PR DESCRIPTION
Taking into account a reserved entry to detect overflow.

Fixes: 14a0fc824f16 ("rdma-core/irdma: Implement device supported verb APIs")