### PR TITLE
tests: Fix runtime error in python 3.12

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -29,7 +29,7 @@ def _show_tests_and_exit(loader, standard_tests, pattern):
     loadTestsFromModule protocol, without modifying standard_tests.
     """
     for mod in __test_modules__:
-        for test in loader.loadTestsFromModule(mod, pattern):
+        for test in loader.loadTestsFromModule(mod, pattern=pattern):
             for test_case in test:
                 print(test_case.id())
     return standard_tests
@@ -40,5 +40,5 @@ def load_tests(loader, standard_tests, pattern):
     if parser.args['list_tests']:
         return _show_tests_and_exit(loader, standard_tests, pattern)
     for mod in __test_modules__:
-        standard_tests.addTests(loader.loadTestsFromModule(mod, pattern))
+        standard_tests.addTests(loader.loadTestsFromModule(mod, pattern=pattern))
     return standard_tests


### PR DESCRIPTION
tests (unittest.loader._FailedTest.tests) ... ERROR

====================================================================== ERROR: tests (unittest.loader._FailedTest.tests)
---------------------------------------------------------------------- Traceback (most recent call last):
  File "/home/leonro/src/rdma-core/tests/__init__.py", line 43, in load_tests
    standard_tests.addTests(loader.loadTestsFromModule(mod, pattern))
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: TestLoader.loadTestsFromModule() takes 2 positional arguments but 3 were given

---------------------------------------------------------------------- Ran 1 test in 0.002s

FAILED (errors=1)