### PR TITLE
verbs: Allow query only device support for QP data in order

### DIFF
--- a/libibverbs/man/ibv_query_qp_data_in_order.3.md
+++ b/libibverbs/man/ibv_query_qp_data_in_order.3.md
@@ -45,6 +45,10 @@ This function describes ordering at the receiving side of the QP, not the sendin
 
 IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS - Query for supported capabilities and return a capabilities vector.
 
+IBV_QUERY_QP_DATA_IN_ORDER_DEVICE_ONLY - Allows querying only the RDMA device side support for data-in-order semantics
+    without enforcing host CPU architecture restrictions. It is the responsibility of the application
+    to ensure data-in-order semantics support for the host CPU or receiver device.
+
 Passing 0 is equivalent to using IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS and checking for IBV_QUERY_QP_DATA_IN_ORDER_WHOLE_MSG support.
 
 # RETURN VALUE

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -1042,6 +1042,7 @@ enum ibv_qp_attr_mask {
 
 enum ibv_query_qp_data_in_order_flags {
 	IBV_QUERY_QP_DATA_IN_ORDER_RETURN_CAPS = 1 << 0,
+	IBV_QUERY_QP_DATA_IN_ORDER_DEVICE_ONLY = 1 << 1,
 };
 
 enum ibv_query_qp_data_in_order_caps {


### PR DESCRIPTION
EFA can support 128 bytes blocks write in-order for some Grace platforms. Move the check on x86 architecture to the mlx5 provider implementation.

Reviewed-by: Michael Margolin <mrgolin@amazon.com>
Reviewed-by: Yonatan Nachum <ynachum@amazon.com>