### PR TITLE
RDMA FLUSH and ATOMIC WRITE with ODP

### DIFF
--- a/kernel-headers/rdma/ib_user_verbs.h
+++ b/kernel-headers/rdma/ib_user_verbs.h
@@ -233,6 +233,22 @@ struct ib_uverbs_ex_query_device {
 	__u32 reserved;
 };
 
+enum ib_uverbs_odp_general_cap_bits {
+	IB_UVERBS_ODP_SUPPORT          = 1 << 0,
+	IB_UVERBS_ODP_SUPPORT_IMPLICIT = 1 << 1,
+};
+
+enum ib_uverbs_odp_transport_cap_bits {
+	IB_UVERBS_ODP_SUPPORT_SEND     = 1 << 0,
+	IB_UVERBS_ODP_SUPPORT_RECV     = 1 << 1,
+	IB_UVERBS_ODP_SUPPORT_WRITE    = 1 << 2,
+	IB_UVERBS_ODP_SUPPORT_READ     = 1 << 3,
+	IB_UVERBS_ODP_SUPPORT_ATOMIC   = 1 << 4,
+	IB_UVERBS_ODP_SUPPORT_SRQ_RECV = 1 << 5,
+	IB_UVERBS_ODP_SUPPORT_FLUSH    = 1 << 6,
+	IB_UVERBS_ODP_SUPPORT_ATOMIC_WRITE     = 1 << 7,
+};
+
 struct ib_uverbs_odp_caps {
 	__aligned_u64 general_caps;
 	struct {

--- a/libibverbs/examples/devinfo.c
+++ b/libibverbs/examples/devinfo.c
@@ -330,7 +330,9 @@ static void print_odp_trans_caps(uint32_t trans)
 					    IBV_ODP_SUPPORT_WRITE |
 					    IBV_ODP_SUPPORT_READ |
 					    IBV_ODP_SUPPORT_ATOMIC |
-					    IBV_ODP_SUPPORT_SRQ_RECV);
+					    IBV_ODP_SUPPORT_SRQ_RECV |
+					    IBV_ODP_SUPPORT_FLUSH |
+					    IBV_ODP_SUPPORT_ATOMIC_WRITE);
 
 	if (!trans) {
 		printf("\t\t\t\t\tNO SUPPORT\n");
@@ -347,6 +349,10 @@ static void print_odp_trans_caps(uint32_t trans)
 			printf("\t\t\t\t\tSUPPORT_ATOMIC\n");
 		if (trans & IBV_ODP_SUPPORT_SRQ_RECV)
 			printf("\t\t\t\t\tSUPPORT_SRQ\n");
+		if (trans & IBV_ODP_SUPPORT_FLUSH)
+			printf("\t\t\t\t\tSUPPORT_FLUSH\n");
+		if (trans & IBV_ODP_SUPPORT_ATOMIC_WRITE)
+			printf("\t\t\t\t\tSUPPORT_ATOMIC_WRITE\n");
 		if (trans & unknown_transport_caps)
 			printf("\t\t\t\t\tUnknown flags: 0x%" PRIX32 "\n",
 			       trans & unknown_transport_caps);

--- a/libibverbs/man/ibv_query_device_ex.3
+++ b/libibverbs/man/ibv_query_device_ex.3
@@ -68,6 +68,8 @@ enum ibv_odp_transport_cap_bits {
         IBV_ODP_SUPPORT_READ     = 1 << 3, /* RDMA-Read operations support on-demand paging */
         IBV_ODP_SUPPORT_ATOMIC   = 1 << 4, /* RDMA-Atomic operations support on-demand paging */
         IBV_ODP_SUPPORT_SRQ_RECV = 1 << 5, /* SRQ receive operations support on-demand paging */
+        IBV_ODP_SUPPORT_FLUSH    = 1 << 6, /* RDMA-Flush operations support on-demand paging */
+        IBV_ODP_SUPPORT_ATOMIC_WRITE     = 1 << 7, /* RDMA-Atomic-write operations support on-demand paing */
 };
 
 struct ibv_tso_caps {

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -228,6 +228,11 @@ struct ibv_query_device_ex_input {
 	uint32_t		comp_mask;
 };
 
+enum ibv_odp_general_caps {
+	IBV_ODP_SUPPORT = 1 << 0,
+	IBV_ODP_SUPPORT_IMPLICIT = 1 << 1,
+};
+
 enum ibv_odp_transport_cap_bits {
 	IBV_ODP_SUPPORT_SEND     = 1 << 0,
 	IBV_ODP_SUPPORT_RECV     = 1 << 1,
@@ -235,6 +240,8 @@ enum ibv_odp_transport_cap_bits {
 	IBV_ODP_SUPPORT_READ     = 1 << 3,
 	IBV_ODP_SUPPORT_ATOMIC   = 1 << 4,
 	IBV_ODP_SUPPORT_SRQ_RECV = 1 << 5,
+	IBV_ODP_SUPPORT_FLUSH    = 1 << 6,
+	IBV_ODP_SUPPORT_ATOMIC_WRITE = 1 << 7,
 };
 
 struct ibv_odp_caps {
@@ -244,11 +251,6 @@ struct ibv_odp_caps {
 		uint32_t uc_odp_caps;
 		uint32_t ud_odp_caps;
 	} per_transport_caps;
-};
-
-enum ibv_odp_general_caps {
-	IBV_ODP_SUPPORT = 1 << 0,
-	IBV_ODP_SUPPORT_IMPLICIT = 1 << 1,
 };
 
 struct ibv_tso_caps {

--- a/pyverbs/device.pyx
+++ b/pyverbs/device.pyx
@@ -567,7 +567,9 @@ cdef class ODPCaps(PyverbsObject):
              e.IBV_ODP_SUPPORT_WRITE: 'IBV_ODP_SUPPORT_WRITE',
              e.IBV_ODP_SUPPORT_READ: 'IBV_ODP_SUPPORT_READ',
              e.IBV_ODP_SUPPORT_ATOMIC: 'IBV_ODP_SUPPORT_ATOMIC',
-             e.IBV_ODP_SUPPORT_SRQ_RECV: 'IBV_ODP_SUPPORT_SRQ_RECV'}
+             e.IBV_ODP_SUPPORT_SRQ_RECV: 'IBV_ODP_SUPPORT_SRQ_RECV',
+             e.IBV_ODP_SUPPORT_FLUSH: 'IBV_ODP_SUPPORT_FLUSH',
+             e.IBV_ODP_SUPPORT_ATOMIC_WRITE: 'IBV_ODP_SUPPORT_ATOMIC_WRITE'}
 
         print_format = '{}: {}\n'
         return print_format.format('ODP General caps', str_from_flags(self.general_caps, general_caps)) +\

--- a/pyverbs/libibverbs_enums.pxd
+++ b/pyverbs/libibverbs_enums.pxd
@@ -417,6 +417,8 @@ cdef extern from '<infiniband/verbs.h>':
         IBV_ODP_SUPPORT_READ
         IBV_ODP_SUPPORT_ATOMIC
         IBV_ODP_SUPPORT_SRQ_RECV
+        IBV_ODP_SUPPORT_FLUSH
+        IBV_ODP_SUPPORT_ATOMIC_WRITE
 
     cpdef enum ibv_device_cap_flags:
         IBV_DEVICE_RESIZE_MAX_WR

--- a/tests/test_odp.py
+++ b/tests/test_odp.py
@@ -7,6 +7,7 @@ from tests.base import RDMATestCase
 from pyverbs.mr import MR
 import pyverbs.enums as e
 import tests.utils as u
+import unittest
 
 HUGE_PAGE_SIZE = 0x200000
 
@@ -131,19 +132,37 @@ class OdpQpExRC(RCResources):
                                          gid_index=gid_index)
         self.msg_size = msg_size
 
-    def create_qps(self):
-        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_ATOMIC_WRITE)
+        if self.odp_caps & e.IBV_ODP_SUPPORT_FLUSH:
+            self.ptype = e.IBV_FLUSH_GLOBAL
+            self.level = e.IBV_FLUSH_RANGE
 
