### PR TITLE
azp: Overcome kernel.org AI protection check

### DIFF
--- a/buildlib/azp-checkpatch
+++ b/buildlib/azp-checkpatch
@@ -24,6 +24,9 @@ with tempfile.TemporaryDirectory() as dfn:
         sys.exit(0)
 
     ckp = os.path.join(dfn, "checkpatch.pl")
+    opener = urllib.request.build_opener()
+    opener.addheaders = [('User-agent', 'rdma-core/1.x (linux-rdma@vger.kernel.org)')]
+    urllib.request.install_opener(opener)
     urllib.request.urlretrieve(
         "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/plain/scripts/checkpatch.pl",
         ckp)


### PR DESCRIPTION
kernel.org added DDOS protection from AI bot scrappers, which causes to the "urllib.error.HTTPError: HTTP Error 403: Forbidden" error while executing azp=checkpatch test.

Official solution is to set meaningful User-agent, so do it.