### PR TITLE
librdmacm/cmtime: Add multi-thread support

### DIFF
--- a/librdmacm/examples/CMakeLists.txt
+++ b/librdmacm/examples/CMakeLists.txt
@@ -2,9 +2,10 @@
 add_library(rdmacm_tools STATIC
   common.c
   )
+target_link_libraries(rdmacm_tools LINK_PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 
 rdma_executable(cmtime cmtime.c)
-target_link_libraries(cmtime LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT} rdmacm_tools)
+target_link_libraries(cmtime LINK_PRIVATE rdmacm rdmacm_tools)
 
 rdma_executable(mckey mckey.c)
 target_link_libraries(mckey LINK_PRIVATE rdmacm ${CMAKE_THREAD_LIBS_INIT} rdmacm_tools)

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -169,13 +169,19 @@ static void show_perf(int iter)
 	/* Reporting the 'sum' of the full connect is meaningless */
 	sum[STEP_FULL_CONNECT] = 0;
 
-	printf("step              us/conn    sum(us)    max(us)    min(us)  total(us)   avg/iter\n");
+	if (atomic_load(&cur_qpn) == 0)
+		printf("qp_conn        %10d\n", iter);
+	else
+		printf("cm_conn        %10d\n", iter);
+	printf("threads        %10d\n", num_threads);
+
+	printf("step             avg/iter  total(us)    us/conn    sum(us)    max(us)    min(us)\n");
 	for (i = 0; i < STEP_CNT; i++) {
 		diff = (uint32_t) (times[i][1] - times[i][0]);
 
-		printf("%-13s: %10u %10u %10u %10u %10d %10u\n",
-			step_str[i], sum[i] / iter, sum[i],
-			max[i], min[i], diff, diff / iter);
+		printf("%-13s  %10u %10u %10u %10u %10d %10u\n",
+			step_str[i], diff / iter, diff,
+			sum[i] / iter, sum[i], max[i], min[i]);
 	}
 }
 

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -369,6 +369,8 @@ static void client_disconnect(struct work_item *item)
 
 	start_perf(n, STEP_DISCONNECT);
 	rdma_disconnect(n->id);
+	end_perf(n, STEP_DISCONNECT);
+	completed[STEP_DISCONNECT]++;
 }
 
 static void server_disconnect(struct work_item *item)
@@ -439,10 +441,16 @@ static void cma_handler(struct rdma_cm_id *id, struct rdma_cm_event *event)
 		exit(EXIT_FAILURE);
 		break;
 	case RDMA_CM_EVENT_DISCONNECTED:
