### PR TITLE
libibumad: Add function that opens SMI ports

### DIFF
--- a/debian/libibumad3.symbols
+++ b/debian/libibumad3.symbols
@@ -3,6 +3,7 @@ libibumad.so.3 libibumad3 #MINVER#
  IBUMAD_1.0@IBUMAD_1.0 1.3.9
  IBUMAD_1.1@IBUMAD_1.1 3.1.26
  IBUMAD_1.2@IBUMAD_1.2 3.2.30
+ IBUMAD_1.3@IBUMAD_1.3 3.3.53
  umad_addr_dump@IBUMAD_1.0 1.3.9
  umad_attribute_str@IBUMAD_1.0 1.3.10.2
  umad_class_str@IBUMAD_1.0 1.3.10.2
@@ -25,6 +26,7 @@ libibumad.so.3 libibumad3 #MINVER#
  umad_init@IBUMAD_1.0 1.3.9
  umad_method_str@IBUMAD_1.0 1.3.10.2
  umad_open_port@IBUMAD_1.0 1.3.9
+ umad_open_smi_port@IBUMAD_1.3 3.3.53
  umad_poll@IBUMAD_1.0 1.3.9
  umad_recv@IBUMAD_1.0 1.3.9
  umad_register2@IBUMAD_1.0 1.3.10.2

--- a/libibumad/CMakeLists.txt
+++ b/libibumad/CMakeLists.txt
@@ -10,7 +10,7 @@ publish_headers(infiniband
 
 rdma_library(ibumad libibumad.map
   # See Documentation/versioning.md
-  3 3.2.${PACKAGE_VERSION}
+  3 3.3.${PACKAGE_VERSION}
   sysfs.c
   umad.c
   umad_str.c

--- a/libibumad/libibumad.map
+++ b/libibumad/libibumad.map
@@ -50,3 +50,8 @@ IBUMAD_1.2 {
 	global:
 		umad_sort_ca_device_list;
 } IBUMAD_1.1;
+
+IBUMAD_1.3 {
+	global:
+		umad_open_smi_port;
+} IBUMAD_1.2;

--- a/libibumad/man/umad_open_smi_port.3
+++ b/libibumad/man/umad_open_smi_port.3
@@ -1,0 +1,37 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH UMAD_OPEN_SMI_PORT 3  "June 18, 2024" "OpenIB" "OpenIB Programmer's Manual"
+.SH "NAME"
+umad_open_smi_port \- open InfiniBand device SMI port for umad access
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/umad.h>
+.sp
+.BI "int umad_open_smi_port(char " "*ca_name" ", int " "portnum" );
+.fi
+.SH "DESCRIPTION"
+.B umad_open_smi_port()
+opens the SMI port
+.I portnum
+of the IB device
+.I ca_name
+for umad access. The port is selected by the library if not all parameters
+are provided (see
+.B umad_get_port()
+for details). Only SMI ports will be selected.
+.fi
+.SH "RETURN VALUE"
+.B umad_open_smi_port()
+returns 0 or an unique positive value of umad device descriptor on success, and a negative value on error as follows:
+ -EOPNOTSUPP ABI version doesn't match
+ -ENODEV     IB device with SMI port can't be resolved
+ -EINVAL     port is not valid (bad
+.I portnum\fR
+or no umad device)
+ -EIO        umad device for this port can't be opened
+.SH "SEE ALSO"
+.BR umad_open_port (3),
+.SH "AUTHOR"
+.TP
+Amir Nir <anir@nvidia.com>

--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -188,6 +188,7 @@ int umad_release_port(umad_port_t * port);
 int umad_get_issm_path(const char *ca_name, int portnum, char path[], int max);
 
 int umad_open_port(const char *ca_name, int portnum);
+int umad_open_smi_port(const char *ca_name, int portnum);
 int umad_close_port(int portid);
 
 void *umad_get_mad(void *umad);


### PR DESCRIPTION
Added umad_open_smi_port which operates the same as umad_open_port, but ensures the port opened is an SMI port.