### PR TITLE
providers/mlx5: Fixed bug with mlx5_post_wq_recv not supporting Multi-Packet queues 

### DIFF
--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -734,6 +734,7 @@ struct mlx5_rwq {
 	void	*pbuff;
 	__be32	*recv_db;
 	int wq_sig;
+	bool is_mprq;
 };
 
 struct mlx5_counter_node {

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -72,8 +72,8 @@ static void *get_wq_recv_wqe(struct mlx5_rwq *rwq, int n)
 }
 
 static void *get_wq_mprq_recv_wqe(struct mlx5_rwq *rwq, int n) {
-	struct mlx5_mprq_wqe* wqe = rwq->pbuff;
-	return &(wqe[n].dseg);
+	return rwq->pbuff + (n << rwq->rq.wqe_shift) 
+		+ sizeof(struct mlx5_wqe_srq_next_seg);
 }
 static int copy_to_scat(struct mlx5_wqe_data_seg *scat, void *buf, int *size,
 			 int max, struct mlx5_context *ctx)

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4173,6 +4173,7 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 	int ret;
 	int32_t				usr_idx = 0;
 	FILE *fp = ctx->dbg_fp;
+	bool is_mprq = false;
 
 	if (attr->wq_type != IBV_WQT_RQ)
 		return NULL;
@@ -4251,6 +4252,8 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 			cmd.two_byte_shift_en =
 				mlx5wq_attr->striding_rq_attrs.two_byte_shift_en;
 			cmd.comp_mask |= MLX5_IB_CREATE_WQ_STRIDING_RQ;
+
+			is_mprq = true;
 		}
 	}
 
@@ -4261,8 +4264,9 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 
 	rwq->rsc.type = MLX5_RSC_TYPE_RWQ;
 	rwq->rsc.rsn =  cmd.user_index;
-
 	rwq->wq.post_recv = mlx5_post_wq_recv;
+	rwq->is_mprq = is_mprq;
+
 	return &rwq->wq;
 
 err_create:


### PR DESCRIPTION
There is a bug in the current implementation of mlx5/mlx5_post_wq_recv when Multi-Packet queues are enabled via - `MLX5DV_WQ_INIT_ATTR_MASK_STRIDING_RQ`. The wqe buffer is allocated with the appropriate size but is not accessed correctly while posting recvs. 

This results in the recv buffers to posted incorrectly and the application receives a local protection error status in the work completion. This PR fixes this with the following changes - 

1. Add a field `bool is_mprq` to the `struct mlx5_rwq`. 
2. Set this field to true in `create_wq` if `MLX5DV_WQ_INIT_ATTR_MASK_STRIDING_RQ` is set. 
3. If this field is set in `mlx5_post_wq_recv`, use `get_wq_mprq_recv_wqe` to get the address of the `struct mlx5_wqe_data_seg` which uses the `struct mlx5_mprq_wqe` to calculate the address. This struct is already defined under mlx5dv.h

This change has been tested and calling `ibv_post_wq_recv` from the application registers the buffers appropriately and the application is able to receive the data. This change doesn't break the behavior when `MLX5DV_WQ_INIT_ATTR_MASK_STRIDING_RQ` is not enabled and has been tested. 