-		if (is_client()) {
+		if (!is_client()) {
+			/* To fix an issue where DREQs are not responded
+			 * to, the client completes its disconnect phase
+			 * as soon as it calls rdma_disconnect and does
+			 * not wait for a response from the server.  The
+			 * OOB sync handles that coordiation
 			end_perf(n, STEP_DISCONNECT);
 			completed[STEP_DISCONNECT]++;
 		} else {
+			 */
 			if (disc_events == 0) {
 				printf("\tDisconnecting\n");
 				start_time(STEP_DISCONNECT);

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -763,7 +763,7 @@ int main(int argc, char **argv)
 
 	hints.ai_port_space = RDMA_PS_TCP;
 	hints.ai_qp_type = IBV_QPT_RC;
-	while ((op = getopt(argc, argv, "s:b:c:m:p:q:r:t:")) != -1) {
+	while ((op = getopt(argc, argv, "s:b:c:m:n:p:q:r:t:")) != -1) {
 		switch (op) {
 		case 's':
 			dst_addr = optarg;
@@ -784,6 +784,9 @@ int main(int argc, char **argv)
 			mimic_qp_delay = (uint32_t) atoi(optarg);
 			mimic = true;
 			break;
+		case 'n':
+			num_threads = (uint32_t) atoi(optarg);
+			break;
 		case 'r':
 			retries = atoi(optarg);
 			break;
@@ -798,6 +801,7 @@ int main(int argc, char **argv)
 			printf("\t[-p port_number]\n");
 			printf("\t[-q base_qpn]\n");
 			printf("\t[-m mimic_qp_delay_us]\n");
+			printf("\t[-n num_threads]\n");
 			printf("\t[-r retries]\n");
 			printf("\t[-t timeout_ms]\n");
 			exit(EXIT_FAILURE);

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -38,7 +38,10 @@
 #include <errno.h>
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
+#include <netinet/tcp.h>
 #include <netdb.h>
+#include <unistd.h>
 
 #include <rdma/rdma_cma.h>
 #include "common.h"
@@ -179,4 +182,115 @@ struct rdma_event_channel *create_event_channel(void)
 			perror("failed to create RDMA CM event channel");
 	}
 	return channel;
+}
+
+int oob_server_setup(const char *src_addr, const char *port, int *sock)
+{
+	struct addrinfo hint = {}, *ai;
+	int listen_sock;
+	int optval = 1;
+	int ret;
+
+	hint.ai_flags = AI_PASSIVE;
+	hint.ai_family = AF_INET;
+	hint.ai_socktype = SOCK_STREAM;
+	ret = getaddrinfo(src_addr, port, &hint, &ai);
+	if (ret) {
+		printf("getaddrinfo error: %s\n", gai_strerror(ret));
+		return ret;
+	}
+
+	listen_sock = socket(ai->ai_family, ai->ai_socktype, 0);
+	if (listen_sock == -1) {
+		ret = -errno;
+		goto free;
+	}
+
+	setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+	ret = bind(listen_sock, ai->ai_addr, ai->ai_addrlen);
+	if (ret) {
+		ret = -errno;
+		goto close;
+	}
+
+	ret = listen(listen_sock, 1);
+	if (ret) {
+		ret = -errno;
+		goto close;
+	}
+
+	*sock = accept(listen_sock, NULL, NULL);
+	if (*sock == -1)
+		ret = -errno;
+	setsockopt(*sock, IPPROTO_TCP, TCP_NODELAY, &optval, sizeof(optval));
+
+close:
+	close(listen_sock);
+free:
+	freeaddrinfo(ai);
+	return ret;
+}
+
+int oob_client_setup(const char *dst_addr, const char *port, int *sock)
+{
+	struct addrinfo hint = {}, *ai;
+	int nodelay = 1;
+	int ret;
+
+	hint.ai_family = AF_INET;
+	hint.ai_socktype = SOCK_STREAM;
+	ret = getaddrinfo(dst_addr, port, &hint, &ai);
+	if (ret) {
+		printf("getaddrinfo error: %s\n", gai_strerror(ret));
+		return ret;
+	}
+
+	*sock = socket(ai->ai_family, ai->ai_socktype, 0);
+	if (*sock == -1) {
+		ret = -errno;
+		goto out;
+	}
+	setsockopt(*sock, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof(nodelay));
+
+	ret = connect(*sock, ai->ai_addr, ai->ai_addrlen);
+out:
+	freeaddrinfo(ai);
+	return ret;
+}
+
+int oob_sendrecv(int sock, char val)
+{
+	char c = val;
+	ssize_t ret;
+
+	ret = send(sock, (void *) &c, sizeof(c), 0);
+	if (ret != sizeof(c))
+		return -errno;
+
+	ret = recv(sock, (void *) &c, sizeof(c), 0);
+	if (ret != sizeof(c))
+		return -errno;
+
+	if (c != val)
+		return -EINVAL;
+	return 0;
+}
+
+int oob_recvsend(int sock, char val)
+{
+	char c = 0;
+	ssize_t ret;
+
+	ret = recv(sock, (void *) &c, sizeof(c), 0);
+	if (ret != sizeof(c))
+		return -errno;
+
+	if (c != val)
+		return -EINVAL;
+
+	ret = send(sock, (void *) &c, sizeof(c), 0);
+	if (ret != sizeof(c))
+		return -errno;
+
+	return 0;
 }

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -395,6 +395,8 @@ static void *wq_handler(void *arg)
 		}
 
 		item = wq_remove(wq);
+		if (wq->head)
+			pthread_cond_signal(&wq->cond);
 		pthread_mutex_unlock(&wq->lock);
 
 		item->work_handler(item);

--- a/librdmacm/examples/common.c
+++ b/librdmacm/examples/common.c
@@ -36,6 +36,7 @@
 #include <string.h>
 #include <stdio.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -293,4 +294,116 @@ int oob_recvsend(int sock, char val)
 		return -errno;
 
 	return 0;
+}
+
+static void *wq_handler(void *arg);
+
+int wq_init(struct work_queue *wq, int thread_cnt)
+{
+	int ret, i;
+
+	wq->head = NULL;
+	wq->tail = NULL;
+
+	ret = pthread_mutex_init(&wq->lock, NULL);
+	if (ret) {
+		perror("pthread_mutex_init");
+		return ret;
+	}
+
+	ret = pthread_cond_init(&wq->cond, NULL);
+	if (ret) {
+		perror("pthread_cond_init");
+		return ret;
+	}
+
+	wq->thread_cnt = thread_cnt;
+	wq->thread = calloc(thread_cnt, sizeof(*wq->thread));
+	if (!wq->thread)
+		return -ENOMEM;
+
+	wq->running = true;
+	for (i = 0; i < thread_cnt; i++) {
+		ret = pthread_create(&wq->thread[i], NULL, wq_handler, wq);
+		if (ret) {
+			perror("pthread_create");
+			return ret;
+		}
+	}
+
+	return 0;
+}
+
+void wq_cleanup(struct work_queue *wq)
+{
+	int i;
+
+	pthread_mutex_lock(&wq->lock);
+	wq->running = false;
+	pthread_cond_broadcast(&wq->cond);
+	pthread_mutex_unlock(&wq->lock);
+
+	for (i = 0; i < wq->thread_cnt; i++)
+		pthread_join(wq->thread[i], NULL);
+	pthread_cond_destroy(&wq->cond);
+	pthread_mutex_destroy(&wq->lock);
+}
+
+void wq_insert(struct work_queue *wq, struct work_item *item,
+	       void (*work_handler)(struct work_item *item))
+{
+	bool empty;
+
+	item->next = NULL;
+	item->work_handler = work_handler;
+	pthread_mutex_lock(&wq->lock);
+	if (wq->head) {
+		wq->tail->next = item;
+		empty = false;
+	} else {
+		wq->head = item;
+		empty = true;
+	}
+	wq->tail = item;
+	pthread_mutex_unlock(&wq->lock);
+
+	if (empty)
+		pthread_cond_signal(&wq->cond);
+}
+
+struct work_item *wq_remove(struct work_queue *wq)
+{
+	struct work_item *item;
+
+	item = wq->head;
+	wq->head = wq->head->next;
+	item->next = NULL;
+	return item;
+}
+
+static void *wq_handler(void *arg)
+{
+	struct work_queue *wq = arg;
+	struct work_item *item;
+
+	pthread_mutex_lock(&wq->lock);
+	while (wq->running) {
+		while (!wq->head) {
+			pthread_cond_wait(&wq->cond, &wq->lock);
+			if (!wq->running)
+				goto out;
+		}
+
+		item = wq_remove(wq);
+		pthread_mutex_unlock(&wq->lock);
+
+		item->work_handler(item);
+		pthread_mutex_lock(&wq->lock);
+	}
+
+out:
+	if (wq->head)
+		pthread_cond_signal(&wq->cond);
+	pthread_mutex_unlock(&wq->lock);
+	return NULL;
 }

--- a/librdmacm/examples/common.h
+++ b/librdmacm/examples/common.h
@@ -119,3 +119,15 @@ static inline uint64_t gettime_us(void)
 {
 	return gettime_ns() / 1000;
 }
+
+static inline int sleep_us(unsigned int time_us)
+{
+	struct timespec spec;
+
+	if (!time_us)
+		return 0;
+
+	spec.tv_sec = 0;
+	spec.tv_nsec = time_us * 1000;
+	return nanosleep(&spec, NULL);
+}

--- a/librdmacm/examples/common.h
+++ b/librdmacm/examples/common.h
@@ -98,6 +98,11 @@ enum rs_optimization {
 int get_rdma_addr(const char *src, const char *dst, const char *port,
 		  struct rdma_addrinfo *hints, struct rdma_addrinfo **rai);
 
+int oob_server_setup(const char *src_addr, const char *port, int *sock);
+int oob_client_setup(const char *dst_addr, const char *port, int *sock);
+int oob_sendrecv(int sock, char val);
+int oob_recvsend(int sock, char val);
+
 void size_str(char *str, size_t ssize, long long size);
 void cnt_str(char *str, size_t ssize, long long cnt);
 int size_to_count(int size);

--- a/librdmacm/man/cmtime.1
+++ b/librdmacm/man/cmtime.1
@@ -57,6 +57,11 @@ The server's port number.
 The first QP number to use when creating connections without allocating
 hardware QPs.  The test will use the values between base_qpn and base_qpn
 plus connections when connecting.  (default 1000)
+.TP
+\-n num_threads
+Sets the number of threads to spawn used to process connection events
+and hardware operations.  (default 1)
+.TP
 \-m mimic_qp_delay_us
 "Simulates" QP creation and modify calls by replacing them with a
 simple sleep function instead.  This allows testing the CM at larger

--- a/librdmacm/man/cmtime.1
+++ b/librdmacm/man/cmtime.1
@@ -57,6 +57,11 @@ The server's port number.
 The first QP number to use when creating connections without allocating
 hardware QPs.  The test will use the values between base_qpn and base_qpn
 plus connections when connecting.  (default 1000)
+\-m mimic_qp_delay_us
+"Simulates" QP creation and modify calls by replacing them with a
+simple sleep function instead.  This allows testing the CM at larger
+scale than would be practical, or even possible given system
+configuration settings, if HW resources needed to be allocated.
 .TP
 \-r retries
 Number of retries when resolving address or route.  (default 2)

--- a/librdmacm/man/cmtime.1
+++ b/librdmacm/man/cmtime.1
@@ -71,6 +71,11 @@ configuration settings, if HW resources needed to be allocated.
 \-r retries
 Number of retries when resolving address or route.  (default 2)
 .TP
+\-S
+Run connection rate test using sockets.  This provides a baseline
+comparison of RDMA connections versus TCP connections.  Sockets are
+set to blocking mode.
+.TP
 \-t timeout_ms
 Timeout in millseconds (ms) when resolving address or
 route.  (default 2000 - 2 seconds)


### PR DESCRIPTION
The primary objective of this series is to add multi-thread support to the cmtime app. Multi-threading is added by abstracting and generalizing the work queue abstraction used by cmtime.  (If there's a usable version of a work queue suitable for rdma-core use, I can switch to that if needed.)  The series also adds:

- Ability to 'mimic' QP operations, by replacing QP calls with sleeps.  This allows testing at scales where QP resources may not be available.
- Add out-of-band synchronization mechanism to enable more precise timing of different testing steps.
- Remove incomplete, complex, and unnecessary error handling.  Just abort test on unexpected errors.

The final version of cmtime could use a review to verify that it is capturing the data as intended.

