### PR TITLE
tests: Skip CQ shrinking for bnxt_re devices.

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -328,8 +328,10 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvctx);
 	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvctx->device);
 
-	if (ncqe > dev->max_cq_depth)
+	if (ncqe > dev->max_cq_depth) {
+		errno = EINVAL;
 		return NULL;
+	}
 
 	cq = calloc(1, (sizeof(*cq) + sizeof(struct bnxt_re_queue)));
 	if (!cq)


### PR DESCRIPTION
bnxt_re driver implement the CQ shrinking operation in a way that allows users to shrink CQ with a size smaller than the existing CQE and still have access to old CQEs please see:

 - https://github.com/linux-rdma/rdma-core/pull/1315

The test_resize_cq assumes that when shrinking an active CQ with unpolled entries it fail with an EINVAL error, which is not true for bnxt_re devices.

To avoid this failure for bnxt we skip part of the test that expect EINVAL.