### PR TITLE
tests: Add SRQ tests and some adjustments

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ rdma_python_test(tests
   test_relaxed_ordering.py
   test_rss_traffic.py
   test_shared_pd.py
+  test_srq.py
   test_tag_matching.py
   utils.py
   )

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -53,8 +53,14 @@ class ActionType:
     COPY_ACTION = 0x3
 
 
+class PRMPacket(Packet):
+
+    def extract_padding(self, p):
+        return "", p
+
+
 # Common
-class SwPas(Packet):
+class SwPas(PRMPacket):
     fields_desc = [
         IntField('pa_h', 0),
         BitField('pa_l', 0, 20),
@@ -63,7 +69,7 @@ class SwPas(Packet):
 
 
 # PD
-class AllocPdIn(Packet):
+class AllocPdIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_ALLOC_PD),
         ShortField('uid', 0),
@@ -73,7 +79,7 @@ class AllocPdIn(Packet):
     ]
 
 
-class AllocPdOut(Packet):
+class AllocPdOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -85,7 +91,7 @@ class AllocPdOut(Packet):
 
 
 # CQ
-class CmdInputFieldSelectResizeCq(Packet):
+class CmdInputFieldSelectResizeCq(PRMPacket):
     fields_desc = [
         BitField('reserved1', 0, 28),
         BitField('umem', 0, 1),
@@ -95,7 +101,7 @@ class CmdInputFieldSelectResizeCq(Packet):
     ]
 
 
-class CmdInputFieldSelectModifyCqFields(Packet):
+class CmdInputFieldSelectModifyCqFields(PRMPacket):
     fields_desc = [
         BitField('reserved_0', 0, 26),
         BitField('status', 0, 1),
@@ -107,7 +113,7 @@ class CmdInputFieldSelectModifyCqFields(Packet):
     ]
 
 
-class SwCqc(Packet):
+class SwCqc(PRMPacket):
     fields_desc = [
         BitField('status', 0, 4),
         BitField('as_notify', 0, 1),
@@ -158,7 +164,7 @@ class SwCqc(Packet):
     ]
 
 
-class CreateCqIn(Packet):
+class CreateCqIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_CQ),
         ShortField('uid', 0),
@@ -177,7 +183,7 @@ class CreateCqIn(Packet):
     ]
 
 
-class CreateCqOut(Packet):
+class CreateCqOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -189,7 +195,7 @@ class CreateCqOut(Packet):
 
 
 # QP
-class SwAds(Packet):
+class SwAds(PRMPacket):
     fields_desc = [
         BitField('fl', 0, 1),
         BitField('free_ar', 0, 1),
@@ -227,7 +233,7 @@ class SwAds(Packet):
     ]
 
 
-class SwQpc(Packet):
+class SwQpc(PRMPacket):
     fields_desc = [
         BitField('state', 0, 4),
         BitField('lag_tx_port_affinity', 0, 4),
@@ -353,7 +359,7 @@ class SwQpc(Packet):
     ]
 
 
-class CreateQpIn(Packet):
+class CreateQpIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_QP),
         ShortField('uid', 0),
@@ -377,7 +383,7 @@ class CreateQpIn(Packet):
     ]
 
 
-class CreateQpOut(Packet):
+class CreateQpOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -388,7 +394,7 @@ class CreateQpOut(Packet):
     ]
 
 
-class ModifyQpIn(Packet):
+class ModifyQpIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', 0),
         ShortField('uid', 0),
@@ -404,7 +410,7 @@ class ModifyQpIn(Packet):
     ]
 
 
-class ModifyQpOut(Packet):
+class ModifyQpOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -413,7 +419,7 @@ class ModifyQpOut(Packet):
     ]
 
 
-class QueryQpIn(Packet):
+class QueryQpIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_QP),
         ShortField('uid', 0),
@@ -425,7 +431,7 @@ class QueryQpIn(Packet):
     ]
 
 
-class QueryQpOut(Packet):
+class QueryQpOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -442,7 +448,7 @@ class QueryQpOut(Packet):
 
 
 # EQ
