### PR TITLE
rsocket: Fix use of uninitialized ret

### DIFF
--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -2641,7 +2641,7 @@ static int rs_send_iomaps(struct rsocket *rs, int flags)
 	struct rs_iomap_mr *iomr;
 	struct ibv_sge sge;
 	struct rs_iomap iom;
-	int ret;
+	int ret = 0;
 
 	fastlock_acquire(&rs->map_lock);
 	while (!dlist_empty(&rs->iomap_queue)) {


### PR DESCRIPTION
Fix use of uninitialized ret, 'ret' may be used uninitialized at librdmacm\rsocket.c line 2703.

This is because it is possible that the 'ret' assignment logic may not be executed due to the empty &rs->iomap_queue in line 2647