### PR TITLE
bnxt_re/lib: SRQ toggle support for GenP7 adapters

### DIFF
--- a/kernel-headers/rdma/bnxt_re-abi.h
+++ b/kernel-headers/rdma/bnxt_re-abi.h
@@ -134,8 +134,14 @@ struct bnxt_re_srq_req {
 	__aligned_u64 srq_handle;
 };
 
+enum bnxt_re_srq_mask {
+	BNXT_RE_SRQ_TOGGLE_PAGE_SUPPORT = 0x1,
+};
+
 struct bnxt_re_srq_resp {
 	__u32 srqid;
+	__u32 rsvd; /* padding */
+	__aligned_u64 comp_mask;
 };
 
 enum bnxt_re_shpg_offt {

--- a/providers/bnxt_re/db.c
+++ b/providers/bnxt_re/db.c
@@ -157,10 +157,14 @@ void bnxt_re_ring_srq_db(struct bnxt_re_srq *srq)
 
 void bnxt_re_ring_srq_arm(struct bnxt_re_srq *srq)
 {
+	uint32_t *pgptr, toggle = 0;
 	struct bnxt_re_db_hdr hdr;
 
+	pgptr = (uint32_t *)srq->toggle_map;
+	if (pgptr)
+		toggle = *pgptr;
 	bnxt_re_do_pacing(srq->cntx, &srq->rand);
-	bnxt_re_init_db_hdr(&hdr, srq->cap.srq_limit, srq->srqid, 0,
+	bnxt_re_init_db_hdr(&hdr, srq->cap.srq_limit, srq->srqid, toggle,
 			    BNXT_RE_QUE_TYPE_SRQ_ARM);
 	bnxt_re_ring_db(srq->udpi, &hdr);
 }

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -173,6 +173,9 @@ struct bnxt_re_srq {
 	int start_idx;
 	int last_idx;
 	bool arm_req;
+	uint32_t mem_handle;
+	uint32_t toggle_size;
+	void *toggle_map;
 };
 
 struct bnxt_re_joint_queue {

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -2215,8 +2215,9 @@ struct ibv_srq *bnxt_re_create_srq(struct ibv_pd *ibvpd,
 				   struct ibv_srq_init_attr *attr)
 {
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvpd->context);
+	struct bnxt_re_mmap_info minfo = {};
+	struct ubnxt_re_srq_resp resp = {};
 	struct bnxt_re_qattr qattr = {};
-	struct ubnxt_re_srq_resp resp;
 	struct ubnxt_re_srq req;
 	struct bnxt_re_srq *srq;
 	void *mem;
@@ -2251,7 +2252,19 @@ struct ibv_srq *bnxt_re_create_srq(struct ibv_pd *ibvpd,
 	srq->cap.max_sge = attr->attr.max_sge;
 	srq->cap.srq_limit = attr->attr.srq_limit;
 	srq->arm_req = false;
-
+	if (resp.comp_mask & BNXT_RE_SRQ_TOGGLE_PAGE_SUPPORT) {
+		minfo.type = BNXT_RE_SRQ_TOGGLE_MEM;
+		minfo.res_id = resp.srqid;
+		ret = bnxt_re_get_toggle_mem(ibvpd->context, &minfo, &srq->mem_handle);
+		if (ret)
+			goto fail;
+		srq->toggle_map = mmap(NULL, minfo.alloc_size, PROT_READ,
+				       MAP_SHARED, ibvpd->context->cmd_fd,
+				       minfo.alloc_offset);
+		if (srq->toggle_map == MAP_FAILED)
+			goto fail;
+		srq->toggle_size = minfo.alloc_size;
+	}
 	return &srq->ibvsrq;
 fail:
 	bnxt_re_free_mem(mem);
@@ -2285,6 +2298,8 @@ int bnxt_re_destroy_srq(struct ibv_srq *ibvsrq)
 	if (ret)
 		return ret;
 
+	if (srq->toggle_map)
+		munmap(srq->toggle_map, srq->toggle_size);
 	mem = srq->mem;
 	bnxt_re_free_mem(mem);
 	return 0;


### PR DESCRIPTION
Implements the UAPI call to get the SRQ toggle page.
 Also, get the toggle bit from the shared page and
 use it while arming the SRQ.
