### PR TITLE
rstream [RFC]: Set INLINE data for iWARP

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -917,8 +917,12 @@ static int rs_create_ep(struct rsocket *rs)
 	int i, ret;
 
 	rs_set_qp_size(rs);
-	if (rs->cm_id->verbs->device->transport_type == IBV_TRANSPORT_IWARP)
+	if (rs->cm_id->verbs->device->transport_type == IBV_TRANSPORT_IWARP) {
 		rs->opts |= RS_OPT_MSG_SEND;
+
+		if (rs->sq_inline < RS_MSG_SIZE)
+			rs->sq_inline = RS_MSG_SIZE;
+	}
 	ret = rs_create_cq(rs, rs->cm_id);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Set rsocket SQ INLINE to RS_MSG_SIZE for iWARP.