### PR TITLE
Remove redundant code for checking max queue sizes and max sgl sizes

### DIFF
--- a/providers/mana/mana.c
+++ b/providers/mana/mana.c
@@ -200,13 +200,6 @@ struct ibv_cq *mana_create_cq(struct ibv_context *context, int cqe,
 	int cq_size;
 	int ret;
 
-	if (cqe > MAX_SEND_BUFFERS_PER_QUEUE) {
-		verbs_err(verbs_get_ctx(context), "CQE %d exceeding limit\n",
-			  cqe);
-		errno = EINVAL;
-		return NULL;
-	}
-
 	if (!ctx->extern_alloc.alloc || !ctx->extern_alloc.free) {
 		/*
 		 * This version of driver doesn't support allocating buffers

--- a/providers/mana/mana.h
+++ b/providers/mana/mana.h
@@ -17,8 +17,6 @@
 #define INLINE_OOB_LARGE_SIZE 24
 
 #define GDMA_WQE_ALIGNMENT_UNIT_SIZE 32
-#define MAX_TX_WQE_SIZE 512
-#define MAX_RX_WQE_SIZE 256
 
 /* The size of a SGE in WQE */
 #define SGE_SIZE 16

--- a/providers/mana/mana.h
+++ b/providers/mana/mana.h
@@ -8,7 +8,6 @@
 
 #include "manadv.h"
 
-#define MAX_SEND_BUFFERS_PER_QUEUE 256
 #define COMP_ENTRY_SIZE 64
 #define MANA_IB_TOEPLITZ_HASH_KEY_SIZE_IN_BYTES 40
 

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -56,14 +56,6 @@ static struct ibv_qp *mana_create_qp_raw(struct ibv_pd *ibpd,
 
 	cq = container_of(attr->send_cq, struct mana_cq, ibcq);
 
-	if (attr->cap.max_send_wr > MAX_SEND_BUFFERS_PER_QUEUE) {
-		verbs_err(verbs_get_ctx(ibpd->context),
-			  "max_send_wr %d exceeds MAX_SEND_BUFFERS_PER_QUEUE\n",
-			  attr->cap.max_send_wr);
-		errno = EINVAL;
-		return NULL;
-	}
-
 	if (get_wqe_size(attr->cap.max_send_sge) > MAX_TX_WQE_SIZE) {
 		verbs_err(verbs_get_ctx(ibpd->context),
 			  "max_send_sge %d exceeding queue size limits\n",

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -56,14 +56,6 @@ static struct ibv_qp *mana_create_qp_raw(struct ibv_pd *ibpd,
 
 	cq = container_of(attr->send_cq, struct mana_cq, ibcq);
 
-	if (get_wqe_size(attr->cap.max_send_sge) > MAX_TX_WQE_SIZE) {
-		verbs_err(verbs_get_ctx(ibpd->context),
-			  "max_send_sge %d exceeding queue size limits\n",
-			  attr->cap.max_send_sge);
-		errno = EINVAL;
-		return NULL;
-	}
-
 	if (!ctx->extern_alloc.alloc || !ctx->extern_alloc.free) {
 		verbs_err(verbs_get_ctx(ibpd->context),
 			  "RAW QP requires extern alloc for buffers\n");

--- a/providers/mana/wq.c
+++ b/providers/mana/wq.c
@@ -41,14 +41,6 @@ struct ibv_wq *mana_create_wq(struct ibv_context *context,
 	struct mana_create_wq_resp wq_resp = {};
 	struct mana_ib_create_wq *wq_cmd_drv;
 
-	if (get_wqe_size(attr->max_sge) > MAX_RX_WQE_SIZE) {
-		verbs_err(verbs_get_ctx(context),
-			  "max_sge %d exceeding WQE size limit\n",
-			  attr->max_sge);
-		errno = EINVAL;
-		return NULL;
-	}
-
 	if (!ctx->extern_alloc.alloc || !ctx->extern_alloc.free) {
 		verbs_err(verbs_get_ctx(context),
 			  "WQ buffer needs to be externally allocated\n");

--- a/providers/mana/wq.c
+++ b/providers/mana/wq.c
@@ -41,14 +41,6 @@ struct ibv_wq *mana_create_wq(struct ibv_context *context,
 	struct mana_create_wq_resp wq_resp = {};
 	struct mana_ib_create_wq *wq_cmd_drv;
 
-	if (attr->max_wr > MAX_SEND_BUFFERS_PER_QUEUE) {
-		verbs_err(verbs_get_ctx(context),
-			  "max_wr %d exceeds MAX_SEND_BUFFERS_PER_QUEUE\n",
-			  attr->max_wr);
-		errno = EINVAL;
-		return NULL;
-	}
-
 	if (get_wqe_size(attr->max_sge) > MAX_RX_WQE_SIZE) {
 		verbs_err(verbs_get_ctx(context),
 			  "max_sge %d exceeding WQE size limit\n",


### PR DESCRIPTION
The checks for those sizes are already done in the kernel driver since day one. The checks in rdma-core are redundant. Remove them to make the code easier to maintain.