### PR TITLE
rdma-core/libibumad: Add all pair SMI&GSI support

### DIFF
--- a/libibumad/libibumad.map
+++ b/libibumad/libibumad.map
@@ -54,4 +54,6 @@ IBUMAD_1.2 {
 IBUMAD_1.3 {
 	global:
 		umad_open_smi_port;
+		umad_get_cas_pairs;
+		umad_get_ca_pair_by_name;
 } IBUMAD_1.2;

--- a/libibumad/man/umad_get_ca_pair_by_name.3
+++ b/libibumad/man/umad_get_ca_pair_by_name.3
@@ -1,0 +1,59 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH UMAD_GET_CAS_PAIRS 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
+.SH "NAME"
+umad_get_ca_pair_by_name \- get SMI/GSI pair ca and port nums based on device name and portnum.
+ the given portnum addresses a port in the given device name (might be smi or gsi).
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/umad.h>
+.sp
+.BI "int umad_get_ca_pair_by_name(const char * " "devname" ", uint8_t " "portnum" ", umad_ca_pair_t " "*ca" );
+.fi
+.SH "DESCRIPTION"
+.B umad_get_ca_pair_by_name()
+fills argument
+.I ca
+with found ca according to name and portnum given in
+.I devname
+and
+.I portnum
+arguments
+.I portnum
+is the port number of a port in
+.I dev name.
+.nf
+.I umad_ca_pair_t as specified in  <infiniband/umad.h>.
+.PP
+.nf
+typedef struct umad_ca_pair {
+.in +1
+umad_ca_pair_item_t smi;
+.in +0
+umad_ca_pair_item_t gsi;
+.in -2
+} umad_ca_pair;
+.nf
+.nf
+typedef struct umad_ca_pair_item {
+.in +1
+	char         name[UMAD_CA_NAME_LEN];
+.in +0
+	uint32_t     ports[UMAD_CA_MAX_PORTS];
+.in +0
+	uint32_t     numports;
+.in +0
+	uint32_t     preferred_port;
+.in -2
+} umad_ca_pair_item_t;
+.fi
+.PP
+
+.SH "RETURN VALUE"
+.B umad_get_ca_pair_by_name()
+returns 0 if a device and ports were found, 1 otherwise
+
+.SH "AUTHORS"
+.TP
+Asaf Mazor <amazor@nvidia.com>

--- a/libibumad/man/umad_get_cas_pairs.3
+++ b/libibumad/man/umad_get_cas_pairs.3
@@ -19,7 +19,7 @@ it fills up to
 devices
 The argument
 .I cas
-is an array of 
+is an array of
 .I umad_ca_pair_t as specified in  <infiniband/umad.h>.
 .PP
 .nf

--- a/libibumad/man/umad_get_cas_pairs.3
+++ b/libibumad/man/umad_get_cas_pairs.3
@@ -1,0 +1,56 @@
+.\" -*- nroff -*-
+.\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
+.\"
+.TH UMAD_GET_CAS_PAIRS 3  "May 21, 2007" "OpenIB" "OpenIB Programmer's Manual"
+.SH "NAME"
+umad_get_cas_pairs \- get cas as SMI/GSI pairs
+.SH "SYNOPSIS"
+.nf
+.B #include <infiniband/umad.h>
+.sp
+.BI "int umad_get_cas_pairs(umad_ca_pair_t " "cas[]" ", size_t " "max" );
+.fi
+.SH "DESCRIPTION"
+.B umad_get_cas_pairs()
+fill a user allocated array of struct
+.I umad_ca_pair\fr
+it fills up to
+.I max
+devices
+The argument
+.I cas
+is an array of 
+.I umad_ca_pair_t as specified in  <infiniband/umad.h>.
+.PP
+.nf
+typedef struct umad_ca_pair {
+.in +1
+umad_ca_pair_item_t smi;
+.in +0
+umad_ca_pair_item_t gsi;
+.in -2
+} umad_ca_pair;
+.nf
+.nf
+typedef struct umad_ca_pair_item {
+.in +1
+	char         name[UMAD_CA_NAME_LEN];
+.in +0
+	uint32_t     ports[UMAD_CA_MAX_PORTS];
+.in +0
+	uint32_t     numports;
+.in +0
+	uint32_t     preferred_port;
+.in -2
+} umad_ca_pair_item_t;
+.fi
+.PP
+
+.SH "RETURN VALUE"
+.B umad_get_cas_pairs()
+returns the number of devices filled,
+or -1 on error.
+
+.SH "AUTHORS"
+.TP
+Asaf Mazor <amazor@nvidia.com>

