### PR TITLE
providers/rxe: Add tracepoint for post send

### DIFF
--- a/libibverbs/enum_strs.c
+++ b/libibverbs/enum_strs.c
@@ -132,3 +132,28 @@ const char *ibv_wc_status_str(enum ibv_wc_status status)
 
 	return wc_status_str[status];
 }
+
+const char *ibv_wr_opcode_str(enum ibv_wr_opcode opcode)
+{
+	static const char *const wr_opcode_str[] = {
+		[IBV_WR_RDMA_WRITE]		= "rdma-write",
+		[IBV_WR_RDMA_WRITE_WITH_IMM]	= "rdma-write-with-imm",
+		[IBV_WR_SEND]			= "send",
+		[IBV_WR_SEND_WITH_IMM]		= "send-with-imm",
+		[IBV_WR_RDMA_READ]		= "rdma-read",
+		[IBV_WR_ATOMIC_CMP_AND_SWP]	= "atomic-cmp-and-swp",
+		[IBV_WR_ATOMIC_FETCH_AND_ADD]	= "atomic-fetch-and-add",
+		[IBV_WR_LOCAL_INV]		= "local-inv",
+		[IBV_WR_BIND_MW]		= "bind-mw",
+		[IBV_WR_SEND_WITH_INV]		= "send-with-inv",
+		[IBV_WR_TSO]			= "tso",
+		[IBV_WR_DRIVER1]		= "driver1",
+		[IBV_WR_FLUSH]			= "flush",
+		[IBV_WR_ATOMIC_WRITE]		= "atomic-write"
+	};
+
+	if (opcode < IBV_WR_RDMA_WRITE || opcode > IBV_WR_ATOMIC_WRITE)
+		return "unknown";
+
+	return wr_opcode_str[opcode];
+}

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -208,6 +208,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_detach_mcast;
 		ibv_cmd_free_dm;
 		ibv_cmd_get_context;
+		ibv_cmd_modify_cq;
 		ibv_cmd_modify_flow_action_esp;
 		ibv_cmd_modify_qp;
 		ibv_cmd_modify_qp_ex;
@@ -235,11 +236,11 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_resize_cq;
 		ibv_query_gid_type;
 		ibv_read_ibdev_sysfs_file;
+		ibv_wr_opcode_str;
 		verbs_allow_disassociate_destroy;
+		verbs_init_cq;
 		verbs_open_device;
 		verbs_register_driver_@IBVERBS_PABI_VERSION@;
 		verbs_set_ops;
 		verbs_uninit_context;
-		verbs_init_cq;
-		ibv_cmd_modify_cq;
 };

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1116,6 +1116,8 @@ enum ibv_wr_opcode {
 	IBV_WR_ATOMIC_WRITE = 15,
 };
 
