### PR TITLE
/sys/class/infiniband_verbs/uverbs0 is a directory

### DIFF
--- a/redhat/rdma.modules-setup.sh
+++ b/redhat/rdma.modules-setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 check() {
-	[ -n "$hostonly" -a -c /sys/class/infiniband_verbs/uverbs0 ] && return 0
+	[ -n "$hostonly" -a -d /sys/class/infiniband_verbs/uverbs0 ] && return 0
 	[ -n "$hostonly" ] && return 255
 	return 0
 }


### PR DESCRIPTION
According to the ABI doc this item supposed to have sub elements (yes they does) [1]

It fixes the issue of /etc/rdma/mlx4.conf  not loaded at initramfs time, in hostonly  (default) mode.

[1] https://www.kernel.org/doc/Documentation/ABI/stable/sysfs-class-infiniband