### PR TITLE
cxgb4: update t4_cqe_common pointer in c4iw_flush_hw_cq()

### DIFF
--- a/providers/cxgb4/cq.c
+++ b/providers/cxgb4/cq.c
@@ -297,6 +297,7 @@ void c4iw_flush_hw_cq(struct c4iw_cq *chp, struct c4iw_qp *flush_qhp)
 next_cqe:
 		t4_hwcq_consume(&chp->cq);
 		ret = t4_next_hw_cqe(&chp->cq, &hw_cqe);
+		com = &hw_cqe->com;
 		if (qhp && flush_qhp != qhp)
 			pthread_spin_unlock(&qhp->lock);
 	}


### PR DESCRIPTION
t4_cqe_common pointer not updated in c4iw_flush_hw_cq(), so it always process first hw_cqe only even though cq contains multiple cqe, this patch resolves the issue by updating the t4_cqe_common pointer.

Fixes: 37e77d53e757 ("cxgb4: Add support for 64Byte cqes")