### PR TITLE
ibdiags: Do not panic on ibstat query failure

### DIFF
--- a/infiniband-diags/ibstat.c
+++ b/infiniband-diags/ibstat.c
@@ -338,7 +338,7 @@ int main(int argc, char *argv[])
 		if (list_only)
 			printf("%s\n", ca_name);
 		else if (ca_stat(ca_name, dev_port, short_format) < 0)
-			IBPANIC("stat of IB device '%s' failed", ca_name);
+			IBWARN("stat of IB device '%s' failed", ca_name);
 	}
 	umad_free_ca_device_list(device_list);
 	return 0;


### PR DESCRIPTION
ibstat relies on umad_get_ca() to retrieve device's statistics. However, in case the latter function fails on a certain device, ibstat panics and exits before processing and displaying other device's statistics which may be obtainable.

Thus, warn on failed device query and continue querying the remaining devices instead of an early exit.