### PR TITLE
azp: Use v2 version of DownloadPipelineArtifact

### DIFF
--- a/buildlib/azure-pipelines.yml
+++ b/buildlib/azure-pipelines.yml
@@ -195,7 +195,7 @@ stages:
         steps:
           - checkout: none
 
-          - task: DownloadPipelineArtifact@0
+          - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: source_tar
               targetPath: .
@@ -229,7 +229,7 @@ stages:
         steps:
           - checkout: none
 
-          - task: DownloadPipelineArtifact@0
+          - task: DownloadPipelineArtifact@2
             inputs:
               artifactName: source_tar
               targetPath: .


### PR DESCRIPTION
AZP is now complaining during builds that the v0 is too old.