### PR TITLE
ibdiags: fix the usage of literal block indicators in the man pages

### DIFF
--- a/infiniband-diags/man/ibportstate.8.in.rst
+++ b/infiniband-diags/man/ibportstate.8.in.rst
@@ -115,6 +115,7 @@ EXAMPLES
 ========
 
 ::
+
         ibportstate -C qib0 -P 1 3 1 disable     # by CA name, CA Port Number, lid, physical port number
         ibportstate -C qib0 -P 1 3 1 enable      # by CA name, CA Port Number, lid, physical port number
         ibportstate -D 0 1                       # (query) by direct route

--- a/infiniband-diags/man/ibroute.8.in.rst
+++ b/infiniband-diags/man/ibroute.8.in.rst
@@ -83,6 +83,7 @@ EXAMPLES
 Unicast examples
 
 ::
+
         ibroute 4               # dump all lids with valid out ports of switch with lid 4
         ibroute -a 4            # same, but dump all lids, even with invalid out ports
         ibroute -n 4            # simple dump format - no destination resolution
@@ -94,6 +95,7 @@ Unicast examples
 Multicast examples
 
 ::
+
         ibroute -M 4                # dump all non empty mlids of switch with lid 4
         ibroute -M 4 0xc010 0xc020  # same, but with range
         ibroute -M -n 4             # simple dump format

--- a/infiniband-diags/man/ibstat.8.in.rst
+++ b/infiniband-diags/man/ibstat.8.in.rst
@@ -66,6 +66,7 @@ EXAMPLES
 ========
 
 ::
+
         ibstat            # display status of all ports on all IB devices
         ibstat -l         # list all IB devices
         ibstat -p         # show port guids

--- a/infiniband-diags/man/ibstatus.8.in.rst
+++ b/infiniband-diags/man/ibstatus.8.in.rst
@@ -37,6 +37,7 @@ EXAMPLES
 ========
 
 ::
+
         ibstatus                    # display status of all IB ports
         ibstatus mthca1             # status of mthca1 ports
         ibstatus mthca1:1 mthca0:2  # show status of specified ports

--- a/infiniband-diags/man/ibtracert.8.in.rst
+++ b/infiniband-diags/man/ibtracert.8.in.rst
@@ -88,6 +88,7 @@ EXAMPLES
 Unicast examples
 
 ::
+
         ibtracert 4 16                                  # show path between lids 4 and 16
         ibtracert -n 4 16                               # same, but using simple output format
         ibtracert -G 0x8f1040396522d 0x002c9000100d051  # use guid addresses
@@ -95,6 +96,7 @@ Unicast examples
 Multicast example
 
 ::
+
         ibtracert -m 0xc000 4 16    # show multicast path of mlid 0xc000 between lids 4 and 16
 
 SEE ALSO

--- a/infiniband-diags/man/sminfo.8.in.rst
+++ b/infiniband-diags/man/sminfo.8.in.rst
@@ -85,6 +85,7 @@ EXAMPLES
 ========
 
 ::
+
         sminfo                  # local port\'s sminfo
         sminfo 32               # show sminfo of lid 32
         sminfo  -G 0x8f1040023  # same but using guid address

--- a/infiniband-diags/man/smpdump.8.in.rst
+++ b/infiniband-diags/man/smpdump.8.in.rst
@@ -81,12 +81,14 @@ EXAMPLES
 Direct Routed Examples
 
 ::
+
         smpdump -D 0,1,2,3,5 16 # NODE DESC
         smpdump -D 0,1,2 0x15 2 # PORT INFO, port 2
 
 LID Routed Examples
 
 ::
+
         smpdump 3 0x15 2        # PORT INFO, lid 3 port 2
         smpdump 0xa0 0x11       # NODE INFO, lid 0xa0
 

--- a/infiniband-diags/man/smpquery.8.in.rst
+++ b/infiniband-diags/man/smpquery.8.in.rst
@@ -110,6 +110,7 @@ EXAMPLES
 ========
 
 ::
+
         smpquery portinfo 3 1                     # portinfo by lid, with port modifier
         smpquery -G switchinfo 0x2C9000100D051 1  # switchinfo by guid
         smpquery -D nodeinfo 0                    # nodeinfo by direct route

--- a/infiniband-diags/man/vendstat.8.in.rst
+++ b/infiniband-diags/man/vendstat.8.in.rst
@@ -44,6 +44,7 @@ OPTIONS
 	Group 0 counter config values:
 
 ::
+
 		0 - PortXmitDataSL0-7
 		1 - PortXmitDataSL8-15
 		2 - PortRcvDataSL0-7
@@ -51,6 +52,7 @@ OPTIONS
 	Group 1 counter config values:
 
 ::
+
 		1 - PortXmitDataSL8-15
 		2 - PortRcvDataSL0-7
 		8 - PortRcvDataSL8-15
@@ -106,6 +108,7 @@ EXAMPLES
 ========
 
 ::
+
 	vendstat -N 6		# read IS3 or IS4 general information
 	vendstat -w 6		# read IS3 port xmit wait counters
 	vendstat -i 6 12	# read IS4 port 12 counter group info


### PR DESCRIPTION
An empty line is needed just after "::" as explained in https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#rst-literal-blocks