-class SwEqc(Packet):
+class SwEqc(PRMPacket):
     fields_desc = [
         BitField('status', 0, 4),
         BitField('reserved1', 0, 9),
@@ -473,7 +479,7 @@ class SwEqc(Packet):
     ]
 
 
-class CreateEqIn(Packet):
+class CreateEqIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_EQ),
         ShortField('uid', 0),
@@ -492,7 +498,7 @@ class CreateEqIn(Packet):
     ]
 
 
-class CreateEqOut(Packet):
+class CreateEqOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -503,7 +509,7 @@ class CreateEqOut(Packet):
     ]
 
 
-class IbSmp(Packet):
+class IbSmp(PRMPacket):
     fields_desc = [
         ByteField('base_version', 0),
         ByteField('mgmt_class', 0),
@@ -527,7 +533,7 @@ class IbSmp(Packet):
     ]
 
 
-class MadIfcIn(Packet):
+class MadIfcIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_MAD_IFC),
         ShortField('uid', 0),
@@ -543,7 +549,7 @@ class MadIfcIn(Packet):
     ]
 
 
-class MadIfcOut(Packet):
+class MadIfcOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -553,7 +559,7 @@ class MadIfcOut(Packet):
     ]
 
 
-class PaosReg(Packet):
+class PaosReg(PRMPacket):
     fields_desc = [
         ByteField('swid', 0),
         ByteField('local_port', 0),
@@ -571,7 +577,7 @@ class PaosReg(Packet):
     ]
 
 
-class AccessPaosRegisterIn(Packet):
+class AccessPaosRegisterIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_ACCESS_REG),
         ShortField('uid', 0),
@@ -584,7 +590,7 @@ class AccessPaosRegisterIn(Packet):
     ]
 
 
-class AccessPaosRegisterOut(Packet):
+class AccessPaosRegisterOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -601,7 +607,7 @@ class EventType:
     PORT_STATE_CHANGE = 0X9
 
 
-class AffiliatedEventHeader(Packet):
+class AffiliatedEventHeader(PRMPacket):
     fields_desc = [
         ShortField('reserved1', 0),
         ShortField('obj_type', 0),
@@ -609,7 +615,7 @@ class AffiliatedEventHeader(Packet):
     ]
 
 
-class CompEvent(Packet):
+class CompEvent(PRMPacket):
     fields_desc = [
         StrFixedLenField('reserved1', None, length=24),
         ByteField('reserved2', 0),
@@ -617,7 +623,7 @@ class CompEvent(Packet):
     ]
 
 
-class CqError(Packet):
+class CqError(PRMPacket):
     fields_desc = [
         ByteField('reserved1', 0),
         BitField('cqn', 0, 24),
@@ -628,7 +634,7 @@ class CqError(Packet):
     ]
 
 
-class PortStateChangeEvent(Packet):
+class PortStateChangeEvent(PRMPacket):
     fields_desc = [
         StrFixedLenField('reserved1', None, length=8),
         BitField('port_num', 0, 4),
@@ -637,7 +643,7 @@ class PortStateChangeEvent(Packet):
     ]
 
 
-class SwEqe(Packet):
+class SwEqe(PRMPacket):
     fields_desc = [
         ByteField('reserved1', 0),
         ByteField('event_type', 0),
@@ -663,7 +669,7 @@ class SwEqe(Packet):
 
 
 # Query HCA VPORT Context
-class QueryHcaVportContextIn(Packet):
+class QueryHcaVportContextIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_HCA_VPORT_CONTEXT),
         ShortField('uid', 0),
@@ -677,7 +683,7 @@ class QueryHcaVportContextIn(Packet):
     ]
 
 
-class HcaVportContext(Packet):
+class HcaVportContext(PRMPacket):
     fields_desc = [
         IntField('field_select', 0),
         StrFixedLenField('reserved1', None, length=28),
@@ -717,7 +723,7 @@ class HcaVportContext(Packet):
     ]
 
 
-class QueryHcaVportContextOut(Packet):
+class QueryHcaVportContextOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -728,7 +734,7 @@ class QueryHcaVportContextOut(Packet):
 
 
 # Query HCA VPORT GID
-class QueryHcaVportGidIn(Packet):
+class QueryHcaVportGidIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_HCA_VPORT_GID),
         ShortField('uid', 0),