-    @u.requires_odp('rc', e.IBV_ODP_SUPPORT_SEND | e.IBV_ODP_SUPPORT_RECV |
-                    e.IBV_ODP_SUPPORT_ATOMIC_WRITE)
+    def create_qps(self):
+        if self.odp_caps & e.IBV_ODP_SUPPORT_ATOMIC_WRITE:
+            u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_ATOMIC_WRITE)
+        elif self.odp_caps & e.IBV_ODP_SUPPORT_FLUSH:
+            u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_FLUSH | e.IBV_QP_EX_WITH_RDMA_WRITE)
+        else:
+            raise unittest.SkipTest('There is no qpex test for the specified ODP caps.')
+
     def create_mr(self):
-        access = self.access
-        if self.request_user_addr:
-            mmap_flags = MAP_ANONYMOUS_| MAP_PRIVATE_
-            length = self.msg_size
-            self.user_addr = mmap(length=length, flags=mmap_flags)
-        self.mr = MR(self.pd, self.msg_size, access, address=self.user_addr,
-                     implicit=self.is_implicit)
+        u.odp_supported(self.ctx, 'rc', self.odp_caps)
+        if self.odp_caps & e.IBV_ODP_SUPPORT_ATOMIC_WRITE:
+            access = self.access
+            if self.request_user_addr:
+                mmap_flags = MAP_ANONYMOUS_| MAP_PRIVATE_
+                length = self.msg_size
+                self.user_addr = mmap(length=length, flags=mmap_flags)
+            self.mr = MR(self.pd, self.msg_size, access, address=self.user_addr,
+                         implicit=self.is_implicit)
+        elif self.odp_caps & e.IBV_ODP_SUPPORT_FLUSH:
+            try:
+                self.mr = u.create_custom_mr(self, e.IBV_ACCESS_FLUSH_GLOBAL | e.IBV_ACCESS_REMOTE_WRITE | e.IBV_ACCESS_ON_DEMAND)
+            except PyverbsRDMAError as ex:
+                if ex.error_code == errno.EINVAL:
+                    raise unittest.SkipTest('Create mr with IBV_ACCESS_FLUSH_GLOBAL access flag is not supported in kernel')
+                raise ex
+        else:
+            raise unittest.SkipTest('There is no qpex test for the specified ODP caps.')
 
 class OdpTestCase(RDMATestCase):
     def setUp(self):
