### PR TITLE
providers/efa: Add src_qp and ah_num to completion trace event

### DIFF
--- a/providers/efa/efa_trace.h
+++ b/providers/efa/efa_trace.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2023-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #if defined(LTTNG_ENABLED)
@@ -81,8 +81,10 @@ LTTNG_UST_TRACEPOINT_EVENT(
 		char *, dev_name,
 		uint64_t, wr_id,
 		int, status,
-		uint32_t, qp_num,
 		int, opcode,
+		uint32_t, src_qp_num,
+		uint32_t, dst_qp_num,
+		uint16_t, ah_num,
 		uint32_t, length
 	),
 
@@ -91,8 +93,10 @@ LTTNG_UST_TRACEPOINT_EVENT(
 		lttng_ust_field_string(dev_name, dev_name)
 		lttng_ust_field_integer(uint64_t, wr_id, wr_id)
 		lttng_ust_field_integer(int, status, status)
-		lttng_ust_field_integer(uint32_t, qp_num, qp_num)
 		lttng_ust_field_integer(int, opcode, opcode)
+		lttng_ust_field_integer(uint32_t, src_qp_num, src_qp_num)
+		lttng_ust_field_integer(uint32_t, dst_qp_num, dst_qp_num)
+		lttng_ust_field_integer(uint16_t, ah_num, ah_num)
 		lttng_ust_field_integer(uint32_t, length, length)
 	)
 )

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -610,6 +610,7 @@ static void efa_process_cqe(struct efa_cq *cq, struct ibv_wc *wc,
 	wc->vendor_err = cqe->status;
 	wc->wc_flags = 0;
 	wc->qp_num = cqe->qp_num;
+	wc->slid = UINT16_MAX;
 
 	op_type = EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_OP_TYPE);
 
@@ -653,7 +654,7 @@ static void efa_process_cqe(struct efa_cq *cq, struct ibv_wc *wc,
 	wc->wr_id = cq->cur_wq->wrid[wrid_idx];
 
 	rdma_tracepoint(rdma_core_efa, process_completion, cq->dev->name, wc->wr_id, wc->status,
-			wc->qp_num, wc->opcode, wc->byte_len);
+			wc->opcode, wc->src_qp, wc->qp_num, wc->slid, wc->byte_len);
 }
 
 static void efa_process_ex_cqe(struct efa_cq *cq, struct efa_qp *qp)


### PR DESCRIPTION
This PR adds some additional info to EFA completion trace events.