### PR TITLE
tests: Extend ODP coverage

### DIFF
--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -208,6 +208,10 @@ cdef class CQ(PyverbsCM):
     def cqe(self):
         return self.cq.cqe
 
+    @property
+    def cq(self):
+       return <object>self.cq
+
 
 cdef class CqInitAttrEx(PyverbsObject):
     def __init__(self, cqe = 100, CompChannel channel = None, comp_vector = 0,

--- a/tests/mlx5_prm_structs.py
+++ b/tests/mlx5_prm_structs.py
@@ -36,6 +36,7 @@ class DevxOps:
     MLX5_QPC_PM_STATE_MIGRATED = 0x3
     MLX5_CMD_OP_QUERY_HCA_CAP = 0x100
     MLX5_CMD_OP_QUERY_QOS_CAP = 0xc
+    MLX5_CMD_OP_QUERY_ODP_CAP = 0x2
     MLX5_CMD_OP_ALLOC_FLOW_COUNTER = 0x939
     MLX5_CMD_OP_DEALLOC_FLOW_COUNTER = 0x93a
     MLX5_CMD_OP_QUERY_FLOW_COUNTER = 0x93b
@@ -1973,6 +1974,65 @@ class QueryQosCapOut(PRMPacket):
         IntField('syndrome', 0),
         StrFixedLenField('reserved2', None, length=8),
         PadField(PacketField('capability', QosCaps(), QosCaps), 4096, padwith=b"\x00"),
+    ]
+
+
+class OdpPerTransportServiceCap(PRMPacket):
+    fields_desc = [
+        BitField('send', 0, 1),
+        BitField('receive', 0, 1),
+        BitField('write', 0, 1),
+        BitField('read', 0, 1),
+        BitField('atomic', 0, 1),
+        BitField('rmp', 0, 1),
+        BitField('tag_matching', 0, 1),
+        BitField('reserved1', 0, 25),
+    ]
+
+
+class OdpSchemeCap(PRMPacket):
+    fields_desc = [
+        StrFixedLenField('reserved1', None, length=8),
+        BitField('sig', 0, 1),
+        BitField('cross_vhca_mkey', 0, 1),
+        BitField('klm_null_mkey', 0, 1),
+        BitField('dpa_process_win', 0, 1),
+        BitField('reserved2', 0, 3),
+        BitField('mmo_wqe', 0, 1),
+        BitField('local_mmo_wqe', 0, 1),
+        BitField('aso_wqe', 0, 1),
+        BitField('umr_wqe', 0, 1),
+        BitField('get_psv_wqe', 0, 1),
+        BitField('rget_psv_wqe', 0, 1),
+        BitField('reserved3', 0, 19),
+        StrFixedLenField('reserved4', None, length=4),
+        PacketField('rc_odp_caps', OdpPerTransportServiceCap(), OdpPerTransportServiceCap),
+        PacketField('uc_odp_caps', OdpPerTransportServiceCap(), OdpPerTransportServiceCap),
+        PacketField('ud_odp_caps', OdpPerTransportServiceCap(), OdpPerTransportServiceCap),
+        PacketField('xrc_odp_caps', OdpPerTransportServiceCap(), OdpPerTransportServiceCap),
+        PacketField('dc_odp_caps', OdpPerTransportServiceCap(), OdpPerTransportServiceCap),
+        StrFixedLenField('reserved5', None, length=28),
+    ]
+
+
+class OdpCap(PRMPacket):
+    fields_desc = [
+        PacketField('transport_page_fault_scheme_cap', OdpSchemeCap(), OdpSchemeCap),
+        PacketField('memory_page_fault_scheme_cap', OdpSchemeCap(), OdpSchemeCap),
+        StrFixedLenField('reserved1', None, length=64),
+        BitField('mem_page_fault', 0, 1),
+        BitField('reserved2', 0, 31),
+        StrFixedLenField('reserved3', None, length=60),
+    ]
+
+
+class QueryOdpCapOut(PRMPacket):
+    fields_desc = [
+        ByteField('status', 0),
+        BitField('reserved1', 0, 24),
+        IntField('syndrome', 0),
+        StrFixedLenField('reserved2', None, length=8),
+        PadField(PacketField('capability', OdpCap(), OdpCap), 4096, padwith=b"\x00"),
     ]
 
 

