### PR TITLE
tests: Skip test_rdmacm_async_udp_traffic

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -520,6 +520,9 @@ class RDMACMBaseTest(RDMATestCase):
 
     @staticmethod
     def _rdmacm_exception_handler(passive, exception):
+        if isinstance(exception, PyverbsRDMAError):
+            if exception.error_code in [errno.EOPNOTSUPP, errno.EPROTONOSUPPORT]:
+                sys.exit(5)
         if isinstance(exception, unittest.case.SkipTest):
             sys.exit(5)
         side = 'passive' if passive else 'active'


### PR DESCRIPTION
Avoid the following failure when running test_rdmacm_async_udp_traffic over the qedr provider because the test is not supported:

test_rdmacm_async_udp_traffic (tests.test_rdmacm.CMTestCase) ... Player active got: Failed to Create QP. Errno: 95, Operation not supported ERROR