### PR TITLE
Introducing Multi-Path DMA support for mlx5 RDMA device

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -32,6 +32,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  MLX5_1.22@MLX5_1.22 38
  MLX5_1.23@MLX5_1.23 40
  MLX5_1.24@MLX5_1.24 42
+ MLX5_1.25@MLX5_1.25 54
  mlx5dv_init_obj@MLX5_1.0 13
  mlx5dv_init_obj@MLX5_1.2 15
  mlx5dv_query_device@MLX5_1.0 13
@@ -161,6 +162,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_crypto_login_query@MLX5_1.24 42
  mlx5dv_destroy_steering_anchor@MLX5_1.24 42
  mlx5dv_dr_action_create_dest_root_table@MLX5_1.24 42
+ mlx5dv_reg_dmabuf_mr@MLX5_1.25 54
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev
  EFA_1.0@EFA_1.0 24

--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -162,6 +162,7 @@ libmlx5.so.1 ibverbs-providers #MINVER#
  mlx5dv_crypto_login_query@MLX5_1.24 42
  mlx5dv_destroy_steering_anchor@MLX5_1.24 42
  mlx5dv_dr_action_create_dest_root_table@MLX5_1.24 42
+ mlx5dv_get_data_direct_sysfs_path@MLX5_1.25 54
  mlx5dv_reg_dmabuf_mr@MLX5_1.25 54
 libefa.so.1 ibverbs-providers #MINVER#
 * Build-Depends-Package: libibverbs-dev

--- a/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_cmds.h
@@ -274,6 +274,10 @@ enum mlx5_ib_create_cq_attrs {
 	MLX5_IB_ATTR_CREATE_CQ_UAR_INDEX = UVERBS_ID_DRIVER_NS_WITH_UHW,
 };
 
