### PR TITLE
mlx5: specify unsupport config mkey write relax ordering

### DIFF
--- a/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
+++ b/providers/mlx5/man/mlx5dv_wr_mkey_configure.3.md
@@ -161,7 +161,7 @@ struct mlx5dv_mkey_conf_attr {
 
 	:	The desired memory protection attributes; it is either 0 or
 		the bitwise OR of one or more of flags in **enum
-		ibv_access_flags**.
+		ibv_access_flags**. IBV_ACCESS_RELAXED_ORDERING is not supported.
 
 ## Data layout setters
 


### PR DESCRIPTION
The API mlx5dv_wr_set_mkey_access_flags access_flags parameter doesn't support IBV_ACCESS_RELAXED_ORDERING.
https://github.com/linux-rdma/rdma-core/blob/v55.0/providers/mlx5/qp.c#L2951-L2958
```C
	if (unlikely(!check_comp_mask(access_flags,
				      IBV_ACCESS_LOCAL_WRITE |
				      IBV_ACCESS_REMOTE_WRITE |
				      IBV_ACCESS_REMOTE_READ |
				      IBV_ACCESS_REMOTE_ATOMIC))) {
		mqp->err = EINVAL;
		return;
	}
```
