### PR TITLE
util: Fix mmio read on ARM

### DIFF
--- a/util/mmio.h
+++ b/util/mmio.h
@@ -158,7 +158,7 @@ static inline void mmio_write8(void *addr, uint8_t value)
 }
 static inline uint8_t mmio_read8(const void *addr)
 {
-	return atomic_load_explicit((_Atomic(uint32_t) *)addr,
+	return atomic_load_explicit((_Atomic(uint8_t) *)addr,
 				    memory_order_relaxed);
 }
 #endif /* __s390x__ */


### PR DESCRIPTION
Cast the addr to uint8_t pointer instead of uint32_t pointer. This fixes a SIGBUS error on ARM system.

Fixes: 3f1f8d9343c2 ("util: Add common mmio macros")