### PR TITLE
bnxt_re/lib: Optimize memory usage by the HW resources

### DIFF
--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -54,12 +54,21 @@ enum {
 	BNXT_RE_UCNTX_CMASK_HAVE_MODE = 0x02ULL,
 	BNXT_RE_UCNTX_CMASK_WC_DPI_ENABLED = 0x04ULL,
 	BNXT_RE_UCNTX_CMASK_DBR_PACING_ENABLED = 0x08ULL,
+	BNXT_RE_UCNTX_CMASK_POW2_DISABLED = 0x10ULL,
 };
 
 enum bnxt_re_wqe_mode {
 	BNXT_QPLIB_WQE_MODE_STATIC	= 0x00,
 	BNXT_QPLIB_WQE_MODE_VARIABLE	= 0x01,
 	BNXT_QPLIB_WQE_MODE_INVALID	= 0x02,
+};
+
+enum {
+	BNXT_RE_COMP_MASK_REQ_UCNTX_POW2_SUPPORT = 0x01,
+};
+
+struct bnxt_re_uctx_req {
+	__aligned_u64 comp_mask;
 };
 
 struct bnxt_re_uctx_resp {

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -556,6 +556,8 @@ enum rdma_nldev_attr {
 	RDMA_NLDEV_ATTR_STAT_HWCOUNTER_INDEX,	/* u32 */
 	RDMA_NLDEV_ATTR_STAT_HWCOUNTER_DYNAMIC, /* u8 */
 
+	RDMA_NLDEV_SYS_ATTR_PRIVILEGED_QKEY_MODE, /* u8 */
+
 	/*
 	 * Always the end
 	 */

--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -54,7 +54,7 @@ DECLARE_DRV_CMD(ubnxt_re_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
 DECLARE_DRV_CMD(ubnxt_re_qp, IB_USER_VERBS_CMD_CREATE_QP,
 		bnxt_re_qp_req, bnxt_re_qp_resp);
 DECLARE_DRV_CMD(ubnxt_re_cntx, IB_USER_VERBS_CMD_GET_CONTEXT,
-		empty, bnxt_re_uctx_resp);
+		bnxt_re_uctx_req, bnxt_re_uctx_resp);
 DECLARE_DRV_CMD(ubnxt_re_mr, IB_USER_VERBS_CMD_REG_MR,
 		empty, empty);
 DECLARE_DRV_CMD(ubnxt_re_srq, IB_USER_VERBS_CMD_CREATE_SRQ,
@@ -212,6 +212,7 @@ enum bnxt_re_ud_cqe_mask {
 enum {
 	BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED = 0x01,
 	BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED = 0x02,
+	BNXT_RE_COMP_MASK_UCNTX_POW2_DISABLED = 0x04,
 };
 
 enum bnxt_re_modes {

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -171,9 +171,9 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 						   void *private_data)
 {
 	struct bnxt_re_dev *rdev = to_bnxt_re_dev(vdev);
-	struct ubnxt_re_cntx_resp resp;
+	struct ubnxt_re_cntx_resp resp = {};
+	struct ubnxt_re_cntx req = {};
 	struct bnxt_re_context *cntx;
-	struct ibv_get_context cmd;
 	int ret;
 
 	cntx = verbs_init_and_alloc_context(vdev, cmd_fd, cntx, ibvctx,
@@ -181,8 +181,8 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 	if (!cntx)
 		return NULL;
 
-	memset(&resp, 0, sizeof(resp));
-	if (ibv_cmd_get_context(&cntx->ibvctx, &cmd, sizeof(cmd),
+	req.comp_mask |= BNXT_RE_COMP_MASK_REQ_UCNTX_POW2_SUPPORT;
+	if (ibv_cmd_get_context(&cntx->ibvctx, &req.ibv_cmd, sizeof(req),
 				&resp.ibv_resp, sizeof(resp)))
 		goto failed;
 
@@ -207,6 +207,8 @@ static struct verbs_context *bnxt_re_alloc_context(struct ibv_device *vdev,
 		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_WC_DPI_ENABLED;
 	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_DBR_PACING_ENABLED)
 		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_DBR_PACING_ENABLED;
+	if (resp.comp_mask & BNXT_RE_UCNTX_CMASK_POW2_DISABLED)
+		cntx->comp_mask |= BNXT_RE_COMP_MASK_UCNTX_POW2_DISABLED;
 
 	/* mmap shared page. */
 	cntx->shpg = mmap(NULL, rdev->pg_size, PROT_READ | PROT_WRITE,

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -538,6 +538,12 @@ static inline void bnxt_re_jqq_mod_last(struct bnxt_re_joint_queue *jqq,
 	jqq->last_idx = jqq->swque[idx].next_idx;
 }
 
+static inline uint32_t bnxt_re_init_depth(uint32_t ent, uint64_t cmask)
+{
+	return cmask & BNXT_RE_COMP_MASK_UCNTX_POW2_DISABLED ?
+		ent : roundup_pow_of_two(ent);
+}
+
 /* Helper function to copy to push buffers */
 static inline void bnxt_re_copy_data_to_pb(struct bnxt_re_push_buffer *pbuf,
 					   uint8_t offset, uint32_t idx)

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -287,7 +287,7 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 	if (!cq)
 		return NULL;
 
-	cq->cqq.depth = roundup_pow_of_two(ncqe + 1);
+	cq->cqq.depth = bnxt_re_init_depth(ncqe + 1, cntx->comp_mask);
 	if (cq->cqq.depth > dev->max_cq_depth + 1)
 		cq->cqq.depth = dev->max_cq_depth + 1;
 	cq->cqq.stride = dev->cqe_size;
@@ -343,6 +343,7 @@ static void bnxt_re_resize_cq_complete(struct bnxt_re_cq *cq)
 
 int bnxt_re_resize_cq(struct ibv_cq *ibvcq, int ncqe)
 {
+	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvcq->context);
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvcq->context->device);
 	struct bnxt_re_cq *cq = to_bnxt_re_cq(ibvcq);
 	struct ib_uverbs_resize_cq_resp resp = {};
@@ -353,7 +354,7 @@ int bnxt_re_resize_cq(struct ibv_cq *ibvcq, int ncqe)
 		return -EINVAL;
 
 	pthread_spin_lock(&cq->cqq.qlock);
-	cq->resize_cqq.depth = roundup_pow_of_two(ncqe + 1);
+	cq->resize_cqq.depth = bnxt_re_init_depth(ncqe + 1, cntx->comp_mask);
 	if (cq->resize_cqq.depth > dev->max_cq_depth + 1)
 		cq->resize_cqq.depth = dev->max_cq_depth + 1;
 	cq->resize_cqq.stride = dev->cqe_size;
@@ -472,7 +473,7 @@ static uint8_t bnxt_re_poll_success_scqe(struct bnxt_re_qp *qp,
 
 	head = qp->jsqq->last_idx;
 	swrid = &qp->jsqq->swque[head];
-	cindx = le32toh(scqe->con_indx) & (qp->cap.max_swr - 1);
+	cindx = le32toh(scqe->con_indx) % qp->cap.max_swr;
 
 	if (!(swrid->sig & IBV_SEND_SIGNALED)) {
 		*cnt = 0;
@@ -1150,10 +1151,11 @@ static int bnxt_re_get_sq_slots(struct bnxt_re_dev *rdev,
 	return slots;
 }
 
-static int bnxt_re_alloc_queues(struct bnxt_re_dev *dev,
+static int bnxt_re_alloc_queues(struct bnxt_re_context *cntx,
 				struct bnxt_re_qp *qp,
 				struct ibv_qp_init_attr *attr,
-				uint32_t pg_size) {
+				uint32_t pg_size)
+{
 	struct bnxt_re_psns_ext *psns_ext;
 	struct bnxt_re_wrid *swque;
 	struct bnxt_re_queue *que;
@@ -1168,11 +1170,11 @@ static int bnxt_re_alloc_queues(struct bnxt_re_dev *dev,
 	que = qp->jsqq->hwque;
 	diff = (qp->qpmode == BNXT_RE_WQE_MODE_VARIABLE) ?
 		0 : BNXT_RE_FULL_FLAG_DELTA;
-	nswr = roundup_pow_of_two(attr->cap.max_send_wr + 1 + diff);
+	nswr = bnxt_re_init_depth(attr->cap.max_send_wr + 1 + diff, cntx->comp_mask);
 	nsge = attr->cap.max_send_sge;
 	if (nsge % 2)
 		nsge++;
-	nslots = bnxt_re_get_sq_slots(dev, qp, nswr, nsge,
+	nslots = bnxt_re_get_sq_slots(cntx->rdev, qp, nswr, nsge,
 				      &attr->cap.max_inline_data);
 	if (nslots < 0)
 		 return nslots;
@@ -1224,11 +1226,11 @@ static int bnxt_re_alloc_queues(struct bnxt_re_dev *dev,
 
 	if (qp->jrqq) {
 		que = qp->jrqq->hwque;
-		nswr = roundup_pow_of_two(attr->cap.max_recv_wr + 1);
+		nswr = bnxt_re_init_depth(attr->cap.max_recv_wr + 1, cntx->comp_mask);
 		nsge = attr->cap.max_recv_sge;
 		if (nsge % 2)
 			nsge++;
-		nslots = bnxt_re_get_rq_slots(dev, qp, nswr, nsge);
+		nslots = bnxt_re_get_rq_slots(cntx->rdev, qp, nswr, nsge);
 		if (nslots < 0) {
 			ret = nslots;
 			goto fail;
@@ -1279,7 +1281,7 @@ struct ibv_qp *bnxt_re_create_qp(struct ibv_pd *ibvpd,
 	qp->cctx = &cntx->cctx;
 	qp->qpmode = cntx->wqe_mode & BNXT_RE_WQE_MODE_VARIABLE;
 	qp->cntx = cntx;
-	if (bnxt_re_alloc_queues(dev, qp, attr, dev->pg_size))
+	if (bnxt_re_alloc_queues(cntx, qp, attr, dev->pg_size))
 		goto failq;
 	/* Fill ibv_cmd */
 	cap = &qp->cap;
@@ -1863,7 +1865,8 @@ static void bnxt_re_srq_free_queue(struct bnxt_re_srq *srq)
 	bnxt_re_free_aligned(srq->srqq);
 }
 
-static int bnxt_re_srq_alloc_queue(struct bnxt_re_srq *srq,
+static int bnxt_re_srq_alloc_queue(struct bnxt_re_context *cntx,
+				   struct bnxt_re_srq *srq,
 				   struct ibv_srq_init_attr *attr,
 				   uint32_t pg_size)
 {
@@ -1871,7 +1874,7 @@ static int bnxt_re_srq_alloc_queue(struct bnxt_re_srq *srq,
 	int ret, idx;
 
 	que = srq->srqq;
-	que->depth = roundup_pow_of_two(attr->attr.max_wr + 1);
+	que->depth = bnxt_re_init_depth(attr->attr.max_wr + 1, cntx->comp_mask);
 	que->diff = que->depth - attr->attr.max_wr;
 	que->stride = bnxt_re_get_srqe_sz();
 	ret = bnxt_re_alloc_aligned(que, pg_size);
@@ -1913,7 +1916,7 @@ struct ibv_srq *bnxt_re_create_srq(struct ibv_pd *ibvpd,
 	if (!srq)
 		goto fail;
 
-	if (bnxt_re_srq_alloc_queue(srq, attr, dev->pg_size))
+	if (bnxt_re_srq_alloc_queue(cntx, srq, attr, dev->pg_size))
 		goto fail;
 
 	req.srqva = (uintptr_t)srq->srqq->va;


### PR DESCRIPTION
Optimize the memory usage of the driver and library. Avoids some of the power of 2 rounding up code while creating the resources like QP/CQ/MRs. 