### PR TITLE
libibverbs: Fix cast-align warning with verbs_get_ctx().

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,9 @@ include(RDMA_DoFixup)
 include(publish_headers)
 include(rdma_functions)
 include(pyverbs_functions)
+
+check_c_compiler_flag("-Wcast-align=strict" HAVE_WCAST_ALIGN_STRICT)
+
 if (NO_MAN_PAGES)
   # define empty stub functions to omit man page processing
   function(rdma_man_pages)

--- a/libibverbs/examples/CMakeLists.txt
+++ b/libibverbs/examples/CMakeLists.txt
@@ -3,6 +3,10 @@ add_library(ibverbs_tools STATIC
   pingpong.c
   )
 
+if(HAVE_WCAST_ALIGN_STRICT)
+    target_compile_options(ibverbs_tools PRIVATE "-Wcast-align=strict")
+endif()
+
 rdma_executable(ibv_asyncwatch asyncwatch.c)
 target_link_libraries(ibv_asyncwatch LINK_PRIVATE ibverbs)
 

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -2220,7 +2220,7 @@ static inline struct verbs_context *verbs_get_ctx(struct ibv_context *ctx)
 		return NULL;
 
 	/* open code container_of to not pollute the global namespace */
-	return (struct verbs_context *)(((uint8_t *)ctx) -
+	return (struct verbs_context *)(((uintptr_t)ctx) -
 					offsetof(struct verbs_context,
 						 context));
 }


### PR DESCRIPTION
Fix cast-align warning with verbs_get_ctx().

Casting using uint8_t * pointer arithmetic may generate a cast-align warning, when using "-Wcast-align=strict" compilation flag.

Fix it by using uintptr_t instead of uint8_t *.