### PR TITLE
rping: Fix typos in comments

### DIFF
--- a/librdmacm/examples/rping.c
+++ b/librdmacm/examples/rping.c
@@ -107,7 +107,7 @@ struct rping_rdma_info {
  * Control block struct.
  */
 struct rping_cb {
-	int server;			/* 0 iff client */
+	int server;			/* 0 if client */
 	pthread_t cqthread;
 	pthread_t persistent_server_thread;
 	struct ibv_comp_channel *channel;


### PR DESCRIPTION
Fix typos in comments. 110 line comment field error in./librdmacm/examples/rping. c file, modify iff to if