### PR TITLE
kernel-boot: Avoid the device renaming step if the name is provided by userspace

### DIFF
--- a/kernel-boot/rdma_rename.c
+++ b/kernel-boot/rdma_rename.c
@@ -57,6 +57,7 @@ struct data {
 	uint64_t node_guid;
 	char *name;
 	int idx;
+	int name_assign_type;
 };
 
 static bool debug_mode;
@@ -555,6 +556,11 @@ static int get_nldata_cb(struct nl_msg *msg, void *data)
 
 	d->idx = nla_get_u32(tb[RDMA_NLDEV_ATTR_DEV_INDEX]);
 	d->node_guid = nla_get_u64(tb[RDMA_NLDEV_ATTR_NODE_GUID]);
+
+	if (tb[RDMA_NLDEV_ATTR_NAME_ASSIGN_TYPE])
+		d->name_assign_type =
+			nla_get_u8(tb[RDMA_NLDEV_ATTR_NAME_ASSIGN_TYPE]);
+
 	return NL_STOP;
 }
 
@@ -636,6 +642,13 @@ int main(int argc, char **argv)
 
 	if (rdmanl_get_devices(nl, get_nldata_cb, &d)) {
 		pr_err("%s: Failed to connect to NETLINK_RDMA\n", d.curr);
+		goto out;
+	}
+
+	if (d.name_assign_type == RDMA_NAME_ASSIGN_TYPE_USER) {
+		pr_dbg("%s: Leave user-assigned names, do nothing\n", d.curr);
+		/* Do nothing */
+		ret = 0;
 		goto out;
 	}
 

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -301,6 +301,10 @@ enum rdma_nldev_command {
 
 	RDMA_NLDEV_CMD_RES_SRQ_GET_RAW,
 
+	RDMA_NLDEV_CMD_NEWDEV,
+
+	RDMA_NLDEV_CMD_DELDEV,
+
 	RDMA_NLDEV_NUM_OPS
 };
 
@@ -564,6 +568,12 @@ enum rdma_nldev_attr {
 	 */
 	RDMA_NLDEV_ATTR_RES_SUBTYPE,		/* string */
 
+	RDMA_NLDEV_ATTR_DEV_TYPE,		/* u8 */
+
+	RDMA_NLDEV_ATTR_PARENT_NAME,		/* string */
+
+	RDMA_NLDEV_ATTR_NAME_ASSIGN_TYPE,	/* u8 */
+
 	/*
 	 * Always the end
 	 */
@@ -602,4 +612,16 @@ enum rdma_nl_counter_mask {
 	RDMA_COUNTER_MASK_QP_TYPE = 1,
 	RDMA_COUNTER_MASK_PID = 1 << 1,
 };
+
+/* Supported rdma device types. */
+enum rdma_nl_dev_type {
+	RDMA_DEVICE_TYPE_SMI = 1,
+};
+
+/* RDMA device name assignment types */
+enum rdma_nl_name_assign_type {
+	RDMA_NAME_ASSIGN_TYPE_UNKNOWN = 0,
+	RDMA_NAME_ASSIGN_TYPE_USER = 1, /* Provided by user-space */
+};
+
 #endif /* _UAPI_RDMA_NETLINK_H */


### PR DESCRIPTION
This series avoids the device renaming step if the name is provided by userspace.

It aligns with the corresponding kernel series that has already been accepted into rdma-next.