### PR TITLE
pyverbs: Fix build failure

### DIFF
--- a/pyverbs/dmabuf_alloc.c
+++ b/pyverbs/dmabuf_alloc.c
@@ -43,7 +43,7 @@ static int i915_alloc(struct drm *drm, uint64_t size, uint32_t *handle, int gtt)
 	return 0;
 }
 
-static int amdgpu_alloc(struct drm *drm, size_t size, uint32_t *handle, int gtt)
+static int amdgpu_alloc(struct drm *drm, uint64_t size, uint32_t *handle, int gtt)
 {
 	union drm_amdgpu_gem_create gem_create = {{}};
 	int err;


### PR DESCRIPTION
Fix the following error:

rdma-core-50.0/pyverbs/dmabuf_alloc.c: In function ‘drm_open’: rdma-core-50.0/pyverbs/dmabuf_alloc.c:122:28: error: assignment to ‘int (*)(struct drm *, uint64_t,  uint32_t *, int)’ {aka ‘int (*)(struct drm *, long long unsigned int,  unsigned int *, int)’} from incompatible pointer type ‘int (*)(struct drm *, size_t,  uint32_t *, int)’ {aka ‘int (*)(struct drm *, unsigned int,  unsigned int *, int)’} [-Wincompatible-pointer-types]
  122 |                 drm->alloc = amdgpu_alloc;