### PR TITLE
efa: Add unsolicited RDMA write with immediate receive support

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -85,11 +85,17 @@ enum {
 	EFA_QP_DRIVER_TYPE_SRD = 0,
 };
 
+enum {
+	EFA_CREATE_QP_WITH_UNSOLICITED_WRITE_RECV = 1 << 0,
+};
+
 struct efa_ibv_create_qp {
 	__u32 comp_mask;
 	__u32 rq_ring_size; /* bytes */
 	__u32 sq_ring_size; /* bytes */
 	__u32 driver_qp_type;
+	__u16 flags;
+	__u8 reserved_90[6];
 };
 
 struct efa_ibv_create_qp_resp {
@@ -123,6 +129,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_CQ_WITH_SGID     = 1 << 3,
 	EFA_QUERY_DEVICE_CAPS_DATA_POLLING_128 = 1 << 4,
 	EFA_QUERY_DEVICE_CAPS_RDMA_WRITE = 1 << 5,
+	EFA_QUERY_DEVICE_CAPS_UNSOLICITED_WRITE_RECV = 1 << 6,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/kernel-headers/rdma/mana-abi.h
+++ b/kernel-headers/rdma/mana-abi.h
@@ -16,8 +16,20 @@
 
 #define MANA_IB_UVERBS_ABI_VERSION 1
 
+enum mana_ib_create_cq_flags {
+	MANA_IB_CREATE_RNIC_CQ	= 1 << 0,
+};
+
 struct mana_ib_create_cq {
 	__aligned_u64 buf_addr;
+	__u16	flags;
+	__u16	reserved0;
+	__u32	reserved1;
+};
+
+struct mana_ib_create_cq_resp {
+	__u32 cqid;
+	__u32 reserved;
 };
 
 struct mana_ib_create_qp {

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -558,6 +558,12 @@ enum rdma_nldev_attr {
 
 	RDMA_NLDEV_SYS_ATTR_PRIVILEGED_QKEY_MODE, /* u8 */
 
+	RDMA_NLDEV_ATTR_DRIVER_DETAILS,		/* u8 */
+	/*
+	 * QP subtype string, used for driver QPs
+	 */
+	RDMA_NLDEV_ATTR_RES_SUBTYPE,		/* string */
+
 	/*
 	 * Always the end
 	 */

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef _EFA_IO_H_
@@ -208,7 +208,7 @@ struct efa_io_rx_desc {
 struct efa_io_cdesc_common {
 	/*
 	 * verbs-generated request ID, as provided in the completed tx or rx
-	 *    descriptor.
+	 * descriptor.
 	 */
 	uint16_t req_id;
 
@@ -221,7 +221,8 @@ struct efa_io_cdesc_common {
 	 * 3 : has_imm - indicates that immediate data is
 	 *    present - for RX completions only
 	 * 6:4 : op_type - enum efa_io_send_op_type
-	 * 7 : reserved31 - MBZ
+	 * 7 : unsolicited - indicates that there is no
+	 *    matching request - for RDMA with imm. RX only
 	 */
 	uint8_t flags;
 
@@ -301,5 +302,6 @@ struct efa_io_rx_cdesc_ex {
 #define EFA_IO_CDESC_COMMON_Q_TYPE_MASK                     GENMASK(2, 1)
 #define EFA_IO_CDESC_COMMON_HAS_IMM_MASK                    BIT(3)
 #define EFA_IO_CDESC_COMMON_OP_TYPE_MASK                    GENMASK(6, 4)
+#define EFA_IO_CDESC_COMMON_UNSOLICITED_MASK                BIT(7)
 
 #endif /* _EFA_IO_H_ */

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -8,6 +8,7 @@
 
 #include <stdio.h>
 #include <sys/types.h>
+#include <stdbool.h>
 
 #include <infiniband/verbs.h>
 
@@ -24,10 +25,15 @@ struct ibv_qp *efadv_create_driver_qp(struct ibv_pd *ibvpd,
 				      struct ibv_qp_init_attr *attr,
 				      uint32_t driver_qp_type);
 
+enum {
+	EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV = 1 << 0,
+};
+
 struct efadv_qp_init_attr {
 	uint64_t comp_mask;
 	uint32_t driver_qp_type;
-	uint8_t reserved[4];
+	uint16_t flags;
+	uint8_t reserved[2];
 };
 
 struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
@@ -40,6 +46,7 @@ enum {
 	EFADV_DEVICE_ATTR_CAPS_RNR_RETRY = 1 << 1,
 	EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID = 1 << 2,
 	EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE = 1 << 3,
+	EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV = 1 << 4,
 };
 
 struct efadv_device_attr {
@@ -70,10 +77,12 @@ int efadv_query_ah(struct ibv_ah *ibvah, struct efadv_ah_attr *attr,
 struct efadv_cq {
 	uint64_t comp_mask;
 	int (*wc_read_sgid)(struct efadv_cq *efadv_cq, union ibv_gid *sgid);
+	bool (*wc_is_unsolicited)(struct efadv_cq *efadv_cq);
 };
 
 enum {
 	EFADV_WC_EX_WITH_SGID = 1 << 0,
+	EFADV_WC_EX_WITH_IS_UNSOLICITED = 1 << 1,
 };
 
 struct efadv_cq_init_attr {
@@ -92,6 +101,11 @@ static inline int efadv_wc_read_sgid(struct efadv_cq *efadv_cq,
 				     union ibv_gid *sgid)
 {
 	return efadv_cq->wc_read_sgid(efadv_cq, sgid);
+}
+
+static inline bool efadv_wc_is_unsolicited(struct efadv_cq *efadv_cq)
+{
+	return efadv_cq->wc_is_unsolicited(efadv_cq);
 }
 
 enum {

--- a/providers/efa/man/efadv_create_cq.3.md
+++ b/providers/efa/man/efadv_create_cq.3.md
@@ -62,12 +62,19 @@ struct efadv_cq_init_attr {
 	EFADV_WC_EX_WITH_SGID:
 		if source AH is unknown, require sgid in WC.
 
+	EFADV_WC_EX_WITH_IS_UNSOLICITED:
+		request for an option to check whether a receive WC is unsolicited.
+
 
 # Completion iterator functions
 
 *efadv_wc_read_sgid*
 :	Get the source GID field from the current completion.
 	If the AH is known, a negative error value is returned.
+
+*efadv_wc_is_unsolicited*
+:	Check whether it's an unsolicited receive completion that has no matching work request.
+	This function is available if the CQ was created with EFADV_WC_EX_WITH_IS_UNSOLICITED.
 
 
 # RETURN VALUE

--- a/providers/efa/man/efadv_create_qp_ex.3.md
+++ b/providers/efa/man/efadv_create_qp_ex.3.md
@@ -44,7 +44,8 @@ Compatibility is handled using the comp_mask and inlen fields.
 struct efadv_qp_init_attr {
 	uint64_t comp_mask;
 	uint32_t driver_qp_type;
-	uint8_t reserved[4];
+	uint16_t flags;
+	uint8_t reserved[2];
 };
 ```
 
@@ -59,6 +60,12 @@ struct efadv_qp_init_attr {
 
 	EFADV_QP_DRIVER_TYPE_SRD:
 		Create an SRD QP.
+
+*flags*
+:       A bitwise OR of the values described below.
+
+	EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV:
+		Receive WRs will not be consumed for RDMA write with imm.
 
 # RETURN VALUE
 

--- a/providers/efa/man/efadv_query_device.3.md
+++ b/providers/efa/man/efadv_query_device.3.md
@@ -79,6 +79,12 @@ struct efadv_device_attr {
 	EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE:
 		RDMA write is supported
 
+	EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV:
+		Indicates the device has support for creating QPs that can receive unsolicited
+		RDMA write with immediate. RQ with this feature enabled will not consume any work
+		requests in order to receive RDMA write with immediate and a WC generated for such
+		receive will be marked as unsolicited.
+
 *max_rdma_size*
 :	Maximum RDMA transfer size in bytes.
 

--- a/pyverbs/providers/efa/efa_enums.pxd
+++ b/pyverbs/providers/efa/efa_enums.pxd
@@ -10,12 +10,17 @@ cdef extern from 'infiniband/efadv.h':
         EFADV_DEVICE_ATTR_CAPS_RNR_RETRY
         EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID
         EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE
+        EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV
 
     cpdef enum:
         EFADV_QP_DRIVER_TYPE_SRD
 
     cpdef enum:
+        EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV
+
+    cpdef enum:
         EFADV_WC_EX_WITH_SGID
+        EFADV_WC_EX_WITH_IS_UNSOLICITED
 
     cpdef enum:
         EFADV_MR_ATTR_VALIDITY_RECV_IC_ID

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -20,6 +20,7 @@ def dev_cap_to_str(flags):
             dve.EFADV_DEVICE_ATTR_CAPS_RNR_RETRY: 'RNR Retry',
             dve.EFADV_DEVICE_ATTR_CAPS_CQ_WITH_SGID: 'CQ entries with source GID',
             dve.EFADV_DEVICE_ATTR_CAPS_RDMA_WRITE: 'RDMA Write',
+            dve.EFADV_DEVICE_ATTR_CAPS_UNSOLICITED_WRITE_RECV: 'Unsolicited RDMA Write receive',
     }
     return bitmask_to_str(flags, l)
 
@@ -170,8 +171,16 @@ cdef class EfaQPInitAttr(PyverbsObject):
         return self.qp_init_attr.driver_qp_type
 
     @driver_qp_type.setter
-    def driver_qp_type(self,val):
+    def driver_qp_type(self, val):
         self.qp_init_attr.driver_qp_type = val
+
+    @property
+    def flags(self):
+        return self.qp_init_attr.flags
+
+    @flags.setter
+    def flags(self, val):
+        self.qp_init_attr.flags = val
 
 
 cdef class SRDQPEx(QPEx):
@@ -251,6 +260,12 @@ cdef class EfaCQ(CQEX):
         if err:
             return None
         return sgid
+
+    def is_unsolicited(self):
+        """
+        Check if current work completion is unsolicited.
+        """
+        return dv.efadv_wc_is_unsolicited(self.dv_cq)
 
 
 cdef class EfaDVMRAttr(PyverbsObject):

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -4,6 +4,7 @@
 #cython: language_level=3
 
 from libc.stdint cimport uint8_t, uint16_t, uint32_t, uint64_t
+from libcpp cimport bool
 cimport pyverbs.libibverbs as v
 
 
@@ -28,7 +29,8 @@ cdef extern from 'infiniband/efadv.h':
     cdef struct efadv_qp_init_attr:
         uint64_t comp_mask;
         uint32_t driver_qp_type;
-        uint8_t reserved[4];
+        uint16_t flags;
+        uint8_t reserved[2];
 
     cdef struct efadv_cq_init_attr:
         uint64_t comp_mask;
@@ -60,4 +62,5 @@ cdef extern from 'infiniband/efadv.h':
                                  uint32_t inlen)
     efadv_cq *efadv_cq_from_ibv_cq_ex(v.ibv_cq_ex *ibvcqx)
     int efadv_wc_read_sgid(efadv_cq *efadv_cq, v.ibv_gid *sgid)
+    bool efadv_wc_is_unsolicited(efadv_cq *efadv_cq)
     int efadv_query_mr(v.ibv_mr *ibvmr, efadv_mr_attr *attr, uint32_t inlen)


### PR DESCRIPTION
This PR extends the EFA direct verbs to enable creation of QPs which RQs do not require explicit receive work requests to anticipate incoming RDMA write with immediate. A new work completion query function allows checking whether a work completion is unsolicited.

Related kernel patch: https://lore.kernel.org/all/20240506104859.9225-1-mrgolin@amazon.com/