### PR TITLE
ibnetdisc: Fix leak in add_to_portlid_hash

### DIFF
--- a/libibnetdisc/ibnetdisc.c
+++ b/libibnetdisc/ibnetdisc.c
@@ -704,8 +704,11 @@ void add_to_portlid_hash(ibnd_port_t * port, f_internal_t *f_int)
 			item = malloc(sizeof(*item));
 			if (item) {
 				item->port = port;
-				cl_qmap_insert(&f_int->lid2guid, lid,
-					       &item->cl_map);
+				if (cl_qmap_insert(&f_int->lid2guid, lid,
+						   &item->cl_map) != &item->cl_map) {
+					/* Port is already in map, release item */
+					free(item);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
When the duplicate port is added to the map cl_qmap_insert() returns pointer to existing value and the new entry is left unused that results in leak:

==1606814== 2,624 bytes in 41 blocks are definitely lost in loss record 1 of 1
==1606814==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==1606814==    by 0x5174B59: add_to_portlid_hash (ibnetdisc.c:704)
==1606814==    by 0x517638E: recv_port_info (ibnetdisc.c:379)
==1606814==    by 0x51789B0: process_one_recv (query_smp.c:200)
==1606814==    by 0x5178EF7: process_mads (query_smp.c:276)
==1606814==    by 0x51755E7: ibnd_discover_fabric (ibnetdisc.c:817)
==1606814==    by 0x109229: main (in /vagrant/go/gpu/ib-ict-manager/a.out)

The solution is to free new item if it was not added to the map.

Fixes: 16168163317b ("ibdiags: Use cl_qmap instead of glib hashtable")


UPD: Fixed format of "Fixes" tag, the only problem reported by CI is a long line in valgrind output, but I think it is better to keep it that way than wrap the line.