### PR TITLE
verbs: Use provider name when generating provider constructor

### DIFF
--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -476,7 +476,7 @@ void verbs_register_driver(const struct verbs_device_ops *ops);
 #define PROVIDER_DRIVER(provider_name, drv_struct)                             \
 	extern const struct verbs_device_ops verbs_provider_##provider_name    \
 		__attribute__((alias(stringify(drv_struct))));                 \
-	static __attribute__((constructor)) void drv##__register_driver(void)  \
+	static __attribute__((constructor)) void provider_name##_register_driver(void) \
 	{                                                                      \
 		verbs_register_driver(&drv_struct);                            \
 	}


### PR DESCRIPTION
Previously, the token pasting operator was not being applied to any of the PROVIDER_DRIVER macro aguments, so every provider's constructor had the same name of "drv__register_driver".

Now, these constructors will be named using the provider name as the prefix, resulting in names like "irdma_register_driver".