### PR TITLE
librdmacm/cmtime: Rework of cmtime example

### DIFF
--- a/librdmacm/examples/cmatose.c
+++ b/librdmacm/examples/cmatose.c
@@ -486,11 +486,9 @@ static int migrate_channel(struct rdma_cm_id *listen_id)
 
 	printf("migrating to new event channel\n");
 
-	channel = rdma_create_event_channel();
-	if (!channel) {
-		perror("cmatose: failed to create event channel");
+	channel = create_event_channel();
+	if (!channel)
 		return -1;
-	}
 
 	ret = 0;
 	if (listen_id)
@@ -715,7 +713,7 @@ int main(int argc, char **argv)
 
 	test.connects_left = connections;
 
-	test.channel = create_first_event_channel();
+	test.channel = create_event_channel();
 	if (!test.channel) {
 		exit(1);
 	}

--- a/librdmacm/examples/cmatose.c
+++ b/librdmacm/examples/cmatose.c
@@ -521,10 +521,8 @@ static int run_server(void)
 	}
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &test.rai);
-	if (ret) {
-		printf("cmatose: getrdmaaddr error: %s\n", gai_strerror(ret));
+	if (ret)
 		goto out;
-	}
 
 	ret = rdma_bind_addr(listen_id, test.rai->ai_src_addr);
 	if (ret) {
@@ -594,10 +592,8 @@ static int run_client(void)
 	printf("cmatose: starting client\n");
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &test.rai);
-	if (ret) {
-		printf("cmatose: getaddrinfo error: %s\n", gai_strerror(ret));
+	if (ret)
 		return ret;
-	}
 
 	printf("cmatose: connecting\n");
 	for (i = 0; i < connections; i++) {

--- a/librdmacm/examples/cmatose.c
+++ b/librdmacm/examples/cmatose.c
@@ -737,8 +737,7 @@ int main(int argc, char **argv)
 	printf("test complete\n");
 	destroy_nodes();
 	rdma_destroy_event_channel(test.channel);
-	if (test.rai)
-		rdma_freeaddrinfo(test.rai);
+	rdma_freeaddrinfo(test.rai);
 
 	printf("return status %d\n", ret);
 	return ret;

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -130,7 +130,7 @@ static inline int __list_empty(struct work_list *list)
 static inline struct list_head *__list_remove_head(struct work_list *work_list)
 {
 	struct list_head *list_item;
-	
+
 	list_item = work_list->list.next;
 	__list_delete(list_item);
 	return list_item;
@@ -542,7 +542,8 @@ static int run_client(void)
 		}
 		started[STEP_RESOLVE_ADDR]++;
 	}
-	while (started[STEP_RESOLVE_ADDR] != completed[STEP_RESOLVE_ADDR]) sched_yield();
+	while (started[STEP_RESOLVE_ADDR] != completed[STEP_RESOLVE_ADDR])
+		sched_yield();
 	end_time(STEP_RESOLVE_ADDR);
 
 	printf("resolving route\n");
@@ -560,7 +561,8 @@ static int run_client(void)
 		}
 		started[STEP_RESOLVE_ROUTE]++;
 	}
-	while (started[STEP_RESOLVE_ROUTE] != completed[STEP_RESOLVE_ROUTE]) sched_yield();
+	while (started[STEP_RESOLVE_ROUTE] != completed[STEP_RESOLVE_ROUTE])
+		sched_yield();
 	end_time(STEP_RESOLVE_ROUTE);
 
 	printf("creating qp\n");
@@ -593,7 +595,8 @@ static int run_client(void)
 		}
 		started[STEP_CONNECT]++;
 	}
-	while (started[STEP_CONNECT] != completed[STEP_CONNECT]) sched_yield();
+	while (started[STEP_CONNECT] != completed[STEP_CONNECT])
+		sched_yield();
 	end_time(STEP_CONNECT);
 
 	printf("disconnecting\n");
@@ -606,7 +609,8 @@ static int run_client(void)
 		rdma_destroy_qp(nodes[i].id);
 		started[STEP_DISCONNECT]++;
 	}
