### PR TITLE
providers/mana: fixes + error CQEs

### DIFF
--- a/providers/mana/mana.c
+++ b/providers/mana/mana.c
@@ -113,7 +113,7 @@ mana_alloc_parent_domain(struct ibv_context *context,
 		verbs_err(
 			verbs_get_ctx(context),
 			"This driver supports IBV_PARENT_DOMAIN_INIT_ATTR_PD_CONTEXT only\n");
-		errno = EINVAL;
+		errno = EOPNOTSUPP;
 		return NULL;
 	}
 

--- a/providers/mana/mana.h
+++ b/providers/mana/mana.h
@@ -127,6 +127,7 @@ struct mana_qp {
 	};
 
 	enum ibv_mtu mtu;
+	int sq_sig_all;
 
 	struct shadow_queue shadow_rq;
 	struct shadow_queue shadow_sq;

--- a/providers/mana/mana.h
+++ b/providers/mana/mana.h
@@ -71,12 +71,15 @@ static inline uint32_t get_large_wqe_size(uint32_t sge)
 	return align(wqe_size, GDMA_WQE_ALIGNMENT_UNIT_SIZE);
 }
 
+struct mana_table {
+	struct mana_qp **table;
+	int refcnt;
+};
+
 struct mana_context {
 	struct verbs_context ibv_ctx;
-	struct {
-		struct mana_qp **table;
-		int refcnt;
-	} qp_table[MANA_QP_TABLE_SIZE];
+	struct mana_table qp_rtable[MANA_QP_TABLE_SIZE];
+	struct mana_table qp_stable[MANA_QP_TABLE_SIZE];
 	pthread_mutex_t qp_table_mutex;
 
 	struct manadv_ctx_allocators extern_alloc;
@@ -110,10 +113,8 @@ struct mana_ib_raw_qp {
 
 struct mana_ib_rc_qp {
 	struct mana_gdma_queue queues[USER_RC_QUEUE_TYPE_MAX];
-
 	uint32_t sq_ssn;
 	uint32_t sq_psn;
-	uint32_t sq_highest_completed_psn;
 };
 
 struct mana_qp {
@@ -157,7 +158,6 @@ struct mana_cq {
 	pthread_spinlock_t lock;
 	uint32_t head;
 	uint32_t last_armed_head;
-	uint32_t ready_wcs;
 	void *db_page;
 	/* list of qp's that use this cq for send completions */
 	struct list_head send_qp_list;
@@ -240,5 +240,7 @@ int mana_post_send(struct ibv_qp *ibqp, struct ibv_send_wr *wr,
 
 int mana_arm_cq(struct ibv_cq *ibcq, int solicited);
 
-struct mana_qp *mana_get_qp_from_rq(struct mana_context *ctx, uint32_t qpn);
+struct mana_qp *mana_get_qp(struct mana_context *ctx, uint32_t qpn, bool is_sq);
+
+void mana_qp_move_flush_err(struct ibv_qp *ibqp);
 #endif

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -327,7 +327,7 @@ struct ibv_qp *mana_create_qp(struct ibv_pd *ibpd,
 	default:
 		verbs_err(verbs_get_ctx(ibpd->context),
 			  "QP type %u is not supported\n", attr->qp_type);
-		errno = EINVAL;
+		errno = EOPNOTSUPP;
 	}
 
 	return NULL;
@@ -533,7 +533,7 @@ struct ibv_qp *mana_create_qp_ex(struct ibv_context *context,
 	default:
 		verbs_err(verbs_get_ctx(context),
 			  "QP type %u is not supported\n", attr->qp_type);
-		errno = EINVAL;
+		errno = EOPNOTSUPP;
 	}
 
 	return NULL;

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -236,6 +236,7 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
 
 	pthread_spin_init(&qp->sq_lock, PTHREAD_PROCESS_PRIVATE);
 	pthread_spin_init(&qp->rq_lock, PTHREAD_PROCESS_PRIVATE);
+	qp->sq_sig_all = attr->sq_sig_all;
 
 	if (create_shadow_queue(&qp->shadow_sq, attr->cap.max_send_wr,
 				sizeof(struct rc_sq_shadow_wqe))) {

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -113,68 +113,114 @@ free_qp:
 	return NULL;
 }
 
-static int mana_store_qp(struct mana_context *ctx, struct mana_qp *qp, uint32_t qid)
+static int mana_store_qid(struct mana_table *qp_table, struct mana_qp *qp, uint32_t qid)
 {
 	uint32_t tbl_idx, tbl_off;
 	int ret = 0;
 
-	pthread_mutex_lock(&ctx->qp_table_mutex);
-
 	tbl_idx = qid >> MANA_QP_TABLE_SHIFT;
 	tbl_off = qid & MANA_QP_TABLE_MASK;
 
-	if (ctx->qp_table[tbl_idx].refcnt == 0) {
-		ctx->qp_table[tbl_idx].table =
+	if (qp_table[tbl_idx].refcnt == 0) {
+		qp_table[tbl_idx].table =
 			calloc(MANA_QP_TABLE_SIZE, sizeof(struct mana_qp *));
-		if (!ctx->qp_table[tbl_idx].table) {
+		if (!qp_table[tbl_idx].table) {
 			ret = ENOMEM;
 			goto out;
 		}
 	}
 
-	if (ctx->qp_table[tbl_idx].table[tbl_off]) {
+	if (qp_table[tbl_idx].table[tbl_off]) {
 		ret = EBUSY;
 		goto out;
 	}
 
-	ctx->qp_table[tbl_idx].table[tbl_off] = qp;
-	ctx->qp_table[tbl_idx].refcnt++;
+	qp_table[tbl_idx].table[tbl_off] = qp;
+	qp_table[tbl_idx].refcnt++;
 
 out:
+	return ret;
+}
+
+static void mana_remove_qid(struct mana_table *qp_table, uint32_t qid)
+{
+	uint32_t tbl_idx, tbl_off;
+
+	tbl_idx = qid >> MANA_QP_TABLE_SHIFT;
+	tbl_off = qid & MANA_QP_TABLE_MASK;
+
+	qp_table[tbl_idx].table[tbl_off] = NULL;
+	qp_table[tbl_idx].refcnt--;
+
+	if (qp_table[tbl_idx].refcnt == 0) {
+		free(qp_table[tbl_idx].table);
+		qp_table[tbl_idx].table = NULL;
+	}
+}
+
+static int mana_store_qp(struct mana_context *ctx, struct mana_qp *qp)
+{
+	uint32_t sreq = qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER].id;
+	uint32_t srep = qp->rc_qp.queues[USER_RC_SEND_QUEUE_RESPONDER].id;
+	uint32_t rreq = qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id;
+	uint32_t rrep = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
+	int ret;
+
+	pthread_mutex_lock(&ctx->qp_table_mutex);
+	ret = mana_store_qid(ctx->qp_stable, qp, sreq);
+	if (ret)
+		goto error;
+	ret = mana_store_qid(ctx->qp_stable, qp, srep);
+	if (ret)
+		goto remove_sreq;
+	ret = mana_store_qid(ctx->qp_rtable, qp, rreq);
+	if (ret)
+		goto remove_srep;
+	ret = mana_store_qid(ctx->qp_rtable, qp, rrep);
+	if (ret)
+		goto remove_rreq;
+
+	pthread_mutex_unlock(&ctx->qp_table_mutex);
+	return 0;
+
+remove_rreq:
+	mana_remove_qid(ctx->qp_rtable, rreq);
+remove_srep:
+	mana_remove_qid(ctx->qp_stable, srep);
+remove_sreq:
+	mana_remove_qid(ctx->qp_stable, sreq);
+error:
 	pthread_mutex_unlock(&ctx->qp_table_mutex);
 	return ret;
 }
 
-static void mana_remove_qp(struct mana_context *ctx, uint32_t qid)
+static void mana_remove_qp(struct mana_context *ctx, struct mana_qp *qp)
 {
-	uint32_t tbl_idx, tbl_off;
+	uint32_t sreq = qp->rc_qp.queues[USER_RC_SEND_QUEUE_REQUESTER].id;
+	uint32_t srep = qp->rc_qp.queues[USER_RC_SEND_QUEUE_RESPONDER].id;
+	uint32_t rreq = qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id;
+	uint32_t rrep = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
 
 	pthread_mutex_lock(&ctx->qp_table_mutex);
-	tbl_idx = qid >> MANA_QP_TABLE_SHIFT;
-	tbl_off = qid & MANA_QP_TABLE_MASK;
-
-	ctx->qp_table[tbl_idx].table[tbl_off] = NULL;
-	ctx->qp_table[tbl_idx].refcnt--;
-
-	if (ctx->qp_table[tbl_idx].refcnt == 0) {
-		free(ctx->qp_table[tbl_idx].table);
-		ctx->qp_table[tbl_idx].table = NULL;
-	}
-
+	mana_remove_qid(ctx->qp_stable, sreq);
+	mana_remove_qid(ctx->qp_stable, srep);
+	mana_remove_qid(ctx->qp_rtable, rreq);
+	mana_remove_qid(ctx->qp_rtable, rrep);
 	pthread_mutex_unlock(&ctx->qp_table_mutex);
 }
 
-struct mana_qp *mana_get_qp_from_rq(struct mana_context *ctx, uint32_t qid)
+struct mana_qp *mana_get_qp(struct mana_context *ctx, uint32_t qid, bool is_sq)
 {
+	struct mana_table *qp_table = is_sq ? ctx->qp_stable : ctx->qp_rtable;
 	uint32_t tbl_idx, tbl_off;
 
 	tbl_idx = qid >> MANA_QP_TABLE_SHIFT;
 	tbl_off = qid & MANA_QP_TABLE_MASK;
 
-	if (!ctx->qp_table[tbl_idx].table)
+	if (!qp_table[tbl_idx].table)
 		return NULL;
 
-	return ctx->qp_table[tbl_idx].table[tbl_off];
+	return qp_table[tbl_idx].table[tbl_off];
 }
 
 static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_types type)
@@ -284,15 +330,10 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
 
 	qp->ibqp.qp.qp_num = qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id;
 
-	ret = mana_store_qp(ctx, qp, qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id);
+	ret = mana_store_qp(ctx, qp);
 	if (ret) {
 		errno = ret;
 		goto destroy_qp;
-	}
-	ret = mana_store_qp(ctx, qp, qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id);
-	if (ret) {
-		errno = ret;
-		goto remove_qp_req;
 	}
 
 	pthread_spin_lock(&send_cq->lock);
@@ -305,8 +346,6 @@ static struct ibv_qp *mana_create_qp_rc(struct ibv_pd *ibpd,
 
 	return &qp->ibqp.qp;
 
-remove_qp_req:
-	mana_remove_qp(ctx, qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id);
 destroy_qp:
 	ibv_cmd_destroy_qp(&qp->ibqp.qp);
 free_rb:
@@ -346,29 +385,32 @@ static void mana_ib_modify_rc_qp(struct mana_qp *qp, struct ibv_qp_attr *attr, i
 	if (attr_mask & IBV_QP_PATH_MTU)
 		qp->mtu = attr->path_mtu;
 
-	switch (attr->qp_state) {
-	case IBV_QPS_RESET:
-		for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i) {
-			qp->rc_qp.queues[i].prod_idx = 0;
-			qp->rc_qp.queues[i].cons_idx = 0;
+	if (attr_mask & IBV_QP_STATE) {
+		qp->ibqp.qp.state = attr->qp_state;
+		switch (attr->qp_state) {
+		case IBV_QPS_RESET:
+			for (i = 0; i < USER_RC_QUEUE_TYPE_MAX; ++i) {
+				qp->rc_qp.queues[i].prod_idx = 0;
+				qp->rc_qp.queues[i].cons_idx = 0;
+			}
+			mana_ib_reset_rb_shmem(qp);
+			reset_shadow_queue(&qp->shadow_rq);
+			reset_shadow_queue(&qp->shadow_sq);
+		case IBV_QPS_INIT:
+			break;
+		case IBV_QPS_RTR:
+			break;
+		case IBV_QPS_RTS:
+			if (attr_mask & IBV_QP_SQ_PSN) {
+				qp->rc_qp.sq_ssn = 1;
+				qp->rc_qp.sq_psn = attr->sq_psn;
+				gdma_arm_normal_cqe(&qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER],
+						    attr->sq_psn);
+			}
+			break;
+		default:
+			break;
 		}
-		mana_ib_reset_rb_shmem(qp);
-		reset_shadow_queue(&qp->shadow_rq);
-		reset_shadow_queue(&qp->shadow_sq);
-	case IBV_QPS_INIT:
-		break;
-	case IBV_QPS_RTR:
-		break;
-	case IBV_QPS_RTS:
-		if (attr_mask & IBV_QP_SQ_PSN) {
-			qp->rc_qp.sq_ssn = 1;
-			qp->rc_qp.sq_psn = attr->sq_psn;
-			qp->rc_qp.sq_highest_completed_psn = PSN_DEC(attr->sq_psn);
-			gdma_arm_normal_cqe(&qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER], attr->sq_psn);
-		}
-		break;
-	default:
-		break;
 	}
 }
 
@@ -381,18 +423,21 @@ int mana_modify_qp(struct ibv_qp *ibqp, struct ibv_qp_attr *attr, int attr_mask)
 	if (ibqp->qp_type != IBV_QPT_RC)
 		return EOPNOTSUPP;
 
-	if (!(attr_mask & IBV_QP_STATE))
-		return 0;
+	pthread_spin_lock(&qp->sq_lock);
+	pthread_spin_lock(&qp->rq_lock);
 
 	err = ibv_cmd_modify_qp(ibqp, attr, attr_mask, &cmd, sizeof(cmd));
 	if (err) {
 		verbs_err(verbs_get_ctx(ibqp->context), "Failed to modify qp\n");
-		return err;
+		goto cleanup;
 	}
 
 	mana_ib_modify_rc_qp(qp, attr, attr_mask);
 
-	return 0;
+cleanup:
+	pthread_spin_unlock(&qp->rq_lock);
+	pthread_spin_unlock(&qp->sq_lock);
+	return err;
 }
 
 static void mana_drain_cqes(struct mana_qp *qp)
@@ -401,18 +446,10 @@ static void mana_drain_cqes(struct mana_qp *qp)
 	struct mana_cq *recv_cq = container_of(qp->ibqp.qp.recv_cq, struct mana_cq, ibcq);
 
 	pthread_spin_lock(&send_cq->lock);
-	while (shadow_queue_get_next_to_consume(&qp->shadow_sq)) {
-		shadow_queue_advance_consumer(&qp->shadow_sq);
-		send_cq->ready_wcs--;
-	}
 	list_del(&qp->send_cq_node);
 	pthread_spin_unlock(&send_cq->lock);
 
 	pthread_spin_lock(&recv_cq->lock);
-	while (shadow_queue_get_next_to_consume(&qp->shadow_rq)) {
-		shadow_queue_advance_consumer(&qp->shadow_rq);
-		recv_cq->ready_wcs--;
-	}
 	list_del(&qp->recv_cq_node);
 	pthread_spin_unlock(&recv_cq->lock);
 }
@@ -424,8 +461,7 @@ int mana_destroy_qp(struct ibv_qp *ibqp)
 	int ret, i;
 
 	if (ibqp->qp_type == IBV_QPT_RC) {
-		mana_remove_qp(ctx, qp->rc_qp.queues[USER_RC_RECV_QUEUE_REQUESTER].id);
-		mana_remove_qp(ctx, qp->rc_qp.queues[USER_RC_RECV_QUEUE_RESPONDER].id);
+		mana_remove_qp(ctx, qp);
 		mana_drain_cqes(qp);
 	}
 
@@ -545,4 +581,12 @@ struct ibv_qp *mana_create_qp_ex(struct ibv_context *context,
 	}
 
 	return NULL;
+}
+
+void mana_qp_move_flush_err(struct ibv_qp *ibqp)
+{
+	struct ibv_qp_attr attr = {};
+
+	attr.qp_state = IBV_QPS_ERR;
+	mana_modify_qp(ibqp, &attr, IBV_QP_STATE);
 }


### PR DESCRIPTION
This patch series addresses several small bugs:
- Use correct return values
- Posting WRs with zero SGEs
- Fix modify_qp to Init and Rts

Then it adds support of the following features:
- signal all RC QPs
- polling error CQEs and providing error completions