### PR TITLE
Changes from Debian upload 55.0 1 plus fixes

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,33 @@ rdma-core (56.0-1) unstable; urgency=medium
 
   * New upstream release.
 
- -- Jason Gunthorpe <jgg@obsidianresearch.com>  Tue, 27 Feb 2024 11:32:22 +0100
+ -- Jason Gunthorpe <jgg@obsidianresearch.com>  Tue, 21 Jan 2025 13:44:36 +0100
+
+rdma-core (55.0-1) unstable; urgency=medium
+
+  * New upstream release.
+  * Bump Standards-Version to 4.7.0
+  * Update library symbols
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Tue, 21 Jan 2025 12:50:59 +0100
+
+rdma-core (52.0-2) unstable; urgency=medium
+
+  * Exclude hns provider on archs without coherent DMA (Closes: #1073050)
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Thu, 27 Jun 2024 13:49:34 +0200
+
+rdma-core (52.0-1) unstable; urgency=medium
+
+  * New upstream release.
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Mon, 03 Jun 2024 11:07:43 +0200
+
+rdma-core (50.0-2) unstable; urgency=medium
+
+  * Rename libraries for 64-bit time_t transition (Closes: #1064313)
+
+ -- Benjamin Drung <bdrung@ubuntu.com>  Thu, 29 Feb 2024 03:11:46 +0100
 
 rdma-core (50.0-1) unstable; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Build-Depends: cmake (>= 2.8.11),
                python3-docutils,
                valgrind [amd64 arm64 armhf i386 mips mips64el mipsel powerpc ppc64 ppc64el s390x]
 Rules-Requires-Root: no
-Standards-Version: 4.6.2
+Standards-Version: 4.7.0
 Vcs-Git: https://github.com/linux-rdma/rdma-core.git
 Vcs-Browser: https://github.com/linux-rdma/rdma-core
 Homepage: https://github.com/linux-rdma/rdma-core

--- a/debian/control
+++ b/debian/control
@@ -162,25 +162,6 @@ Description: Library for direct userspace use of RDMA (InfiniBand/iWARP)
  .
  This package contains the shared library.
 
-Package: libibverbs1-dbg
-Section: debug
-Architecture: linux-any
-Multi-Arch: same
-Depends: libibverbs1 (= ${binary:Version}), ${misc:Depends}
-Description: Debug symbols for the libibverbs library
- libibverbs is a library that allows userspace processes to use RDMA
- "verbs" as described in the InfiniBand Architecture Specification and
- the RDMA Protocol Verbs Specification.  iWARP ethernet NICs support
- RDMA over hardware-offloaded TCP/IP, while InfiniBand is a
- high-throughput, low-latency networking technology.  InfiniBand host
- channel adapters (HCAs) and iWARP NICs commonly support direct
- hardware access from userspace (kernel bypass), and libibverbs
- supports this when available.
- .
- This package contains the debug symbols associated with
- libibverbs1. They will automatically be used by gdb for debugging
- libibverbs-related issues.
-
 Package: libibumad-dev
 Section: libdevel
 Architecture: linux-any
@@ -207,19 +188,6 @@ Description: InfiniBand Userspace Management Datagram (uMAD) library
  These are used by InfiniBand diagnostic and management tools.
  .
  This package contains the shared library.
-
-Package: libibumad3-dbg
-Section: debug
-Architecture: linux-any
-Depends: libibumad3 (= ${binary:Version}), ${misc:Depends}
-Description: Debug symbols for the libibumad3 library
- libibumad provides userspace Infiniband Management Datagram (uMAD)
- functions which sit on top of the uMAD modules in the kernel.
- These are used by InfiniBand diagnostic and management tools.
- .
- This package contains the debug symbols associated with
- libibumad3. They will automatically be used by gdb for debugging
- libibumad-related issues.
 
 Package: librdmacm-dev
 Section: libdevel
@@ -265,28 +233,6 @@ Description: Library for managing RDMA connections
  transfer data.
  .
  This package contains the shared library.
-
-Package: librdmacm1-dbg
-Section: debug
-Architecture: linux-any
-Depends: librdmacm1 (= ${binary:Version}), ${misc:Depends}
-Description: Debug symbols for the librdmacm library
- librdmacm is a library that allows applications to set up reliable
- connected and unreliable datagram transfers when using RDMA adapters.
- It provides a transport-neutral interface in the sense that the same
- code can be used for both InfiniBand and iWARP adapters.  The
- interface is based on sockets, but adapted for queue pair (QP) based
- semantics: communication must use a specific RDMA device, and data
- transfers are message-based.
- .
- librdmacm only provides communication management (connection setup
- and tear-down) and works in conjunction with the verbs interface
- provided by libibverbs, which provides the interface used to actually
- transfer data.
- .
- This package contains the debug symbols associated with
- librdmacm1. They will automatically be used by gdb for debugging
- librdmacm-related issues.
 
 Package: rdmacm-utils
 Architecture: linux-any
@@ -363,21 +309,6 @@ Description: Infiniband Management Datagram (MAD) library
  .
  This package contains the shared library.
 
-Package: libibmad5-dbg
-Section: debug
-Architecture: linux-any
-Pre-Depends: ${misc:Pre-Depends}
-Depends: libibmad5 (= ${binary:Version}), ${misc:Depends}
-Description: Debug symbols for Infiniband Management Datagram (MAD) library
- libibmad provides low layer InfiniBand functions for use by the
- Infiniband diagnostic and management programs. These include
- Management Datagrams (MAD), Subnet Administration (SA), Subnet
- Management Packets (SMP) and other basic functions.
- .
- This package contains the debug symbols associated with
- libibmad5. They will automatically be used by gdb for debugging
- libibmad-related issues.
-
 Package: libibmad-dev
 Section: libdevel
 Architecture: linux-any
@@ -407,21 +338,6 @@ Description: InfiniBand diagnostics library
  .
  This package provides libraries required by the InfiniBand
  diagnostic programs.
-
-Package: libibnetdisc5-dbg
-Section: debug
-Architecture: linux-any
-Multi-Arch: same
-Depends: libibnetdisc5 (= ${binary:Version}), ${misc:Depends}
-Description: Debug symbols for the libibnetdisc library
- InfiniBand is a switched fabric communications link used in
- high-performance computing and enterprise data centers. Its features
- include high throughput, low latency, quality of service and
- failover, and it is designed to be scalable.
- .
- This package contains the debug symbols associated with
- libibnetdisc5. They will automatically be used by gdb for debugging
- libibnetdisc-related issues.
 
 Package: libibnetdisc-dev
 Section: libdevel

--- a/debian/ibverbs-providers.install
+++ b/debian/ibverbs-providers.install
@@ -1,7 +1,7 @@
 etc/libibverbs.d/
 usr/lib/*/libefa.so.*
-usr/lib/*/libibverbs/lib*-rdmav*.so
 usr/lib/*/libhns.so.*
+usr/lib/*/libibverbs/lib*-rdmav*.so
 usr/lib/*/libmana.so.*
 usr/lib/*/libmlx4.so.*
 usr/lib/*/libmlx5.so.*

--- a/debian/libibmad5.symbols
+++ b/debian/libibmad5.symbols
@@ -2,6 +2,7 @@ libibmad.so.5 libibmad5 #MINVER#
 * Build-Depends-Package: libibmad-dev
  IBMAD_1.3@IBMAD_1.3 1.3.11
  IBMAD_1.4@IBMAD_1.4 54
+ IBMAD_1.5@IBMAD_1.5 56
  bm_call_via@IBMAD_1.3 1.3.11
  cc_config_status_via@IBMAD_1.3 1.3.11
  cc_query_status_via@IBMAD_1.3 1.3.11
@@ -157,6 +158,5 @@ libibmad.so.5 libibmad5 #MINVER#
  smp_set_via@IBMAD_1.3 1.3.11
  str2drpath@IBMAD_1.3 1.3.11
  xdump@IBMAD_1.3 1.3.11
- mad_rpc_open_port2@IBMAD_1.5 5.5.56
- mad_rpc_close_port2@IBMAD_1.5 5.5.56
-
+ mad_rpc_open_port2@IBMAD_1.5 56
+ mad_rpc_close_port2@IBMAD_1.5 56

--- a/debian/libibmad5.symbols
+++ b/debian/libibmad5.symbols
@@ -1,6 +1,7 @@
 libibmad.so.5 libibmad5 #MINVER#
 * Build-Depends-Package: libibmad-dev
  IBMAD_1.3@IBMAD_1.3 1.3.11
+ IBMAD_1.4@IBMAD_1.4 54
  bm_call_via@IBMAD_1.3 1.3.11
  cc_config_status_via@IBMAD_1.3 1.3.11
  cc_query_status_via@IBMAD_1.3 1.3.11

--- a/debian/libibumad3.symbols
+++ b/debian/libibumad3.symbols
@@ -4,6 +4,7 @@ libibumad.so.3 libibumad3 #MINVER#
  IBUMAD_1.1@IBUMAD_1.1 3.1.26
  IBUMAD_1.2@IBUMAD_1.2 3.2.30
  IBUMAD_1.3@IBUMAD_1.3 3.3.53
+ IBUMAD_1.4@IBUMAD_1.4 56
  umad_addr_dump@IBUMAD_1.0 1.3.9
  umad_attribute_str@IBUMAD_1.0 1.3.10.2
  umad_class_str@IBUMAD_1.0 1.3.10.2
@@ -44,6 +45,5 @@ libibumad.so.3 libibumad3 #MINVER#
  umad_sort_ca_device_list@IBUMAD_1.2 3.2.30
  umad_status@IBUMAD_1.0 1.3.9
  umad_unregister@IBUMAD_1.0 1.3.9
- umad_get_smi_gsi_pairs@IBUMAD_1.4 3.4.56
- umad_get_smi_gsi_pair_by_ca_name@IBUMAD_1.4 3.4.56
-
+ umad_get_smi_gsi_pairs@IBUMAD_1.4 56
+ umad_get_smi_gsi_pair_by_ca_name@IBUMAD_1.4 56

--- a/debian/libibverbs-dev.install
+++ b/debian/libibverbs-dev.install
@@ -35,8 +35,8 @@ usr/lib/*/pkgconfig/libmlx5.pc
 usr/share/man/man3/efadv_*.3
 usr/share/man/man3/hnsdv_*.3
 usr/share/man/man3/ibv_*
-usr/share/man/man3/mbps_to_ibv_rate.3
 usr/share/man/man3/manadv_*.3
+usr/share/man/man3/mbps_to_ibv_rate.3
 usr/share/man/man3/mlx4dv_*.3
 usr/share/man/man3/mlx5dv_*.3
 usr/share/man/man3/mult_to_ibv_rate.3

--- a/debian/rules
+++ b/debian/rules
@@ -98,14 +98,6 @@ SHLIBS_EXCLUDE := $(addprefix --exclude=,$(SHLIBS_EXCLUDE))
 override_dh_makeshlibs:
 	dh_makeshlibs $(SHLIBS_EXCLUDE)
 
-override_dh_strip:
-	dh_strip -plibibmad5 --dbg-package=libibmad5-dbg
-	dh_strip -plibibnetdisc5 --dbg-package=libibnetdisc5-dbg
-	dh_strip -plibibumad3 --dbg-package=libibumad3-dbg
-	dh_strip -plibibverbs1 --dbg-package=libibverbs1-dbg
-	dh_strip -plibrdmacm1 --dbg-package=librdmacm1-dbg
-	dh_strip --remaining-packages
-
 # Upstream encourages the use of 'build' as the developer build output
 # directory, allow that directory to be present and still allow dh to work.
 .PHONY: build


### PR DESCRIPTION
* debian: Bump Standards-Version to 4.7.0
* debian: add IBMAD_1.4@IBMAD_1.4 symbol (fixes 57b50e2064f4)
* debian: run wrap-and-sort
* debian: Add Debian uploads up to version 55.0-1
* libibumad: Correct symbols for new API to support SMI/GSI seperation (fixes be54b52e94be)
* libibmad: Correct symbols for new API to support SMI/GSI seperation (fixes fb11e5a40402)
* debian: Switch to automatically created -dbgsym packages

See individual commits for details. Switch to automatically created -dbgsym packages should be safe, because since the stable releases support it.