@@ -189,6 +208,20 @@ class OdpTestCase(RDMATestCase):
         self.server.msg_size = 8
         u.rdma_traffic(**self.traffic_args,
                        new_send=True, send_op=e.IBV_WR_ATOMIC_WRITE)
+
+    def test_odp_qp_ex_rc_flush(self):
+        super().create_players(OdpQpExRC, request_user_addr=self.force_page_faults,
+                               odp_caps=e.IBV_ODP_SUPPORT_FLUSH)
+        wcs = u.flush_traffic(**self.traffic_args, new_send=True,
+                              send_op=e.IBV_WR_FLUSH)
+        if wcs[0].status != e.IBV_WC_SUCCESS:
+            raise PyverbsError(f'Unexpected {wc_status_to_str(wcs[0].status)}')
+
+        self.client.level = e.IBV_FLUSH_MR
+        wcs = u.flush_traffic(**self.traffic_args, new_send=True,
+                              send_op=e.IBV_WR_FLUSH)
+        if wcs[0].status != e.IBV_WC_SUCCESS:
+            raise PyverbsError(f'Unexpected {wc_status_to_str(wcs[0].status)}')
 
     def test_odp_rc_atomic_cmp_and_swp(self):
         self.create_players(OdpRC, request_user_addr=self.force_page_faults,

--- a/tests/test_qpex.py
+++ b/tests/test_qpex.py
@@ -12,51 +12,14 @@ import pyverbs.enums as e
 from tests.base import UDResources, RCResources, RDMATestCase, XRCResources
 import tests.utils as u
 
-
-def create_qp_ex(agr_obj, qp_type, send_flags):
-    if qp_type == e.IBV_QPT_XRC_SEND:
-        cap = QPCap(max_send_wr=agr_obj.num_msgs, max_recv_wr=0, max_recv_sge=0,
-                    max_send_sge=1)
-    else:
-        cap = QPCap(max_send_wr=agr_obj.num_msgs, max_recv_wr=agr_obj.num_msgs,
-                    max_recv_sge=1, max_send_sge=1)
-    qia = QPInitAttrEx(cap=cap, qp_type=qp_type, scq=agr_obj.cq,
-                       rcq=agr_obj.cq, pd=agr_obj.pd, send_ops_flags=send_flags,
-                       comp_mask=e.IBV_QP_INIT_ATTR_PD |
-                                 e.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS)
-    qp_attr = QPAttr(port_num=agr_obj.ib_port)
-    if qp_type == e.IBV_QPT_UD:
-        qp_attr.qkey = agr_obj.UD_QKEY
-        qp_attr.pkey_index = agr_obj.UD_PKEY_INDEX
-    if qp_type == e.IBV_QPT_RC:
-        qp_attr.qp_access_flags = e.IBV_ACCESS_REMOTE_WRITE | \
-                                  e.IBV_ACCESS_REMOTE_READ | \
-                                  e.IBV_ACCESS_REMOTE_ATOMIC | \
-                                  e.IBV_ACCESS_FLUSH_GLOBAL | \
-                                  e.IBV_ACCESS_FLUSH_PERSISTENT
-    try:
-        # We don't have capability bits for this
-        qp = QPEx(agr_obj.ctx, qia, qp_attr)
-    except PyverbsRDMAError as ex:
-        if ex.error_code == errno.EOPNOTSUPP:
-            raise unittest.SkipTest('Extended QP is not supported on this device')
-        raise ex
-    if qp_type != e.IBV_QPT_XRC_SEND:
-        agr_obj.qps.append(qp)
-        agr_obj.qps_num.append(qp.qp_num)
-        agr_obj.psns.append(random.getrandbits(24))
-    else:
-        return qp
-
-
 class QpExUDSend(UDResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_UD, e.IBV_QP_EX_WITH_SEND)
+        u.create_qp_ex(self, e.IBV_QPT_UD, e.IBV_QP_EX_WITH_SEND)
 
 
 class QpExRCSend(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_SEND)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_SEND)
 
 
 class QpExXRCSend(XRCResources):
