### PR TITLE
debian: Correct libhns library name in lintian override

### DIFF
--- a/debian/ibverbs-providers.lintian-overrides
+++ b/debian/ibverbs-providers.lintian-overrides
@@ -1,2 +1,2 @@
 # libefa, libhns, libmana, libmlx4 and libmlx5 are ibverbs provider that provides more functions.
-ibverbs-providers: package-name-doesnt-match-sonames libefa1 libhns-1 libmana1 libmlx4-1 libmlx5-1
+ibverbs-providers: package-name-doesnt-match-sonames libefa1 libhns1 libmana1 libmlx4-1 libmlx5-1


### PR DESCRIPTION
The libhns library is named `libhns1` instead of `libhns-1`.

Fixes: cf6d9149f8f5 ("libhns: Introduce hns direct verbs")