### PR TITLE
libibmad: Misc. items

### DIFF
--- a/debian/libibmad5.symbols
+++ b/debian/libibmad5.symbols
@@ -48,8 +48,11 @@ libibmad.so.5 libibmad5 #MINVER#
  mad_dump_linkspeed@IBMAD_1.3 1.3.11
  mad_dump_linkspeeden@IBMAD_1.3 1.3.11
  mad_dump_linkspeedext@IBMAD_1.3 1.3.11
+ mad_dump_linkspeedext2@IBMAD_1.4 5.4.54
  mad_dump_linkspeedexten@IBMAD_1.3 1.3.11
+ mad_dump_linkspeedexten2@IBMAD_1.4 5.4.54
  mad_dump_linkspeedextsup@IBMAD_1.3 1.3.11
+ mad_dump_linkspeedextsup2@IBMAD_1.4 5.4.54
  mad_dump_linkspeedsup@IBMAD_1.3 1.3.11
  mad_dump_linkwidth@IBMAD_1.3 1.3.11
  mad_dump_linkwidthen@IBMAD_1.3 1.3.11

--- a/libibmad/CMakeLists.txt
+++ b/libibmad/CMakeLists.txt
@@ -9,7 +9,7 @@ publish_internal_headers(util
 
 rdma_library(ibmad libibmad.map
   # See Documentation/versioning.md
-  5 5.3.${PACKAGE_VERSION}
+  5 5.4.${PACKAGE_VERSION}
   bm.c
   cc.c
   dump.c

--- a/libibmad/libibmad.map
+++ b/libibmad/libibmad.map
@@ -154,3 +154,10 @@ IBMAD_1.3 {
 		ib_node_query_via;
 	local: *;
 };
+
+IBMAD_1.4 {
+	global:
+		mad_dump_linkspeedext2;
+		mad_dump_linkspeedexten2;
+		mad_dump_linkspeedextsup2;
+} IBMAD_1.3;

--- a/libibmad/mad.h
+++ b/libibmad/mad.h
@@ -1504,7 +1504,6 @@ int mad_get_timeout(const struct ibmad_port *srcport, int override_ms);
 int mad_get_retries(const struct ibmad_port *srcport);
 
 /* register.c */
-int mad_register_port_client(int port_id, int mgmt, uint8_t rmpp_version);
 int mad_register_client(int mgmt, uint8_t rmpp_version)
 	__attribute__((deprecated));
 int mad_register_server(int mgmt, uint8_t rmpp_version,

--- a/libibmad/register.c
+++ b/libibmad/register.c
@@ -78,7 +78,7 @@ int mad_class_agent(int mgmt)
 	return ibmp->class_agents[mgmt];
 }
 
-int mad_register_port_client(int port_id, int mgmt, uint8_t rmpp_version)
+static int mad_register_port_client(int port_id, int mgmt, uint8_t rmpp_version)
 {
 	int vers, agent;
 


### PR DESCRIPTION
This series includes the below changes in libibmad:
- Remove mad_register_port_client() from mad.h as it's not actually exported from the library.
- Expose the XDR speed decoding functions from the library.

Further details exist in the commit logs.