### PR TITLE
debian: exclude hns provider on archs without coherent DMA

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,7 @@ ifeq (,$(filter-out $(NON_COHERENT_DMA_ARCHS),$(DEB_HOST_ARCH)))
 	for package in ibverbs-providers libibverbs-dev rdma-core; do \
 		test -e debian/$$package.install.backup || cp debian/$$package.install debian/$$package.install.backup; \
 	done
-	sed -i '/efa\|mana\|mlx[45]/d' debian/ibverbs-providers.install debian/libibverbs-dev.install debian/rdma-core.install
+	sed -i '/efa\|hns\|mana\|mlx[45]/d' debian/ibverbs-providers.install debian/libibverbs-dev.install debian/rdma-core.install
 endif
 	DESTDIR=$(CURDIR)/debian/tmp ninja -C build-deb install
 


### PR DESCRIPTION
The provider `hns` requires coherent DMA and will not build on architectures that lack coherent DMA. So exclude trying to install them on those architectures.

Bug-Debian: https://bugs.debian.org/1073050