### PR TITLE
bnxt_re/lib: Add dmabuf support in bnxt_re

### DIFF
--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -97,6 +97,7 @@ static const struct verbs_context_ops bnxt_re_cntx_ops = {
 	.alloc_pd      = bnxt_re_alloc_pd,
 	.dealloc_pd    = bnxt_re_free_pd,
 	.reg_mr        = bnxt_re_reg_mr,
+	.reg_dmabuf_mr = bnxt_re_reg_dmabuf_mr,
 	.dereg_mr      = bnxt_re_dereg_mr,
 	.create_cq     = bnxt_re_create_cq,
 	.poll_cq       = bnxt_re_poll_cq,

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -225,6 +225,24 @@ struct ibv_mr *bnxt_re_reg_mr(struct ibv_pd *ibvpd, void *sva, size_t len,
 	return &mr->vmr.ibv_mr;
 }
 
+struct ibv_mr *bnxt_re_reg_dmabuf_mr(struct ibv_pd *ibvpd, uint64_t start, size_t len,
+				     uint64_t iova, int fd, int access)
+{
+	struct bnxt_re_mr *mr;
+
+	mr = calloc(1, sizeof(*mr));
+	if (!mr)
+		return NULL;
+
+	if (ibv_cmd_reg_dmabuf_mr(ibvpd, start, len, iova, fd,
+				  access, &mr->vmr)) {
+		free(mr);
+		return NULL;
+	}
+
+	return &mr->vmr.ibv_mr;
+}
+
 int bnxt_re_dereg_mr(struct verbs_mr *vmr)
 {
 	struct bnxt_re_mr *mr = (struct bnxt_re_mr *)vmr;

--- a/providers/bnxt_re/verbs.h
+++ b/providers/bnxt_re/verbs.h
@@ -69,6 +69,8 @@ struct ibv_pd *bnxt_re_alloc_pd(struct ibv_context *uctx);
 int bnxt_re_free_pd(struct ibv_pd *ibvpd);
 struct ibv_mr *bnxt_re_reg_mr(struct ibv_pd *ibvpd, void *buf, size_t len,
 			      uint64_t hca_va, int ibv_access_flags);
+struct ibv_mr *bnxt_re_reg_dmabuf_mr(struct ibv_pd *, uint64_t start, size_t len,
+				     uint64_t iova, int fd, int access);
 int bnxt_re_dereg_mr(struct verbs_mr *vmr);
 
 struct ibv_cq *bnxt_re_create_cq(struct ibv_context *uctx, int ncqe,


### PR DESCRIPTION
Add the support for dmabuf verb for bnxt devices.