### PR TITLE
bnxt_re/lib: Fix doorbell fifo register read

### DIFF
--- a/providers/bnxt_re/db.c
+++ b/providers/bnxt_re/db.c
@@ -54,7 +54,7 @@ static int calculate_fifo_occupancy(struct bnxt_re_context *cntx)
 	struct bnxt_re_dev *rdev = cntx->rdev;
 	uint32_t read_val, fifo_occup;
 	uint64_t fifo_reg_off;
-	uint64_t *dbr_map;
+	uint32_t *dbr_map;
 
 	fifo_reg_off =  pacing_data->grc_reg_offset & ~(BNXT_RE_PAGE_MASK(rdev->pg_size));
 	dbr_map = cntx->bar_map + fifo_reg_off;


### PR DESCRIPTION
Doorbell FIFO information register is a 32 bit register. Reading it as a 64bit from the BAR area may give wrong values. So change the variable pointer to 32 bit.

Fixes: ef9d1cd30a27 ("bnxt_re/lib: Implement doorbell pacing algorithm")