### PR TITLE
efa: Fix CQ poll after QP destroy

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -769,9 +769,6 @@ static inline int efa_poll_sub_cqs(struct efa_cq *cq, struct ibv_wc *wc,
 		sub_cq = &cq->sub_cq_arr[cq->next_poll_idx++];
 		cq->next_poll_idx %= num_sub_cqs;
 
-		if (!sub_cq->ref_cnt)
-			continue;
-
 		err = efa_poll_sub_cq(cq, sub_cq, &qp, wc, extended);
 		if (err != ENOENT) {
 			cq->cc++;


### PR DESCRIPTION
After a QP has been destroyed there might still be pending CQEs. As an optimization for some cases, poll functions ignore CQs that are not in use by any QP, preventing completions from being read after destruction of the last QP that uses this CQ. Remove this optimization.