### PR TITLE
tests: small improvement and fix

### DIFF
--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -151,7 +151,6 @@ class OdpTestCase(RDMATestCase):
         u.traffic(**self.traffic_args)
 
     def test_odp_rc_atomic_cmp_and_swp(self):
-        self.force_page_faults = False
         self.create_players(OdpRC, request_user_addr=self.force_page_faults,
                             msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
         u.atomic_traffic(**self.traffic_args,
@@ -160,7 +159,6 @@ class OdpTestCase(RDMATestCase):
                          send_op=e.IBV_WR_ATOMIC_CMP_AND_SWP)
 
     def test_odp_rc_atomic_fetch_and_add(self):
-        self.force_page_faults = False
         self.create_players(OdpRC, request_user_addr=self.force_page_faults,
                             msg_size=8, odp_caps=e.IBV_ODP_SUPPORT_ATOMIC)
         u.atomic_traffic(**self.traffic_args,

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -254,7 +254,7 @@ class QpExTestCase(RDMATestCase):
         u.traffic(**self.traffic_args,
                   new_send=True, send_op=e.IBV_WR_RDMA_WRITE_WITH_IMM)
 
-    def test_qp_ex_rc_rdma_write_zero_length(self):
+    def test_qp_ex_rc_rdma_write_zero_size(self):
         self.create_players(QpExRCRDMAWrite)
         self.client.msg_size = 0
         self.server.msg_size = 0


### PR DESCRIPTION
tests: Apply unified naming convention to zero size tests
tests: Force page fault for ODP atomic testcases

For the better coverage of test scenarios, it is better to force page fault in ODP atomic testcases.