### PR TITLE
providers: Fix overrun-buffer-arg issues

### DIFF
--- a/providers/hfi1verbs/verbs.c
+++ b/providers/hfi1verbs/verbs.c
@@ -598,7 +598,7 @@ int hfi1_modify_srq(struct ibv_srq *ibsrq,
 	}
 	cmd.offset_addr = (uintptr_t) &offset;
 	ret = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				 &cmd.ibv_cmd, sizeof cmd);
+				 &cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
 	if (ret) {
 		if (attr_mask & IBV_SRQ_MAX_WR)
 			pthread_spin_unlock(&srq->rq.lock);

--- a/providers/ipathverbs/verbs.c
+++ b/providers/ipathverbs/verbs.c
@@ -574,7 +574,7 @@ int ipath_modify_srq(struct ibv_srq *ibsrq,
 	}
 	cmd.offset_addr = (uintptr_t) &offset;
 	ret = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				 &cmd.ibv_cmd, sizeof cmd);
+				 &cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
 	if (ret) {
 		if (attr_mask & IBV_SRQ_MAX_WR)
 			pthread_spin_unlock(&srq->rq.lock);

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -665,7 +665,7 @@ static int rxe_modify_srq(struct ibv_srq *ibsrq,
 
 	cmd.mmap_info_addr = (__u64)(uintptr_t) &mi;
 	rc = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				&cmd.ibv_cmd, sizeof(cmd));
+				&cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
 	if (rc)
 		goto out;
 


### PR DESCRIPTION
Fix the following issue:
overrun-buffer-arg: Overrunning struct type ibv_modify_srq of 24 bytes by passing it to a function which accesses it at byte offset 31 using argument "32UL".