### PR TITLE
mana: add PCI vendor/device match for 3.10

### DIFF
--- a/providers/mana/mana.c
+++ b/providers/mana/mana.c
@@ -28,8 +28,13 @@ DECLARE_DRV_CMD(mana_alloc_pd, IB_USER_VERBS_CMD_ALLOC_PD, empty, empty);
 DECLARE_DRV_CMD(mana_create_cq, IB_USER_VERBS_CMD_CREATE_CQ, mana_ib_create_cq,
 		empty);
 
+#define MICROSOFT_MANA_VENDOR_ID	0x1414
+#define MICROSOFT_MANA_DEVICE_ID	0x00ba
+
 static const struct verbs_match_ent hca_table[] = {
 	VERBS_DRIVER_ID(RDMA_DRIVER_MANA),
+	/* For support of the legacy kernels that have no CHARDEV NL support */
+	VERBS_PCI_MATCH(MICROSOFT_MANA_VENDOR_ID, MICROSOFT_MANA_DEVICE_ID, NULL),
 	{},
 };
 


### PR DESCRIPTION
This patch adds PCI vendor-device match for the MANA RDMA provider, which allows to use it on older kernels such as 3.10 which lacks support of the CHARDEV NetLink interface.