@@ -72,7 +35,7 @@ class QpExXRCSend(XRCResources):
             recv_qp = QP(self.ctx, attr_ex, qp_attr)
             self.rqp_lst.append(recv_qp)
 
-            send_qp = create_qp_ex(self, e.IBV_QPT_XRC_SEND, e.IBV_QP_EX_WITH_SEND)
+            send_qp = u.create_qp_ex(self, e.IBV_QPT_XRC_SEND, e.IBV_QP_EX_WITH_SEND)
             self.sqp_lst.append(send_qp)
             self.qps_num.append((recv_qp.qp_num, send_qp.qp_num))
             self.psns.append(random.getrandbits(24))
@@ -80,12 +43,12 @@ class QpExXRCSend(XRCResources):
 
 class QpExUDSendImm(UDResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_UD, e.IBV_QP_EX_WITH_SEND_WITH_IMM)
+        u.create_qp_ex(self, e.IBV_QPT_UD, e.IBV_QP_EX_WITH_SEND_WITH_IMM)
 
 
 class QpExRCSendImm(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_SEND_WITH_IMM)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_SEND_WITH_IMM)
 
 
 class QpExXRCSendImm(XRCResources):
@@ -101,7 +64,7 @@ class QpExXRCSendImm(XRCResources):
             recv_qp = QP(self.ctx, attr_ex, qp_attr)
             self.rqp_lst.append(recv_qp)
 
