### PR TITLE
bnxt_re/lib: Fix the toggle bit changes in resize cq path

### DIFF
--- a/providers/bnxt_re/db.c
+++ b/providers/bnxt_re/db.c
@@ -182,9 +182,13 @@ void bnxt_re_ring_cq_arm_db(struct bnxt_re_cq *cq, uint8_t aflag)
 	struct bnxt_re_db_hdr hdr;
 	uint32_t *pgptr;
 
-	pgptr = (uint32_t *)cq->toggle_map;
-	if (pgptr)
-		toggle = *pgptr;
+	if (aflag == BNXT_RE_QUE_TYPE_CQ_CUT_ACK) {
+		toggle = cq->resize_tog;
+	} else {
+		pgptr = (uint32_t *)cq->toggle_map;
+		if (pgptr)
+			toggle = *pgptr;
+	}
 
 	bnxt_re_do_pacing(cq->cntx, &cq->rand);
 	epoch = (cq->cqq.flags & BNXT_RE_FLAG_EPOCH_HEAD_MASK) <<  BNXT_RE_DB_EPOCH_HEAD_SHIFT;

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -105,6 +105,7 @@ struct bnxt_re_cq {
 	uint32_t mem_handle;
 	void *toggle_map;
 	uint32_t toggle_size;
+	uint8_t resize_tog;
 	bool deffered_db_sup;
 	uint32_t hw_cqes;
 };


### PR DESCRIPTION
Toggle bit to be used in cut off ack Doorbell needs to be copied from the Cut off CQ entry. Fix the same.

Also, format the variable declarations to reverse xmas tree style.

Fixes: d5d79c8f50cb ("bnxt_re/lib: Get the shared CQ toggle page")