### PR TITLE
bnxt_re/lib: Reduce the Doorbells during SRQ and CQ handling

### DIFF
--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -105,6 +105,8 @@ struct bnxt_re_cq {
 	uint32_t mem_handle;
 	void *toggle_map;
 	uint32_t toggle_size;
+	bool deffered_db_sup;
+	uint32_t hw_cqes;
 };
 
 struct bnxt_re_push_buffer {


### PR DESCRIPTION
Some optimizations in data path for Broadcom devices. This series implements some Doorbell moderation techniques to avoid some latency in data path and help to reduce the Doorbell HW FIFO congestion. 