### PR TITLE
ibtracert: Fix memory leak

### DIFF
--- a/infiniband-diags/ibtracert.c
+++ b/infiniband-diags/ibtracert.c
@@ -542,11 +542,15 @@ static Node *find_mcpath(ib_portid_t * from, int mlid)
 
 	DEBUG("from %s", portid2str(from));
 
-	if (!(node = calloc(1, sizeof(Node))))
+	node = calloc(1, sizeof(Node));
+	if (!node)
 		IBEXIT("out of memory");
 
-	if (!(port = calloc(1, sizeof(Port))))
+	port = calloc(1, sizeof(Port));
+	if (!port) {
+		free(node);
 		IBEXIT("out of memory");
+	}
 
 	if (get_node(node, port, from) < 0) {
 		IBWARN("can't reach node %s", portid2str(from));
@@ -564,8 +568,11 @@ static Node *find_mcpath(ib_portid_t * from, int mlid)
 			return NULL;	/* ibtracert from host to itself is unsupported */
 		}
 
-		if (switch_mclookup(node, from, mlid, map) < 0 || !map[0])
+		if (switch_mclookup(node, from, mlid, map) < 0 || !map[0]) {
+			free(node);
+			free(port);
 			return NULL;
+		}
 		return node;
 	}
 
@@ -612,7 +619,8 @@ static Node *find_mcpath(ib_portid_t * from, int mlid)
 					if (from->drpath.cnt > 0)
 						path->drpath.cnt--;
 				} else {
-					if (!(port = calloc(1, sizeof(Port))))
+					port = calloc(1, sizeof(Port));
+					if (!port)
 						IBEXIT("out of memory");
 
 					if (get_port(port, i, path) < 0) {
@@ -637,11 +645,18 @@ static Node *find_mcpath(ib_portid_t * from, int mlid)
 					}
 				}
 
-				if (!(remotenode = calloc(1, sizeof(Node))))
+				remotenode = calloc(1, sizeof(Node));
+				if (!remotenode) {
+					free(port);
 					IBEXIT("out of memory");
+				}
 
-				if (!(remoteport = calloc(1, sizeof(Port))))
+				remoteport = calloc(1, sizeof(Port));
+				if (!remoteport) {
+					free(port);
+					free(remotenode);
 					IBEXIT("out of memory");
+				}
 
 				if (get_node(remotenode, remoteport, path) < 0) {
 					IBWARN
@@ -670,6 +685,9 @@ static Node *find_mcpath(ib_portid_t * from, int mlid)
 						     remotenode, remoteport);
 
 				path->drpath.cnt--;	/* restore path */
+				free(port);
+				free(remotenode);
+				free(remoteport);
 			}
 		}
 	}


### PR DESCRIPTION
Avoid memory leak in find_mcpath() by freeing the allocated memory.

Fixes: https://github.com/linux-rdma/rdma-core/commit/e4d681de516743f6a0d94d679b8332c57c71528f ("Diags: Renamed openib-diags to infiniband-diags")