--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -1556,7 +1556,7 @@ static int umad_check_active(umad_ca_pair_item_t *dev, int prefered)
 	return !(state > 1);
 }
 
-static int umad_find_active(umad_ca_pair_item_t *dev) 
+static int umad_find_active(umad_ca_pair_item_t *dev)
 {
 	int i;
 
@@ -1617,10 +1617,10 @@ int umad_get_ca_pair_by_name(const char *name, uint8_t portnum, umad_ca_pair_t *
 			found_port = false;
 
 			for (port_idx = 0; port_idx < dev->numports; ++port_idx) {
-				
+
 				if (!dev->ports[port_idx])
 					break;
-				
+
 				if (dev->ports[port_idx] == portnum)
 					found_port = true;
 			}

--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -34,6 +34,7 @@
 
 #include <config.h>
 
+#include <stdbool.h>
 #include <sys/poll.h>
 #include <unistd.h>
 #include <string.h>
@@ -77,6 +78,16 @@ struct ib_user_mad_reg_req2 {
 	uint32_t oui;
 	uint8_t  rmpp_version;
 	uint8_t  reserved[3];
+};
+
+struct port_guid_port_count {
+	__be64 port_guid;
+	uint8_t   count;
+};
+
+struct guid_ca_pairs_mapping {
+	__be64 port_guid;
+	umad_ca_pair_t *ca_pair;
 };
 
 #define IBWARN(fmt, args...) fprintf(stderr, "ibwarn: [%d] %s: " fmt "\n", getpid(), __func__, ## args)
@@ -1354,3 +1365,295 @@ void umad_free_ca_device_list(struct umad_device_node *head)
 		free(node);
 	}
 }
