### PR TITLE
Fix for cm_svc_run

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -4678,8 +4678,11 @@ static void *cm_svc_run(void *arg)
 			fds[i].revents = 0;
 
 		poll(fds, svc->cnt + 1, -1);
-		if (fds[0].revents)
+		if (fds[0].revents) {
 			cm_svc_process_sock(svc);
+			/* svc->contexts may have been reallocated, so need to assign again */
+			fds = svc->contexts;
+		}
 
 		for (i = 1; i <= svc->cnt; i++) {
 			if (!fds[i].revents)


### PR DESCRIPTION
When the cm_svc_run thread starts, the four element size rss will be allocated to svc->contexts. When the rss reallocates memory due to an increase in the number of elements in the cm_svc_process_sock function, the rss will point to a new address, but the cm_svc_run function does not get the new address again, leading to an exception in the future