### PR TITLE
providers/irdma: Remove unnecessary copy of sg list

### DIFF
--- a/providers/irdma/osdep.h
+++ b/providers/irdma/osdep.h
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 #include <pthread.h>
 #include <endian.h>
+#include <infiniband/verbs.h>
 
 static inline void db_wr32(__u32 val, __u32 *wqe_word)
 {

--- a/providers/irdma/umain.h
+++ b/providers/irdma/umain.h
@@ -102,7 +102,6 @@ struct irdma_uqp {
 	struct ibv_recv_wr *pend_rx_wr;
 	struct irdma_qp_uk qp;
 	enum ibv_qp_type qp_type;
-	struct irdma_sge *recv_sges;
 };
 
 struct irdma_umr {

--- a/providers/irdma/user.h
+++ b/providers/irdma/user.h
@@ -18,7 +18,6 @@
 #define irdma_access_privileges __u32
 #define irdma_physical_fragment __u64
 #define irdma_address_list __u64 *
-#define irdma_sgl struct irdma_sge *
 
 #define	IRDMA_MAX_MR_SIZE       0x200000000000ULL
 
@@ -154,12 +153,6 @@ struct irdma_cq_uk;
 struct irdma_qp_uk_init_info;
 struct irdma_cq_uk_init_info;
 
-struct irdma_sge {
-	irdma_tagged_offset tag_off;
-	__u32 len;
-	irdma_stag stag;
-};
-
 struct irdma_ring {
 	__u32 head;
 	__u32 tail;
@@ -175,7 +168,7 @@ struct irdma_extended_cqe {
 };
 
 struct irdma_post_send {
-	irdma_sgl sg_list;
+	struct ibv_sge *sg_list;
 	__u32 num_sges;
 	__u32 qkey;
 	__u32 dest_qp;
@@ -184,20 +177,20 @@ struct irdma_post_send {
 
 struct irdma_post_rq_info {
 	__u64 wr_id;
-	irdma_sgl sg_list;
+	struct ibv_sge *sg_list;
 	__u32 num_sges;
 };
 
 struct irdma_rdma_write {
-	irdma_sgl lo_sg_list;
+	struct ibv_sge *lo_sg_list;
 	__u32 num_lo_sges;
-	struct irdma_sge rem_addr;
+	struct ibv_sge rem_addr;
 };
 
 struct irdma_rdma_read {
-	irdma_sgl lo_sg_list;
+	struct ibv_sge *lo_sg_list;
 	__u32 num_lo_sges;
-	struct irdma_sge rem_addr;
+	struct ibv_sge rem_addr;
 };
 
 struct irdma_bind_window {
@@ -287,10 +280,10 @@ int irdma_uk_stag_local_invalidate(struct irdma_qp_uk *qp,
 				   bool post_sq);
 
 struct irdma_wqe_uk_ops {
-	void (*iw_copy_inline_data)(__u8 *dest, struct irdma_sge *sge_list,
+	void (*iw_copy_inline_data)(__u8 *dest, struct ibv_sge *sge_list,
 				    __u32 num_sges, __u8 polarity);
 	__u16 (*iw_inline_data_size_to_quanta)(__u32 data_size);
-	void (*iw_set_fragment)(__le64 *wqe, __u32 offset, struct irdma_sge *sge,
+	void (*iw_set_fragment)(__le64 *wqe, __u32 offset, struct ibv_sge *sge,
 				__u8 valid);
 	void (*iw_set_mw_bind_wqe)(__le64 *wqe,
 				   struct irdma_bind_window *op_info);


### PR DESCRIPTION
In the function irdma_post_recv, the function irdma_copy_sg_list is not needed since the struct irdma_sge and ibv_sge have the similar member variables. The struct irdma_sge can be replaced with the struct ibv_sge.

This change follows along the lines of the irdma kernel patch [1]

[1] https://patchwork.kernel.org/project/linux-rdma/patch/20211030104226.253346-1-yanjun.zhu@linux.dev/