+
+static void add_new_port(umad_ca_pair_item_t *dev, umad_port_t *p_port)
+{
+	if (!dev->name[0]) {
+		memcpy(dev->name, p_port->ca_name, UMAD_CA_NAME_LEN);
+		dev->numports = 0;
+	}
+
+	if (dev->numports < UMAD_CA_MAX_PORTS)
+		dev->ports[dev->numports++] = p_port->portnum;
+}
+
+static umad_ca_pair_t *get_ca_pair_from_arr_by_guid(__be64 port_guid,
+					struct guid_ca_pairs_mapping mapping[],
+					size_t map_max, size_t *map_added,
+					umad_ca_pair_t devs[],
+					size_t devs_max, size_t *devs_added)
+{
+	umad_ca_pair_t *dev = NULL;
+	// attempt to find the port guid in the mapping
+	size_t i = 0;
+	for (i = 0; i < *map_added; ++i) {
+		if (mapping[i].port_guid == port_guid)
+			return mapping[i].ca_pair;
+	}
+
+	// attempt to add a new mapping/device
+	if (*map_added >= map_max || *devs_added >= devs_max)
+		return NULL;
+
+	dev = &devs[*devs_added];
+	mapping[*map_added].port_guid = port_guid;
+	mapping[*map_added].ca_pair = dev;
+	(*devs_added)++;
+	(*map_added)++;
+
+	return dev;
+}
+
+static uint8_t get_port_guid_count(__be64 guid, const struct port_guid_port_count counts[],
+							size_t max_guids)
+{
+	size_t i = 0;
+	for (i = 0; i < max_guids; ++i) {
+		if (counts[i].port_guid == guid)
+			return counts[i].count;
+	}
+
+	return 0;
+}
+
+
+static bool find_port_guid_count(struct port_guid_port_count counts[], size_t max,
+						  __be64 port_guid, size_t *index)
+{
+	size_t i = 0;
+	for (i = 0; i < max; ++i) {
+		if (counts[i].port_guid == 0) {
+			*index = i;
+			return false;
+		}
+		if (counts[i].port_guid == port_guid) {
+			*index = i;
+			return true;
+		}
+	}
+
+	*index = max;
+	return false;
+}
+
+static int count_ports_by_guid(char legacy_ca_names[][UMAD_CA_NAME_LEN], size_t num_cas,
+						struct port_guid_port_count counts[], size_t max)
+{
+	// how many unique port GUIDs were added
+	size_t num_of_guid = 0;
+
+	memset(counts, 0, max * sizeof(struct port_guid_port_count));
+
+	size_t c_idx = 0;
+	for (c_idx = 0; c_idx < num_cas; ++c_idx) {
+		umad_ca_t curr_ca;
+
+		if (umad_get_ca(legacy_ca_names[c_idx], &curr_ca) < 0)
+			continue;
+
+		size_t p_idx = 1;
+		for (p_idx = 1; p_idx < (size_t)curr_ca.numports + 1; ++p_idx) {
+			umad_port_t *p_port = curr_ca.ports[p_idx];
+			size_t count_idx = 0;
+
+			if (!p_port)
+				continue;
+
+			if (find_port_guid_count(counts, max, p_port->port_guid, &count_idx)) {
+				// port GUID already has a count struct
+				++counts[count_idx].count;
+			} else {
+				// add a new count struct for this GUID.
+				// if the maximum amount was already added, do nothing.
+				if (count_idx != max) {
+					counts[count_idx].port_guid = p_port->port_guid;
+					counts[count_idx].count = 1;
+					++num_of_guid;
+				}
+			}
+		}
+
+		umad_release_ca(&curr_ca);
+	}
+
+	return num_of_guid;
+}
+
+int umad_get_cas_pairs(umad_ca_pair_t cas[], size_t max)
+{
+	size_t added_devices = 0, added_mappings = 0;
+	char legacy_ca_names[UMAD_MAX_DEVICES][UMAD_CA_NAME_LEN] = {};
+	struct port_guid_port_count counts[UMAD_MAX_PORTS] = {};
+	struct guid_ca_pairs_mapping mapping[UMAD_MAX_PORTS] = {};
+
+	memset(cas, 0, sizeof(umad_ca_pair_t) * max);
+	int cas_found = umad_get_cas_names(legacy_ca_names, UMAD_MAX_DEVICES);
+
+	if (cas_found < 0)
+		return 0;
+
+	count_ports_by_guid(legacy_ca_names, cas_found, counts, UMAD_MAX_PORTS);
+
+	size_t c_idx = 0;
+	for (c_idx = 0; c_idx < (size_t)cas_found; ++c_idx) {
+		umad_ca_t curr_ca;
+
+		if (umad_get_ca(legacy_ca_names[c_idx], &curr_ca) < 0)
+			continue;
+
+		size_t p_idx = 1;
+		for (p_idx = 1; p_idx < (size_t)curr_ca.numports + 1; ++p_idx) {
+			umad_port_t *p_port = curr_ca.ports[p_idx];
+			uint8_t guid_count = 0;
+
+			if (!p_port)
+				continue;
+
+			guid_count = get_port_guid_count(curr_ca.ports[p_idx]->port_guid,
+								counts, UMAD_MAX_PORTS);
+			umad_ca_pair_t *dev = get_ca_pair_from_arr_by_guid(p_port->port_guid,
+								mapping, UMAD_MAX_PORTS,
+								&added_mappings, cas,
+								max, &added_devices);
+				if (!dev)
+					continue;
+			if (guid_count > 1) {
+				// planarized port
+				add_new_port(is_smi_disabled(p_port) ?
+						&dev->gsi : &dev->smi, p_port);
+			} else if (guid_count == 1) {
+				if (!is_smi_disabled(p_port))
+					add_new_port(&dev->smi, p_port);
+
+				// all ports are GSI ports in legacy HCAs
+				add_new_port(&dev->gsi, p_port);
+			} else {
+				return -1;
+			}
+		}
+
+		umad_release_ca(&curr_ca);
+	}
+
+	return added_devices;
+}
+
+static int umad_check_active(umad_ca_pair_item_t *dev, int prefered)
+{
+	umad_ca_t ca;
+
+	if (!dev)
+		return 1;
+
+	// check if candidate is active
+	if (umad_get_ca(dev->name, &ca) < 0)
+		return 2;
+
+	int state = ca.ports[prefered]->state;
+
+	umad_release_ca(&ca);
+
+	return !(state > 1);
+}
+
+static int umad_find_active(umad_ca_pair_item_t *dev) 
+{
+	int i;
+
+	if (!dev)
+		return 1;
+
+	for (i = 0; i < dev->numports; ++i)
+		if (!umad_check_active(dev, dev->ports[i])) {
+			dev->preferred_port = dev->ports[i];
+			return 0;
+		}
+
+	return 1;
+}
+
+int umad_get_ca_pair_by_name(const char *name, uint8_t portnum, umad_ca_pair_t *ca)
+{
+	int rc			= 1;
+	size_t i		= 0;
+	int num_cas		= 0;
+	size_t port_idx = 0;
+	bool is_gsi		= false;
+	bool found_port = false;
+
+	umad_ca_pair_item_t *dev                     = NULL;
+	umad_ca_pair_t       cas_pair[UMAD_MAX_PORTS] = {};
+
+	if (!ca)
+		return -1;
+
+	memset(cas_pair, 0, sizeof(cas_pair));
+	memset(ca, 0, sizeof(*ca));
+
+	num_cas = umad_get_cas_pairs(cas_pair, UMAD_MAX_PORTS);
+
+	if (num_cas <= 0)
+		return num_cas;
+
+	for (i = 0; i < (size_t)num_cas; ++i) {
+		if (!cas_pair[i].gsi.name[0] || !cas_pair[i].smi.name[0] ||
+				!cas_pair[i].gsi.numports || !cas_pair[i].smi.numports)
+			continue;
+
+		if (name)
+			// name doesn't match - keep searching
+			if (strncmp(cas_pair[i].gsi.name, name, UMAD_CA_NAME_LEN)
+				&& strncmp(cas_pair[i].smi.name, name, UMAD_CA_NAME_LEN)) {
+				continue;
+			}
+
+		// check that the device given by "name" has a port number "portnum"
+		// (if name doesn't exist, assume SMI port is given)
+		is_gsi = (name && !strncmp(name, cas_pair[i].gsi.name, UMAD_CA_NAME_LEN));
+
+		if (portnum) {
+			dev = is_gsi ? &cas_pair[i].gsi : &cas_pair[i].smi;
+
+			found_port = false;
+
+			for (port_idx = 0; port_idx < dev->numports; ++port_idx) {
+				
+				if (!dev->ports[port_idx])
+					break;
+				
+				if (dev->ports[port_idx] == portnum)
+					found_port = true;
+			}
+
+			// couldn't find portnum - keep searching
+			if (!found_port)
+				continue;
+		}
+
+		// fill candidate
+		*ca = cas_pair[i];
+
+		if (portnum)
+			if (is_gsi)
+				rc = umad_find_active(&ca->smi)
+						+ umad_check_active(&ca->gsi, portnum);
+			else
+				rc = umad_check_active(&ca->smi, portnum)
+						+ umad_find_active(&ca->gsi);
+		else {
+			rc = umad_find_active(&ca->smi)
+					+ umad_find_active(&ca->gsi);
+		}
+
+		if (!rc)
+			break;
+	}
+
+	if (rc) {
+		errno = ENODEV;
+		return -errno;
+	}
+
+	return rc;
+}
+

