### PR TITLE
efa: Fix receive SGE length overflow

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause
 /*
- * Copyright 2019-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2025 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #include <assert.h>
@@ -2451,7 +2451,7 @@ int efa_post_recv(struct ibv_qp *ibvqp, struct ibv_recv_wr *wr,
 			addr = wr->sg_list[i].addr;
 
 			/* Set RX buffer desc from SGE */
-			rx_buf.length = wr->sg_list[i].length;
+			rx_buf.length = min_t(uint32_t, wr->sg_list[i].length, UINT16_MAX);
 			EFA_SET(&rx_buf.lkey_ctrl, EFA_IO_RX_DESC_LKEY,
 				wr->sg_list[i].lkey);
 			rx_buf.buf_addr_lo = addr;


### PR DESCRIPTION
EFA supports 16 bit length for receive buffers, but will receive only up to MTU size messages, so the rest of the receive buffer is unused. Posting a 64KB buffer will end up wrapping around to zero. Instead, Truncate it to the maximum size, which is higher than EFA MTU.

Reviewed-by: Michael Margolin <mrgolin@amazon.com>
Reviewed-by: Yonatan Nachum <ynachum@amazon.com>