### PR TITLE
providers/irdma: Verify max_send_wr and max_recv_wr

### DIFF
--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -1328,6 +1328,8 @@ struct ibv_qp *irdma_ucreate_qp(struct ibv_pd *pd,
 
 	if (attr->cap.max_send_sge > uk_attrs->max_hw_wq_frags ||
 	    attr->cap.max_recv_sge > uk_attrs->max_hw_wq_frags ||
+	    attr->cap.max_send_wr > uk_attrs->max_hw_wq_quanta ||
+	    attr->cap.max_recv_wr > uk_attrs->max_hw_rq_quanta ||
 	    attr->cap.max_inline_data > uk_attrs->max_hw_inline) {
 		errno = EINVAL;
 		return NULL;


### PR DESCRIPTION
Make sure to verify that the provided max_send_wr and max_recv_wr are in the supported range.

Fixes: 14a0fc824f16 ("rdma-core/irdma: Implement device supported verb APIs")