### PR TITLE
mlx5: DR, Few extensions and improvements 

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -670,10 +670,10 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				dr_dbg(dmn, "Destination table belongs to a different domain\n");
 				goto out_invalid_arg;
 			}
-			if (dest_tbl->level <= matcher->tbl->level) {
-				dr_dbg(dmn, "Destination table level should be higher than source table\n");
-				goto out_invalid_arg;
-			}
+
+			if (dest_tbl->level <= matcher->tbl->level)
+				dr_dbg(dmn, "Destination table level not higher than source\n");
+
 			attr.final_icm_addr = rx_rule ?
 				dr_icm_pool_get_chunk_icm_addr(dest_tbl->rx.s_anchor->chunk) :
 				dr_icm_pool_get_chunk_icm_addr(dest_tbl->tx.s_anchor->chunk);

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -623,6 +623,28 @@ dr_action_validate_and_get_next_state(enum dr_action_domain action_domain,
 	return 0;
 }
 
+static int dr_action_send_modify_header_args(struct mlx5dv_dr_action *action,
+					     uint8_t send_ring_idx)
+{
+	int ret;
+
+	if (!(action->rewrite.args_send_qp & (1 << send_ring_idx))) {
+		ret = dr_send_postsend_args(action->rewrite.dmn,
+					    dr_arg_get_object_id(action->rewrite.ptrn_arg.arg),
+					    action->rewrite.param.num_of_actions,
+					    action->rewrite.param.data,
+					    send_ring_idx);
+		if (ret) {
+			dr_dbg(action->rewrite.dmn, "Failed writing args object\n");
+			return ret;
+		}
+
+		action->rewrite.args_send_qp |= 1 << send_ring_idx;
+	}
+
+	return 0;
+}
+
 #define WITH_VLAN_NUM_HW_ACTIONS 6
 
 int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
@@ -631,7 +653,8 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			     uint32_t num_actions,
 			     uint8_t *ste_arr,
 			     uint32_t *new_hw_ste_arr_sz,
