### PR TITLE
Added suffix libdrm to CMakeLists.txt for drm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -539,7 +539,7 @@ RDMA_DoFixup("${SYSTEMD_FOUND}" "systemd/sd-daemon.h")
 # drm headers
 
 # Check if the headers have been installed by kernel-headers
-find_path(DRM_INCLUDE_DIRS "drm.h" PATH_SUFFIXES "drm")
+find_path(DRM_INCLUDE_DIRS "drm.h" PATH_SUFFIXES "drm" "libdrm")
 
 # Alternatively the headers could have been installed by libdrm
 if (NOT DRM_INCLUDE_DIRS)


### PR DESCRIPTION
Canonical `libdrm` package installation results in headers installed at `\usr\include\libdrm.` The current `CMakeLists.txt` installation script searches the headers only in the `drm` suffix, where headers are found in RedHat-based distros.  This is not the canonical location. I propose adding the canonical path `libdrm`, also used in distros like archlinux. Cuurently such distros must patch the main `CMakeLists.txt`  file before installation.

https://gitlab.archlinux.org/archlinux/packaging/packages/rdma-core