### PR TITLE
Revert "providers: Fix overrun-buffer-arg issues"

### DIFF
--- a/providers/hfi1verbs/verbs.c
+++ b/providers/hfi1verbs/verbs.c
@@ -598,7 +598,7 @@ int hfi1_modify_srq(struct ibv_srq *ibsrq,
 	}
 	cmd.offset_addr = (uintptr_t) &offset;
 	ret = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				 &cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
+				 &cmd.ibv_cmd, sizeof cmd);
 	if (ret) {
 		if (attr_mask & IBV_SRQ_MAX_WR)
 			pthread_spin_unlock(&srq->rq.lock);

--- a/providers/ipathverbs/verbs.c
+++ b/providers/ipathverbs/verbs.c
@@ -574,7 +574,7 @@ int ipath_modify_srq(struct ibv_srq *ibsrq,
 	}
 	cmd.offset_addr = (uintptr_t) &offset;
 	ret = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				 &cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
+				 &cmd.ibv_cmd, sizeof cmd);
 	if (ret) {
 		if (attr_mask & IBV_SRQ_MAX_WR)
 			pthread_spin_unlock(&srq->rq.lock);

--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -665,7 +665,7 @@ static int rxe_modify_srq(struct ibv_srq *ibsrq,
 
 	cmd.mmap_info_addr = (__u64)(uintptr_t) &mi;
 	rc = ibv_cmd_modify_srq(ibsrq, attr, attr_mask,
-				&cmd.ibv_cmd, sizeof(cmd.ibv_cmd));
+				&cmd.ibv_cmd, sizeof(cmd));
 	if (rc)
 		goto out;
 


### PR DESCRIPTION
This reverts commit f14033565dc0152bb2902046a1c2464a61eb652c. Avoid regression that could introduced as the lower level functions are supposed to accept the full size of the struct including the driver data portion.

Fixes: f14033565dc0 ("providers: Fix overrun-buffer-arg issues")