+const char *ibv_wr_opcode_str(enum ibv_wr_opcode opcode);
+
 enum ibv_send_flags {
 	IBV_SEND_FENCE		= 1 << 0,
 	IBV_SEND_SIGNALED	= 1 << 1,

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -10,8 +10,13 @@ if (MLX5_MW_DEBUG)
   add_definitions("-DMW_DEBUG")
 endif()
 
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+  set(TRACE_FILE mlx5_trace.c)
+endif()
+
 rdma_shared_provider(mlx5 libmlx5.map
   1 1.24.${PACKAGE_VERSION}
+  ${TRACE_FILE}
   buf.c
   cq.c
   dbrec.c
@@ -47,3 +52,8 @@ publish_headers(infiniband
 )
 
 rdma_pkg_config("mlx5" "libibverbs" "${CMAKE_THREAD_LIBS_INIT}")
+
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+	target_include_directories(mlx5 PUBLIC ".")
+	target_link_libraries(mlx5 LINK_PRIVATE LTTng::UST)
+endif()

--- a/providers/mlx5/mlx5_trace.c
+++ b/providers/mlx5/mlx5_trace.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Bytedance.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "mlx5_trace.h"

--- a/providers/mlx5/mlx5_trace.h
+++ b/providers/mlx5/mlx5_trace.h
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Bytedance.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#if defined(LTTNG_ENABLED)
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER rdma_core_mlx5
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "mlx5_trace.h"
+
+#if !defined(__MLX5_TRACE_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __MLX5_TRACE_H__
+
+#include <lttng/tracepoint.h>
+#include <infiniband/verbs.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	rdma_core_mlx5,
+
+	/* Tracepoint name */
+	post_send,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		char *, dev,
+		uint32_t, src_qp_num,
+		char *, opcode,
+		uint32_t, bytes
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(dev, dev)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_string(opcode, opcode)
+		lttng_ust_field_integer(uint32_t, bytes, bytes)
+	)
+)
+
+#define rdma_tracepoint(arg...) lttng_ust_tracepoint(arg)
+
+#endif /* __MLX5_TRACE_H__*/
+
+#include <lttng/tracepoint-event.h>
+
+#else
+
+#ifndef __MLX5_TRACE_H__
+#define __MLX5_TRACE_H__
+
+#define MLX5_TP_rdma_core_mlx5 ""
+#define MLX5_TP_post_send ""
+static inline void dummy_tracepoint(const char *p, const char *n, ...) {};
+
+#define rdma_tracepoint(P, N, arg...) \
+		dummy_tracepoint(MLX5_TP_##P, MLX5_TP_##N, arg)
+
+#endif /* __MLX5_TRACE_H__*/
+
+#endif /* defined(LTTNG_ENABLED) */

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -42,6 +42,7 @@
 
 #include "mlx5.h"
 #include "mlx5_ifc.h"
+#include "mlx5_trace.h"
 #include "wqe.h"
 
 #define MLX5_ATOMIC_SIZE 8
@@ -823,6 +824,7 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 	uint8_t fence;
 	uint8_t next_fence;
 	uint32_t max_tso = 0;
+	unsigned int length = 0;
 	FILE *fp = to_mctx(ibqp->context)->dbg_fp; /* The compiler ignores in non-debug mode */
 
 	mlx5_spin_lock(&qp->sq.lock);
@@ -1137,6 +1139,14 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 		if (mlx5_debug_mask & MLX5_DBG_QP_SEND)
 			dump_wqe(to_mctx(ibqp->context), idx, size, qp);
 #endif
+		for (i = 0; i < wr->num_sge; i++)
+			length += wr->sg_list[i].length;
+
+		rdma_tracepoint(rdma_core_mlx5, post_send,
+				ibqp->context->device->name,
+				ibqp->qp_num,
+				(char *)ibv_wr_opcode_str(wr->opcode),
+				length);
 	}
 
 out:

--- a/providers/rxe/CMakeLists.txt
+++ b/providers/rxe/CMakeLists.txt
@@ -1,3 +1,13 @@
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+  set(TRACE_FILE rxe_trace.c)
+endif()
+
 rdma_provider(rxe
+  ${TRACE_FILE}
   rxe.c
   )
+
+if (ENABLE_LTTNG AND LTTNGUST_FOUND)
+	target_include_directories("rxe-rdmav${IBVERBS_PABI_VERSION}" PUBLIC ".")
+	target_link_libraries("rxe-rdmav${IBVERBS_PABI_VERSION}" LINK_PRIVATE LTTng::UST)
+endif()

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -55,6 +55,7 @@
 #include "rxe_queue.h"
 #include "rxe-abi.h"
 #include "rxe.h"
+#include "rxe_trace.h"
 
 static void rxe_free_context(struct ibv_context *ibctx);
 
@@ -1619,6 +1620,11 @@ static int post_one_send(struct rxe_qp *qp, struct rxe_wq *sq,
 		return ENOMEM;
 
 	advance_producer(sq->queue);
+	rdma_tracepoint(rdma_core_rxe, post_send,
+			qp->vqp.qp.context->device->name,
+			qp->vqp.qp.qp_num,
+			(char *)ibv_wr_opcode_str(ibwr->opcode),
+			length);
 
 	return 0;
 }

--- a/providers/rxe/rxe_trace.c
+++ b/providers/rxe/rxe_trace.c
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Bytedance.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#define LTTNG_UST_TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+#include "rxe_trace.h"

