### PR TITLE
providers/bnxt_re: Fix memory leak

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -357,7 +357,7 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 	 */
 	cq->cqq->va = cq->mem->va_head;
 	if (!cq->cqq->va)
-		goto fail;
+		goto cmdfail;
 
 	pthread_spin_init(&cq->cqq->qlock, PTHREAD_PROCESS_PRIVATE);
 


### PR DESCRIPTION
Avoid memory leak in bnxt_re_create_cq() by freeing "cq->mem".

Fixes: d035125e3643 ("bnxt_re/lib: Refactor CQ create verb implementation")