-			     struct cross_dmn_params *cross_dmn_p)
+			     struct cross_dmn_params *cross_dmn_p,
+			     uint8_t send_ring_idx)
 {
 	struct dr_domain_rx_tx *nic_dmn = nic_matcher->nic_tbl->nic_dmn;
 	bool rx_rule = nic_dmn->type == DR_DOMAIN_NIC_TYPE_RX;
@@ -754,6 +777,10 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 				     action->rewrite.ptrn_arg.ptrn->rewrite_param.num_of_actions;
 				attr.decap_pat_idx =
 					action->rewrite.ptrn_arg.ptrn->rewrite_param.index;
+				if (dmn->info.use_mqs) {
+					if (dr_action_send_modify_header_args(action, send_ring_idx))
+						goto out_errno;
+				}
 			} else {
 				attr.decap_index = action->rewrite.param.index;
 				attr.decap_actions = action->rewrite.param.num_of_actions;
@@ -780,6 +807,10 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 					attr.modify_actions =
 						action->rewrite.ptrn_arg.ptrn->rewrite_param.
 										num_of_actions;
+					if (dmn->info.use_mqs) {
+						if (dr_action_send_modify_header_args(action, send_ring_idx))
+							goto out_errno;
+					}
 				} else {
 					attr.modify_actions = action->rewrite.param.num_of_actions;
 					attr.modify_index = action->rewrite.param.index;

--- a/providers/mlx5/dr_arg.c
+++ b/providers/mlx5/dr_arg.c
@@ -206,12 +206,14 @@ struct dr_arg_obj *dr_arg_get_obj(struct dr_arg_mngr *mngr,
 		return NULL;
 	}
 
-	/* write it into the hw */
-	ret = dr_send_postsend_args(mngr->dmn, dr_arg_get_object_id(arg_obj),
-				    num_of_actions, data);
-	if (ret) {
-		dr_dbg(mngr->dmn, "Failed writing args object\n");
-		goto put_obj;
+	if (!mngr->dmn->info.use_mqs) {
+		/* write it into the hw */
+		ret = dr_send_postsend_args(mngr->dmn, dr_arg_get_object_id(arg_obj),
+					    num_of_actions, data, 0);
+		if (ret) {
+			dr_dbg(mngr->dmn, "Failed writing args object\n");
+			goto put_obj;
+		}
 	}
 
 	return arg_obj;

--- a/providers/mlx5/dr_domain.c
+++ b/providers/mlx5/dr_domain.c
@@ -435,6 +435,7 @@ static int dr_domain_check_icm_memory_caps(struct mlx5dv_dr_domain *dmn)
 	max_req_chunks_log = max_req_bytes_log - DR_STE_LOG_SIZE;
 	dmn->info.max_log_sw_icm_sz =
 		min_t(uint32_t, DR_CHUNK_SIZE_1024K, max_req_chunks_log);
+	dmn->info.max_log_sw_icm_rehash_sz = dmn->info.max_log_sw_icm_sz;
 
 	if (dmn->info.caps.sw_format_ver >= MLX5_HW_CONNECTX_6DX) {
 		if (dmn->info.caps.log_modify_pattern_icm_size < DR_CHUNK_SIZE_4K +

--- a/providers/mlx5/dr_matcher.c
+++ b/providers/mlx5/dr_matcher.c
@@ -177,7 +177,7 @@ static bool dr_mask_is_tnl_geneve_set(struct dr_match_misc *misc)
 
 static bool dr_mask_is_ib_l4_set(struct dr_match_misc *misc)
 {
-	return misc->bth_opcode || misc->bth_dst_qp;
+	return misc->bth_opcode || misc->bth_dst_qp || misc->bth_a;
 }
 
 static int dr_matcher_supp_geneve_tlv_option(struct dr_devx_caps *caps)

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -569,7 +569,8 @@ static struct dr_ste_htbl *dr_rule_rehash(struct mlx5dv_dr_rule *rule,
 	enum dr_icm_chunk_size new_size;
 
 	new_size = dr_icm_next_higher_chunk(cur_htbl->chunk_size);
-	new_size = min_t(uint32_t, new_size, dmn->info.max_log_sw_icm_sz);
+	new_size = min_t(uint32_t, new_size,
+			 dmn->info.max_log_sw_icm_rehash_sz);
 
 	if (new_size == cur_htbl->chunk_size)
 		return NULL; /* Skip rehash, we already at the max size */

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -1367,15 +1367,17 @@ dr_rule_create_rule_nic(struct mlx5dv_dr_rule *rule,
 	if (ret)
 		return ret;
 
+	/* Set the lock index, and use the relative lock  */
+	dr_rule_lock(nic_rule, hw_ste_arr);
+
 	/* Set the actions values/addresses inside the ste array */
 	ret = dr_actions_build_ste_arr(matcher, nic_matcher, actions,
 				       num_actions, hw_ste_arr,
 				       &new_hw_ste_arr_sz,
-				       &cross_dmn_p);
+				       &cross_dmn_p,
+				       nic_rule->lock_index);
 	if (ret)
-		return ret;
-
-	dr_rule_lock(nic_rule, hw_ste_arr);
+		goto out_unlock;
 
 	cur_htbl = nic_matcher->s_htbl;
 

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -829,6 +829,7 @@ int dr_ste_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 static void dr_ste_copy_mask_misc(char *mask, struct dr_match_misc *spec, bool clear)
 {
 	spec->gre_c_present = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_c_present, clear);
+	spec->bth_a = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, bth_a, clear);
 	spec->gre_k_present = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_k_present, clear);
 	spec->gre_s_present = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_s_present, clear);
 	spec->source_vhca_port = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, source_vhca_port, clear);

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -839,6 +839,8 @@ static void dr_ste_copy_mask_misc(char *mask, struct dr_match_misc *spec, bool c
 	spec->source_vhca_port = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, source_vhca_port, clear);
 	spec->source_sqn = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, source_sqn, clear);
 
+	spec->source_eswitch_owner_vhca_id =
+		DEVX_GET(dr_match_set_misc, mask, source_eswitch_owner_vhca_id);
 	spec->source_port = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, source_port, clear);
 
 	spec->outer_second_prio = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, outer_second_prio, clear);
@@ -856,7 +858,8 @@ static void dr_ste_copy_mask_misc(char *mask, struct dr_match_misc *spec, bool c
 		DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, outer_second_svlan_tag, clear);
 	spec->inner_second_svlan_tag =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, inner_second_svlan_tag, clear);
