### PR TITLE
verbs: reserve unused 24bits in sq_sig_all for extension

### DIFF
--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -922,7 +922,15 @@ struct ibv_qp_init_attr {
 	struct ibv_srq	       *srq;
 	struct ibv_qp_cap	cap;
 	enum ibv_qp_type	qp_type;
-	int			sq_sig_all;
+	struct {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		int sq_sig_all:8;
+		int reserved:24;
+#else
+		int reserved:24;
+		int sq_sig_all:8;
+#endif
+	};
 };
 
 enum ibv_qp_init_attr_mask {
@@ -975,7 +983,15 @@ struct ibv_qp_init_attr_ex {
 	struct ibv_srq	       *srq;
 	struct ibv_qp_cap	cap;
 	enum ibv_qp_type	qp_type;
-	int			sq_sig_all;
+	struct {
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+		int sq_sig_all:8;
+		int reserved:24;
+#else
+		int reserved:24;
+		int sq_sig_all:8;
+#endif
+	};
 
 	uint32_t		comp_mask;
 	struct ibv_pd	       *pd;


### PR DESCRIPTION
1. keep compatibility
2. [ib_uverbs_create_qp::sq_sig_all](https://github.com/linux-rdma/rdma-core/blob/v49.0/kernel-headers/rdma/ib_user_verbs.h#L598) occupy 8 bits.