### PR TITLE
cxgb4: Fix uninit_use issues

### DIFF
--- a/providers/cxgb4/verbs.c
+++ b/providers/cxgb4/verbs.c
@@ -289,6 +289,7 @@ struct ibv_srq *c4iw_create_srq(struct ibv_pd *pd,
 	if (!srq)
 		goto err;
 
+	memset(&resp, 0, sizeof(resp));
 	ret = ibv_cmd_create_srq(pd, &srq->ibv_srq, attr, &cmd,
 			sizeof(cmd), &resp.ibv_resp, sizeof(resp));
 	if (ret)
@@ -428,6 +429,7 @@ static struct ibv_qp *create_qp_v0(struct ibv_pd *pd,
 	if (!qhp)
 		goto err1;
 
+	memset(&resp, 0, sizeof(resp));
 	ret = ibv_cmd_create_qp(pd, &qhp->ibv_qp, attr, &cmd,
 				sizeof cmd, &resp.ibv_resp, sizeof resp);
 	if (ret)
@@ -532,6 +534,7 @@ static struct ibv_qp *create_qp(struct ibv_pd *pd,
 	if (!qhp)
 		goto err1;
 
+	memset(&resp, 0, sizeof(resp));
 	ret = ibv_cmd_create_qp(pd, &qhp->ibv_qp, attr, &cmd,
 				sizeof cmd, &resp.ibv_resp, sizeof resp);
 	if (ret)


### PR DESCRIPTION
Error: UNINIT (CWE-457): [#def102] [important]
providers/cxgb4/verbs.c:280:2: var_decl: Declaring variable "resp" without initializer.
providers/cxgb4/verbs.c:303:2: uninit_use: Using uninitialized value "resp.srqid".

Error: UNINIT (CWE-457): [#def103] [important]
providers/cxgb4/verbs.c:420:2: var_decl: Declaring variable "resp" without initializer.
providers/cxgb4/verbs.c:443:2: uninit_use: Using uninitialized value "resp.qid_mask".

Error: UNINIT (CWE-457): [#def104] [important]
providers/cxgb4/verbs.c:523:2: var_decl: Declaring variable "resp" without initializer.
providers/cxgb4/verbs.c:547:2: uninit_use: Using uninitialized value "resp.qid_mask".