### PR TITLE
ocrdma: Fix uninit_use issues

### DIFF
--- a/providers/ocrdma/ocrdma_main.c
+++ b/providers/ocrdma/ocrdma_main.c
@@ -115,7 +115,7 @@ static struct verbs_context *ocrdma_alloc_context(struct ibv_device *ibdev,
 {
 	struct ocrdma_devctx *ctx;
 	struct uocrdma_get_context cmd;
-	struct uocrdma_get_context_resp resp;
+	struct uocrdma_get_context_resp resp = {};
 
 	ctx = verbs_init_and_alloc_context(ibdev, cmd_fd, ctx, ibv_ctx,
 					   RDMA_DRIVER_OCRDMA);

--- a/providers/ocrdma/ocrdma_verbs.c
+++ b/providers/ocrdma/ocrdma_verbs.c
@@ -356,7 +356,7 @@ struct ibv_srq *ocrdma_create_srq(struct ibv_pd *pd,
 	int status = 0;
 	struct ocrdma_srq *srq;
 	struct uocrdma_create_srq cmd;
-	struct uocrdma_create_srq_resp resp;
+	struct uocrdma_create_srq_resp resp = {};
 	void *map_addr;
 
 	srq = calloc(1, sizeof *srq);
@@ -466,7 +466,7 @@ struct ibv_qp *ocrdma_create_qp(struct ibv_pd *pd,
 {
 	int status = 0;
 	struct uocrdma_create_qp cmd;
-	struct uocrdma_create_qp_resp resp;
+	struct uocrdma_create_qp_resp resp = {};
 	struct ocrdma_qp *qp;
 	void *map_addr;
 #ifdef DPP_CQ_SUPPORT


### PR DESCRIPTION
Fix the following issues:
Error: UNINIT (CWE-457): [#def138] [important]
providers/ocrdma/ocrdma_main.c:118:2: var_decl: Declaring variable "resp" without initializer. providers/ocrdma/ocrdma_main.c:132:2: uninit_use: Using uninitialized value "resp.dev_id".

Error: UNINIT (CWE-457): [#def140] [important]
providers/ocrdma/ocrdma_verbs.c:359:2: var_decl: Declaring variable "resp" without initializer.
providers/ocrdma/ocrdma_verbs.c:373:2: uninit_use: Using uninitialized value "resp.rq_dbid".

Error: UNINIT (CWE-457): [#def141] [important]
providers/ocrdma/ocrdma_verbs.c:469:2: var_decl: Declaring variable "resp" without initializer.
providers/ocrdma/ocrdma_verbs.c:504:2: uninit_use: Using uninitialized value "resp.qp_id".

Fixes: ede311583f51 ("Added libocrdma files")