### PR TITLE
mlx5: Fix the license disclaimer of mlx5_vfio.c/h

### DIFF
--- a/providers/mlx5/mlx5_vfio.c
+++ b/providers/mlx5/mlx5_vfio.c
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0 or Linux-OpenIB
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved
  */

--- a/providers/mlx5/mlx5_vfio.h
+++ b/providers/mlx5/mlx5_vfio.h
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-only
+// SPDX-License-Identifier: GPL-2.0 or Linux-OpenIB
 /*
  * Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved
  */


### PR DESCRIPTION
Fix the license disclaimer of the mlx5_vfio.c and mlx5_vfio.h files to align with the overall library license.