### PR TITLE
mlx5: Fix the rdma_tracepoint() code

### DIFF
--- a/providers/mlx5/mlx5_trace.h
+++ b/providers/mlx5/mlx5_trace.h
@@ -52,12 +52,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
 #ifndef __MLX5_TRACE_H__
 #define __MLX5_TRACE_H__
 
-#define MLX5_TP_rdma_core_mlx5 ""
-#define MLX5_TP_post_send ""
-static inline void dummy_tracepoint(const char *p, const char *n, ...) {};
-
-#define rdma_tracepoint(P, N, arg...) \
-		dummy_tracepoint(MLX5_TP_##P, MLX5_TP_##N, arg)
+#define rdma_tracepoint(arg...)
 
 #endif /* __MLX5_TRACE_H__*/
 

--- a/providers/mlx5/qp.c
+++ b/providers/mlx5/qp.c
@@ -824,7 +824,6 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 	uint8_t fence;
 	uint8_t next_fence;
 	uint32_t max_tso = 0;
-	unsigned int length = 0;
 	FILE *fp = to_mctx(ibqp->context)->dbg_fp; /* The compiler ignores in non-debug mode */
 
 	mlx5_spin_lock(&qp->sq.lock);
@@ -1139,14 +1138,12 @@ static inline int _mlx5_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 		if (mlx5_debug_mask & MLX5_DBG_QP_SEND)
 			dump_wqe(to_mctx(ibqp->context), idx, size, qp);
 #endif
-		for (i = 0; i < wr->num_sge; i++)
-			length += wr->sg_list[i].length;
 
 		rdma_tracepoint(rdma_core_mlx5, post_send,
 				ibqp->context->device->name,
 				ibqp->qp_num,
 				(char *)ibv_wr_opcode_str(wr->opcode),
-				length);
+				wr->num_sge);
 	}
 
 out:


### PR DESCRIPTION
As part of adding rdma_tracepoint() to _mlx5_post_send() the total length of the SGs is calculated unconditionally even if the trace point mechanism is compiled out.

The above extra code in the data path must be prevented.

As such, the trace point was changed to include some exiting data as of num_sge.

In addition, drop the dummy trace point function and have an empty definition for rdma_tracepoint as was done for rxe and the efa drivers.