### PR TITLE
pyverbs: Expose fd of ibv_comp_channel.

### DIFF
--- a/pyverbs/cq.pyx
+++ b/pyverbs/cq.pyx
@@ -69,6 +69,10 @@ cdef class CompChannel(PyverbsCM):
         if isinstance(obj, CQ) or isinstance(obj, CQEX):
             self.cqs.add(obj)
 
+    @property
+    def fd(self):
+        return self.cc.fd
+
 
 cdef class CQ(PyverbsCM):
     """


### PR DESCRIPTION
This allows using pollfd to wait with a timeout, e.g. as in https://www.rdmamojo.com/2013/03/09/ibv_get_cq_event/

I found it hard to use `ibv_get_cq_event` in a race-free way without setting the fd to `O_NONBLOCK`.