### PR TITLE
Fix compiling warnings on fedora40

### DIFF
--- a/libibnetdisc/ibnetdisc_cache.c
+++ b/libibnetdisc/ibnetdisc_cache.c
@@ -557,7 +557,7 @@ static int _rebuild_nodes(ibnd_fabric_cache_t * fabric_cache)
 		/* Rebuild node ports array */
 
 		if (!(node->ports =
-		      calloc(sizeof(*node->ports), node->numports + 1))) {
+		      calloc(node->numports + 1, sizeof(*node->ports)))) {
 			IBND_DEBUG("OOM: node->ports\n");
 			return -1;
 		}

--- a/librdmacm/examples/cmtime.c
+++ b/librdmacm/examples/cmtime.c
@@ -990,7 +990,7 @@ int main(int argc, char **argv)
 		exit(EXIT_FAILURE);
 	}
 
-	nodes = calloc(sizeof *nodes, iter);
+	nodes = calloc(iter, sizeof *nodes);
 	if (!nodes) {
 		perror("calloc");
 		exit(EXIT_FAILURE);

--- a/providers/mlx5/dr_vports.c
+++ b/providers/mlx5/dr_vports.c
@@ -241,7 +241,8 @@ void dr_vports_table_del_wire(struct dr_devx_vports *vports)
 		goto out_unlock;
 	}
 
-	vport = h->buckets[idx];
+	prev = h->buckets[idx];
+	vport = prev->next;
 	while (vport) {
 		if (vport == wire) {
 			prev->next = vport->next;

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1513,7 +1513,7 @@ cdef class WqeCtrlSeg(WqeSeg):
         using mlx5dv_set_ctrl_seg, segment values are accessed
         through the getters/setters.
         """
-        self.segment = calloc(sizeof(dv.mlx5_wqe_ctrl_seg), 1)
+        self.segment = calloc(1, sizeof(dv.mlx5_wqe_ctrl_seg))
         self.set_ctrl_seg(pi, opcode, opmod, qp_num, fm_ce_se, ds, signature, imm)
 
     def __str__(self):
@@ -1584,7 +1584,7 @@ cdef class WqeDataSeg(WqeSeg):
         Create a dv.mlx5_wqe_data_seg by allocating it and using
         dv.mlx5dv_set_data_seg with the values received in init
         """
-        self.segment = calloc(sizeof(dv.mlx5_wqe_data_seg), 1)
+        self.segment = calloc(1, sizeof(dv.mlx5_wqe_data_seg))
         self.set_data_seg(length, lkey, addr)
 
     @staticmethod
@@ -1646,7 +1646,7 @@ cdef class Wqe(PyverbsCM):
             self.is_user_addr = False
             allocation_size = sum(map(lambda x: x.sizeof() if isinstance(x, WqeSeg) else len(x),
                                       self.segments))
-            self.addr = calloc(allocation_size, 1)
+            self.addr = calloc(1, allocation_size)
         addr = <uintptr_t>self.addr
         for seg in self.segments:
             if isinstance(seg, WqeSeg):


### PR DESCRIPTION
Recently, I updated my host to fedora40 and rebuilt the rdma-core. The compiler complained a few warnings.
gcc: gcc (GCC) 14.2.1 20240912 (Red Hat 14.2.1-3)

```
make -C build 2>&1 | grep -i -A3 -B1 warning
[ 37%] Building C object librdmacm/CMakeFiles/rspreload.dir/preload.c.o
/home/lizhijian/rdma-core/librdmacm/preload.c:1175:5: warning: no previous prototype for ‘__fxstat’ [-Wmissing-prototypes]
 1175 | int __fxstat(int ver, int socket, struct stat *buf)
      |     ^~~~~~~~
[ 37%] Linking C shared module ../lib/librspreload.so
--
/home/lizhijian/rdma-core/providers/mlx5/dr_vports.c: In function ‘dr_vports_table_del_wire’:
/home/lizhijian/rdma-core/providers/mlx5/dr_vports.c:247:36: warning: ‘prev’ may be used uninitialized [-Wmaybe-uninitialized]
  247 |                         prev->next = vport->next;
      |                         ~~~~~~~~~~~^~~~~~~~~~~~~
/home/lizhijian/rdma-core/providers/mlx5/dr_vports.c:231:43: note: ‘prev’ was declared here
--
/home/lizhijian/rdma-core/libibnetdisc/ibnetdisc_cache.c: In function ‘_rebuild_nodes’:
/home/lizhijian/rdma-core/libibnetdisc/ibnetdisc_cache.c:560:36: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  560 |                       calloc(sizeof(*node->ports), node->numports + 1))) {
      |                                    ^
/home/lizhijian/rdma-core/libibnetdisc/ibnetdisc_cache.c:560:36: note: earlier argument should specify number of elements, later size of each element
--
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c: In function ‘__pyx_pf_7pyverbs_9providers_4mlx5_6mlx5dv_10WqeCtrlSeg___init__’:
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c:48608:53: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
48608 |   __pyx_v_self->__pyx_base.segment = calloc((sizeof(struct mlx5_wqe_ctrl_seg)), 1);
      |                                                     ^~~~~~
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c:48608:53: note: earlier argument should specify number of elements, later size of each element
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c: In function ‘__pyx_pf_7pyverbs_9providers_4mlx5_6mlx5dv_10WqeDataSeg___init__’:
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c:50301:53: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
50301 |   __pyx_v_self->__pyx_base.segment = calloc((sizeof(struct mlx5_wqe_data_seg)), 1);
      |                                                     ^~~~~~
/home/lizhijian/rdma-core/build/pyverbs/providers/mlx5/mlx5dv.c:50301:53: note: earlier argument should specify number of elements, later size of each element
At top level:
cc1: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1: note: unrecognized command-line option ‘-Wno-unknown-warning’ may have been intended to silence earlier diagnostics
[ 82%] Linking C shared library ../../../python/pyverbs/providers/mlx5/mlx5dv.cpython-312-x86_64-linux-gnu.so
[ 82%] Built target mlx5dv.cpython-312-x86_64-linux-gnu
[ 83%] Linking C shared library ../../../python/pyverbs/providers/mlx5/mlx5dv_crypto.cpython-312-x86_64-linux-gnu.so
--
/home/lizhijian/rdma-core/librdmacm/examples/cmtime.c: In function ‘main’:
/home/lizhijian/rdma-core/librdmacm/examples/cmtime.c:993:31: warning: ‘calloc’ sizes specified with ‘sizeof’ in the earlier argument and not in the later argument [-Wcalloc-transposed-args]
  993 |         nodes = calloc(sizeof *nodes, iter);
      |                               ^
/home/lizhijian/rdma-core/librdmacm/examples/cmtime.c:993:31: note: earlier argument should specify number of elements, later size of each element
```

Thi PR intends to fix them.