### PR TITLE
libhns: Fix double-free of rinl buf->wqe list

### DIFF
--- a/providers/hns/hns_roce_u_verbs.c
+++ b/providers/hns/hns_roce_u_verbs.c
@@ -1256,12 +1256,13 @@ static int qp_alloc_wqe(struct ibv_qp_cap *cap, struct hns_roce_qp *qp,
 	}
 
 	if (hns_roce_alloc_buf(&qp->buf, qp->buf_size, HNS_HW_PAGE_SIZE))
-		goto err_alloc;
+		goto err_alloc_recv_rinl_buf;
 
 	return 0;
 
-err_alloc:
+err_alloc_recv_rinl_buf:
 	free_recv_rinl_buf(&qp->rq_rinl_buf);
+err_alloc:
 	if (qp->rq.wrid)
 		free(qp->rq.wrid);
 


### PR DESCRIPTION
rinl_buf->wqe_list will be double-freed in error flow, first in alloc_recv_rinl_buf() and then in free_recv_rinl_buf(). Actually free_recv_rinl_buf() shouldn't be called when alloc_recv_rinl_buf() failed.