### PR TITLE
verbs: fix build warning with set uninitialized data

### DIFF
--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -506,6 +506,7 @@ struct ibv_comp_channel *ibv_create_comp_channel(struct ibv_context *context)
 		return NULL;
 
 	req.core_payload = (struct ib_uverbs_create_comp_channel){};
+	resp.fd = -1;
 	if (execute_cmd_write(context, IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL,
 			      &req, sizeof(req), &resp, sizeof(resp))) {
 		free(channel);


### PR DESCRIPTION
```
Fix below build warning
$ EXTRA_CMAKE_FLAGS="-DCMAKE_BUILD_TYPE=Debug -DMLX5_DEBUG=TRUE" ./build.sh
|| In file included from ../libibverbs/verbs.c:50:
|| ../libibverbs/verbs.c: In function ‘ibv_create_comp_channel’:
|| include/infiniband/cmd_write.h:157:48: warning: ‘resp’ may be used uninitialized [-Wmaybe-uninitialized]
||   157 |                 (cmd)->core_payload.response = ioctl_ptr_to_u64(resp);         \
||       |                                                ^~~~~~~~~~~~~~~~~~~~~~
|| ../libibverbs/verbs.c:509:13: note: in expansion of macro ‘execute_cmd_write’
||   509 |         if (execute_cmd_write(context, IB_USER_VERBS_CMD_CREATE_COMP_CHANNEL,
||       |             ^~~~~~~~~~~~~~~~~
|| In file included from include/infiniband/cmd_write.h:36,
||                  from ../libibverbs/verbs.c:50:
|| include/infiniband/cmd_ioctl.h:45:24: note: by argument 1 of type ‘const void *’ to ‘ioctl_ptr_to_u64’ declared here
||    45 | static inline uint64_t ioctl_ptr_to_u64(const void *ptr)
||       |                        ^~~~~~~~~~~~~~~~
|| ../libibverbs/verbs.c:501:51: note: ‘resp’ declared here
||   501 |         struct ib_uverbs_create_comp_channel_resp resp;
||       |                                                   ^~~~
```