### PR TITLE
buildlib: set a proper name when creating a github release

### DIFF
--- a/buildlib/azure-pipelines-release.yml
+++ b/buildlib/azure-pipelines-release.yml
@@ -28,6 +28,10 @@ stages:
 
           - bash: |
               set -e
+              git_tag=$(git describe --exact-match HEAD)
+              rel_ver=$(echo $git_tag | sed -e 's/^v//')
+              echo "Version is $rel_ver"
+              echo "##vso[task.setvariable variable=rel_ver]$rel_ver"
               mkdir build-pandoc artifacts
               cd build-pandoc
               CC=gcc-12 cmake -GNinja ..
@@ -37,12 +41,13 @@ stages:
               python3 buildlib/cbuild make-dist-tar build-pandoc
             displayName: Prebuild Documentation
 
-          - task: GithubRelease@0
+          - task: GithubRelease@1
             displayName: 'Create GitHub Release'
             inputs:
               githubConnection: github_release
               repositoryName: linux-rdma/rdma-core
               assets: ./*.tar.gz
               action: create
+              title: rdma-core-$(rel_ver)
               isDraft: true
               addChangeLog: true


### PR DESCRIPTION
By default, AZP creates a release on Github names vXX.YY which does not match the format currently used: rdma-core-XX.YY This changes the release name to match the expected format.

Fixes: 936cf8e17cf3 ("build/azp: Have Azure Pipelines create releases when tags are made")