### PR TITLE
tests: Add irdma_base.py

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ rdma_python_test(tests
   base_rdmacm.py
   cuda_utils.py
   efa_base.py
+  irdma_base.py
   mlx5_base.py
   mlx5_prm_structs.py
   rdmacm_utils.py


### PR DESCRIPTION
The patch that added irdma_base.py forgot to update CMakeLists.txt.

Fixes: 371028ff ("tests: Skip CQ shrinking for irdma devices")