### PR TITLE
debian: Bump Standards-Version to 4.6.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Build-Depends: cmake (>= 2.8.11),
                python3-docutils,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Rules-Requires-Root: no
-Standards-Version: 4.6.1
+Standards-Version: 4.6.2
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
 Homepage: https://github.com/linux-rdma/rdma-core


### PR DESCRIPTION
No changes are needed to support the new Debian policy version. See https://www.debian.org/doc/debian-policy/ for details.