### PR TITLE
Add convenience functions to ioctl mechanism

### DIFF
--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -36,6 +36,7 @@
 #include <config.h>
 
 #include <stdint.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <rdma/rdma_user_ioctl_cmds.h>
 #include <infiniband/verbs.h>
@@ -243,6 +244,18 @@ static inline struct ib_uverbs_attr *attr_optional(struct ib_uverbs_attr *attr)
 
 	attr->flags &= ~UVERBS_ATTR_F_MANDATORY;
 	return attr;
+}
+
+/*
+ * Get output attribute validity. Can be called on an optional output attribute
+ * after executing ioctl to check whether its data was filled in the kernel.
+ */
+static inline bool attr_output_valid(struct ib_uverbs_attr *attr)
+{
+	if (!attr)
+		return false;
+
+	return !!(attr->flags & UVERBS_ATTR_F_VALID_OUTPUT);
 }
 
 /* Send attributes of kernel type UVERBS_ATTR_TYPE_IDR */

--- a/libibverbs/cmd_ioctl.h
+++ b/libibverbs/cmd_ioctl.h
@@ -424,4 +424,19 @@ fill_attr_in_objs_arr(struct ibv_command_buffer *cmd, uint16_t attr_id,
 			    _array_len(sizeof(*idrs_arr), nelems));
 }
 
+static inline struct ib_uverbs_attr *
+find_attr_by_id(struct ibv_command_buffer *link, uint16_t attr_id)
+{
+	struct ib_uverbs_attr *attr;
+
+	for (; link; link = link->next) {
+		for (attr = link->hdr.attrs; attr < link->next_attr; attr++) {
+			if (attr->attr_id == attr_id)
+				return attr;
+		}
+	}
+
+	return NULL;
+}
+
 #endif


### PR DESCRIPTION
From discussions [here](https://github.com/linux-rdma/rdma-core/pull/1412) and [here](https://lore.kernel.org/all/20240108180636.GM50406@nvidia.com/) seems it will be useful to have an easy way to get optional output field validity.