### PR TITLE
Add QP service level in EFA DV

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -95,7 +95,8 @@ struct efa_ibv_create_qp {
 	__u32 sq_ring_size; /* bytes */
 	__u32 driver_qp_type;
 	__u16 flags;
-	__u8 reserved_90[6];
+	__u8 sl;
+	__u8 reserved_98[5];
 };
 
 struct efa_ibv_create_qp_resp {

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -15,6 +15,7 @@ enum {
 enum {
 	RDMA_NL_GROUP_IWPM = 2,
 	RDMA_NL_GROUP_LS,
+	RDMA_NL_GROUP_NOTIFY,
 	RDMA_NL_NUM_GROUPS
 };
 
@@ -305,6 +306,8 @@ enum rdma_nldev_command {
 
 	RDMA_NLDEV_CMD_DELDEV,
 
+	RDMA_NLDEV_CMD_MONITOR,
+
 	RDMA_NLDEV_NUM_OPS
 };
 
@@ -574,6 +577,9 @@ enum rdma_nldev_attr {
 
 	RDMA_NLDEV_ATTR_NAME_ASSIGN_TYPE,	/* u8 */
 
+	RDMA_NLDEV_ATTR_EVENT_TYPE,		/* u8 */
+
+	RDMA_NLDEV_SYS_ATTR_MONITOR_MODE,	/* u8 */
 	/*
 	 * Always the end
 	 */
@@ -622,6 +628,16 @@ enum rdma_nl_dev_type {
 enum rdma_nl_name_assign_type {
 	RDMA_NAME_ASSIGN_TYPE_UNKNOWN = 0,
 	RDMA_NAME_ASSIGN_TYPE_USER = 1, /* Provided by user-space */
+};
+
+/*
+ * Supported rdma monitoring event types.
+ */
+enum rdma_nl_notify_event_type {
+	RDMA_REGISTER_EVENT,
+	RDMA_UNREGISTER_EVENT,
+	RDMA_NETDEV_ATTACH_EVENT,
+	RDMA_NETDEV_DETACH_EVENT,
 };
 
 #endif /* _UAPI_RDMA_NETLINK_H */

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -33,7 +33,8 @@ struct efadv_qp_init_attr {
 	uint64_t comp_mask;
 	uint32_t driver_qp_type;
 	uint16_t flags;
-	uint8_t reserved[2];
+	uint8_t sl;
+	uint8_t reserved[1];
 };
 
 struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,

--- a/providers/efa/man/efadv_create_qp_ex.3.md
+++ b/providers/efa/man/efadv_create_qp_ex.3.md
@@ -45,7 +45,8 @@ struct efadv_qp_init_attr {
 	uint64_t comp_mask;
 	uint32_t driver_qp_type;
 	uint16_t flags;
-	uint8_t reserved[2];
+	uint8_t sl;
+	uint8_t reserved[1];
 };
 ```
 
@@ -66,6 +67,9 @@ struct efadv_qp_init_attr {
 
 	EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV:
 		Receive WRs will not be consumed for RDMA write with imm.
+
+*sl*
+:	Service Level - 0 value implies default level.
 
 # RETURN VALUE
 

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -1500,6 +1500,8 @@ static struct ibv_qp *create_qp(struct ibv_context *ibvctx,
 	if (efa_attr->flags & EFADV_QP_FLAGS_UNSOLICITED_WRITE_RECV)
 		req.flags |= EFA_CREATE_QP_WITH_UNSOLICITED_WRITE_RECV;
 
+	req.sl = efa_attr->sl;
+
 	err = ibv_cmd_create_qp_ex(ibvctx, &qp->verbs_qp,
 				   attr, &req.ibv_cmd, sizeof(req),
 				   &resp.ibv_resp, sizeof(resp));

--- a/pyverbs/providers/efa/efadv.pyx
+++ b/pyverbs/providers/efa/efadv.pyx
@@ -182,6 +182,14 @@ cdef class EfaQPInitAttr(PyverbsObject):
     def flags(self, val):
         self.qp_init_attr.flags = val
 
+    @property
+    def sl(self):
+        return self.qp_init_attr.sl
+
+    @sl.setter
+    def sl(self,val):
+        self.qp_init_attr.sl = val
+
 
 cdef class SRDQPEx(QPEx):
     """

--- a/pyverbs/providers/efa/libefa.pxd
+++ b/pyverbs/providers/efa/libefa.pxd
@@ -30,7 +30,8 @@ cdef extern from 'infiniband/efadv.h':
         uint64_t comp_mask;
         uint32_t driver_qp_type;
         uint16_t flags;
-        uint8_t reserved[2];
+        uint8_t sl;
+        uint8_t reserved[1];
 
     cdef struct efadv_cq_init_attr:
         uint64_t comp_mask;


### PR DESCRIPTION
Add SL parameter to EFA create QP direct verb and pass it to the kernel.
Update Pyverbs and documentation accordingly.

The related kernel patches are [here](https://lore.kernel.org/all/20241015174242.3490-1-mrgolin@amazon.com/).