### PR TITLE
include libgen.h for basename

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -2,6 +2,7 @@
 /* Copyright (c) 2019, Mellanox Technologies. All rights reserved. See COPYING file */
 
 #define _GNU_SOURCE
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -33,6 +33,7 @@
 #define _GNU_SOURCE
 #include <endian.h>
 #include <getopt.h>
+#include <libgen.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -6,6 +6,7 @@
 #define _GNU_SOURCE
 #include <config.h>
 
+#include <libgen.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>


### PR DESCRIPTION
basename prototype has been removed from string.h from latest musl [1] compilers e.g. clang-18 flags the absense of prototype as error. therefore include libgen.h for providing it.

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7