### PR TITLE
bnxt_re/lib: Fix the inline size check

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -1674,7 +1674,7 @@ static inline int bnxt_re_calc_inline_len(struct ibv_send_wr *swr)
 	illen = 0;
 	for (indx = 0; indx < swr->num_sge; indx++)
 		illen += swr->sg_list[indx].length;
-	return align(illen, sizeof(struct bnxt_re_sge));
+	return illen;
 }
 
 static int bnxt_re_put_inline(struct bnxt_re_queue *que, uint32_t *idx,
@@ -1738,6 +1738,7 @@ static int bnxt_re_required_slots(struct bnxt_re_qp *qp, struct ibv_send_wr *wr,
 		ilsize = bnxt_re_calc_inline_len(wr);
 		if (ilsize > qp->cap.max_inline)
 			return -EINVAL;
+		ilsize = align(ilsize, sizeof(struct bnxt_re_sge));
 		if (qp->push_st_en && ilsize <= qp->max_push_sz)
 			*pbuf = bnxt_re_get_pbuf(&qp->push_st_en, qp->cntx);
 		wqe_byte = (ilsize + bnxt_re_get_sqe_hdr_sz());


### PR DESCRIPTION
Align the inline size only after the max_inline_check to avoid failures.

Fixes: b9c6f8c3691e ("bnxt_re/lib: Refactor post_send and post_recv")