### PR TITLE
mthca: Fix malloc() return value without detecting null pointer

### DIFF
--- a/providers/mthca/memfree.c
+++ b/providers/mthca/memfree.c
@@ -175,6 +175,8 @@ struct mthca_db_table *mthca_alloc_db_tab(int uarc_size)
 	npages = uarc_size / MTHCA_DB_REC_PAGE_SIZE;
 	db_tab = malloc(sizeof (struct mthca_db_table) +
 			npages * sizeof (struct mthca_db_page));
+	if (!db_tab)
+		return db_tab;
 
 	pthread_mutex_init(&db_tab->mutex, NULL);
 


### PR DESCRIPTION
mthca: Fix malloc() return value without detecting null pointer