### PR TITLE
libhns: Bugfixes and one debug improvement

### DIFF
--- a/libibverbs/cmd_srq.c
+++ b/libibverbs/cmd_srq.c
@@ -63,6 +63,7 @@ static int ibv_icmd_create_srq(struct ibv_pd *pd, struct verbs_srq *vsrq,
 	struct verbs_xrcd *vxrcd = NULL;
 	enum ibv_srq_type srq_type;
 
+	srq->pd = pd;
 	srq->context = pd->context;
 	pthread_mutex_init(&srq->mutex, NULL);
 	pthread_cond_init(&srq->cond, NULL);

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -854,16 +854,20 @@ static struct ibv_srq *create_srq(struct ibv_context *context,
 	if (pad)
 		atomic_fetch_add(&pad->pd.refcount, 1);
 
-	if (hns_roce_srq_spinlock_init(srq, init_attr))
+	ret = hns_roce_srq_spinlock_init(srq, init_attr);
+	if (ret)
 		goto err_free_srq;
 
 	set_srq_param(context, srq, init_attr);
-	if (alloc_srq_buf(srq))
+	ret = alloc_srq_buf(srq);
+	if (ret)
 		goto err_destroy_lock;
 
 	srq->rdb = hns_roce_alloc_db(hr_ctx, HNS_ROCE_SRQ_TYPE_DB);
-	if (!srq->rdb)
+	if (!srq->rdb) {
+		ret = ENOMEM;
 		goto err_srq_buf;
+	}
 
 	ret = exec_srq_create_cmd(context, srq, init_attr);
 	if (ret)

--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -177,6 +177,7 @@ err:
 struct ibv_pd *hns_roce_u_alloc_pad(struct ibv_context *context,
 				    struct ibv_parent_domain_init_attr *attr)
 {
+	struct hns_roce_pd *protection_domain;
 	struct hns_roce_pad *pad;
 
 	if (ibv_check_alloc_parent_domain(attr))
@@ -193,12 +194,16 @@ struct ibv_pd *hns_roce_u_alloc_pad(struct ibv_context *context,
 		return NULL;
 	}
 
+	protection_domain = to_hr_pd(attr->pd);
 	if (attr->td) {
 		pad->td = to_hr_td(attr->td);
 		atomic_fetch_add(&pad->td->refcount, 1);
+		verbs_debug(verbs_get_ctx(context),
+			    "set PAD(0x%x) to lock-free mode.\n",
+			    protection_domain->pdn);
 	}
 
-	pad->pd.protection_domain = to_hr_pd(attr->pd);
+	pad->pd.protection_domain = protection_domain;
 	atomic_fetch_add(&pad->pd.protection_domain->refcount, 1);
 
 	atomic_init(&pad->pd.refcount, 1);


### PR DESCRIPTION
The issue of the last commit was found when I created a XRC SRQ in lock-free mode but failed to destroy it because of the refcnt check added in the previous commit.

The failure was because the PAD was acquired through ibv_srq->pd in destroy_srq(), while ibv_srq->pd wasn't assigned when the SRQ was created by ibv_create_srq_ex(). So let's assign ibv_srq->pd in the common ibv_icmd_create_srq() , so that drivers can get the correct pd no matter which api the SRQ is created by.