--- a/tests/test_mlx5_devx.py
+++ b/tests/test_mlx5_devx.py
@@ -6,6 +6,21 @@ Test module for mlx5 DevX.
 """
 
 from tests.mlx5_base import Mlx5DevxRcResources, Mlx5DevxTrafficBase
+import pyverbs.mem_alloc as mem
+from pyverbs.mr import MR
+import pyverbs.enums as e
+import tests.utils as u
+
+
+class Mlx5DevxRcOdpRes(Mlx5DevxRcResources):
+    @u.requires_odpv2
+    def create_mr(self):
+        self.with_odp = True
+        self.user_addr = mem.mmap(length=self.msg_size,
+                                  flags=mem.MAP_ANONYMOUS_ | mem.MAP_PRIVATE_)
+        access = e.IBV_ACCESS_LOCAL_WRITE | e.IBV_ACCESS_REMOTE_READ | \
+                 e.IBV_ACCESS_ON_DEMAND
+        self.mr = MR(self.pd, self.msg_size, access, self.user_addr)
 
 
 class Mlx5DevxRcTrafficTest(Mlx5DevxTrafficBase):
@@ -30,5 +45,15 @@ class Mlx5DevxRcTrafficTest(Mlx5DevxTrafficBase):
         from tests.mlx5_prm_structs import SendDbrMode
 
         self.create_players(Mlx5DevxRcResources, send_dbr_mode=SendDbrMode.NO_DBR_EXT)
+        # Send traffic
+        self.send_imm_traffic()
+
+    @u.requires_odp('rc', e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV)
+    def test_devx_rc_qp_odp_traffic(self):
+        """
+        Creates two DevX RC QPs using ODP enabled MKeys.
+        Then does SEND_IMM traffic.
+        """
+        self.create_players(Mlx5DevxRcOdpRes)
         # Send traffic
         self.send_imm_traffic()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1377,7 +1377,8 @@ def xrc_traffic(client, server, is_cq_ex=False, send_op=None, force_page_faults=
 def requires_odp(qp_type, required_odp_caps):
     def outer(func):
         def inner(instance):
-            odp_supported(instance.ctx, qp_type, required_odp_caps)
+            ctx = getattr(instance, 'ctx', d.Context(name=instance.dev_name))
+            odp_supported(ctx, qp_type, required_odp_caps)
             if getattr(instance, 'is_implicit', False):
                 odp_implicit_supported(instance.ctx)
             return func(instance)
@@ -1436,6 +1437,30 @@ def odp_implicit_supported(ctx):
     has_odp_implicit = odp_caps.general_caps & e.IBV_ODP_SUPPORT_IMPLICIT
     if has_odp_implicit == 0:
         raise unittest.SkipTest('ODP implicit is not supported')
+
+
+def odp_v2_supported(ctx):
+    """
+    ODPv2 check
+    :return: True/False if ODPv2 supported
+    """
+    from tests.mlx5_prm_structs import QueryHcaCapIn, QueryOdpCapOut, DevxOps, QueryHcaCapMod
+    query_cap_in = QueryHcaCapIn(op_mod=DevxOps.MLX5_CMD_OP_QUERY_ODP_CAP << 1 | \
+                                        QueryHcaCapMod.CURRENT)
+    cmd_res = ctx.devx_general_cmd(query_cap_in, len(QueryOdpCapOut()))
+    query_cap_out = QueryOdpCapOut(cmd_res)
+    if query_cap_out.status:
+        raise PyverbsRDMAError(f'QUERY_HCA_CAP has failed with status ({query_cap_out.status}) '
+                               f'and syndrome ({query_cap_out.syndrome})')
+    return query_cap_out.capability.mem_page_fault == 1
+
+
+def requires_odpv2(func):
+    def inner(instance):
+        if not odp_v2_supported(instance.ctx):
+            raise unittest.SkipTest('ODPv2 is not supported')
+        return func(instance)
+    return inner
 
 
 def get_pci_name(dev_name):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -697,7 +697,6 @@ def poll_cq_ex(cqex, count=1, data=None, sgid=None):
             if isinstance(cqex, EfaCQ):
                 if sgid is not None and cqex.read_opcode() == e.IBV_WC_RECV:
                     assert sgid.gid == cqex.read_sgid().gid
-            count -= 1
         if count > 0:
             raise PyverbsError(f'Got timeout on polling ({count} CQEs remaining)')
     finally:


### PR DESCRIPTION
Extend ODP coverage by adding ODP over DevX and ODP with indirect mkey tests.
The series includes a minor test fix and an exposure of the CQ C object for Python users' usage.