### PR TITLE
mlx5: DR, Using sq ts format when RoCE is disabled

### DIFF
--- a/providers/mlx5/dr_devx.c
+++ b/providers/mlx5/dr_devx.c
@@ -243,6 +243,9 @@ int dr_devx_query_device(struct ibv_context *ctx, struct dr_devx_caps *caps)
 	caps->roce_caps.fl_rc_qp_when_roce_disabled = DEVX_GET(query_hca_cap_out, out,
 					capability.cmd_hca_cap.fl_rc_qp_when_roce_disabled);
 
+	caps->roce_caps.qp_ts_format = DEVX_GET(query_hca_cap_out, out,
+						capability.cmd_hca_cap.sq_ts_format);
+
 	if (caps->support_modify_argument) {
 		caps->log_header_modify_argument_granularity =
 			DEVX_GET(query_hca_cap_out, out,

--- a/providers/mlx5/mlx5_ifc.h
+++ b/providers/mlx5/mlx5_ifc.h
@@ -1183,7 +1183,8 @@ struct mlx5_ifc_cmd_hca_cap_bits {
 
 	u8         general_obj_types[0x40];
 
-	u8         reserved_at_440[0x4];
+	u8         sq_ts_format[0x2];
+	u8         rq_ts_format[0x2];
 	u8         steering_format_version[0x4];
 	u8         create_qp_start_hint[0x18];
 


### PR DESCRIPTION
This patch fixes an issue in the DR area, to use a proper timestamp format for its internal QP, when RoCE is disabled.

Further details exist as part of the commit log. 