### PR TITLE
libibverbs: ignore IBV_FORK_SAFE et.al. when kernel has fork support

### DIFF
--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -134,6 +134,9 @@ int ibv_fork_init(void)
 	if (mm_root)
 		return 0;
 
+	if (ibv_is_fork_initialized() == IBV_FORK_UNNEEDED)
+		return 0;
+
 	if (too_late)
 		return EINVAL;
 


### PR DESCRIPTION
ibv_fork_init will now check if IBV_FORK_UNNEEDED is true, and if so will skip initialization of mm_root.  Environment variables like IBV_FORK_SAFE and UCX_IB_FORK_INIT are silently ignored when the kernel has the necessary fork support.