@@ -743,14 +749,14 @@ class QueryHcaVportGidIn(Packet):
     ]
 
 
-class IbGidCmd(Packet):
+class IbGidCmd(PRMPacket):
     fields_desc = [
         LongField('prefix', 0),
         LongField('guid', 0),
     ]
 
 
-class QueryHcaVportGidOut(Packet):
+class QueryHcaVportGidOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -779,7 +785,7 @@ class SendDbrMode:
 
 
 # Query HCA CAP
-class QueryHcaCapIn(Packet):
+class QueryHcaCapIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_HCA_CAP),
         ShortField('uid', 0),
@@ -792,7 +798,7 @@ class QueryHcaCapIn(Packet):
     ]
 
 
-class CmdHcaCap(Packet):
+class CmdHcaCap(PRMPacket):
     fields_desc = [
         BitField('access_other_hca_roce', 0, 1),
         BitField('reserved1', 0, 30),
@@ -1292,7 +1298,7 @@ class CmdHcaCap(Packet):
     ]
 
 
-class QueryCmdHcaCapOut(Packet):
+class QueryCmdHcaCapOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1302,7 +1308,7 @@ class QueryCmdHcaCapOut(Packet):
     ]
 
 
-class FlowTableEntryMatchSetMisc(Packet):
+class FlowTableEntryMatchSetMisc(PRMPacket):
     fields_desc = [
         BitField('gre_c_present', 0, 1),
         BitField('bth_a', 0, 1),
@@ -1350,7 +1356,7 @@ class FlowTableEntryMatchSetMisc(Packet):
     ]
 
 
-class FlowTableEntryMatchSetMisc2(Packet):
+class FlowTableEntryMatchSetMisc2(PRMPacket):
     fields_desc = [
         BitField('outer_first_mpls_label', 0, 20),
         BitField('outer_first_mpls_exp', 0, 3),
@@ -1382,7 +1388,7 @@ class FlowTableEntryMatchSetMisc2(Packet):
     ]
 
 
-class FlowTableEntryMatchSetMisc3(Packet):
+class FlowTableEntryMatchSetMisc3(PRMPacket):
     fields_desc = [
         IntField('inner_tcp_seq_num', 0),
         IntField('outer_tcp_seq_num', 0),
@@ -1412,7 +1418,7 @@ class FlowTableEntryMatchSetMisc3(Packet):
     ]
 
 
-class FlowTableEntryMatchSetLyr24(Packet):
+class FlowTableEntryMatchSetLyr24(PRMPacket):
     fields_desc = [
         MACField('smac', '00:00:00:00:00:00'),
         ShortField('ethertype', 0),
@@ -1461,21 +1467,21 @@ class FlowTableEntryMatchSetLyr24(Packet):
     ]
 
 
-class ProgSampleField(Packet):
+class ProgSampleField(PRMPacket):
     fields_desc = [
         IntField('prog_sample_field_value', 0),
         IntField('prog_sample_field_id', 0),
     ]
 
 
-class FlowTableEntryMatchSetMisc4(Packet):
+class FlowTableEntryMatchSetMisc4(PRMPacket):
     fields_desc = [
         PacketListField('prog_sample_field', [ProgSampleField() for x in range(4)], ProgSampleField, count_from=lambda pkt:4),
         StrFixedLenField('reserved1', None, length=32),
     ]
 
 
-class FlowTableEntryMatchSetMisc5(Packet):
+class FlowTableEntryMatchSetMisc5(PRMPacket):
     fields_desc = [
         IntField('macsec_tag_0', 0),
         IntField('macsec_tag_1', 0),
@@ -1489,7 +1495,7 @@ class FlowTableEntryMatchSetMisc5(Packet):
     ]
 
 
-class FlowTableEntryMatchParam(Packet):
+class FlowTableEntryMatchParam(PRMPacket):
     fields_desc = [
         PacketField('outer_headers', FlowTableEntryMatchSetLyr24(), FlowTableEntryMatchSetLyr24),
         PacketField('misc_parameters', FlowTableEntryMatchSetMisc(), FlowTableEntryMatchSetMisc),
@@ -1504,7 +1510,7 @@ class FlowTableEntryMatchParam(Packet):
     ]
 
 
