### PR TITLE
rxe: Fix uninit_use_in_call issues

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -578,7 +578,7 @@ static struct ibv_srq *rxe_create_srq(struct ibv_pd *ibpd,
 	struct rxe_srq *srq;
 	struct ibv_srq *ibsrq;
 	struct ibv_create_srq cmd;
-	struct urxe_create_srq_resp resp;
+	struct urxe_create_srq_resp resp = {};
 	int ret;
 
 	srq = calloc(1, sizeof(*srq));
@@ -617,7 +617,7 @@ static struct ibv_srq *rxe_create_srq_ex(
 	struct rxe_srq *srq;
 	struct ibv_srq *ibsrq;
 	struct ibv_create_xsrq cmd;
-	struct urxe_create_srq_ex_resp resp;
+	struct urxe_create_srq_ex_resp resp = {};
 	int ret;
 
 	srq = calloc(1, sizeof(*srq));


### PR DESCRIPTION
Fix the following issues:
Error: UNINIT (CWE-457): [#def142] [important]
providers/rxe/rxe.c:584:2: var_decl: Declaring variable "resp" without initializer. providers/rxe/rxe.c:600:2: uninit_use_in_call: Using uninitialized value "resp.mi.size" when calling "mmap".

Error: UNINIT (CWE-457): [#def143] [important]
rdma-core-54.0/providers/rxe/rxe.c:623:2: var_decl: Declaring variable "resp" without initializer.
rdma-core-54.0/providers/rxe/rxe.c:639:2: uninit_use_in_call: Using uninitialized value "resp.mi.size" when calling "mmap".

Fixes: e05647a484a5 ("providers/rxe: Implement create_srq_ex")