### PR TITLE
cmake: Avoid "Unknown arguments specified"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -547,7 +547,7 @@ if (NOT DRM_INCLUDE_DIRS)
 endif()
 
 if (DRM_INCLUDE_DIRS)
-  if (EXISTS ${DRM_INCLUDE_DIRS}/i915_drm.h AND EXISTS ${DRM_INCLUDE_DIRS}/amdgpu_drm.h)
+  if (EXISTS "${DRM_INCLUDE_DIRS}/i915_drm.h" AND EXISTS "${DRM_INCLUDE_DIRS}/amdgpu_drm.h")
     include_directories(${DRM_INCLUDE_DIRS})
   else()
     unset(DRM_INCLUDE_DIRS CACHE)


### PR DESCRIPTION
Without these arguments quoted, cmake 3.30.0 fails with

```
CMake Error at CMakeLists.txt:550 (if):
  if given arguments:

    "EXISTS" "/usr/include" "/usr/include/libdrm/i915_drm.h" "AND" "EXISTS" "/usr/include" "/usr/include/libdrm/amdgpu_drm.h"

  Unknown arguments specified
```