+enum mlx5_ib_reg_dmabuf_mr_attrs {
+	MLX5_IB_ATTR_REG_DMABUF_MR_ACCESS_FLAGS = (1U << UVERBS_ID_NS_SHIFT),
+};
+
 #define MLX5_IB_DW_MATCH_PARAM 0xA0
 
 struct mlx5_ib_match_params {
@@ -344,11 +348,16 @@ enum mlx5_ib_pd_methods {
 
 enum mlx5_ib_device_methods {
 	MLX5_IB_METHOD_QUERY_PORT = (1U << UVERBS_ID_NS_SHIFT),
+	MLX5_IB_METHOD_GET_DATA_DIRECT_SYSFS_PATH,
 };
 
 enum mlx5_ib_query_port_attrs {
 	MLX5_IB_ATTR_QUERY_PORT_PORT_NUM = (1U << UVERBS_ID_NS_SHIFT),
 	MLX5_IB_ATTR_QUERY_PORT,
+};
+
+enum mlx5_ib_get_data_direct_sysfs_path_attrs {
+	MLX5_IB_ATTR_GET_DATA_DIRECT_SYSFS_PATH = (1U << UVERBS_ID_NS_SHIFT),
 };
 
 #endif

--- a/kernel-headers/rdma/mlx5_user_ioctl_verbs.h
+++ b/kernel-headers/rdma/mlx5_user_ioctl_verbs.h
@@ -54,6 +54,10 @@ enum mlx5_ib_uapi_flow_action_packet_reformat_type {
 	MLX5_IB_UAPI_FLOW_ACTION_PACKET_REFORMAT_TYPE_L2_TO_L3_TUNNEL = 0x3,
 };
 
+enum mlx5_ib_uapi_reg_dmabuf_flags {
+	MLX5_IB_UAPI_REG_DMABUF_ACCESS_DATA_DIRECT = 1 << 0,
+};
+
 struct mlx5_ib_uapi_devx_async_cmd_hdr {
 	__aligned_u64	wr_id;
 	__u8		out_data[];

--- a/libibverbs/cmd_mr.c
+++ b/libibverbs/cmd_mr.c
@@ -119,11 +119,13 @@ int ibv_cmd_query_mr(struct ibv_pd *pd, struct verbs_mr *vmr,
 
 int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 			  uint64_t iova, int fd, int access,
-			  struct verbs_mr *vmr)
+			  struct verbs_mr *vmr,
+			  struct ibv_command_buffer *driver)
 {
-	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_MR,
-			       UVERBS_METHOD_REG_DMABUF_MR,
-			       9);
+	DECLARE_COMMAND_BUFFER_LINK(cmdb, UVERBS_OBJECT_MR,
+				    UVERBS_METHOD_REG_DMABUF_MR,
+				    9,
+				    driver);
 	struct ib_uverbs_attr *handle;
 	uint32_t lkey, rkey;
 	int ret;

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -556,7 +556,8 @@ int ibv_cmd_advise_mr(struct ibv_pd *pd,
 		      uint32_t num_sge);
 int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 			  uint64_t iova, int fd, int access,
-			  struct verbs_mr *vmr);
+			  struct verbs_mr *vmr,
+			  struct ibv_command_buffer *driver);
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -277,7 +277,7 @@ struct ibv_mr *bnxt_re_reg_dmabuf_mr(struct ibv_pd *ibvpd, uint64_t start, size_
 		return NULL;
 
 	if (ibv_cmd_reg_dmabuf_mr(ibvpd, start, len, iova, fd,
-				  access, &mr->vmr)) {
+				  access, &mr->vmr, NULL)) {
 		free(mr);
 		return NULL;
 	}

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -247,7 +247,7 @@ struct ibv_mr *efa_reg_dmabuf_mr(struct ibv_pd *ibvpd, uint64_t offset,
 		return NULL;
 
 	err = ibv_cmd_reg_dmabuf_mr(ibvpd, offset, length, iova, fd, acc,
-				    &mr->vmr);
+				    &mr->vmr, NULL);
 	if (err) {
 		free(mr);
 		errno = err;

--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -163,7 +163,7 @@ struct ibv_mr *irdma_ureg_mr_dmabuf(struct ibv_pd *pd, uint64_t offset,
 		return NULL;
 
 	err = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access,
-				    &umr->vmr);
+				    &umr->vmr, NULL);
 	if (err) {
 		free(umr);
 		errno = err;

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -15,7 +15,7 @@ if (ENABLE_LTTNG AND LTTNGUST_FOUND)
 endif()
 
 rdma_shared_provider(mlx5 libmlx5.map
-  1 1.24.${PACKAGE_VERSION}
+  1 1.25.${PACKAGE_VERSION}
   ${TRACE_FILE}
   buf.c
   cq.c

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -232,5 +232,6 @@ MLX5_1.24 {
 
 MLX5_1.25 {
 	global:
+		mlx5dv_get_data_direct_sysfs_path;
 		mlx5dv_reg_dmabuf_mr;
 } MLX5_1.24;

--- a/providers/mlx5/libmlx5.map
+++ b/providers/mlx5/libmlx5.map
@@ -229,3 +229,8 @@ MLX5_1.24 {
 		mlx5dv_destroy_steering_anchor;
 		mlx5dv_dr_action_create_dest_root_table;
 } MLX5_1.23;
+
+MLX5_1.25 {
+	global:
+		mlx5dv_reg_dmabuf_mr;
+} MLX5_1.24;

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -29,6 +29,7 @@ rdma_man_pages(
   mlx5dv_dump.3.md
   mlx5dv_flow_action_esp.3.md
   mlx5dv_get_clock_info.3
+  mlx5dv_get_data_direct_sysfs_path.3.md
   mlx5dv_get_vfio_device_list.3.md
   mlx5dv_init_obj.3
   mlx5dv_is_supported.3.md

--- a/providers/mlx5/man/CMakeLists.txt
+++ b/providers/mlx5/man/CMakeLists.txt
@@ -43,6 +43,7 @@ rdma_man_pages(
   mlx5dv_query_device.3
   mlx5dv_query_port.3.md
   mlx5dv_query_qp_lag_port.3.md
+  mlx5dv_reg_dmabuf_mr.3.md
   mlx5dv_reserved_qpn_alloc.3.md
   mlx5dv_sched_node_create.3.md
   mlx5dv_ts_to_ns.3

--- a/providers/mlx5/man/mlx5dv_get_data_direct_sysfs_path.3.md
+++ b/providers/mlx5/man/mlx5dv_get_data_direct_sysfs_path.3.md
@@ -1,0 +1,63 @@
+---
+layout: page
+title: mlx5dv_get_data_direct_sysfs_path
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_get_data_direct_sysfs_path - Get the sysfs path of a data direct device
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+int mlx5dv_get_data_direct_sysfs_path(struct ibv_context *context, char *buf,
+                                      size_t buf_len)
+```
+
+# DESCRIPTION
+
+Get the sysfs path of the data direct device that is associated with the  given *context*.
+
+This lets an application to discover whether/which data direct device is associated with the given *context*.
+
+# ARGUMENTS
+*context*
+:	RDMA device context to work on.
+
+*buf*
+:	The buffer where to place the sysfs path of the associated data direct device.
+
+*buf_len*
+:       The length of the buffer.
+
+# RETURN VALUE
+
+Upon success 0 is returned or the value of errno on a failure.
+
+# ERRORS
+
+The below specific error values should be considered.
+
+ENODEV
+
+:       There is no associated data direct device for the given *context*.
+
+ENOSPC
+
+:       The input buffer size is too small to hold the full sysfs path.
+
+# NOTES
+
+Upon succees, the caller should add the /sys/ prefix to get the full sysfs path.
+
+# SEE ALSO
+
+*mlx5dv_reg_dmabuf_mr(3)*
+
+# AUTHOR
+
+Yishai Hadas <yishaih@nvidia.com>

--- a/providers/mlx5/man/mlx5dv_reg_dmabuf_mr.3.md
+++ b/providers/mlx5/man/mlx5dv_reg_dmabuf_mr.3.md
@@ -1,0 +1,63 @@
+---
+layout: page
+title: mlx5dv_reg_dmabuf_mr
+section: 3
+tagline: Verbs
+---
+
+# NAME
+
+mlx5dv_reg_dmabuf_mr - Register a dma-buf based memory region (MR)
+
+# SYNOPSIS
+
+```c
+#include <infiniband/mlx5dv.h>
+
+struct ibv_mr *mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+                                    size_t length, uint64_t iova, int fd,
+                                    int access, int mlx5_access)
+```
+
+# DESCRIPTION
+
+Register a dma-buf based memory region (MR), it follows the functionality of
+*ibv_reg_dmabuf_mr()* with the ability to supply specific mlx5 access flags.
+
+# ARGUMENTS
+*pd*
+:	The associated protection domain.
+
+*offset*
+:	The offset of the dma-buf where the MR starts.
+
+*length*
+:       The length of the MR.
+
+*iova*
+:	Specifies the virtual base address of the MR when accessed through a lkey or rkey.
+	It must have the same page offset as *offset* and be aligned with the system page size.
+
+*fd*
+:	The file descriptor that the dma-buf is identified by.
+
+*access*
+:	The desired memory protection attributes; it is either 0 or the bitwise OR of one or more of *enum ibv_access_flags*.
+
+*mlx5_access*
+:	A specific device access flags, it is either 0 or the below.
+
+	*MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT*
+		if set, this MR will be accessed through the Data Direct engine bonded with that RDMA device.
+
+# RETURN VALUE
+
+Upon success returns a pointer to the registered MR, or NULL if the request fails, in that case the value of errno indicates the failure reason.
+
+# SEE ALSO
+
+*ibv_reg_dmabuf_mr(3)*, *mlx5dv_get_data_direct_sysfs_path(3)*
+
+# AUTHOR
+
+Yishai Hadas <yishaih@nvidia.com>

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1625,6 +1625,7 @@ struct mlx5_dv_context_ops {
 	struct ibv_mr *(*reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset,
 					size_t length, uint64_t iova, int fd,
 					int access, int mlx5_access);
+	int (*get_data_direct_sysfs_path)(struct ibv_context *context, char *buf, size_t buf_len);
 };
 
 struct mlx5_dv_context_ops *mlx5_get_dv_ops(struct ibv_context *context);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1622,6 +1622,9 @@ struct mlx5_dv_context_ops {
 						 const void *in, size_t inlen,
 						 void *out, size_t outlen);
 	int (*devx_destroy_eq)(struct mlx5dv_devx_eq *eq);
+	struct ibv_mr *(*reg_dmabuf_mr)(struct ibv_pd *pd, uint64_t offset,
+					size_t length, uint64_t iova, int fd,
+					int access, int mlx5_access);
 };
 
 struct mlx5_dv_context_ops *mlx5_get_dv_ops(struct ibv_context *context);

--- a/providers/mlx5/mlx5_api.h
+++ b/providers/mlx5/mlx5_api.h
@@ -70,5 +70,6 @@
 #define MLX5DV_QUERY_PORT_ESW_OWNER_VHCA_ID MLX5_IB_UAPI_QUERY_PORT_ESW_OWNER_VHCA_ID
 #define mlx5dv_port mlx5_ib_uapi_query_port
 #define mlx5dv_reg mlx5_ib_uapi_reg
+#define MLX5DV_REG_DMABUF_ACCESS_DATA_DIRECT MLX5_IB_UAPI_REG_DMABUF_ACCESS_DATA_DIRECT
 
 #endif

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -919,6 +919,10 @@ struct ibv_dm *mlx5dv_alloc_dm(struct ibv_context *context,
 
 void *mlx5dv_dm_map_op_addr(struct ibv_dm *dm, uint8_t op);
 
+struct ibv_mr *mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+				    size_t length, uint64_t iova, int fd,
+				    int access, int mlx5_access);
+
 struct mlx5_wqe_av;
 
 struct mlx5dv_ah {

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -922,6 +922,8 @@ void *mlx5dv_dm_map_op_addr(struct ibv_dm *dm, uint8_t op);
 struct ibv_mr *mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 				    size_t length, uint64_t iova, int fd,
 				    int access, int mlx5_access);
+int mlx5dv_get_data_direct_sysfs_path(struct ibv_context *context, char *buf,
+				      size_t buf_len);
 
 struct mlx5_wqe_av;
 

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -662,7 +662,7 @@ struct ibv_mr *mlx5_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t len
 		return NULL;
 
 	ret = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, acc,
-				    &mr->vmr);
+				    &mr->vmr, NULL);
 	if (ret) {
 		free(mr);
 		return NULL;

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4892,6 +4892,48 @@ void *mlx5dv_dm_map_op_addr(struct ibv_dm *dm, uint8_t op)
 	return dvops->dm_map_op_addr(dm, op);
 }
 
+static struct ibv_mr *
+_mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+		      size_t length, uint64_t iova, int fd,
+		      int access, int mlx5_access)
+{
+	DECLARE_COMMAND_BUFFER_LINK(driver_attr, UVERBS_OBJECT_MR,
+				    UVERBS_METHOD_REG_DMABUF_MR, 1,
+				    NULL);
+	struct mlx5_mr *mr;
+	int ret;
+
+	mr = calloc(1, sizeof(*mr));
+	if (!mr)
+		return NULL;
+
+	fill_attr_in_uint32(driver_attr, MLX5_IB_ATTR_REG_DMABUF_MR_ACCESS_FLAGS, mlx5_access);
+	ret = ibv_cmd_reg_dmabuf_mr(pd, offset, length, iova, fd, access,
+				    &mr->vmr, driver_attr);
+	if (ret) {
+		free(mr);
+		return NULL;
+	}
+	mr->alloc_flags = access;
+
+	return &mr->vmr.ibv_mr;
+}
+
+struct ibv_mr *mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
+				    size_t length, uint64_t iova, int fd,
+				    int access, int mlx5_access)
+{
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(pd->context);
+
+	if (!dvops || !dvops->reg_dmabuf_mr) {
+		errno = EOPNOTSUPP;
+		return NULL;
+	}
+
+	return dvops->reg_dmabuf_mr(pd, offset, length, iova, fd,
+				    access, mlx5_access);
+}
+
 void mlx5_unimport_dm(struct ibv_dm *ibdm)
 {
 	struct mlx5_dm *dm = to_mdm(ibdm);
@@ -7888,4 +7930,6 @@ void mlx5_set_dv_ctx_ops(struct mlx5_dv_context_ops *ops)
 
 	ops->create_steering_anchor = _mlx5dv_create_steering_anchor;
 	ops->destroy_steering_anchor = _mlx5dv_destroy_steering_anchor;
+
+	ops->reg_dmabuf_mr = _mlx5dv_reg_dmabuf_mr;
 }

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -4934,6 +4934,30 @@ struct ibv_mr *mlx5dv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 				    access, mlx5_access);
 }
 
+static int _mlx5dv_get_data_direct_sysfs_path(struct ibv_context *context, char *buf,
+					      size_t buf_len)
+{
+	DECLARE_COMMAND_BUFFER(cmd,
+			       UVERBS_OBJECT_DEVICE,
+			       MLX5_IB_METHOD_GET_DATA_DIRECT_SYSFS_PATH,
+			       1);
+
+	fill_attr_out(cmd, MLX5_IB_ATTR_GET_DATA_DIRECT_SYSFS_PATH, buf, buf_len);
+
+	return execute_ioctl(context, cmd);
+}
+
+int mlx5dv_get_data_direct_sysfs_path(struct ibv_context *context, char *buf,
+				      size_t buf_len)
+{
+	struct mlx5_dv_context_ops *dvops = mlx5_get_dv_ops(context);
+
+	if (!dvops || !dvops->get_data_direct_sysfs_path)
+		return EOPNOTSUPP;
+
+	return dvops->get_data_direct_sysfs_path(context, buf, buf_len);
+}
+
 void mlx5_unimport_dm(struct ibv_dm *ibdm)
 {
 	struct mlx5_dm *dm = to_mdm(ibdm);
@@ -7932,4 +7956,5 @@ void mlx5_set_dv_ctx_ops(struct mlx5_dv_context_ops *ops)
 	ops->destroy_steering_anchor = _mlx5dv_destroy_steering_anchor;
 
 	ops->reg_dmabuf_mr = _mlx5dv_reg_dmabuf_mr;
+	ops->get_data_direct_sysfs_path = _mlx5dv_get_data_direct_sysfs_path;
 }


### PR DESCRIPTION
This patch series aims to enable multi-path DMA support, allowing an mlx5 RDMA device to issue DMA commands through multiple paths.

This feature is critical for improving performance and achieving line rates in environments where issuing PCI transactions over one path may be significantly faster than over another. These differences can arise from various PCI generations in the system or the specific system topology.

The series introduces the following two mlx5 DV APIs:

mlx5dv_reg_dmabuf_mr() -  This API allows applications to register a memory region (MR) based on dma-buf with specific mlx5 device flags to request the data direct functionality.

mlx5dv_get_data_direct_sysfs_path() - This API returns the sysfs path of the data direct device associated with a given RDMA device.

Detailed man pages are available for the new DV APIs.

This pull request follows the kernel series that was posted to rdma-next.
