### PR TITLE
libhns: Fix no locking in the exception branch of wr start()

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -2558,6 +2558,7 @@ static void wr_start(struct ibv_qp_ex *ibv_qp)
 	if (state == IBV_QPS_RESET ||
 	    state == IBV_QPS_INIT ||
 	    state == IBV_QPS_RTR) {
+		hns_roce_spin_lock(&qp->sq.hr_lock);
 		qp->err = EINVAL;
 		return;
 	}


### PR DESCRIPTION
According to the man page ibv_wr_post.3.md,
"The provider should provide locking to ensure that ibv_wr_start() and ibv_wr_complete()/abort() form a per-QP critical section where no other threads can enter."

Currently the exception branch of wr_start() is not locked, add a lock here.

Fixes: 36446a56eea5 ("libhns: Extended QP supports the new post send mechanism")