### PR TITLE
verbs: fix compilation warning with C++20

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2589,7 +2589,7 @@ __ibv_reg_mr(struct ibv_pd *pd, void *addr, size_t length, unsigned int access,
 #define ibv_reg_mr(pd, addr, length, access)                                   \
 	__ibv_reg_mr(pd, addr, length, access,                                 \
 		     __builtin_constant_p(				       \
-			     ((access) & IBV_ACCESS_OPTIONAL_RANGE) == 0))
+			     ((int)(access) & IBV_ACCESS_OPTIONAL_RANGE) == 0))
 
 /**
  * ibv_reg_mr_iova - Register a memory region with a virtual offset


### PR DESCRIPTION
Our customer reported the below warning whe using Clang v16.0.4 and C++20, on a code that includes the header "/usr/include/infiniband/verbs.h":

error: bitwise operation between different enumeration types ('ibv_access_flags' and 'ib_uverbs_access_flags') is deprecated [-Werror,-Wdeprecated-enum-enum-conversion]
                mem->mr = ibv_reg_mr(dev->pd, (void*)start, len, IBV_ACCESS_LOCAL_WRITE);
                          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/infiniband/verbs.h:2514:19: note: expanded from macro 'ibv_reg_mr'
                             ((access) & IBV_ACCESS_OPTIONAL_RANGE) == 0))
                              ~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.

According to the article "Clang 11 warning: Bitwise operation between different enumeration types is deprecated":

C++20's P1120R0 deprecated bitwise operations between different enums. Such code is likely to become ill-formed in C++23. Clang 11 warns about such cases. It should be fixed.

Reported-by: Rogerio Moraes <rogerio@cadence.com>

Link: https://lore.kernel.org/r/20230613131931.738436-1-neelx@redhat.com