### PR TITLE
suse: fix issue on non dma-coherent system

### DIFF
--- a/suse/rdma-core.spec
+++ b/suse/rdma-core.spec
@@ -478,7 +478,9 @@ mkdir -p %{buildroot}%{_unitdir}
 # Port type setup for mlx4 dual port cards
 install -D -m0644 redhat/rdma.mlx4.sys.modprobe %{buildroot}%{_modprobedir}/50-libmlx4.conf
 install -D -m0644 redhat/rdma.mlx4.conf %{buildroot}/%{_sysconfdir}/rdma/mlx4.conf
+%if 0%{?dma_coherent}
 chmod 0644 %{buildroot}%{_modprobedir}/mlx4.conf
+%endif
 install -D -m0755 redhat/rdma.mlx4-setup.sh %{buildroot}%{_libexecdir}/mlx4-setup.sh
 
 # Dracut file for IB support during boot


### PR DESCRIPTION
modprobe mlx4.conf is not available on non dma-coherent arch. This causes rpmbuild to fail on armv7.

Fixes: f5a69fbd96dc ("suse: Change install path for modprobe.d")