### PR TITLE
mlx5: Add support for creating a CQ with a large UAR page index

### DIFF
--- a/kernel-headers/rdma/ib_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/ib_user_ioctl_cmds.h
@@ -37,9 +37,6 @@
 #define UVERBS_ID_NS_MASK 0xF000
 #define UVERBS_ID_NS_SHIFT 12
 
-#define UVERBS_UDATA_DRIVER_DATA_NS	1
-#define UVERBS_UDATA_DRIVER_DATA_FLAG	(1UL << UVERBS_ID_NS_SHIFT)
-
 enum uverbs_default_objects {
 	UVERBS_OBJECT_DEVICE, /* No instances of DEVICE are allowed */
 	UVERBS_OBJECT_PD,
@@ -61,8 +58,10 @@ enum uverbs_default_objects {
 };
 
 enum {
-	UVERBS_ATTR_UHW_IN = UVERBS_UDATA_DRIVER_DATA_FLAG,
+	UVERBS_ID_DRIVER_NS = 1UL << UVERBS_ID_NS_SHIFT,
+	UVERBS_ATTR_UHW_IN = UVERBS_ID_DRIVER_NS,
 	UVERBS_ATTR_UHW_OUT,
+	UVERBS_ID_DRIVER_NS_WITH_UHW,
 };
 
 enum uverbs_methods_device {

--- a/kernel-headers/rdma/mana-abi.h
+++ b/kernel-headers/rdma/mana-abi.h
@@ -45,6 +45,15 @@ struct mana_ib_create_qp_resp {
 	__u32 reserved;
 };
 
+struct mana_ib_create_rc_qp {
+	__aligned_u64 queue_buf[4];
+	__u32 queue_size[4];
+};
+
+struct mana_ib_create_rc_qp_resp {
+	__u32 queue_id[4];
+};
+
 struct mana_ib_create_wq {
 	__aligned_u64 wq_buf_addr;
 	__u32 wq_buf_size;

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -270,6 +270,10 @@ enum mlx5_ib_device_query_context_attrs {
 	MLX5_IB_ATTR_QUERY_CONTEXT_RESP_UCTX = (1U << UVERBS_ID_NS_SHIFT),
 };
 
+enum mlx5_ib_create_cq_attrs {
+	MLX5_IB_ATTR_CREATE_CQ_UAR_INDEX = UVERBS_ID_DRIVER_NS_WITH_UHW,
+};
+
 #define MLX5_IB_DW_MATCH_PARAM 0xA0
 
 struct mlx5_ib_match_params {

--- a/libibverbs/cmd_write.h
+++ b/libibverbs/cmd_write.h
@@ -96,6 +96,13 @@ void _write_set_uhw(struct ibv_command_buffer *cmdb, const void *req,
 	_write_set_uhw(_name, cmd, sizeof(*cmd), cmd_size, resp,               \
 		       sizeof(*resp), resp_size)
 
+#define DECLARE_CMD_BUFFER_LINK_COMPAT(_name, _object_id, _method_id,	       \
+				       _link, cmd, cmd_size,		       \
+				       resp, resp_size)			       \
+	DECLARE_COMMAND_BUFFER_LINK(_name, _object_id, _method_id, 2, _link);  \
+	_write_set_uhw(_name, cmd, sizeof(*cmd), cmd_size, resp,               \
+		       sizeof(*resp), resp_size)
+
 /*
  * The fallback scheme keeps track of which ioctls succeed in a per-context
  * bitmap. If ENOTTY or EPROTONOSUPPORT is seen then the ioctl is never

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -575,6 +575,15 @@ int ibv_cmd_create_cq_ex(struct ibv_context *context,
 			 struct ib_uverbs_ex_create_cq_resp *resp,
 			 size_t resp_size,
 			 uint32_t cmd_flags);
+int ibv_cmd_create_cq_ex2(struct ibv_context *context,
+			  const struct ibv_cq_init_attr_ex *cq_attr,
+			  struct verbs_cq *cq,
+			  struct ibv_create_cq_ex *cmd,
+			  size_t cmd_size,
+			  struct ib_uverbs_ex_create_cq_resp *resp,
+			  size_t resp_size,
+			  uint32_t cmd_flags,
+			  struct ibv_command_buffer *driver);
 int ibv_cmd_poll_cq(struct ibv_cq *cq, int ne, struct ibv_wc *wc);
 int ibv_cmd_req_notify_cq(struct ibv_cq *cq, int solicited_only);
 int ibv_cmd_resize_cq(struct ibv_cq *cq, int cqe,

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -184,6 +184,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_create_counters;
 		ibv_cmd_create_cq;
 		ibv_cmd_create_cq_ex;
+		ibv_cmd_create_cq_ex2;
 		ibv_cmd_create_flow;
 		ibv_cmd_create_flow_action_esp;
 		ibv_cmd_create_qp;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -1123,6 +1123,12 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 		cmd_drv->flags |= MLX5_IB_CREATE_CQ_FLAGS_REAL_TIME_TS;
 
 	if (mctx->nc_uar) {
+		if (mctx->nc_uar->page_id >= (1ul << 16)) {
+			mlx5_dbg(fp, MLX5_DBG_CQ,
+				 "UAR page index larger than 16 bits is not supported\n");
+			errno = EINVAL;
+			goto err_db;
+		}
 		cmd_drv->flags |= MLX5_IB_CREATE_CQ_FLAGS_UAR_PAGE_INDEX;
 		cmd_drv->uar_page_index = mctx->nc_uar->page_id;
 	}

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -961,6 +961,9 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 				   int cq_alloc_flags,
 				   struct mlx5dv_cq_init_attr *mlx5cq_attr)
 {
+	DECLARE_COMMAND_BUFFER_LINK(driver_attrs, UVERBS_OBJECT_CQ,
+				    UVERBS_METHOD_CQ_CREATE, 1,
+				    NULL);
 	struct mlx5_create_cq_ex	cmd_ex = {};
 	struct mlx5_create_cq_ex_resp	resp_ex = {};
 	struct mlx5_ib_create_cq       *cmd_drv;
@@ -1124,23 +1127,23 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *context,
 
 	if (mctx->nc_uar) {
 		if (mctx->nc_uar->page_id >= (1ul << 16)) {
-			mlx5_dbg(fp, MLX5_DBG_CQ,
-				 "UAR page index larger than 16 bits is not supported\n");
-			errno = EINVAL;
-			goto err_db;
+			fill_attr_in_uint32(driver_attrs, MLX5_IB_ATTR_CREATE_CQ_UAR_INDEX,
+					    mctx->nc_uar->page_id);
+		} else {
+			cmd_drv->flags |= MLX5_IB_CREATE_CQ_FLAGS_UAR_PAGE_INDEX;
+			cmd_drv->uar_page_index = mctx->nc_uar->page_id;
 		}
-		cmd_drv->flags |= MLX5_IB_CREATE_CQ_FLAGS_UAR_PAGE_INDEX;
-		cmd_drv->uar_page_index = mctx->nc_uar->page_id;
 	}
 
 	{
 		struct ibv_cq_init_attr_ex cq_attr_ex = *cq_attr;
 
 		cq_attr_ex.cqe = ncqe - 1;
-		ret = ibv_cmd_create_cq_ex(context, &cq_attr_ex, &cq->verbs_cq,
-					   &cmd_ex.ibv_cmd, sizeof(cmd_ex),
-					   &resp_ex.ibv_resp, sizeof(resp_ex),
-					   CREATE_CQ_CMD_FLAGS_TS_IGNORED_EX);
+		ret = ibv_cmd_create_cq_ex2(context, &cq_attr_ex, &cq->verbs_cq,
+					    &cmd_ex.ibv_cmd, sizeof(cmd_ex),
+					    &resp_ex.ibv_resp, sizeof(resp_ex),
+					    CREATE_CQ_CMD_FLAGS_TS_IGNORED_EX,
+					    driver_attrs);
 	}
 
 	if (ret) {


### PR DESCRIPTION
This series adds support for creating a CQ with a large UAR page index.

The first patch addresses a bug by explicitly failing any creation attempt where the index value exceeds 16 bits, preventing overflow.

Subsequent patches provide the necessary support to allow CQ creation with an index of up to 32 bits.

This series aligns with the kernel series that have already been submitted to rdma-next.