### PR TITLE
Revert "mlx4: Fix overrun-buffer-arg"

### DIFF
--- a/providers/mlx4/verbs.c
+++ b/providers/mlx4/verbs.c
@@ -639,8 +639,8 @@ int mlx4_resize_cq(struct ibv_cq *ibcq, int cqe)
 	old_cqe = ibcq->cqe;
 	cmd.buf_addr = (uintptr_t) buf.buf;
 
-	ret = ibv_cmd_resize_cq(ibcq, cqe - 1, &cmd.ibv_cmd,
-				sizeof(cmd.ibv_cmd), &resp, sizeof(resp));
+	ret = ibv_cmd_resize_cq(ibcq, cqe - 1, &cmd.ibv_cmd, sizeof cmd,
+				&resp, sizeof resp);
 	if (ret) {
 		mlx4_free_buf(to_mctx(ibcq->context), &buf);
 		goto out;


### PR DESCRIPTION
This reverts commit 4d92ff74aa3d4a4b0181ea0db103377c7034dcb4.

A regression was found when testing resize_cq using pyverbs.

Fixes: 4d92ff74aa3d ("mlx4: Fix overrun-buffer-arg")