--- a/libibumad/umad.c
+++ b/libibumad/umad.c
@@ -1386,6 +1386,7 @@ static umad_ca_pair_t *get_ca_pair_from_arr_by_guid(__be64 port_guid,
 	umad_ca_pair_t *dev = NULL;
 	// attempt to find the port guid in the mapping
 	size_t i = 0;
+
 	for (i = 0; i < *map_added; ++i) {
 		if (mapping[i].port_guid == port_guid)
 			return mapping[i].ca_pair;
@@ -1408,6 +1409,7 @@ static uint8_t get_port_guid_count(__be64 guid, const struct port_guid_port_coun
 							size_t max_guids)
 {
 	size_t i = 0;
+
 	for (i = 0; i < max_guids; ++i) {
 		if (counts[i].port_guid == guid)
 			return counts[i].count;
@@ -1421,6 +1423,7 @@ static bool find_port_guid_count(struct port_guid_port_count counts[], size_t ma
 						  __be64 port_guid, size_t *index)
 {
 	size_t i = 0;
+
 	for (i = 0; i < max; ++i) {
 		if (counts[i].port_guid == 0) {
 			*index = i;
@@ -1445,6 +1448,7 @@ static int count_ports_by_guid(char legacy_ca_names[][UMAD_CA_NAME_LEN], size_t 
 	memset(counts, 0, max * sizeof(struct port_guid_port_count));
 
 	size_t c_idx = 0;
+
 	for (c_idx = 0; c_idx < num_cas; ++c_idx) {
 		umad_ca_t curr_ca;
 
@@ -1452,6 +1456,7 @@ static int count_ports_by_guid(char legacy_ca_names[][UMAD_CA_NAME_LEN], size_t 
 			continue;
 
 		size_t p_idx = 1;
+
 		for (p_idx = 1; p_idx < (size_t)curr_ca.numports + 1; ++p_idx) {
 			umad_port_t *p_port = curr_ca.ports[p_idx];
 			size_t count_idx = 0;
@@ -1495,6 +1500,7 @@ int umad_get_cas_pairs(umad_ca_pair_t cas[], size_t max)
 	count_ports_by_guid(legacy_ca_names, cas_found, counts, UMAD_MAX_PORTS);
 
 	size_t c_idx = 0;
+
 	for (c_idx = 0; c_idx < (size_t)cas_found; ++c_idx) {
 		umad_ca_t curr_ca;
 
@@ -1502,6 +1508,7 @@ int umad_get_cas_pairs(umad_ca_pair_t cas[], size_t max)
 			continue;
 
 		size_t p_idx = 1;
+
 		for (p_idx = 1; p_idx < (size_t)curr_ca.numports + 1; ++p_idx) {
 			umad_port_t *p_port = curr_ca.ports[p_idx];
 			uint8_t guid_count = 0;

--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -169,6 +169,19 @@ typedef struct umad_ca {
 	umad_port_t *ports[UMAD_CA_MAX_PORTS];
 } umad_ca_t;
 
+typedef struct umad_ca_pair_item {
+	char         name[UMAD_CA_NAME_LEN];
+	uint32_t     ports[UMAD_CA_MAX_PORTS];
+	uint32_t     numports;
+	uint32_t     preferred_port;
+} umad_ca_pair_item_t;
+
+typedef struct umad_ca_pair {
+	umad_ca_pair_item_t smi;
+	umad_ca_pair_item_t gsi;
+} umad_ca_pair_t;
+
+
 struct umad_device_node {
 	struct umad_device_node *next; /* next umad device node  */
 	const char *ca_name; /* ca name */
@@ -237,6 +250,8 @@ int umad_register2(int port_fd, struct umad_reg_attr *attr,
 int umad_debug(int level);
 void umad_addr_dump(ib_mad_addr_t * addr);
 void umad_dump(void *umad);
+int umad_get_cas_pairs(umad_ca_pair_t cas[], size_t max);
+int umad_get_ca_pair_by_name(const char *devname, uint8_t portnum, umad_ca_pair_t *ca);
 
 static inline void *umad_alloc(int num, size_t size)
 {				/* alloc array of umad buffers */


### PR DESCRIPTION
Added 2 new methods to libibumad:
 - umad_get_cas_pairs
 - umad_get_ca_pair_by_name

Also 2 new strucures to represent smi/gsi pairs:
 - umad_ca_pair
 - umad_ca_pair_item_t