### PR TITLE
mlx5: DR, Few fixes

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -667,6 +667,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 	uint8_t *last_ste;
 	int i;
 
+	attr.dmn = dmn;
 	attr.gvmi = dmn->info.caps.gvmi;
 	attr.hit_gvmi = dmn->info.caps.gvmi;
 	attr.final_icm_addr = nic_dmn->default_icm_addr;

--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -2485,6 +2485,8 @@ dr_action_convert_to_fte_dest(struct mlx5dv_dr_domain *dmn,
 
 		fte_attr->action |= MLX5_FLOW_CONTEXT_ACTION_FWD_DEST;
 		dest_info->type = MLX5_FLOW_DEST_TYPE_VPORT;
+		if (dmn->info.caps.is_ecpf)
+			dest_info->vport_num = ECPF_PORT;
 		break;
 	case DR_ACTION_TYP_VPORT:
 		if (dmn->type != MLX5DV_DR_DOMAIN_TYPE_FDB)

--- a/providers/mlx5/dr_ste_v1.c
+++ b/providers/mlx5/dr_ste_v1.c
@@ -755,7 +755,7 @@ static void dr_ste_v1_set_actions_tx(uint8_t *action_type_set,
 	}
 
 	if (action_type_set[DR_ACTION_TYP_ASO_CT]) {
-		if (attr->aso->dmn->info.caps.gvmi != attr->gvmi ||
+		if (attr->aso->dmn != attr->dmn ||
 		    action_sz < DR_STE_ACTION_DOUBLE_SZ) {
 			dr_ste_v1_arr_init_next_match(&last_ste, added_stes,
 						      attr->gvmi);
@@ -764,7 +764,7 @@ static void dr_ste_v1_set_actions_tx(uint8_t *action_type_set,
 			action_sz = DR_STE_ACTION_TRIPLE_SZ;
 		}
 
-		if (attr->aso->dmn->info.caps.gvmi != attr->gvmi) {
+		if (attr->aso->dmn != attr->dmn) {
 			attr->aso_ste_loc = ste_loc;
 		} else {
 			dr_ste_v1_set_aso_ct(action,
@@ -1023,7 +1023,7 @@ static void dr_ste_v1_set_actions_rx(uint8_t *action_type_set,
 	}
 
 	if (action_type_set[DR_ACTION_TYP_ASO_CT]) {
-		if (attr->aso->dmn->info.caps.gvmi != attr->gvmi ||
+		if (attr->aso->dmn != attr->dmn ||
 		    action_sz < DR_STE_ACTION_DOUBLE_SZ) {
 			dr_ste_v1_arr_init_next_match(&last_ste, added_stes,
 						      attr->gvmi);
@@ -1033,7 +1033,7 @@ static void dr_ste_v1_set_actions_rx(uint8_t *action_type_set,
 			allow_ctr = true;
 		}
 
-		if (attr->aso->dmn->info.caps.gvmi != attr->gvmi) {
+		if (attr->aso->dmn != attr->dmn) {
 			attr->aso_ste_loc = ste_loc;
 		} else {
 			dr_ste_v1_set_aso_ct(action,

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -414,6 +414,7 @@ struct dr_ste_actions_attr {
 	} vlans;
 	struct dr_action_aso *aso;
 	uint32_t aso_ste_loc;
+	struct mlx5dv_dr_domain *dmn;
 };
 
 struct cross_dmn_params {


### PR DESCRIPTION
This series in the DR area includes the below two fixes.

- Use the correct destination vport while considering whether the function is ECPF or PF.
- Allow two different domains on the same GVMI to share the same ASO CT action.