-
+	spec->outer_emd_tag = DEVX_GET(dr_match_set_misc, mask, outer_emd_tag);
+	spec->reserved_at_65 = DEVX_GET(dr_match_set_misc, mask, reserved_at_65);
 	spec->gre_protocol = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_protocol, clear);
 
 	spec->gre_key_h = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, gre_key_h, clear);
@@ -866,21 +869,33 @@ static void dr_ste_copy_mask_misc(char *mask, struct dr_match_misc *spec, bool c
 	spec->bth_opcode = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, bth_opcode, clear);
 
 	spec->geneve_vni = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_vni, clear);
+	spec->reserved_at_e4 = DEVX_GET(dr_match_set_misc, mask, reserved_at_e4);
 	spec->geneve_oam = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_oam, clear);
+	spec->reserved_at_ec = DEVX_GET(dr_match_set_misc, mask, reserved_at_ec);
 	spec->geneve_tlv_option_0_exist =
 		DEVX_GET(dr_match_set_misc, mask, geneve_tlv_option_0_exist);
 
 	spec->outer_ipv6_flow_label =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, outer_ipv6_flow_label, clear);
 
+	spec->reserved_at_100 = DEVX_GET(dr_match_set_misc, mask, reserved_at_100);
 	spec->inner_ipv6_flow_label =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, inner_ipv6_flow_label, clear);
 
+	spec->reserved_at_120 = DEVX_GET(dr_match_set_misc, mask, reserved_at_120);
 	spec->geneve_opt_len = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_opt_len, clear);
 	spec->geneve_protocol_type =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, geneve_protocol_type, clear);
 
+	spec->reserved_at_140 = DEVX_GET(dr_match_set_misc, mask, reserved_at_140);
 	spec->bth_dst_qp = DR_DEVX_GET_CLEAR(dr_match_set_misc, mask, bth_dst_qp, clear);
+
+	spec->inner_esp_spi = DEVX_GET(dr_match_set_misc, mask, inner_esp_spi);
+	spec->outer_esp_spi = DEVX_GET(dr_match_set_misc, mask, outer_esp_spi);
+
+	spec->reserved_at_1a0 = DEVX_GET(dr_match_set_misc, mask, reserved_at_1a0);
+	spec->reserved_at_1c0 = DEVX_GET(dr_match_set_misc, mask, reserved_at_1c0);
+	spec->reserved_at_1e0 = DEVX_GET(dr_match_set_misc, mask, reserved_at_1e0);
 }
 
 static void dr_ste_copy_mask_spec(char *mask, struct dr_match_spec *spec, bool clear)
@@ -908,6 +923,7 @@ static void dr_ste_copy_mask_spec(char *mask, struct dr_match_spec *spec, bool c
 	spec->tcp_sport = DR_DEVX_GET_CLEAR(dr_match_spec, mask, tcp_sport, clear);
 	spec->tcp_dport = DR_DEVX_GET_CLEAR(dr_match_spec, mask, tcp_dport, clear);
 
+	spec->reserved_at_c0 = DEVX_GET(dr_match_spec, mask, reserved_at_c0);
 	spec->ipv4_ihl = DR_DEVX_GET_CLEAR(dr_match_spec, mask, ipv4_ihl, clear);
 	spec->l3_ok = DR_DEVX_GET_CLEAR(dr_match_spec, mask, l3_ok, clear);
 	spec->l4_ok = DR_DEVX_GET_CLEAR(dr_match_spec, mask, l4_ok, clear);
@@ -978,6 +994,9 @@ static void dr_ste_copy_mask_misc2(char *mask, struct dr_match_misc2 *spec, bool
 	spec->metadata_reg_c_1 = DR_DEVX_GET_CLEAR(dr_match_set_misc2, mask, metadata_reg_c_1, clear);
 	spec->metadata_reg_c_0 = DR_DEVX_GET_CLEAR(dr_match_set_misc2, mask, metadata_reg_c_0, clear);
 	spec->metadata_reg_a = DR_DEVX_GET_CLEAR(dr_match_set_misc2, mask, metadata_reg_a, clear);
+	spec->reserved_at_1a0 = DEVX_GET(dr_match_set_misc2, mask, reserved_at_1a0);
+	spec->reserved_at_1c0 = DEVX_GET(dr_match_set_misc2, mask, reserved_at_1c0);
+	spec->reserved_at_1e0 = DEVX_GET(dr_match_set_misc2, mask, reserved_at_1e0);
 }
 
 static void dr_ste_copy_mask_misc3(char *mask, struct dr_match_misc3 *spec, bool clear)
@@ -986,12 +1005,16 @@ static void dr_ste_copy_mask_misc3(char *mask, struct dr_match_misc3 *spec, bool
 	spec->outer_tcp_seq_num = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, outer_tcp_seq_num, clear);
 	spec->inner_tcp_ack_num = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, inner_tcp_ack_num, clear);
 	spec->outer_tcp_ack_num = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, outer_tcp_ack_num, clear);
