### PR TITLE
Fix infiniband-diags tools to support planarized network

### DIFF
--- a/infiniband-diags/dump_fts.c
+++ b/infiniband-diags/dump_fts.c
@@ -50,6 +50,7 @@
 #include "ibdiag_common.h"
 
 static struct ibmad_port *srcport;
+static struct ibmad_ports_pair *srcports;
 
 static unsigned startlid, endlid;
 
@@ -457,10 +458,16 @@ int main(int argc, char **argv)
 	if ((fabric = ibnd_discover_fabric(ibd_ca, ibd_ca_port, NULL,
 						&config)) != NULL) {
 
-		srcport = mad_rpc_open_port(ibd_ca, ibd_ca_port, mgmt_classes, 3);
-		if (!srcport) {
+		srcports = mad_rpc_open_port2(ibd_ca, ibd_ca_port, mgmt_classes, 3, 1);
+		if (!srcports) {
 			fprintf(stderr,
 				"Failed to open '%s' port '%d'\n", ibd_ca, ibd_ca_port);
+			rc = -1;
+			goto Exit;
+		}
+		srcport = srcports->smi.port;
+		if (!srcport) {
+			fprintf(stderr, "Failed to open '%s' port '%d'\n", ibd_ca, ibd_ca_port);
 			rc = -1;
 			goto Exit;
 		}
@@ -472,7 +479,7 @@ int main(int argc, char **argv)
 
 		ibnd_iter_nodes_type(fabric, process_switch, IB_NODE_SWITCH, fabric);
 
-		mad_rpc_close_port(srcport);
+		mad_rpc_close_port2(srcports);
 
 	} else {
 		fprintf(stderr, "Failed to discover fabric\n");

--- a/infiniband-diags/ibccquery.c
+++ b/infiniband-diags/ibccquery.c
@@ -47,6 +47,7 @@
 #include "ibdiag_common.h"
 
 static struct ibmad_port *srcport;
+static struct ibmad_ports_pair *srcports;
 
 static op_fn_t class_port_info;
 static op_fn_t congestion_info;
@@ -204,7 +205,7 @@ static const char *switch_port_congestion_setting(ib_portid_t *dest,
 		portnum = strtol(argv[0], NULL, 0);
 
 	/* Figure out number of ports first */
-	if (!smp_query_via(data, dest, IB_ATTR_NODE_INFO, 0, 0, srcport))
+	if (!smp_query_via(data, dest, IB_ATTR_NODE_INFO, 0, 0, srcports->smi.port))
 		return "node info query failed";
 
 	mad_decode_field((uint8_t *)data, IB_NODE_TYPE_F, &type);
@@ -391,18 +392,22 @@ int main(int argc, char **argv)
 	if (!(fn = match_op(match_tbl, argv[0])))
 		IBEXIT("operation '%s' not supported", argv[0]);
 
-	srcport = mad_rpc_open_port(ibd_ca, ibd_ca_port, mgmt_classes, 3);
+	srcports = mad_rpc_open_port2(ibd_ca, ibd_ca_port, mgmt_classes, 3, 0);
+	if (!srcports)
+		IBEXIT("Failed to open '%s' port '%d'", ibd_ca, ibd_ca_port);
+
+	srcport = srcports->gsi.port;
 	if (!srcport)
 		IBEXIT("Failed to open '%s' port '%d'", ibd_ca, ibd_ca_port);
 
-	smp_mkey_set(srcport, ibd_mkey);
+	smp_mkey_set(srcports->smi.port, ibd_mkey);
 
-	if (resolve_portid_str(ibd_ca, ibd_ca_port, &portid, argv[1],
+	if (resolve_portid_str(srcports->gsi.ca_name, ibd_ca_port, &portid, argv[1],
 			       ibd_dest_type, ibd_sm_id, srcport) < 0)
 		IBEXIT("can't resolve destination %s", argv[1]);
 	if ((err = fn(&portid, argv + 2, argc - 2)))
 		IBEXIT("operation %s: %s", argv[0], err);
 
-	mad_rpc_close_port(srcport);
+	mad_rpc_close_port2(srcports);
 	exit(0);
 }

--- a/infiniband-diags/ibdiag_sa.h
+++ b/infiniband-diags/ibdiag_sa.h
@@ -59,7 +59,7 @@ struct sa_query_result {
 };
 
 /* NOTE: umad_init must be called prior to sa_get_handle */
-struct sa_handle * sa_get_handle(void);
+struct sa_handle *sa_get_handle(char *ca_name);
 void sa_free_handle(struct sa_handle * h);
 
 int sa_query(struct sa_handle *h, uint8_t method,

--- a/infiniband-diags/iblinkinfo.c
+++ b/infiniband-diags/iblinkinfo.c
@@ -593,6 +593,7 @@ int main(int argc, char **argv)
 	ibnd_fabric_t *fabric = NULL;
 	ibnd_fabric_t *diff_fabric = NULL;
 	struct ibmad_port *ibmad_port;
+	struct ibmad_ports_pair *ibmad_ports;
 	ib_portid_t port_id = { 0 };
 	uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 	int mgmt_classes[3] =
@@ -640,7 +641,14 @@ int main(int argc, char **argv)
 	argc -= optind;
 	argv += optind;
 
-	ibmad_port = mad_rpc_open_port(ibd_ca, ibd_ca_port, mgmt_classes, 3);
+	ibmad_ports = mad_rpc_open_port2(ibd_ca, ibd_ca_port, mgmt_classes, 3, 1);
+	if (!ibmad_ports) {
+		fprintf(stderr, "Failed to open %s port %d\n", ibd_ca,
+			ibd_ca_port);
+		exit(1);
+	}
+
+	ibmad_port = ibmad_ports->smi.port;
 	if (!ibmad_port) {
 		fprintf(stderr, "Failed to open %s port %d\n", ibd_ca,
 			ibd_ca_port);
@@ -660,7 +668,7 @@ int main(int argc, char **argv)
 	node_name_map = open_node_name_map(node_name_map_file);
 
 	if (dr_path && load_cache_file) {
-		mad_rpc_close_port(ibmad_port);
+		mad_rpc_close_port2(ibmad_ports);
 		fprintf(stderr, "Cannot specify cache and direct route path\n");
 		exit(1);
 	}
@@ -668,14 +676,14 @@ int main(int argc, char **argv)
 	if (dr_path) {
 		/* only scan part of the fabric */
 		if ((resolved =
-		     resolve_portid_str(ibd_ca, ibd_ca_port, &port_id, dr_path,
-					IB_DEST_DRPATH, NULL, ibmad_port)) < 0)
+		     resolve_portid_str(ibmad_ports->gsi.ca_name, ibd_ca_port, &port_id, dr_path,
+					IB_DEST_DRPATH, NULL, ibmad_ports->gsi.port)) < 0)
 			IBWARN("Failed to resolve %s; attempting full scan",
 			       dr_path);
 	} else if (node_label.guid_str) {
 		if ((resolved = resolve_portid_str(
-			     ibd_ca, ibd_ca_port, &port_id, node_label.guid_str,
-			     IB_DEST_GUID, NULL, ibmad_port)) < 0)
+			     ibmad_ports->gsi.ca_name, ibd_ca_port, &port_id, node_label.guid_str,
+			     IB_DEST_GUID, NULL, ibmad_ports->gsi.port)) < 0)
 			IBWARN("Failed to resolve %s; attempting full scan\n",
 			       node_label.guid_str);
 	}
@@ -683,12 +691,12 @@ int main(int argc, char **argv)
 	if (!all && dr_path) {
 		if (!smp_query_via(ni, &port_id, IB_ATTR_NODE_INFO, 0,
 				   ibd_timeout, ibmad_port)){
-			mad_rpc_close_port(ibmad_port);
+			mad_rpc_close_port2(ibmad_ports);
 			fprintf(stderr, "Failed to get local Node Info\n");
 			exit(1);
 		}
 	}
-	mad_rpc_close_port(ibmad_port);
+	mad_rpc_close_port2(ibmad_ports);
 
 	if (diff_cache_file &&
 	    !(diff_fabric = ibnd_load_fabric(diff_cache_file, 0)))

--- a/infiniband-diags/ibping.c
+++ b/infiniband-diags/ibping.c
@@ -44,6 +44,7 @@
 #include "ibdiag_common.h"
 
 static struct ibmad_port *srcport;
+static struct ibmad_ports_pair *srcports;
 
 static uint64_t time_stamp(void)
 {
@@ -216,7 +217,11 @@ int main(int argc, char **argv)
 	if (!argc && !server)
 		ibdiag_show_usage();
 
-	srcport = mad_rpc_open_port(ibd_ca, ibd_ca_port, mgmt_classes, 1);
+	srcports = mad_rpc_open_port2(ibd_ca, ibd_ca_port, mgmt_classes, 1, 0);
+	if (!srcports)
+		IBEXIT("Failed to open '%s' port '%d'", ibd_ca, ibd_ca_port);
+
+	srcport = srcports->gsi.port;
 	if (!srcport)
 		IBEXIT("Failed to open '%s' port '%d'", ibd_ca, ibd_ca_port);
 
@@ -236,7 +241,7 @@ int main(int argc, char **argv)
 		IBEXIT("can't register ping class %d on this port",
 			ping_class);
 
-	if (resolve_portid_str(ibd_ca, ibd_ca_port, &portid, argv[0],
+	if (resolve_portid_str(srcports->gsi.ca_name, ibd_ca_port, &portid, argv[0],
 			       ibd_dest_type, ibd_sm_id, srcport) < 0)
 		IBEXIT("can't resolve destination port %s", argv[0]);
 
@@ -265,7 +270,7 @@ int main(int argc, char **argv)
 
 	report(0);
 
-	mad_rpc_close_port(srcport);
+	mad_rpc_close_port2(srcports);
 
 	exit(-1);
 }

--- a/infiniband-diags/mcm_rereg_test.c
+++ b/infiniband-diags/mcm_rereg_test.c
@@ -60,6 +60,7 @@ static ibmad_gid_t mgid_ipoib = {
 };
 
 static struct ibmad_port *srcport;
+static struct ibmad_ports_pair *srcports;
 
 static uint64_t build_mcm_rec(uint8_t *data, ibmad_gid_t mgid,
 			      ibmad_gid_t port_gid)
@@ -367,7 +368,11 @@ int main(int argc, const char **argv)
 	if (argc > 1)
 		guid_file = argv[1];
 
-	srcport = mad_rpc_open_port(NULL, 0, mgmt_classes, 2);
+	srcports = mad_rpc_open_port2(NULL, 0, mgmt_classes, 2, 0);
+	if (!srcports)
+		err("Failed to open port");
+
+	srcport = srcports->gsi.port;
 	if (!srcport)
 		err("Failed to open port");
 
@@ -390,7 +395,7 @@ int main(int argc, const char **argv)
 
 	free(umad);
 	umad_unregister(port, agent);
-	umad_close_port(port);
+	mad_rpc_close_port2(srcports);
 	umad_done();
 
 	return 0;

--- a/infiniband-diags/saquery.c
+++ b/infiniband-diags/saquery.c
@@ -1859,7 +1859,7 @@ int main(int argc, char **argv)
 	if (umad_init())
 		IBEXIT("Failed to initialized umad library");
 
-	h = sa_get_handle();
+	h = sa_get_handle(NULL);
 	if (!h)
 		IBPANIC("Failed to bind to the SA");
 


### PR DESCRIPTION
Use API supporting SMI/GSI separation to fix the following infiniband-diags tools:

- ibnetdisc
- dump_fts
- ibaddr
- ibccconfig
- ibccquery
- iblinkinfo
- ibping
- ibportstate
- ibqueryerrors
- ibroute
- ibsendtrap
- ibsysstat
- ibtracert
- mcm_reregtest
- perfquery
- sminfo
- vendstat