### PR TITLE
Changes from Debian upload 50.0-1

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,39 @@ rdma-core (51.0-1) unstable; urgency=medium
 
   * New upstream release.
 
- -- Jason Gunthorpe <jgg@obsidianresearch.com>  Tue, 03 Jan 2023 17:46:57 +0100
+ -- Jason Gunthorpe <jgg@obsidianresearch.com>  Tue, 27 Feb 2024 11:32:22 +0100
+
+rdma-core (50.0-1) unstable; urgency=medium
+
+  * New upstream release.
+    - support cython 3.0.x (Closes: #1056882)
+    - add support for loongarch64 (Closes: #1059022)
+  * Replace obsolete pkg-config by pkgconf
+  * Update years in debian/copyright
+  * Use unversioned library names in package description
+  * Installs udev/systemd files below /usr/lib (Closes: #1059188)
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 26 Feb 2024 17:41:04 +0100
+
+rdma-core (48.0-1) unstable; urgency=medium
+
+  * New upstream release.
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 23 Oct 2023 18:40:29 +0200
+
+rdma-core (47.0-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Drop obsolete versioned dependency on lsb-base
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 07 Aug 2023 11:26:40 +0200
+
+rdma-core (44.0-2) unstable; urgency=medium
+
+  * debian: Add 32-bit MIPS architectures to COHERENT_DMA_ARCHS and
+    inverse the list to NON_COHERENT_DMA_ARCHS (Closes: #1026088)
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Tue, 10 Jan 2023 13:59:10 +0100
 
 rdma-core (44.0-1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -240,7 +240,7 @@ Description: Development files for the librdmacm library
  provided by libibverbs, which provides the interface used to actually
  transfer data.
  .
- This package is needed to compile programs against librdmacm1.
+ This package is needed to compile programs against librdmacm.
  It contains the header files and static libraries (optionally)
  needed for compiling.
 
@@ -305,7 +305,7 @@ Description: Examples for the librdmacm library
  provided by libibverbs, which provides the interface used to actually
  transfer data.
  .
- This package contains useful librdmacm1 example programs such as
+ This package contains useful librdmacm example programs such as
  rping and udaddy.
 
 Package: srptools
@@ -437,5 +437,5 @@ Description: InfiniBand diagnostics library headers
  failover, and it is designed to be scalable.
  .
  This package provides development files required to build
- applications aginast the libibnetdisc5 InfiniBand diagnostic
+ applications against the libibnetdisc InfiniBand diagnostic
  libraries.

--- a/debian/copyright
+++ b/debian/copyright
@@ -12,7 +12,7 @@ Files: debian/*
 Copyright: 2008, Genome Research Ltd
            2014, Ana Beatriz Guerrero Lopez <ana@debian.org>
            2015-2016, Jason Gunthorpe <jgunthorpe@obsidianresearch.com>
-           2016-2023, Benjamin Drung <bdrung@ubuntu.com>
+           2016-2024, Benjamin Drung <bdrung@ubuntu.com>
            2016-2017, Talat Batheesh <talatb@mellanox.com>
 License: GPL-2+
  This program is free software; you can redistribute it and/or modify
@@ -153,7 +153,8 @@ Copyright: 2003-2016, Chelsio Communications, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/efa/*
-Copyright: 2019 Amazon.com, Inc. or its affiliates.
+       pyverbs/providers/efa/*
+Copyright: 2019-2024 Amazon.com, Inc. or its affiliates.
 License: BSD-2-clause or GPL-2
 
 Files: providers/erdma/*
@@ -177,7 +178,7 @@ Copyright: 2006-2010, QLogic Corp.
 License: BSD-MIT or GPL-2
 
 Files: providers/irdma/*
-Copyright: 2015-2021, Intel Corporation.
+Copyright: 2015-2023, Intel Corporation.
 License: BSD-MIT or GPL-2
 
 Files: providers/mana/*
@@ -191,7 +192,8 @@ Copyright: 2004-2005, Topspin Communications.
 License: BSD-MIT or GPL-2
 
 Files: providers/mlx5/*
-Copyright: 2010-2017, Mellanox Technologies, Inc.
+Copyright: 2019, Mellanox Technologies, Inc.
+           2020-2024 Nvidia, Inc.
 License: BSD-MIT or GPL-2
 
 Files: providers/mlx5/man/*.3

--- a/debian/libibnetdisc5.symbols
+++ b/debian/libibnetdisc5.symbols
@@ -1,6 +1,7 @@
 libibnetdisc.so.5 libibnetdisc5 #MINVER#
 * Build-Depends-Package: libibnetdisc-dev
  IBNETDISC_1.0@IBNETDISC_1.0 1.6.1
+ IBNETDISC_1.1@IBNETDISC_1.1 49
  ibnd_cache_fabric@IBNETDISC_1.0 1.6.1
  ibnd_destroy_fabric@IBNETDISC_1.0 1.6.1
  ibnd_discover_fabric@IBNETDISC_1.0 1.6.1
@@ -19,11 +20,11 @@ libibnetdisc.so.5 libibnetdisc5 #MINVER#
  ibnd_iter_nodes_type@IBNETDISC_1.0 1.6.1
  ibnd_iter_ports@IBNETDISC_1.0 1.6.1
  ibnd_load_fabric@IBNETDISC_1.0 1.6.1
- ibnd_get_agg_linkspeedext_field@IBNETDISC_1.1 1.6.1
- ibnd_get_agg_linkspeedext@IBNETDISC_1.1 1.6.1
- ibnd_get_agg_linkspeedexten@IBNETDISC_1.1 1.6.1
- ibnd_get_agg_linkspeedextsup@IBNETDISC_1.1 1.6.1
- ibnd_dump_agg_linkspeedext_bits@IBNETDISC_1.1 1.6.1
- ibnd_dump_agg_linkspeedext@IBNETDISC_1.1 1.6.1
- ibnd_dump_agg_linkspeedexten@IBNETDISC_1.1 1.6.1
- ibnd_dump_agg_linkspeedextsup@IBNETDISC_1.1 1.6.1
+ ibnd_get_agg_linkspeedext_field@IBNETDISC_1.1 49
+ ibnd_get_agg_linkspeedext@IBNETDISC_1.1 49
+ ibnd_get_agg_linkspeedexten@IBNETDISC_1.1 49
+ ibnd_get_agg_linkspeedextsup@IBNETDISC_1.1 49
+ ibnd_dump_agg_linkspeedext_bits@IBNETDISC_1.1 49
+ ibnd_dump_agg_linkspeedext@IBNETDISC_1.1 49
+ ibnd_dump_agg_linkspeedexten@IBNETDISC_1.1 49
+ ibnd_dump_agg_linkspeedextsup@IBNETDISC_1.1 49


### PR DESCRIPTION
*  debian: fix minimum version for new libibnetdisc symbols
* debian: update years in debian/copyright
* debian: use unversioned library names in description
* debian: Add Debian uploads up to version 50.0-1

See individual commits for details.