+
+	spec->reserved_at_80 = DEVX_GET(dr_match_set_misc3, mask, reserved_at_80);
 	spec->outer_vxlan_gpe_vni =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, outer_vxlan_gpe_vni, clear);
 	spec->outer_vxlan_gpe_next_protocol =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, outer_vxlan_gpe_next_protocol, clear);
 	spec->outer_vxlan_gpe_flags =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, outer_vxlan_gpe_flags, clear);
+	spec->reserved_at_b0 = DEVX_GET(dr_match_set_misc3, mask, reserved_at_b0);
+
 	spec->icmpv4_header_data = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, icmp_header_data, clear);
 	spec->icmpv6_header_data =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, icmpv6_header_data, clear);
@@ -1001,13 +1024,15 @@ static void dr_ste_copy_mask_misc3(char *mask, struct dr_match_misc3 *spec, bool
 	spec->icmpv6_code = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, icmpv6_code, clear);
 	spec->geneve_tlv_option_0_data =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, geneve_tlv_option_0_data, clear);
-	spec->gtpu_msg_flags = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_msg_flags, clear);
-	spec->gtpu_msg_type = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_msg_type, clear);
 	spec->gtpu_teid = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_teid, clear);
-	spec->gtpu_dw_0 = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_dw_0, clear);
+	spec->gtpu_msg_type = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_msg_type, clear);
+	spec->gtpu_msg_flags = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_msg_flags, clear);
+	spec->reserved_at_170 = DEVX_GET(dr_match_set_misc3, mask, reserved_at_170);
 	spec->gtpu_dw_2 = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_dw_2, clear);
 	spec->gtpu_first_ext_dw_0 =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_first_ext_dw_0, clear);
+	spec->gtpu_dw_0 = DR_DEVX_GET_CLEAR(dr_match_set_misc3, mask, gtpu_dw_0, clear);
+	spec->reserved_at_1e0 = DEVX_GET(dr_match_set_misc3, mask, reserved_at_1e0);
 }
 
 static void dr_ste_copy_mask_misc4(char *mask, struct dr_match_misc4 *spec, bool clear)
