### PR TITLE
bnxt_re/lib: Fix the data copy during the low latency push path

### DIFF
--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -598,7 +598,7 @@ static inline void bnxt_re_copy_data_to_pb(struct bnxt_re_push_buffer *pbuf,
 	int indx;
 
 	for (indx = 0; indx < idx; indx++) {
-		dst = (uintptr_t *)(pbuf->pbuf + 2 * (indx + offset));
+		dst = (uintptr_t *)(pbuf->pbuf) + 2 * indx + offset;
 		src = (uintptr_t *)(pbuf->wqe[indx]);
 		mmio_write64(dst, *src);
 


### PR DESCRIPTION
The pointer used in the destination buffer is not correctly type casted, because of which the data gets corrupted while copying. The issue is seen in the previous adapters that has the low latency push enabled. Fixing the pointer casting.

Fixes: 52d0870c3eac ("bnxt_re/lib: Enable low latency push")
Reported-By: Kamal Heib <kheib@redhat.com>