### PR TITLE
rxe: Prefetching pages with ibv_advise_mr(3)

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -1854,6 +1854,7 @@ static const struct verbs_context_ops rxe_ctx_ops = {
 	.attach_mcast = ibv_cmd_attach_mcast,
 	.detach_mcast = ibv_cmd_detach_mcast,
 	.free_context = rxe_free_context,
+	.advise_mr = ibv_cmd_advise_mr,
 };
 
 static struct verbs_context *rxe_alloc_context(struct ibv_device *ibdev,


### PR DESCRIPTION
ibv_advise_mr(3) has been available only in mlx5, but it is now possible to use it with rxe because the ODP feature was already merged.
This change enables the library API for user-space applications.

There are kernel-side patches to handle prefetching requests in the kernel:
cf. https://lore.kernel.org/linux-rdma/20250522111955.3227-1-dskmtsd@gmail.com/T/#t
**(merged)**