@@ -1064,6 +1089,22 @@ static void dr_ste_copy_mask_misc5(char *mask, struct dr_match_misc5 *spec, bool
 		DR_DEVX_GET_CLEAR(dr_match_set_misc5, mask, tunnel_header_2, clear);
 	spec->tunnel_header_3 =
 		DR_DEVX_GET_CLEAR(dr_match_set_misc5, mask, tunnel_header_3, clear);
+	spec->reserved_at_100 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_100);
+	spec->reserved_at_120 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_120);
+	spec->reserved_at_140 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_140);
+	spec->reserved_at_160 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_160);
+	spec->reserved_at_180 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_180);
+	spec->reserved_at_1a0 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_1a0);
+	spec->reserved_at_1c0 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_1c0);
+	spec->reserved_at_1e0 =
+		DEVX_GET(dr_match_set_misc5, mask, reserved_at_1e0);
 }
 
 void dr_ste_copy_param(uint8_t match_criteria,

--- a/providers/mlx5/dr_ste.c
+++ b/providers/mlx5/dr_ste.c
@@ -247,6 +247,12 @@ dr_ste_remove_head_ste(struct dr_ste_ctx *ste_ctx,
 	uint8_t formated_ste[DR_STE_SIZE] = {};
 	struct dr_htbl_connect_info info;
 
+	stats_tbl->ctrl.num_of_valid_entries--;
+
+	/* Hash table will be deleted, no need to update STE */
+	if (atomic_load(&ste->htbl->refcount) == 1)
+		return;
+
 	info.type = CONNECT_MISS;
 	info.miss_icm_addr =
 		dr_icm_pool_get_chunk_icm_addr(nic_matcher->e_anchor->chunk);
@@ -266,8 +272,6 @@ dr_ste_remove_head_ste(struct dr_ste_ctx *ste_ctx,
 					      ste_info_head,
 					      send_ste_list,
 					      true /* Copy data */);
-
-	stats_tbl->ctrl.num_of_valid_entries--;
 }
 
 /*

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -2405,6 +2405,7 @@ static int dr_ste_v1_build_ib_l4_tag(struct dr_match_param *value,
 
 	DR_STE_SET_TAG(ib_l4, tag, opcode, misc, bth_opcode);
 	DR_STE_SET_TAG(ib_l4, tag, qp, misc, bth_dst_qp);
+	DR_STE_SET_TAG(ib_l4, tag, ackreq, misc, bth_a);
 
 	return 0;
 }

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -598,7 +598,9 @@ struct mlx5_ifc_dr_match_set_misc_bits {
 
 	u8	   outer_esp_spi[0x20];
 
-	u8	   reserved_at_1a0[0x60];
+	u8         reserved_at_1a0[0x20];
+	u8         reserved_at_1c0[0x20];
+	u8         reserved_at_1e0[0x20];
 };
 
 struct mlx5_ifc_dr_match_set_misc2_bits {
@@ -633,7 +635,9 @@ struct mlx5_ifc_dr_match_set_misc2_bits {
 
 	u8         metadata_reg_a[0x20];
 
-	u8         reserved_at_1a0[0x60];
+	u8         reserved_at_1a0[0x20];
+	u8         reserved_at_1c0[0x20];
+	u8         reserved_at_1e0[0x20];
 };
 
 struct mlx5_ifc_dr_match_set_misc3_bits {
@@ -667,7 +671,7 @@ struct mlx5_ifc_dr_match_set_misc3_bits {
 
 	u8         gtpu_msg_type[0x8];
 	u8         gtpu_msg_flags[0x8];
-	u8         reserved_at_150[0x10];
+	u8         reserved_at_170[0x10];
 
 	u8         gtpu_dw_2[0x20];
 
@@ -675,7 +679,7 @@ struct mlx5_ifc_dr_match_set_misc3_bits {
 
 	u8         gtpu_dw_0[0x20];
 
-	u8         reserved_at_1c0[0x20];
+	u8         reserved_at_1e0[0x20];
 };
 
 struct mlx5_ifc_dr_match_set_misc4_bits {
@@ -729,7 +733,21 @@ struct mlx5_ifc_dr_match_set_misc5_bits {
 
 	u8	tunnel_header_3[0x20];
 
-	u8	reserved[0x100];
+	u8	reserved_at_100[0x20];
+
+	u8	reserved_at_120[0x20];
+
+	u8      reserved_at_140[0x20];
+
+	u8      reserved_at_160[0x20];
+
+	u8      reserved_at_180[0x20];
+
+	u8      reserved_at_1a0[0x20];
+
+	u8      reserved_at_1c0[0x20];
+
+	u8      reserved_at_1e0[0x20];
 };
 
 struct mlx5_ifc_dr_match_param_bits {

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -546,7 +546,7 @@ struct mlx5_ifc_dr_match_spec_bits {
 
 struct mlx5_ifc_dr_match_set_misc_bits {
 	u8         gre_c_present[0x1];
-	u8         reserved_auto1[0x1];
+	u8         bth_a[0x1];
 	u8         gre_k_present[0x1];
 	u8         gre_s_present[0x1];
 	u8         source_vhca_port[0x4];

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -88,6 +88,9 @@ enum dr_icm_chunk_size {
 	DR_CHUNK_SIZE_512K,
 	DR_CHUNK_SIZE_1024K,
 	DR_CHUNK_SIZE_2048K,
+	DR_CHUNK_SIZE_4096K,
+	DR_CHUNK_SIZE_8192K,
+	DR_CHUNK_SIZE_16384K,
 	DR_CHUNK_SIZE_MAX,
 };
 
@@ -1039,7 +1042,8 @@ struct dr_domain_info {
 	uint32_t		max_log_sw_icm_sz;
 	uint32_t		max_log_action_icm_sz;
 	uint32_t		max_log_modify_hdr_pattern_icm_sz;
-	uint32_t		max_send_size;
+	uint32_t                max_log_sw_icm_rehash_sz;
+	uint32_t                max_send_size;
 	struct dr_domain_rx_tx	rx;
 	struct dr_domain_rx_tx	tx;
 	struct ibv_device_attr_ex attr;

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -723,7 +723,7 @@ struct dr_match_spec {
 
 struct dr_match_misc {
 	uint32_t gre_c_present:1;		/* used with GRE, checksum exist when gre_c_present == 1 */
-	uint32_t reserved_at1:1;
+	uint32_t bth_a:1;
 	uint32_t gre_k_present:1;		/* used with GRE, key exist when gre_k_present == 1 */
 	uint32_t gre_s_present:1;		/* used with GRE, sequence number exist when gre_s_present == 1 */
 	uint32_t source_vhca_port:4;

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -765,7 +765,9 @@ struct dr_match_misc {
 	uint32_t bth_dst_qp:24;			/* Destination QP in BTH header */
 	uint32_t inner_esp_spi;
 	uint32_t outer_esp_spi;
-	uint32_t reserved_at_1a0[3];
+	uint32_t reserved_at_1a0;
+	uint32_t reserved_at_1c0;
+	uint32_t reserved_at_1e0;
 };
 
 struct dr_match_misc2 {
@@ -794,11 +796,9 @@ struct dr_match_misc2 {
 	uint32_t metadata_reg_c_1;			/* metadata_reg_c_1 */
 	uint32_t metadata_reg_c_0;			/* metadata_reg_c_0 */
 	uint32_t metadata_reg_a;			/* metadata_reg_a */
-	uint32_t psp_syndrome:8;
-	uint32_t reserved_at_1a8:8;
-	uint32_t ipsec_syndrome:8;
-	uint32_t ipsec_next_header:8;
-	uint32_t reserved_at_260[2];
+	uint32_t reserved_at_1a0;
+	uint32_t reserved_at_1c0;
+	uint32_t reserved_at_1e0;
 };
 
 struct dr_match_misc3 {
@@ -821,11 +821,11 @@ struct dr_match_misc3 {
 	uint32_t gtpu_teid;
 	uint32_t gtpu_msg_type:8;
 	uint32_t gtpu_msg_flags:8;
-	uint32_t reserved_at_150:16;
+	uint32_t reserved_at_170:16;
 	uint32_t gtpu_dw_2;
 	uint32_t gtpu_first_ext_dw_0;
 	uint32_t gtpu_dw_0;
-	uint32_t reserved_at_1c0;
+	uint32_t reserved_at_1e0;
 };
 
 struct dr_match_misc4 {
@@ -856,7 +856,14 @@ struct dr_match_misc5 {
 	uint32_t tunnel_header_1;
 	uint32_t tunnel_header_2;
 	uint32_t tunnel_header_3;
-	uint32_t reserved[0x8];
+	uint32_t reserved_at_100;
+	uint32_t reserved_at_120;
+	uint32_t reserved_at_140;
+	uint32_t reserved_at_160;
+	uint32_t reserved_at_180;
+	uint32_t reserved_at_1a0;
+	uint32_t reserved_at_1c0;
+	uint32_t reserved_at_1e0;
 };
 
 struct dr_match_param {

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -679,7 +679,8 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 			     uint32_t num_actions,
 			     uint8_t *ste_arr,
 			     uint32_t *new_hw_ste_arr_sz,
-			     struct cross_dmn_params *cross_dmn_p);
+			     struct cross_dmn_params *cross_dmn_p,
+			     uint8_t send_ring_idx);
 int dr_actions_build_attr(struct mlx5dv_dr_matcher *matcher,
 			  struct mlx5dv_dr_action *actions[],
 			  size_t num_actions,
@@ -1245,6 +1246,7 @@ struct mlx5dv_dr_action {
 		struct {
 			struct mlx5dv_dr_domain	*dmn;
 			bool			is_root_level;
+			uint32_t		args_send_qp;
 			union {
 				struct ibv_flow_action	*flow_action; /* root*/
 				struct {
@@ -1703,7 +1705,8 @@ int dr_send_postsend_pattern(struct mlx5dv_dr_domain *dmn,
 			     uint16_t num_of_actions,
 			     uint8_t *data);
 int dr_send_postsend_args(struct mlx5dv_dr_domain *dmn, uint64_t arg_id,
-			  uint16_t num_of_actions, uint8_t *actions_data);
+			  uint16_t num_of_actions, uint8_t *actions_data,
+			  uint32_t ring_index);
 
 /* buddy functions & structure */
 struct dr_icm_mr;

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -1303,7 +1303,7 @@ class QueryCmdHcaCapOut(Packet):
 class FlowTableEntryMatchSetMisc(Packet):
     fields_desc = [
         BitField('gre_c_present', 0, 1),
-        BitField('reserved1', 0, 1),
+        BitField('bth_a', 0, 1),
         BitField('gre_k_present', 0, 1),
         BitField('gre_s_present', 0, 1),
         BitField('source_vhca_port', 0, 4),

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -380,9 +380,11 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         roce_mask = FlowTableEntryMatchParam()
         roce_mask.misc_parameters.bth_opcode = 0xff
         roce_mask.misc_parameters.bth_dst_qp = 0xffffff
+        roce_mask.misc_parameters.bth_a = 0x1
         roce_value = FlowTableEntryMatchParam()
         roce_value.misc_parameters.bth_opcode = PacketConsts.BTH_OPCODE
         roce_value.misc_parameters.bth_dst_qp = PacketConsts.BTH_DST_QP
+        roce_value.misc_parameters.bth_a = PacketConsts.BTH_A
         mask_param = Mlx5FlowMatchParameters(len(roce_mask), roce_mask)
         value_param = Mlx5FlowMatchParameters(len(roce_value), roce_value)
         return mask_param, value_param

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -109,6 +109,7 @@ class PacketConsts:
     BTH_HEADER_SIZE = 16
     BTH_OPCODE = 0x81
     BTH_DST_QP = 0xd2
+    BTH_A = 0x1
     BTH_PARTITION_KEY = 0xffff
     BTH_BECN = 1
     ROCE_PORT = 4791
@@ -857,15 +858,16 @@ def gen_geneve_header(vni=PacketConsts.GENEVE_VNI, oam=PacketConsts.GENEVE_OAM,
     """
     return struct.pack('!BBHL', (0 << 6) + 0, (oam << 7) + (0 << 6) + 0, proto, (vni << 8) + 0)
 
-def gen_bth_header(opcode=PacketConsts.BTH_OPCODE, dst_qp=PacketConsts.BTH_DST_QP):
+def gen_bth_header(opcode=PacketConsts.BTH_OPCODE, dst_qp=PacketConsts.BTH_DST_QP, a=PacketConsts.BTH_A):
     """
     Generates ROCE BTH header using the values from the PacketConst class by default.
     :param opcode: BTH opcode
     :param dst_qp: BTH dst QP
+    :param a: BTH acknowledgment bit
     :return: ROCE BTH header
     """
     return struct.pack('!2BH2BH2L', opcode, 0, PacketConsts.BTH_PARTITION_KEY,
-                       PacketConsts.BTH_BECN << 6, dst_qp >> 16, dst_qp & 0xffff, 0, 0)
+                       PacketConsts.BTH_BECN << 6, dst_qp >> 16, dst_qp & 0xffff, a << 31, 0)
 
 
 def gen_packet(msg_size, l3=PacketConsts.IP_V4, l4=PacketConsts.UDP_PROTO, with_vlan=False, **kwargs):


### PR DESCRIPTION
This series in the DR area includes a few extensions and improvements as of below.

- Optimize argument sending in multi-QP mode.
- Add a check for unsupported and reserved fields in the match param
- Remove table level check to enable some extra functionality.
- In rehash write the line in the entry immediately to save allocations and improve performance.
- Support new sizes for pre-allocated fixed matcher tables.
- Add support for matching on bth_a bit.

In addition, a pyverbs test was added for matching on the bth_a bit.