-	while (started[STEP_DISCONNECT] != completed[STEP_DISCONNECT]) sched_yield();
+	while (started[STEP_DISCONNECT] != completed[STEP_DISCONNECT])
+		sched_yield();
 	end_time(STEP_DISCONNECT);
 
 	return ret;

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -459,10 +459,8 @@ static int run_server(void)
 	}
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &rai);
-	if (ret) {
-		printf("getrdmaaddr error: %s\n", gai_strerror(ret));
+	if (ret)
 		goto out;
-	}
 
 	ret = rdma_bind_addr(listen_id, rai->ai_src_addr);
 	if (ret) {
@@ -488,10 +486,8 @@ static int run_client(void)
 	int i, ret;
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &rai);
-	if (ret) {
+	if (ret)
 		printf("getaddrinfo error: %s\n", gai_strerror(ret));
-		return ret;
-	}
 
 	conn_param.responder_resources = 1;
 	conn_param.initiator_depth = 1;

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -683,8 +683,6 @@ freenodes:
 
 destroy:
 	rdma_destroy_event_channel(channel);
-	if (rai)
-		rdma_freeaddrinfo(rai);
-
+	rdma_freeaddrinfo(rai);
 	return ret;
 }

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -649,9 +649,9 @@ int main(int argc, char **argv)
 	if (ret)
 		goto out;
 
-	channel = create_first_event_channel();
+	channel = create_event_channel();
 	if (!channel) {
-		ret = -ENOMEM;
+		ret = -errno;
 		goto freeinfo;
 	}
 

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -167,7 +167,7 @@ int do_poll(struct pollfd *fds, int timeout)
 	return ret == 1 ? (fds->revents & (POLLERR | POLLHUP)) : ret;
 }
 
