### PR TITLE
tests: Add QP basic test and enhance stability

### DIFF
--- a/pyverbs/wr.pyx
+++ b/pyverbs/wr.pyx
@@ -95,8 +95,6 @@ cdef class RecvWR(PyverbsCM):
         """
         super().__init__()
         cdef v.ibv_sge *dst
-        if num_sge < 1 or sg is None:
-            raise PyverbsUserError('A WR needs at least one SGE')
         self.recv_wr.sg_list = <v.ibv_sge*>malloc(num_sge * sizeof(v.ibv_sge))
         if self.recv_wr.sg_list == NULL:
             raise PyverbsRDMAErrno('Failed to malloc SG buffer')

--- a/tests/base.py
+++ b/tests/base.py
@@ -705,6 +705,21 @@ class RoCETrafficResources(TrafficResources):
 
 
 class RCResources(RoCETrafficResources):
+    def __init__(self, dev_name, ib_port, gid_index,
+                 max_dest_rd_atomic=MAX_DEST_RD_ATOMIC, max_rd_atomic=MAX_RD_ATOMIC, **kwargs):
+        """
+        Initializes a TrafficResources object with the given values and creates
+        basic RDMA resources.
+        :param dev_name: Device name to be used
+        :param ib_port: IB port of the device to use
+        :param gid_index: Which GID index to use
+        :param max_dest_rd_atomic: Number of responder incoming rd_atomic operations that can
+                                   be handled
+        :param max_rd_atomic: Number of outstanding destination rd_atomic operations
+        """
+        self.max_dest_rd_atomic = max_dest_rd_atomic
+        self.max_rd_atomic = max_rd_atomic
+        super().__init__(dev_name, ib_port, gid_index, **kwargs)
 
     def to_rts(self):
         """
@@ -714,9 +729,9 @@ class RCResources(RoCETrafficResources):
         """
         attr = self.create_qp_attr()
         attr.path_mtu = PATH_MTU
-        attr.max_dest_rd_atomic = MAX_DEST_RD_ATOMIC
+        attr.max_dest_rd_atomic = self.max_dest_rd_atomic
         set_rnr_attributes(attr)
-        attr.max_rd_atomic = MAX_RD_ATOMIC
+        attr.max_rd_atomic = self.max_rd_atomic
         gr = GlobalRoute(dgid=self.ctx.query_gid(self.ib_port, self.gid_index),
                          sgid_index=self.gid_index)
         ah_attr = AHAttr(port_num=self.ib_port, is_global=1, gr=gr,

--- a/tests/test_mlx5_dr.py
+++ b/tests/test_mlx5_dr.py
@@ -142,7 +142,7 @@ class Mlx5DrResources(RawResources):
                                    f'and syndrome ({query_cap_out.syndrome})')
         bit_regs = query_cap_out.capability.flow_meter_reg_id
         if bit_regs == 0:
-            raise PyverbsRDMAError(f'Reg C is not supported)')
+            raise unittest.SkipTest('Reg C is not supported')
         return int(math.log2(bit_regs & -bit_regs))
 
 


### PR DESCRIPTION
Extend basic QP tests with RD atomic.
Allow RecvWR to have 0 SGEs in PyVerbs (it was required to have at least one).
The series includes adjustments to fix corner case failures such as race, specific unsupported platforms, etc.