-            send_qp = create_qp_ex(self, e.IBV_QPT_XRC_SEND,
+            send_qp = u.create_qp_ex(self, e.IBV_QPT_XRC_SEND,
                                    e.IBV_QP_EX_WITH_SEND_WITH_IMM)
             self.sqp_lst.append(send_qp)
             self.qps_num.append((recv_qp.qp_num, send_qp.qp_num))
@@ -112,7 +75,7 @@ class QpExRCFlush(RCResources):
     ptype = e.IBV_FLUSH_GLOBAL
     level = e.IBV_FLUSH_RANGE
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_FLUSH | e.IBV_QP_EX_WITH_RDMA_WRITE)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_FLUSH | e.IBV_QP_EX_WITH_RDMA_WRITE)
 
     def create_mr(self):
         try:
@@ -125,7 +88,7 @@ class QpExRCFlush(RCResources):
 
 class QpExRCAtomicWrite(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_ATOMIC_WRITE)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_ATOMIC_WRITE)
 
     def create_mr(self):
         self.mr = u.create_custom_mr(self, e.IBV_ACCESS_REMOTE_WRITE)
@@ -133,7 +96,7 @@ class QpExRCAtomicWrite(RCResources):
 
 class QpExRCRDMAWrite(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_WRITE)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_WRITE)
 
     def create_mr(self):
         self.mr = u.create_custom_mr(self, e.IBV_ACCESS_REMOTE_WRITE)
@@ -141,7 +104,7 @@ class QpExRCRDMAWrite(RCResources):
 
 class QpExRCRDMAWriteImm(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC,
+        u.create_qp_ex(self, e.IBV_QPT_RC,
                                e.IBV_QP_EX_WITH_RDMA_WRITE_WITH_IMM)
 
     def create_mr(self):
@@ -150,7 +113,7 @@ class QpExRCRDMAWriteImm(RCResources):
 
 class QpExRCRDMARead(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_READ)
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_READ)
 
     def create_mr(self):
         self.mr = u.create_custom_mr(self, e.IBV_ACCESS_REMOTE_READ)
@@ -158,21 +121,21 @@ class QpExRCRDMARead(RCResources):
 
 class QpExRCAtomicCmpSwp(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC,
+        u.create_qp_ex(self, e.IBV_QPT_RC,
                                e.IBV_QP_EX_WITH_ATOMIC_CMP_AND_SWP)
         self.mr = u.create_custom_mr(self, e.IBV_ACCESS_REMOTE_ATOMIC)
 
 
 class QpExRCAtomicFetchAdd(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC,
+        u.create_qp_ex(self, e.IBV_QPT_RC,
                                e.IBV_QP_EX_WITH_ATOMIC_FETCH_AND_ADD)
         self.mr = u.create_custom_mr(self, e.IBV_ACCESS_REMOTE_ATOMIC)
 
 
 class QpExRCBindMw(RCResources):
     def create_qps(self):
-        create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_WRITE |
+        u.create_qp_ex(self, e.IBV_QPT_RC, e.IBV_QP_EX_WITH_RDMA_WRITE |
                      e.IBV_QP_EX_WITH_BIND_MW)
 
     def create_mr(self):


### PR DESCRIPTION
RDMA FLUSH[1] and ATOMIC WRITE[2] were added to rxe, but they cannot run
in the ODP mode as of now. This series is for the userspace enablement.

The former three patches correspond to an uapi change in the kernel.
(**v1/merged**) https://lore.kernel.org/linux-rdma/20250418051345.1022339-1-matsuda-daisuke@fujitsu.com/T/#t

The latter four add definitions of ODP capabilities and rdma-core testcases for the new features.
For kernel-side enablement in rxe, please see:
(**Updated v3/merged**) https://lore.kernel.org/linux-rdma/20250324075649.3313968-1-matsuda-daisuke@fujitsu.com/T/#t

[1] [for-next PATCH 00/10] RDMA/rxe: Add RDMA FLUSH operation
https://lore.kernel.org/lkml/20221206130201.30986-1-lizhijian@fujitsu.com/

[2] [PATCH v7 0/8] RDMA/rxe: Add atomic write operation
https://lore.kernel.org/linux-rdma/1669905432-14-1-git-send-email-yangx.jy@fujitsu.com/