### PR TITLE
vmw_pvrdma: Fix uninit_use issue

### DIFF
--- a/providers/vmw_pvrdma/pvrdma_main.c
+++ b/providers/vmw_pvrdma/pvrdma_main.c
@@ -112,7 +112,7 @@ static int pvrdma_init_context_shared(struct pvrdma_context *context,
 				      int cmd_fd)
 {
 	struct ibv_get_context cmd;
-	struct user_pvrdma_alloc_ucontext_resp resp;
+	struct user_pvrdma_alloc_ucontext_resp resp = {};
 
 	context->ibv_ctx.context.cmd_fd = cmd_fd;
 	if (ibv_cmd_get_context(&context->ibv_ctx, &cmd, sizeof(cmd),

--- a/providers/vmw_pvrdma/qp.c
+++ b/providers/vmw_pvrdma/qp.c
@@ -108,7 +108,7 @@ struct ibv_srq *pvrdma_create_srq(struct ibv_pd *pd,
 {
 	struct pvrdma_device *dev = to_vdev(pd->context->device);
 	struct user_pvrdma_create_srq cmd;
-	struct user_pvrdma_create_srq_resp resp;
+	struct user_pvrdma_create_srq_resp resp = {};
 	struct pvrdma_srq *srq;
 	int ret;
 


### PR DESCRIPTION
Fix the following issues:
Error: UNINIT (CWE-457): [#def152] [important]
providers/vmw_pvrdma/pvrdma_main.c:115:2: var_decl: Declaring variable "resp" without initializer. providers/vmw_pvrdma/pvrdma_main.c:122:2: uninit_use: Using uninitialized value "resp.qp_tab_size".

Error: UNINIT (CWE-457): [#def153] [important]
providers/vmw_pvrdma/qp.c:111:2: var_decl: Declaring variable "resp" without initializer.
providers/vmw_pvrdma/qp.c:150:2: uninit_use: Using uninitialized value "resp.srqn".

Fixes: 4c8ed14eb6b7 ("vmw_pvrdma: Add SRQ support")