### PR TITLE
providers/bnxt_re: Fix return value for bnxt_re_check_qp_limits()

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1002,9 +1002,9 @@ static int bnxt_re_check_qp_limits(struct bnxt_re_context *cntx,
 	if (attr->cap.max_inline_data > BNXT_RE_MAX_INLINE_SIZE)
 		return EINVAL;
 	if (attr->cap.max_send_wr > devattr->max_qp_wr)
-		attr->cap.max_send_wr = devattr->max_qp_wr;
+		return EINVAL;
 	if (attr->cap.max_recv_wr > devattr->max_qp_wr)
-		attr->cap.max_recv_wr = devattr->max_qp_wr;
+		return EINVAL;
 
 	return 0;
 }


### PR DESCRIPTION
Make sure to return EINVAL when the passed max_recv_wr or max_send_wr are out of the supported range.