--- a/providers/rxe/rxe_trace.h
+++ b/providers/rxe/rxe_trace.h
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2023 Bytedance.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#if defined(LTTNG_ENABLED)
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER rdma_core_rxe
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "rxe_trace.h"
+
+#if !defined(__RXE_TRACE_H__) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define __RXE_TRACE_H__
+
+#include <lttng/tracepoint.h>
+#include <infiniband/verbs.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+	/* Tracepoint provider name */
+	rdma_core_rxe,
+
+	/* Tracepoint name */
+	post_send,
+
+	/* Input arguments */
+	LTTNG_UST_TP_ARGS(
+		char *, dev,
+		uint32_t, src_qp_num,
+		char *, opcode,
+		uint32_t, bytes
+	),
+
+	/* Output event fields */
+	LTTNG_UST_TP_FIELDS(
+		lttng_ust_field_string(dev, dev)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_string(opcode, opcode)
+		lttng_ust_field_integer(uint32_t, bytes, bytes)
+	)
+)
+
+#define rdma_tracepoint(arg...) lttng_ust_tracepoint(arg)
+
+#endif /* __RXE_TRACE_H__*/
+
+#include <lttng/tracepoint-event.h>
+
+#else
+
+#ifndef __RXE_TRACE_H__
+#define __RXE_TRACE_H__
+
+#define rdma_tracepoint(arg...)
+
+#endif /* __RXE_TRACE_H__*/
+
+#endif /* defined(LTTNG_ENABLED) */


### PR DESCRIPTION
Hi,
I'd like to introduce LTTng based tracepoints for RXE into rdma-core for trouble shooting/performance monitor..

An sample of python script:
```
#!/usr/bin/env python3
# SPDX-License-Identifier: (GPL-2.0 OR Linux-OpenIB)
# Copyright (c) 2023, Bytedance. All rights reserved.  See COPYING file

import argparse
import bt2
import collections
import sys


def stats(args):
	stats = {}

	tcm_it = bt2.TraceCollectionMessageIterator(args.tracepoints)
	for msg in tcm_it:
		if type(msg) is not bt2._EventMessageConst:
			continue

		event = msg.event
		if event.cls.name != "rdma_core_rxe:post_send":
			continue

		# device filter
		dev = str(event.payload_field["dev"])
		if args.device != None and args.device != dev:
			continue;

		# QPN filter
		qpn = event.payload_field['src_qp_num']
		if args.qpn != None and args.qpn != qpn:
			continue;

		# opcode filter
		opcode = event.payload_field['opcode']
		if args.opcode != None and args.opcode != opcode:
			continue;

		key = dev + "-" + str(qpn)
		qpstats = stats.get(key)
		if qpstats is None:
			qpstats = {}
			qpstats["dev"] = dev
			qpstats["qpn"] = qpn
			qpstats["bytes"] = 0
			qpstats["ops"] = 0
			stats[key] = qpstats

		bytes = event.payload_field['bytes']
		qpstats["bytes"] += bytes
		qpstats["ops"] += 1

		qpstat = qpstats.get(opcode)
		if qpstat is None:
			qpstats[opcode] = bytes
		else:
			qpstats[opcode] += bytes

	# sorted by total bytes of a QP
	sorted_stats = sorted(stats.items(),
		key=lambda item: (item[1].get("bytes", 0)),
		reverse=True)

	# show header
	print("%16s %10s %10s %10s" % ("Device", "QPN", "Bytes", "Operations"))

	# show QP stats
	for qpstats in sorted_stats:
		stats = qpstats[1]
		print("%16s %10d %10d %10d" %
			(stats["dev"], stats["qpn"], stats["bytes"], stats["ops"]))

def parse_arg():
	examples = """LTTng tracing examples:
	# lttng create rdma-core-stats-session
	# lttng list --userspace
	# lttng enable-event --userspace rdma_core_ibverbs:post_send
	# lttng start
	# ...
	# lttng destroy
	# ibv_stats -t /path/to/lttng/tracepoints
	"""

	parser = argparse.ArgumentParser(
			description="Summarize IB verbs statistics",
			formatter_class=argparse.RawDescriptionHelpFormatter,
			epilog=examples)

	parser.add_argument("-t", "--tracepoints",
		help="specify the LTTng tracepoints directory")

	parser.add_argument("-d", "--device",
		help="specify IB device filter")

	parser.add_argument("-q", "--qpn", type=int,
		help="specify source QP number filter")

	parser.add_argument("-o", "--opcode",
 		help="specify opcode filter")

	return parser.parse_args()


if __name__ == '__main__':
	args = parse_arg()

	if args.tracepoints is None:
		print("Missing LTTng tracepoints directory(use -t/--tracepoints)")
		sys.exit(0)

	stats(args)


```