### PR TITLE
Switch to POSIX implementation of basename

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -4,7 +4,7 @@
 #define _GNU_SOURCE
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#include <libgen.h>
 #include <stdbool.h>
 #include <errno.h>
 #include <unistd.h>

--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -34,7 +34,6 @@
 #include <endian.h>
 #include <getopt.h>
 #include <stdlib.h>
-#include <string.h>
 #include <stdio.h>
 #include <errno.h>
 #include <sys/types.h>
@@ -1253,9 +1252,9 @@ static int get_addr(char *dst, struct sockaddr *addr)
 static void usage(const char *name)
 {
 	printf("%s -s [-vVd] [-S size] [-C count] [-a addr] [-p port]\n", 
-	       basename(name));
+	       name);
 	printf("%s -c [-vVd] [-S size] [-C count] [-I addr] -a addr [-p port]\n", 
-	       basename(name));
+	       name);
 	printf("\t-c\t\tclient side\n");
 	printf("\t-I\t\tSource address to bind to for client.\n");
 	printf("\t-s\t\tserver side.  To bind to any address with IPv6 use -a ::0\n");

--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -14,7 +14,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <sys/mman.h>
-#include <string.h>
+#include <libgen.h>
 #include <sys/param.h>
 #include <linux/vfio.h>
 #include <sys/eventfd.h>


### PR DESCRIPTION
- Drop the useless basename calls in rping
- Include libgen for the POSIX version if kernel-boot and mlx5

Both call basename on non-const string generated by readlink of a sysfs path. The original string never re-used afterward.
So in these cases, both flavours of basename behave exactly the same from the code PoV

This should solve the issue raised in #1467 and #1443 