-class SetActionIn(Packet):
+class SetActionIn(PRMPacket):
     fields_desc = [
         BitField('action_type', ActionType.SET_ACTION, 4),
         BitField('field', 0, 12),
@@ -1516,7 +1522,7 @@ class SetActionIn(Packet):
     ]
 
 
-class CopyActionIn(Packet):
+class CopyActionIn(PRMPacket):
     fields_desc = [
         BitField('action_type', ActionType.COPY_ACTION, 4),
         BitField('src_field', 0, 12),
@@ -1532,7 +1538,7 @@ class CopyActionIn(Packet):
     ]
 
 
-class AllocFlowCounterIn(Packet):
+class AllocFlowCounterIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_ALLOC_FLOW_COUNTER),
         ShortField('uid', 0),
@@ -1544,7 +1550,7 @@ class AllocFlowCounterIn(Packet):
     ]
 
 
-class AllocFlowCounterOut(Packet):
+class AllocFlowCounterOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1554,7 +1560,7 @@ class AllocFlowCounterOut(Packet):
     ]
 
 
-class DeallocFlowCounterIn(Packet):
+class DeallocFlowCounterIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_DEALLOC_FLOW_COUNTER),
         ShortField('uid', 0),
@@ -1565,7 +1571,7 @@ class DeallocFlowCounterIn(Packet):
     ]
 
 
-class DeallocFlowCounterOut(Packet):
+class DeallocFlowCounterOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1574,7 +1580,7 @@ class DeallocFlowCounterOut(Packet):
     ]
 
 
-class QueryFlowCounterIn(Packet):
+class QueryFlowCounterIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_QUERY_FLOW_COUNTER),
         ShortField('uid', 0),
@@ -1590,14 +1596,14 @@ class QueryFlowCounterIn(Packet):
     ]
 
 
-class TrafficCounter(Packet):
+class TrafficCounter(PRMPacket):
     fields_desc = [
         LongField('packets', 0),
         LongField('octets', 0),
     ]
 
 
-class QueryFlowCounterOut(Packet):
+class QueryFlowCounterOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1607,7 +1613,7 @@ class QueryFlowCounterOut(Packet):
     ]
 
 
-class RxHashFieldSelect(Packet):
+class RxHashFieldSelect(PRMPacket):
     fields_desc = [
         BitField('l3_prot_type', 0, 1),
         BitField('l4_prot_type', 0, 1),
@@ -1615,7 +1621,7 @@ class RxHashFieldSelect(Packet):
     ]
 
 
-class Tirc(Packet):
+class Tirc(PRMPacket):
     fields_desc = [
         StrFixedLenField('reserved1', None, length=4),
         BitField('disp_type', 0, 4),
@@ -1653,7 +1659,7 @@ class Tirc(Packet):
     ]
 
 
-class CreateTirIn(Packet):
+class CreateTirIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_TIR),
         ShortField('uid', 0),
@@ -1664,7 +1670,7 @@ class CreateTirIn(Packet):
     ]
 
 
-class CreateTirOut(Packet):
+class CreateTirOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('icm_address_63_40', 0, 24),
@@ -1675,7 +1681,7 @@ class CreateTirOut(Packet):
     ]
 
 
-class SwMkc(Packet):
+class SwMkc(PRMPacket):
     fields_desc = [
         BitField('reserved1', 0, 1),
         BitField('free', 0, 1),
@@ -1727,7 +1733,7 @@ class SwMkc(Packet):
     ]
 
 
-class CreateMkeyIn(Packet):
+class CreateMkeyIn(PRMPacket):
     fields_desc = [
         ShortField('opcode', DevxOps.MLX5_CMD_OP_CREATE_MKEY),
         ShortField('uid', 0),
@@ -1750,7 +1756,7 @@ class CreateMkeyIn(Packet):
     ]
 
 
-class CreateMkeyOut(Packet):
+class CreateMkeyOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1761,7 +1767,7 @@ class CreateMkeyOut(Packet):
     ]
 
 
