### PR TITLE
mlx5: Misc. items

### DIFF
--- a/providers/mlx5/man/mlx5dv_init_obj.3
+++ b/providers/mlx5/man/mlx5dv_init_obj.3
@@ -3,7 +3,7 @@
 .\"
 .TH MLX5DV_INIT_OBJ 3 2017-02-02 1.0.0
 .SH "NAME"
-mlx5dv_init_obj \- Initialize mlx5 direct verbs object from ibv_xxx structures
+mlx5dv_init_obj \- Initialize mlx5 direct verbs object from ibv_xxx or mlx5dv_xxx structures
 .SH "SYNOPSIS"
 .nf
 .B #include <infiniband/mlx5dv.h>
@@ -13,7 +13,7 @@ mlx5dv_init_obj \- Initialize mlx5 direct verbs object from ibv_xxx structures
 .SH "DESCRIPTION"
 .B mlx5dv_init_obj()
 This function will initialize mlx5dv_xxx structs based on supplied type. The information
-for initialization is taken from ibv_xx structs supplied as part of input.
+for initialization is taken from ibv_xx or mlx5dv_xxx structs supplied as part of input.
 
 Request information of CQ marks its owned by direct verbs for all consumer index
 related actions. The initialization type can be combination of several types together.
@@ -109,6 +109,12 @@ uint64_t              comp_mask;
 .in -8
 };
 
+struct mlx5dv_devx {
+.in +8
+uint32_t              handle; /* The kernel handle, can be used upon direct ioctl destroy */
+.in -8
+};
+
 struct mlx5dv_obj {
 .in +8
 struct {
@@ -153,6 +159,12 @@ struct ibv_pd           *in;
 struct mlx5dv_pd        *out;
 .in -8
 } pd;
+struct {
+.in +8
+struct mlx5dv_devx_obj  *in;
+struct mlx5dv_devx      *out;
+.in -8
+} devx;
 .in -8
 };
 
@@ -165,6 +177,7 @@ MLX5DV_OBJ_RWQ  = 1 << 3,
 MLX5DV_OBJ_DM   = 1 << 4,
 MLX5DV_OBJ_AH   = 1 << 5,
 MLX5DV_OBJ_PD   = 1 << 6,
+MLX5DV_OBJ_DEVX = 1 << 7,
 .in -8
 };
 .fi

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -1141,6 +1141,14 @@ static int mlx5dv_get_pd(struct ibv_pd *pd_in,
 	return 0;
 }
 
+static int mlx5dv_get_devx(struct mlx5dv_devx_obj *devx_in,
+			   struct mlx5dv_devx *devx_out)
+{
+	devx_out->handle = devx_in->handle;
+
+	return 0;
+}
+
 static int query_lag(struct ibv_context *ctx, uint8_t *lag_state,
 		     uint8_t *tx_remap_affinity_1,
 		     uint8_t *tx_remap_affinity_2)
@@ -2075,6 +2083,8 @@ static int _mlx5dv_init_obj(struct mlx5dv_obj *obj, uint64_t obj_type)
 		ret = mlx5dv_get_av(obj->ah.in, obj->ah.out);
 	if (!ret && (obj_type & MLX5DV_OBJ_PD))
 		ret = mlx5dv_get_pd(obj->pd.in, obj->pd.out);
+	if (!ret && (obj_type & MLX5DV_OBJ_DEVX))
+		ret = mlx5dv_get_devx(obj->devx.in, obj->devx.out);
 
 	return ret;
 }
@@ -2096,6 +2106,8 @@ get_context_from_obj(struct mlx5dv_obj *obj, uint64_t obj_type)
 		return obj->ah.in->context;
 	if (obj_type & MLX5DV_OBJ_PD)
 		return obj->pd.in->context;
+	if (obj_type & MLX5DV_OBJ_DEVX)
+		return obj->devx.in->context;
 
 	return NULL;
 }

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -83,6 +83,7 @@ const struct verbs_match_ent mlx5_hca_table[] = {
 	HCA(MELLANOX, 0x101f),	/* ConnectX-6 LX */
 	HCA(MELLANOX, 0x1021),  /* ConnectX-7 */
 	HCA(MELLANOX, 0x1023),  /* ConnectX-8 */
+	HCA(MELLANOX, 0x1025),  /* ConnectX-9 */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
 	HCA(MELLANOX, 0xa2d6),  /* BlueField-2 integrated ConnectX-6 Dx network controller */

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -937,6 +937,10 @@ struct mlx5dv_pd {
 	uint64_t		comp_mask;
 };
 
+struct mlx5dv_devx {
+	uint32_t handle;
+};
+
 struct mlx5dv_obj {
 	struct {
 		struct ibv_qp		*in;
@@ -966,6 +970,10 @@ struct mlx5dv_obj {
 		struct ibv_pd		*in;
 		struct mlx5dv_pd	*out;
 	} pd;
+	struct {
+		struct mlx5dv_devx_obj *in;
+		struct mlx5dv_devx *out;
+	} devx;
 };
 
 enum mlx5dv_obj_type {
@@ -976,6 +984,7 @@ enum mlx5dv_obj_type {
 	MLX5DV_OBJ_DM	= 1 << 4,
 	MLX5DV_OBJ_AH	= 1 << 5,
 	MLX5DV_OBJ_PD	= 1 << 6,
+	MLX5DV_OBJ_DEVX	= 1 << 7,
 };
 
 enum mlx5dv_wq_init_attr_mask {
@@ -1017,8 +1026,8 @@ struct ibv_wq *mlx5dv_create_wq(struct ibv_context *context,
 				struct mlx5dv_wq_init_attr *mlx5_wq_attr);
 /*
  * This function will initialize mlx5dv_xxx structs based on supplied type.
- * The information for initialization is taken from ibv_xx structs supplied
- * as part of input.
+ * The information for initialization is taken from either ibv_xx or
+ * mlx5dv_xxx structs supplied as part of input.
  *
  * Request information of CQ marks its owned by DV for all consumer index
  * related actions.


### PR DESCRIPTION
This series enhances the mlx5 provider with the following functionality:
- Expands the mlx5dv_init_obj() API to support the devx object.
- Adds ConnectX-9 to the list of supported devices.

Additional details can be found in the commit logs.