### PR TITLE
Ensure RDMA service loads modules in initrd

### DIFF
--- a/kernel-boot/rdma-load-modules@.service.in
+++ b/kernel-boot/rdma-load-modules@.service.in
@@ -5,6 +5,9 @@ Documentation=file:@CMAKE_INSTALL_FULL_DOCDIR@/udev.md
 # systemd-modules-load.service
 DefaultDependencies=no
 Before=sysinit.target
+# Kernel modules must load in initrd before initrd.target to avoid being killed
+# when initrd-cleanup.service isolates to initrd-switch-root.target.
+Before=initrd.target
 # Do not execute concurrently with an ongoing shutdown
 Conflicts=shutdown.target
 Before=shutdown.target

--- a/redhat/rdma.modules-setup.sh
+++ b/redhat/rdma.modules-setup.sh
@@ -25,6 +25,13 @@ install() {
 	inst_multiple -o \
                   $systemdsystemunitdir/rdma-hw.target \
                   $systemdsystemunitdir/rdma-load-modules@.service
+
+	for i in \
+		rdma-load-modules@rdma.service \
+		rdma-load-modules@roce.service \
+		rdma-load-modules@infiniband.service; do
+		$SYSTEMCTL -q --root "$initdir" add-wants initrd.target "$i"
+	done
 }
 
 installkernel() {

--- a/suse/module-setup.sh
+++ b/suse/module-setup.sh
@@ -23,6 +23,13 @@ install() {
 	inst_multiple -o \
                   $systemdsystemunitdir/rdma-hw.target \
                   $systemdsystemunitdir/rdma-load-modules@.service
+
+	for i in \
+		rdma-load-modules@rdma.service \
+		rdma-load-modules@roce.service \
+		rdma-load-modules@infiniband.service; do
+		$SYSTEMCTL -q --root "$initdir" add-wants initrd.target "$i"
+	done
 }
 
 installkernel() {


### PR DESCRIPTION
Fixed an issue where the RDMA service was killed during switch to root. Added a wants symlink for initrd.target in the dracut arrangement and Before=initrd.target to the systemd service to ensure it runs and completes during initrd.