### PR TITLE
fix potential CQ deadlock in mlx5 provider

### DIFF
--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1163,8 +1163,11 @@ static inline int mlx5_start_poll(struct ibv_cq_ex *ibcq, struct ibv_poll_cq_att
 		goto out;
 	}
 
-	if (clock_update && !err)
+	if (clock_update && !err) {
 		err = mlx5dv_get_clock_info(ibcq->context, &cq->last_clock_info);
+		if (lock && err)
+			mlx5_spin_unlock(&cq->lock);
+	}
 
 out:
 	return err;


### PR DESCRIPTION
We saw deadlock in mlx5_destroy_qp() if ibv_start_poll() returns EBUSY failure.
According to reference (https://man7.org/linux/man-pages/man3/ibv_create_cq_ex.3.html), if ibv_start_poll() returns error, ibv_end_poll() shouldn't be called.
Therefore, we must release the CQ lock in mlx5_start_poll() if mlx5dv_get_clock_info() returns error e.g. EBUSY.