### PR TITLE
util/udma_barrier.h: adjust ARMv8 memory barriers

### DIFF
--- a/util/udma_barrier.h
+++ b/util/udma_barrier.h
@@ -93,7 +93,7 @@
 #elif defined(__sparc_v9__)
 #define udma_to_device_barrier() asm volatile("membar #StoreStore" ::: "memory")
 #elif defined(__aarch64__)
-#define udma_to_device_barrier() asm volatile("dsb st" ::: "memory");
+#define udma_to_device_barrier() asm volatile("dmb oshst" ::: "memory")
 #elif defined(__sparc__) || defined(__s390x__)
 #define udma_to_device_barrier() asm volatile("" ::: "memory")
 #elif defined(__loongarch__)
@@ -131,7 +131,7 @@
 #elif defined(__sparc_v9__)
 #define udma_from_device_barrier() asm volatile("membar #LoadLoad" ::: "memory")
 #elif defined(__aarch64__)
-#define udma_from_device_barrier() asm volatile("dsb ld" ::: "memory");
+#define udma_from_device_barrier() asm volatile("dmb oshld" ::: "memory")
 #elif defined(__sparc__) || defined(__s390x__)
 #define udma_from_device_barrier() asm volatile("" ::: "memory")
 #elif defined(__loongarch__)


### PR DESCRIPTION
Change the barrier APIs for IO to reflect that Armv8-a is other-multi-copy atomicity memory model.

Armv8-a memory model has been strengthened to require other-multi-copy atomicity. This property requires memory accesses from an observer to become visible to all other observers simultaneously [3]. This means

a) A write arriving at an endpoint shared between multiple CPUs is
   visible to all CPUs
b) A write that is visible to all CPUs is also visible to all other
   observers in the shareability domain

This allows for using cheaper DMB instructions in the place of DSB for devices that are visible to all CPUs

Please refer to [1], [2] and [3] for more information.

[1] https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=22ec71615d824f4f11d38d0e55a88d8956b7e45f
[2] https://www.youtube.com/watch?v=i6DayghhA8Q
[3] https://www.cl.cam.ac.uk/~pes20/armv8-mca/