-struct rdma_event_channel *create_first_event_channel(void)
+struct rdma_event_channel *create_event_channel(void)
 {
 	struct rdma_event_channel *channel;
 

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -51,15 +51,17 @@ int get_rdma_addr(const char *src, const char *dst, const char *port,
 	struct rdma_addrinfo rai_hints, *res;
 	int ret;
 
-	if (hints->ai_flags & RAI_PASSIVE)
-		return rdma_getaddrinfo(src, port, hints, rai);
+	if (hints->ai_flags & RAI_PASSIVE) {
+		ret = rdma_getaddrinfo(src, port, hints, rai);
+		goto out;
+	}
 
 	rai_hints = *hints;
 	if (src) {
 		rai_hints.ai_flags |= RAI_PASSIVE;
 		ret = rdma_getaddrinfo(src, NULL, &rai_hints, &res);
 		if (ret)
-			return ret;
+			goto out;
 
 		rai_hints.ai_src_addr = res->ai_src_addr;
 		rai_hints.ai_src_len = res->ai_src_len;
@@ -70,6 +72,9 @@ int get_rdma_addr(const char *src, const char *dst, const char *port,
 	if (src)
 		rdma_freeaddrinfo(res);
 
+out:
+	if (ret)
+		printf("rdma_getaddrinfo error: %s\n", gai_strerror(ret));
 	return ret;
 }
 

--- a/librdmacm/examples/common.h
+++ b/librdmacm/examples/common.h
@@ -36,6 +36,7 @@
 #include <sys/types.h>
 #include <endian.h>
 #include <poll.h>
+#include <time.h>
 
 #include <rdma/rdma_cma.h>
 #include <rdma/rsocket.h>
@@ -105,3 +106,16 @@ int verify_buf(void *buf, int size);
 int do_poll(struct pollfd *fds, int timeout);
 
 struct rdma_event_channel *create_event_channel(void);
+
+static inline uint64_t gettime_ns(void)
+{
+	struct timespec now;
+
+	clock_gettime(CLOCK_MONOTONIC, &now);
+	return now.tv_sec * 1000000000 + now.tv_nsec;
+}
+
+static inline uint64_t gettime_us(void)
+{
+	return gettime_ns() / 1000;
+}

--- a/librdmacm/examples/common.h
+++ b/librdmacm/examples/common.h
@@ -103,4 +103,5 @@ int size_to_count(int size);
 void format_buf(void *buf, int size);
 int verify_buf(void *buf, int size);
 int do_poll(struct pollfd *fds, int timeout);
-struct rdma_event_channel *create_first_event_channel(void);
+
+struct rdma_event_channel *create_event_channel(void);

--- a/librdmacm/examples/mckey.c
+++ b/librdmacm/examples/mckey.c
@@ -651,7 +651,7 @@ int main(int argc, char **argv)
 	test.dst_addr = (struct sockaddr *) &test.dst_in;
 	test.connects_left = connections;
 
-	test.channel = create_first_event_channel();
+	test.channel = create_event_channel();
 	if (!test.channel) {
 		exit(1);
 	}

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -1362,7 +1362,7 @@ int main(int argc, char *argv[])
 		goto out;
 	}
 
-	cb->cm_channel = create_first_event_channel();
+	cb->cm_channel = create_event_channel();
 	if (!cb->cm_channel) {
 		ret = errno;
 		goto out;

--- a/librdmacm/examples/rstream.c
+++ b/librdmacm/examples/rstream.c
@@ -487,12 +487,10 @@ close:
 	if (ret)
 		rs_close(rs);
 free:
-	if (rai)
-		rdma_freeaddrinfo(rai);
+	rdma_freeaddrinfo(rai);
 	if (ai)
 		freeaddrinfo(ai);
-	if (rai_src)
-		rdma_freeaddrinfo(rai_src);
+	rdma_freeaddrinfo(rai_src);
 	if (ai_src)
 		freeaddrinfo(ai_src);
 	return ret;

--- a/librdmacm/examples/udaddy.c
+++ b/librdmacm/examples/udaddy.c
@@ -693,8 +693,7 @@ int main(int argc, char **argv)
 	printf("test complete\n");
 	destroy_nodes();
 	rdma_destroy_event_channel(test.channel);
-	if (test.rai)
-		rdma_freeaddrinfo(test.rai);
+	rdma_freeaddrinfo(test.rai);
 
 	printf("return status %d\n", ret);
 	return ret;

--- a/librdmacm/examples/udaddy.c
+++ b/librdmacm/examples/udaddy.c
@@ -671,7 +671,7 @@ int main(int argc, char **argv)
 
 	test.connects_left = connections;
 
-	test.channel = create_first_event_channel();
+	test.channel = create_event_channel();
 	if (!test.channel) {
 		exit(1);
 	}

--- a/librdmacm/examples/udaddy.c
+++ b/librdmacm/examples/udaddy.c
@@ -522,10 +522,8 @@ static int run_server(void)
 	}
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &test.rai);
-	if (ret) {
-		printf("udaddy: getrdmaaddr error: %s\n", gai_strerror(ret));
+	if (ret)
 		goto out;
-	}
 
 	ret = rdma_bind_addr(listen_id, test.rai->ai_src_addr);
 	if (ret) {
@@ -571,10 +569,8 @@ static int run_client(void)
 	printf("udaddy: starting client\n");
 
 	ret = get_rdma_addr(src_addr, dst_addr, port, &hints, &test.rai);
-	if (ret) {
-		printf("udaddy: getaddrinfo error: %s\n", gai_strerror(ret));
+	if (ret)
 		return ret;
-	}
 
 	printf("udaddy: connecting\n");
 	for (i = 0; i < connections; i++) {

--- a/librdmacm/man/cmtime.1
+++ b/librdmacm/man/cmtime.1
@@ -7,15 +7,35 @@ cmtime \- RDMA CM connection steps timing test.
 .nf
 \fIcmtime\fR [-s server_address] [-b bind_address]
 			[-c connections] [-p port_number]
+			[-q base_qpn]
 			[-r retries] [-t timeout_ms]
 .fi
 .SH "DESCRIPTION"
-Determines min and max times for various "steps" in RDMA CM
+Determines min, max, and average times for various "steps" in RDMA CM
 connection setup and teardown between a client and server
 application.
 
-"Steps" that are timed are: create id, bind address, resolve address,
-resolve route, create qp, connect, disconnect, and destroy.
+"Steps" that are timed are: create ID, bind address, resolve address,
+resolve route, create QP, modify QP to INIT, modify QP to RTR,
+modify QP to RTS, CM connect, client establish, disconnect, destroy QP,
+and destroy ID.
+
+Many operations are asynchronous, allowing progress on multiple connections
+simultanesously.  The 'sum' output adds the time that all connections took
+for a given step.  The average 'us/conn' is the sum divided by the number
+of connections.  This is useful to identify steps which take a significant
+amount of time.  The min and max values are the smallest and largest times
+that any single connection took to complete a given step.
+
+The 'total' and 'avg/iter' times measure the time to complete a given step
+for all connections.  These two values take into account asynchronous
+operations.  For steps which are serial, the total and sum values will be
+roughly the same.  For asynchronous steps, the total may be significantly
+lower than the sum, as multiple connections will be in progress simultanesously.
+The avg/iter is the total time divided by the number of connections.
+
+In many cases, times may not be available or only available on the client.
+Is such situations, the output will show 0.
 .SH "OPTIONS"
 .TP
 \-s server_address
@@ -32,6 +52,11 @@ server.  (default 100)
 .TP
 \-p port_number
 The server's port number.
+.TP
+\-q base_qpn
+The first QP number to use when creating connections without allocating
+hardware QPs.  The test will use the values between base_qpn and base_qpn
+plus connections when connecting.  (default 1000)
 .TP
 \-r retries
 Number of retries when resolving address or route.  (default 2)


### PR DESCRIPTION
There's a need to analyze and improve the CM flow.  To support that, significantly update the cmtime test to provide additional data and make it more suitable to be extended.

Changes include: Code cleanups and restructuring.  Reduce test overhead.  Replace rdma_cm management of QPs with direct QP manipulation, to get better timings of the cost of creating and modifying QPs.  Expand timing to include other steps.  Provide additional data as output.  Switch to improved time stamp calls.  Enable execution of CM paths without interacting with HW QPs.

New output looks like this:
```
Client warmup
        Creating IDs
        Binding addresses
        Resolving addresses
        Resolving routes
        Creating QPs
        Allocating verbs resources
        Modify QPs to INIT
        Connecting
        Disconnecting
        Destroying QPs
        Destroying IDs
Connect (1000) QPs test
        Creating IDs
        Binding addresses
        Resolving addresses
        Resolving routes
        Creating QPs
        Modify QPs to INIT
        Connecting
        Disconnecting
        Destroying QPs
        Destroying IDs
step              us/conn    sum(us)    max(us)    min(us)  total(us)   avg/iter
full connect :          0          0     888620     449073     889795        889
create id    :          1       1111          9          0       1173          1
bind addr    :          1       1451         73          1       1487          1
resolve addr :         15      15068         42          5       1537          1
resolve route:      78510   78510725     204775         97     206685        206
create qp    :        118     118524        251        111     118595        118
init qp attr :          0        550          2          0          0          0
init qp      :        117     117412        218        114     118060        118
rtr qp attr  :          0        611          1          0          0          0
rtr qp       :        122     122798        397        114          0          0
rts qp attr  :          0        510          1          0          0          0
rts qp       :         80      80296        108         73          0          0
cm connect   :     221221  221221333     438878       1508     442226        442
establish    :          1       1661          8          1          0          0
disconnect   :      81566   81566044    6392013       3400    6393192       6393
destroy id   :          1       1552         89          1       1588          1
destroy qp   :        588     588545       1084        554     588582        588
Connect (1000) test - no QPs
        Creating IDs
        Binding addresses
        Resolving addresses
        Resolving routes
        Creating QPs
        Modify QPs to INIT
        Connecting
        Disconnecting
        Destroying QPs
        Destroying IDs
step              us/conn    sum(us)    max(us)    min(us)  total(us)   avg/iter
full connect :          0          0     221590     214196     222545        222
create id    :          0        898          4          0        951          0
bind addr    :          1       1431        103          1       1459          1
resolve addr :         10      10818         25          3       1839          1
resolve route:     101123  101123659     204358       3613     205703        205
create qp    :          0         42          1          0         87          0
init qp attr :          0        471          2          0          0          0
init qp      :          0         33          1          0        559          0
rtr qp attr  :          0        500          2          0          0          0
rtr qp       :          0         28          1          0          0          0
rts qp attr  :          0        370          1          0          0          0
rts qp       :          0         34          7          0          0          0
cm connect   :       5936    5936575       8439       3152      11911         11
establish    :          2       2475         30          1          0          0
disconnect   :       8251    8251319       9008       5193      10659         10
destroy id   :          1       1537         65          1       1564          1
destroy qp   :          0         28          1          0         72          0
```