-class MigrationTagVersion0(Packet):
+class MigrationTagVersion0(PRMPacket):
     fields_desc = [
         ShortField('reserved1', 0),
         ShortField('device_id', 0),
@@ -1772,7 +1778,7 @@ class MigrationTagVersion0(Packet):
     ]
 
 
-class CmdHcaCap2(Packet):
+class CmdHcaCap2(PRMPacket):
     fields_desc = [
         StrFixedLenField('reserved1', None, length=16),
         BitField('migratable', 0, 1),
@@ -1871,7 +1877,7 @@ class CmdHcaCap2(Packet):
     ]
 
 
-class QueryCmdHcaCap2Out(Packet):
+class QueryCmdHcaCap2Out(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1881,7 +1887,7 @@ class QueryCmdHcaCap2Out(Packet):
     ]
 
 
-class FlowMeterParams(Packet):
+class FlowMeterParams(PRMPacket):
     fields_desc = [
         BitField('valid', 0, 1),
         BitField('bucket_overflow', 0, 1),
@@ -1906,7 +1912,7 @@ class FlowMeterParams(Packet):
     ]
 
 
-class QosCaps(Packet):
+class QosCaps(PRMPacket):
     fields_desc = [
         BitField('packet_pacing', 0, 1),
         BitField('esw_scheduling', 0, 1),
@@ -1960,7 +1966,7 @@ class QosCaps(Packet):
     ]
 
 
-class QueryQosCapOut(Packet):
+class QueryQosCapOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),
@@ -1970,7 +1976,7 @@ class QueryQosCapOut(Packet):
     ]
 
 
-class FlowTableFieldsSupported2(Packet):
+class FlowTableFieldsSupported2(PRMPacket):
     fields_desc = [
         BitField('reserved1', 0, 10),
         BitField('lag_rx_port_affinity', 0, 1),
@@ -1999,7 +2005,7 @@ class FlowTableFieldsSupported2(Packet):
     ]
 
 
-class FlowTableFieldsSupported(Packet):
+class FlowTableFieldsSupported(PRMPacket):
     fields_desc = [
         BitField('outer_dmac', 0, 1),
         BitField('outer_smac', 0, 1),
@@ -2131,7 +2137,7 @@ class FlowTableFieldsSupported(Packet):
     ]
 
 
-class HeaderModifyCapProperties(Packet):
+class HeaderModifyCapProperties(PRMPacket):
     fields_desc = [
         PacketField('set_action_field_support', FlowTableFieldsSupported(),
                     FlowTableFieldsSupported),
@@ -2149,7 +2155,7 @@ class HeaderModifyCapProperties(Packet):
     ]
 
 
-class FlowTablePropLayout(Packet):
+class FlowTablePropLayout(PRMPacket):
     fields_desc = [
         BitField('ft_support', 0, 1),
         BitField('flow_tag', 0, 1),
@@ -2227,7 +2233,7 @@ class FlowTablePropLayout(Packet):
     ]
 
 
-class FlowTableNicCap(Packet):
+class FlowTableNicCap(PRMPacket):
     fields_desc = [
         BitField('nic_rx_multi_path_tirs', 0, 1),
         BitField('nic_rx_multi_path_tirs_fts', 0, 1),
@@ -2294,7 +2300,7 @@ class FlowTableNicCap(Packet):
     ]
 
 
