### PR TITLE
Provide own basename API implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,11 +547,7 @@ if (NOT DRM_INCLUDE_DIRS)
 endif()
 
 if (DRM_INCLUDE_DIRS)
-  if (EXISTS ${DRM_INCLUDE_DIRS}/i915_drm.h AND EXISTS ${DRM_INCLUDE_DIRS}/amdgpu_drm.h)
     include_directories(${DRM_INCLUDE_DIRS})
-  else()
-    unset(DRM_INCLUDE_DIRS CACHE)
-  endif()
 endif()
 
 # LTTng Tracer support

--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -19,6 +19,7 @@
 #include <linux/pci_regs.h>
 #include <util/rdma_nl.h>
 
+#include "util/util.h"
 /*
  * Rename modes:
  * NAME_FALLBACK - Try to name devices in the following order:
@@ -259,7 +260,7 @@ static int fill_pci_info(struct data *d, struct pci_info *p)
 
 	buf[ret] = 0;
 
-	pci = basename(buf);
+	pci = rdma_basename(buf);
 	/*
 	 * pci = 0000:00:0c.0
 	 */
@@ -377,7 +378,7 @@ static int by_pci(struct data *d)
 	}
 	buf[ret] = 0;
 
-	subs = basename(buf);
+	subs = rdma_basename(buf);
 	if (strcmp(subs, "pci")) {
 		/* Ball out virtual devices */
 		pr_dbg("%s: Non-PCI device (%s) was detected\n", d->curr, subs);

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -45,6 +45,7 @@
 #include <inttypes.h>
 #include <rdma/rdma_cma.h>
 #include "common.h"
+#include "util/util.h"
 
 static int debug = 0;
 #define DEBUG_LOG if (debug) printf
@@ -1253,9 +1254,9 @@ static int get_addr(char *dst, struct sockaddr *addr)
 static void usage(const char *name)
 {
 	printf("%s -s [-vVd] [-S size] [-C count] [-a addr] [-p port]\n", 
-	       basename(name));
+	       rdma_basename(name));
 	printf("%s -c [-vVd] [-S size] [-C count] [-I addr] -a addr [-p port]\n", 
-	       basename(name));
+	       rdma_basename(name));
 	printf("\t-c\t\tclient side\n");
 	printf("\t-I\t\tSource address to bind to for client.\n");
 	printf("\t-s\t\tserver side.  To bind to any address with IPv6 use -a ::0\n");

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -3508,7 +3508,7 @@ static int mlx5_vfio_get_iommu_group_id(const char *pci_name)
 		return -1;
 
 	iommu_group_path[len] = 0;
-	group_name = basename(iommu_group_path);
+	group_name = rdma_basename(iommu_group_path);
 
 	if (sscanf(group_name, "%d", &groupid) != 1)
 		return -1;

--- a/util/util.c
+++ b/util/util.c
@@ -65,3 +65,10 @@ uint32_t xorshift32(struct xorshift32_state *state)
 	x ^= x << 5;
 	return state->seed = x;
 }
+/* implement a common basename function which behaves like
+   GNU version */
+char *rdma_basename(const char *path)
+{
+  char *p = strrchr(path, '/');
+  return p ? p + 1 : (char *)path;
+}

--- a/util/util.h
+++ b/util/util.h
@@ -100,4 +100,7 @@ int open_cdev(const char *devname_hint, dev_t cdev);
 unsigned int get_random(void);
 
 bool check_env(const char *var);
+
+char *rdma_basename(const char *path);
+
 #endif


### PR DESCRIPTION
basename prototype has been removed from string.h from latest musl [1] compilers e.g. clang-18 flags the absense of prototype as error, it turns out the basename has two different implementations and musl only provides POSIX implementation, whereas glibc has GNU version and posix version both depending upon if string.h is included or not it will pick GNU version,

to avoid this dependency, lets implement own basename function which reflects GNU basename behavior, it will work across all libcs

[1] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7