### PR TITLE
libhns: Support SRQ record doorbell

### DIFF
--- a/kernel-headers/rdma/hns-abi.h
+++ b/kernel-headers/rdma/hns-abi.h
@@ -52,15 +52,25 @@ struct hns_roce_ib_create_cq_resp {
 	__aligned_u64 cap_flags;
 };
 
+enum hns_roce_srq_cap_flags {
+	HNS_ROCE_SRQ_CAP_RECORD_DB = 1 << 0,
+};
+
+enum hns_roce_srq_cap_flags_resp {
+	HNS_ROCE_RSP_SRQ_CAP_RECORD_DB = 1 << 0,
+};
+
 struct hns_roce_ib_create_srq {
 	__aligned_u64 buf_addr;
 	__aligned_u64 db_addr;
 	__aligned_u64 que_addr;
+	__u32 req_cap_flags; /* Use enum hns_roce_srq_cap_flags */
+	__u32 reserved;
 };
 
 struct hns_roce_ib_create_srq_resp {
 	__u32	srqn;
-	__u32	reserved;
+	__u32	cap_flags; /* Use enum hns_roce_srq_cap_flags */
 };
 
 struct hns_roce_ib_create_qp {

--- a/providers/hns/hns_roce_u.h
+++ b/providers/hns/hns_roce_u.h
@@ -172,6 +172,7 @@ struct hns_roce_buf {
 enum hns_roce_db_type {
 	HNS_ROCE_QP_TYPE_DB,
 	HNS_ROCE_CQ_TYPE_DB,
+	HNS_ROCE_SRQ_TYPE_DB,
 	HNS_ROCE_DB_TYPE_NUM
 };
 
@@ -274,7 +275,8 @@ struct hns_roce_srq {
 	unsigned int			max_gs;
 	unsigned int			rsv_sge;
 	unsigned int			wqe_shift;
-	unsigned int			*db;
+	unsigned int			*rdb;
+	unsigned int			cap_flags;
 	unsigned short			counter;
 };
 

--- a/providers/hns/hns_roce_u_db.c
+++ b/providers/hns/hns_roce_u_db.c
@@ -41,6 +41,7 @@
 static const unsigned int db_size[] = {
 	[HNS_ROCE_QP_TYPE_DB] = 4,
 	[HNS_ROCE_CQ_TYPE_DB] = 4,
+	[HNS_ROCE_SRQ_TYPE_DB] = 4,
 };
 
 static struct hns_roce_db_page *hns_roce_add_db_page(

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -637,7 +637,8 @@ static int exec_srq_create_cmd(struct ibv_context *context,
 
 	cmd_ex.buf_addr = (uintptr_t)srq->wqe_buf.buf;
 	cmd_ex.que_addr = (uintptr_t)srq->idx_que.buf.buf;
-	cmd_ex.db_addr = (uintptr_t)srq->db;
+	cmd_ex.db_addr = (uintptr_t)srq->rdb;
+	cmd_ex.req_cap_flags |= HNS_ROCE_SRQ_CAP_RECORD_DB;
 
 	ret = ibv_cmd_create_srq_ex(context, &srq->verbs_srq, init_attr,
 				    &cmd_ex.ibv_cmd, sizeof(cmd_ex),
@@ -646,6 +647,7 @@ static int exec_srq_create_cmd(struct ibv_context *context,
 		return ret;
 
 	srq->srqn = resp_ex.srqn;
+	srq->cap_flags = resp_ex.cap_flags;
 
 	return 0;
 }
@@ -674,11 +676,11 @@ static struct ibv_srq *create_srq(struct ibv_context *context,
 	if (alloc_srq_buf(srq))
 		goto err_free_srq;
 
-	srq->db = hns_roce_alloc_db(hr_ctx, HNS_ROCE_QP_TYPE_DB);
-	if (!srq->db)
+	srq->rdb = hns_roce_alloc_db(hr_ctx, HNS_ROCE_SRQ_TYPE_DB);
+	if (!srq->rdb)
 		goto err_srq_buf;
 
-	*srq->db = 0;
+	*srq->rdb = 0;
 
 	ret = exec_srq_create_cmd(context, srq, init_attr);
 	if (ret)
@@ -698,7 +700,7 @@ err_destroy_srq:
 	ibv_cmd_destroy_srq(&srq->verbs_srq.srq);
 
 err_srq_db:
-	hns_roce_free_db(hr_ctx, srq->db, HNS_ROCE_QP_TYPE_DB);
+	hns_roce_free_db(hr_ctx, srq->rdb, HNS_ROCE_SRQ_TYPE_DB);
 
 err_srq_buf:
 	free_srq_buf(srq);
@@ -776,7 +778,7 @@ int hns_roce_u_destroy_srq(struct ibv_srq *ibv_srq)
 
 	hns_roce_clear_srq(ctx, srq->srqn);
 
-	hns_roce_free_db(ctx, srq->db, HNS_ROCE_QP_TYPE_DB);
+	hns_roce_free_db(ctx, srq->rdb, HNS_ROCE_SRQ_TYPE_DB);
 	free_srq_buf(srq);
 	free(srq);
 


### PR DESCRIPTION
Compared with normal doorbell, using record doorbell can shorten the process of ringing the doorbell and reduce the latency.

During SRQ creation, the kernel driver will allocate doorbell buffer and notify userspace whether the SRQ record doorbell is enabled with the flag HNS_ROCE_RSP_SRQ_CAP_RECORD_DB. The userspace driver will decide whether to use record doorbell or normal doorbell based on this flag in post SRQ recv process.

This patch relies on the corresponding kernel patch: RDMA/hns: Support SRQ record doorbell