### PR TITLE
bnxt_re/lib: Fix the stride calculation for MSN/PSN area

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1391,7 +1391,7 @@ static int bnxt_re_alloc_queues(struct bnxt_re_qp *qp,
 	 */
 	que->pad = (que->va + que->depth * que->stride);
 	psn_size = bnxt_re_get_psne_size(qp->cntx);
-	que->pad_stride_log2 = ilog32(psn_size);
+	que->pad_stride_log2 = ilog32(psn_size - 1);
 
 	ret = bnxt_re_alloc_init_swque(qp->jsqq, qp->mem, &qattr[indx]);
 	if (ret)


### PR DESCRIPTION
Library expects ilog2 of psn_size while calculating the stride. ilog32 returns log2(v) + 1 and the calculation fails since the psn size is a power of 2 value. Fix by passing psn_size - 1.

Fixes: 0a0e0d0114c5 ("bnxt_re/lib: Adds MSN table capability for Gen P7 adapters")