-class QueryCmdHcaNicFlowTableCapOut(Packet):
+class QueryCmdHcaNicFlowTableCapOut(PRMPacket):
     fields_desc = [
         ByteField('status', 0),
         BitField('reserved1', 0, 24),

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -1141,7 +1141,6 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         """
         self.roce_bth_match(domain_flag=dve.MLX5DV_DR_DOMAIN_TYPE_NIC_TX)
 
-    @requires_reformat_support
     @skip_unsupported
     def test_packet_reformat_l2_gre(self):
         """
@@ -1164,7 +1163,6 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         encap_header = self.gen_gre_tunnel_encap_header(self.client.msg_size, is_l2_tunnel=True)
         self.packet_reformat_actions(outer=encap_header, root_only=True)
 
-    @requires_reformat_support
     @skip_unsupported
     def test_packet_reformat_l3_gre(self):
         """
@@ -1187,7 +1185,6 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         encap_header = self.gen_gre_tunnel_encap_header(self.client.msg_size, is_l2_tunnel=False)
         self.packet_reformat_actions(outer=encap_header, root_only=True, l2_ref_type=False)
 
-    @requires_reformat_support
     @skip_unsupported
     def test_packet_reformat_l2_geneve(self):
         """
@@ -1210,7 +1207,6 @@ class Mlx5DrTest(Mlx5RDMATestCase):
         encap_header = self.gen_geneve_tunnel_encap_header(self.client.msg_size, is_l2_tunnel=True)
         self.packet_reformat_actions(outer=encap_header, root_only=True)
 
-    @requires_reformat_support
     @skip_unsupported
     def test_packet_reformat_l3_geneve(self):
         """

--- a/tests/test_srq.py
+++ b/tests/test_srq.py
@@ -1,0 +1,64 @@
+import unittest
+
+from tests.base import RCResources, RDMATestCase
+from pyverbs.srq import SrqAttr
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class SrqTestCase(RDMATestCase):
+    def setUp(self):
+        super().setUp()
+        self.iters = 100
+        self.create_players(RCResources, qp_count=2, with_srq=True)
+
+    def test_rc_srq_traffic(self):
+        """
+        Test RC traffic with SRQ.
+        """
+        u.traffic(**self.traffic_args)
+
+    def test_resize_srq(self):
+        """
+        Test modify_srq with IBV_SRQ_MAX_WR which allows to modify max_wr and
+        max_sge. Modify both parameters, query the SRQ and verify that they've
+        been updated correctly.
+        """
+        device_attr = self.server.ctx.query_device()
+        if not device_attr.device_cap_flags & e.IBV_DEVICE_SRQ_RESIZE:
+            raise unittest.SkipTest('SRQ resize is not supported')
+        srq_query_attr = self.server.srq.query()
+        srq_query_max_wr = srq_query_attr.max_wr
+        srq_query_max_sge = srq_query_attr.max_sge
+        srq_max_wr = min(device_attr.max_srq_wr, srq_query_max_wr*2)
+        srq_max_sge = min(device_attr.max_srq_sge, srq_query_max_sge*2)
+        srq_attr = SrqAttr(max_wr=srq_max_wr, max_sge=srq_max_sge)
+        self.server.srq.modify(srq_attr, e.IBV_SRQ_MAX_WR)
+        srq_attr_modified = self.server.srq.query()
+        self.assertEqual(srq_attr_modified.max_wr, srq_attr.max_wr, 'Resize SRQ failed')
+        self.assertEqual(srq_attr_modified.max_sge, srq_attr.max_sge, 'Resize SRQ failed')
+
+    def test_modify_srq_limit(self):
+        """
+        Test IBV_SRQ_LIMIT modification.
+        Add 10 wr to the SRQ and set the limit to 7,
+        Query and verify that the SRQ limit changed to the expected value.
+        send 4 packets from the client to the server, only 6 wr remain in the
+        server SRQ so IBV_EVENT_SRQ_LIMIT_REACHED should be generated.
+        Listen for income event and if one received check if it's equal to
+        IBV_EVENT_SRQ_LIMIT_REACHED else fail.
+        """
+        for _ in range(10):
+            self.server.srq.post_recv(u.get_recv_wr(self.server))
+        srq_modify_attr = SrqAttr(srq_limit=7)
+        self.server.srq.modify(srq_modify_attr, e.IBV_SRQ_LIMIT)
+        server_query = self.server.srq.query()
+        self.assertEqual(srq_modify_attr.srq_limit, server_query.srq_limit, 'Modify SRQ failed')
+        for _ in range(4):
+            c_send_wr, c_sg = u.get_send_elements(self.client, False)
+            u.send(self.client, c_send_wr)
+            u.poll_cq(self.client.cq)
+            u.poll_cq(self.server.cq)
+        event = self.server.ctx.get_async_event()
+        event.ack()
+        self.assertEqual(event.event_type, e.IBV_EVENT_SRQ_LIMIT_REACHED)


### PR DESCRIPTION
Add tests that cover SRQ modify and query APIs.
The series also includes a minor fix and an adjustment related to mlx5 SW steering tests and PRM packets.