### PR TITLE
mlx5: Expose BlueFlame capability

### DIFF
--- a/providers/mlx5/man/mlx5dv_query_device.3
+++ b/providers/mlx5/man/mlx5dv_query_device.3
@@ -87,6 +87,7 @@ enum mlx5dv_context_flags {
  * If CQ was created with IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK, CQEs timestamp will be in real time format.
  */
  MLX5DV_CONTEXT_FLAGS_REAL_TIME_TS = (1 << 7),
+ MLX5DV_CONTEXT_FLAGS_BLUEFLAME = (1 << 8), /* Indicates if BlueFlame is supported by the device */
 .in -8
 };
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -894,6 +894,9 @@ static int _mlx5dv_query_device(struct ibv_context *ctx_in,
 		MLX5_VENDOR_CAP_FLAGS_PACKET_BASED_CREDIT_MODE)
 		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_PACKET_BASED_CREDIT_MODE;
 
+	if (mctx->bf_reg_size > 0)
+		attrs_out->flags |= MLX5DV_CONTEXT_FLAGS_BLUEFLAME;
+
 	if (attrs_out->comp_mask & MLX5DV_CONTEXT_MASK_SWP) {
 		attrs_out->sw_parsing_caps = mctx->sw_parsing_caps;
 		comp_mask_out |= MLX5DV_CONTEXT_MASK_SWP;

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -261,6 +261,7 @@ enum mlx5dv_context_flags {
 	MLX5DV_CONTEXT_FLAGS_CQE_128B_PAD = (1 << 5), /* Support CQE 128B padding */
 	MLX5DV_CONTEXT_FLAGS_PACKET_BASED_CREDIT_MODE = (1 << 6),
 	MLX5DV_CONTEXT_FLAGS_REAL_TIME_TS = (1 << 7),
+	MLX5DV_CONTEXT_FLAGS_BLUEFLAME = (1 << 8), /* Support BlueFlame */
 };
 
 enum mlx5dv_cq_init_attr_mask {

--- a/pyverbs/providers/mlx5/mlx5_enums.pxd
+++ b/pyverbs/providers/mlx5/mlx5_enums.pxd
@@ -62,6 +62,7 @@ cdef extern from 'infiniband/mlx5dv.h':
         MLX5DV_CONTEXT_FLAGS_CQE_128B_PAD               = 1 << 5
         MLX5DV_CONTEXT_FLAGS_PACKET_BASED_CREDIT_MODE   = 1 << 6
         MLX5DV_CONTEXT_FLAGS_REAL_TIME_TS               = 1 << 7
+        MLX5DV_CONTEXT_FLAGS_BLUEFLAME                  = 1 << 8
 
     cpdef enum mlx5dv_sw_parsing_offloads:
         MLX5DV_SW_PARSING       = 1 << 0

--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1242,7 +1242,8 @@ def context_flags_to_str(flags):
          dve.MLX5DV_CONTEXT_FLAGS_CQE_128B_COMP: 'Support CQE 128B compression',
          dve.MLX5DV_CONTEXT_FLAGS_CQE_128B_PAD: 'Support CQE 128B padding',
          dve.MLX5DV_CONTEXT_FLAGS_PACKET_BASED_CREDIT_MODE:
-         'Support packet based credit mode (in RC QP)'}
+         'Support packet based credit mode (in RC QP)',
+         dve.MLX5DV_CONTEXT_FLAGS_BLUEFLAME: 'Support BlueFlame'}
     return bitmask_to_str(flags, l)
 
 


### PR DESCRIPTION
Add a flag to indicate BlueFlame support through mlx5dv_query_device().

This can be used by an application to consider whether BlueFlame is supported by the device.

A matching pyverbs patch was added as well.