### PR TITLE
util/udma_barrier.h: fix mips4 build

### DIFF
--- a/util/udma_barrier.h
+++ b/util/udma_barrier.h
@@ -101,7 +101,7 @@
 #elif defined(__riscv)
 #define udma_to_device_barrier() asm volatile("fence ow,ow" ::: "memory")
 #elif defined(__mips__)
-#define udma_to_device_barrier() asm volatile("sync 0" ::: "memory")
+#define udma_to_device_barrier() asm volatile("sync" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif
@@ -139,7 +139,7 @@
 #elif defined(__riscv)
 #define udma_from_device_barrier() asm volatile("fence ir,ir" ::: "memory")
 #elif defined(__mips__)
-#define udma_from_device_barrier() asm volatile("sync 0" ::: "memory")
+#define udma_from_device_barrier() asm volatile("sync" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif
@@ -212,7 +212,7 @@
 #include "s390_mmio_insn.h"
 #define mmio_flush_writes() s390_pciwb()
 #elif defined(__mips__)
-#define mmio_flush_writes() asm volatile("sync 0" ::: "memory")
+#define mmio_flush_writes() asm volatile("sync" ::: "memory")
 #else
 #error No architecture specific memory barrier defines found!
 #endif


### PR DESCRIPTION
The 'sync' instruction for MIPS was defined in MIPS-II as taking no operands. MIPS32 extended the define of 'sync' as taking an optional unsigned 5 bit immediate.

As a result, replace "sync 0" by "sync" to fix the following build failure on mips4 raised since version 43.0 and
https://github.com/linux-rdma/rdma-core/commit/b7c428344ea96d446f6ffe31c620a238a7f25c9e:

```
/tmp/ccrBy9fV.s: Assembler messages:
/tmp/ccrBy9fV.s:994: Error: invalid operands `sync 0'
```

Fixes:
 - http://autobuild.buildroot.org/results/2ab22a3ec4287fc15ff6a90d8715b4897b32a933