### PR TITLE
tests: Fix rdmacm async udp

### DIFF
--- a/tests/base_rdmacm.py
+++ b/tests/base_rdmacm.py
@@ -37,6 +37,7 @@ class CMResources(abc.ABC):
         self.passive = passive
         self.with_ext_qp = kwargs.get('with_ext_qp', False)
         self.port = kwargs.get('port') if kwargs.get('port') else '7471'
+        self.ib_port = int(kwargs.get('ib_port', '1'))
         self.port_space = kwargs.get('port_space', ce.RDMA_PS_TCP)
         self.remote_operation = kwargs.get('remote_op')
         self.qp_type = qp_type_per_ps[self.port_space]

--- a/tests/rdmacm_utils.py
+++ b/tests/rdmacm_utils.py
@@ -154,7 +154,7 @@ class CMConnection(abc.ABC):
                 self.cm_res.mr.write(send_msg, self.cm_res.msg_size)
                 cmid.post_send(self.cm_res.mr)
             else:
-                ah = AH(cmid.pd, wc=wc, port_num=1, grh=self.cm_res.mr.buf)
+                ah = AH(cmid.pd, wc=wc, port_num=self.cm_res.ib_port, grh=self.cm_res.mr.buf)
                 rqpn = self.cm_res.remote_qpn
                 self.cm_res.mr.write(send_msg, self.cm_res.msg_size + GRH_SIZE)
                 cmid.post_ud_send(self.cm_res.mr, ah, rqpn=rqpn,

--- a/tests/test_rdmacm.py
+++ b/tests/test_rdmacm.py
@@ -61,7 +61,7 @@ class CMTestCase(RDMACMBaseTest):
 
     def test_rdmacm_async_udp_traffic(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection, self.rdmacm_traffic,
-                                      port_space=self.get_port_space())
+                                      port_space=self.get_port_space(), ib_port=self.ib_port)
 
     def test_rdmacm_async_read(self):
         self.two_nodes_rdmacm_traffic(CMAsyncConnection,


### PR DESCRIPTION
In case of dual port the wrong port was used for AH creation.