### PR TITLE
qedr: Fix uninit_use issue

### DIFF
--- a/providers/qedr/qelr_verbs.c
+++ b/providers/qedr/qelr_verbs.c
@@ -700,7 +700,7 @@ static inline int qelr_configure_qp(struct qelr_devctx *cxt, struct qelr_qp *qp,
 				    struct ibv_qp_init_attr_ex *attrx,
 				    struct qelr_create_qp_resp *resp)
 {
-	int rc;
+	int rc = 0;
 
 	/* general */
 	pthread_spin_init(&qp->q_lock, PTHREAD_PROCESS_PRIVATE);


### PR DESCRIPTION
Fix the following issue:
providers/qedr/qelr_verbs.c:703:2: var_decl: Declaring variable "rc" without initializer. providers/qedr/qelr_verbs.c:726:2: uninit_use: Using uninitialized value "rc".

Fixes: cae4a99ae679 ("libqedr: add support for XRC-SRQ's.")