### PR TITLE
rxe: Fix double unlock in cq_ex polling

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -266,7 +266,6 @@ static int cq_next_poll(struct ibv_cq_ex *current)
 
 	if (next_index == load_producer_index(q)) {
 		store_consumer_index(cq->queue, cq->cur_index);
-		pthread_spin_unlock(&cq->lock);
 		errno = ENOENT;
 		return errno;
 	}


### PR DESCRIPTION
Fix a bug in rxe cq_ex polling where the cq lock is unlocked twice causing undefined behavior. According the man page, the user should call `cq_end_poll` even if `cq_next_poll` returns ENOENT. This fix removes the `pthread_spin_unlock` call in `cq_next_poll` so that it is correctly called only once in `cq_end_poll`.

Fixes: e3af50b ("Provider/rxe: Implement Ibv_create_cq_ex verb")