### PR TITLE
Fix failing tests due to query_qp attribute mask

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -349,8 +349,6 @@ class RDMATestCase(unittest.TestCase):
         self.pre_run()
         if sync_attrs:
             self.sync_remote_attr()
-        self.server_qp_attr, _ = self.server.qp.query(0x1ffffff)
-        self.client_qp_attr, _ = self.client.qp.query(0x1ffffff)
         self.traffic_args = {'client': self.client, 'server': self.server,
                              'iters': self.iters, 'gid_idx': self.gid_index,
                              'port': self.ib_port}

--- a/tests/test_mr.py
+++ b/tests/test_mr.py
@@ -114,6 +114,8 @@ class MRTest(RDMATestCase):
         succeeds.
         """
         self.create_players(MRRes)
+        self.server_qp_attr, _ = self.server.qp.query(0x1ffffff)
+        self.client_qp_attr, _ = self.client.qp.query(0x1ffffff)
         u.traffic(**self.traffic_args)
         server_new_pd = PD(self.server.ctx)
         self.server.rereg_mr(flags=e.IBV_REREG_MR_CHANGE_PD, pd=server_new_pd)
@@ -128,6 +130,8 @@ class MRTest(RDMATestCase):
 
     def test_mr_rereg_addr(self):
         self.create_players(MRRes)
+        self.server_qp_attr, _ = self.server.qp.query(0x1ffffff)
+        self.client_qp_attr, _ = self.client.qp.query(0x1ffffff)
         s_recv_wr = u.get_recv_wr(self.server)
         self.server.qp.post_recv(s_recv_wr)
         server_addr = posix_memalign(self.server.msg_size)


### PR DESCRIPTION
Move attribute query out of base create_players.
Not all vendors support all query_qp attribute mask values and this breaks all tests. It is only required for a single test suite, so move it there as it was prior to PR https://github.com/linux-rdma/rdma-core/pull/1349/

Fixes: 78f6a6556dc4 ("tests: Remove code duplication")