### PR TITLE
srp_daemon: remove check after mutex init

### DIFF
--- a/srp_daemon/srp_sync.c
+++ b/srp_daemon/srp_sync.c
@@ -105,29 +105,16 @@ bool sync_resources_error(struct sync_resources *res)
 
 int sync_resources_init(struct sync_resources *res)
 {
-	int ret;
-
 	res->stop_threads = 0;
 	res->error = false;
 	__schedule_rescan(res, 0);
 	res->next_task = 0;
-	ret = pthread_mutex_init(&res->mutex, NULL);
-	if (ret < 0) {
-		pr_err("could not initialize mutex\n");
-		return ret;
-	}
+	pthread_mutex_init(&res->mutex, NULL);
 
 	res->retry_tasks_head = NULL;
-	ret = pthread_mutex_init(&res->retry_mutex, NULL);
-	if (ret < 0) {
-		pr_err("could not initialize mutex\n");
-		return ret;
-	}
-	ret = pthread_cond_init(&res->retry_cond, NULL);
-	if (ret < 0)
-		pr_err("could not initialize cond\n");
+	pthread_mutex_init(&res->retry_mutex, NULL);
 
-	return ret;
+	return pthread_cond_init(&res->retry_cond, NULL);
 }
 
 void sync_resources_cleanup(struct sync_resources *res)


### PR DESCRIPTION
Hello maintainers,

Here is my first ever patch to the project; I would like to understand the internals of RDMA.

The patch addresses a warning found by static analysis. It is about [`pthread_mutex_init`](https://man7.org/linux/man-pages/man3/pthread_mutex_lock.3.html):

> pthread_mutex_init always returns 0. The other mutex functions return 0 on success and a non-zero error code on error.

Your feedback is much appreciated