### PR TITLE
rxe: use ibv_inc_rkey helper for generating type 1 bind rkey

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -162,11 +162,6 @@ static int rxe_dealloc_mw(struct ibv_mw *ibmw)
 	return 0;
 }
 
-static int next_rkey(int rkey)
-{
-	return (rkey & 0xffffff00) | ((rkey + 1) & 0x000000ff);
-}
-
 static int rxe_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr_list,
 			 struct ibv_send_wr **bad_wr);
 
@@ -191,7 +186,7 @@ static int rxe_bind_mw(struct ibv_qp *ibqp, struct ibv_mw *ibmw,
 	ibwr.send_flags = mw_bind->send_flags;
 	ibwr.bind_mw.bind_info = mw_bind->bind_info;
 	ibwr.bind_mw.mw = ibmw;
-	ibwr.bind_mw.rkey = next_rkey(ibmw->rkey);
+	ibwr.bind_mw.rkey = ibv_inc_rkey(ibmw->rkey);
 
 	ret = rxe_post_send(ibqp, &ibwr, &bad_wr);
 	if (ret)


### PR DESCRIPTION
The rkeys are being calculated the same way, so just use the helper instead.