### PR TITLE
mlx5: fix max length of hostname

### DIFF
--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -39,6 +39,7 @@
 #include <stdarg.h>
 #include <stdatomic.h>
 #include <util/compiler.h>
+#include <limits.h>
 
 #include <infiniband/driver.h>
 #include <util/udma_barrier.h>
@@ -363,7 +364,7 @@ struct mlx5_context {
 	int				stall_cycles;
 	struct mlx5_bf		       *bfs;
 	FILE			       *dbg_fp;
-	char				hostname[40];
+	char				hostname[HOST_NAME_MAX + 1];
 	struct mlx5_spinlock            hugetlb_lock;
 	struct list_head                hugetlb_list;
 	int				cqe_version;


### PR DESCRIPTION
The current length of `mlx5_context.hostname` is a 40 bytes long. According to `gethostname`'s man-page, and also the standard of POSIX. The maximum length is `HOST_NAME_MAX`, which is 64 bytes.

And also, the [RFC1034](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1), the maximum length is also about 64 bytes.

So, I made this patch to follow the standards.