### PR TITLE
tests: Fixes and Cython 3.x adjustment

### DIFF
--- a/pyverbs/pd.pyx
+++ b/pyverbs/pd.pyx
@@ -151,7 +151,7 @@ cdef class PD(PyverbsCM):
 
     @property
     def pd(self):
-        return <object>self.pd
+        return <uintptr_t>self.pd
 
 
 cdef void *pd_alloc(v.ibv_pd *pd, void *pd_context, size_t size,

--- a/pyverbs/providers/mlx5/mlx5dv_objects.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv_objects.pyx
@@ -182,7 +182,7 @@ cdef class Mlx5DvObj(PyverbsObject):
             self.dv_qp = dv_qp
         if pd:
             dv_pd = Mlx5DvPD()
-            self.obj.pd.in_ = <v.ibv_pd*>pd.pd
+            self.obj.pd.in_ = <v.ibv_pd*><uintptr_t>pd.pd
             self.obj.pd.out = &(dv_pd.dv_pd)
             self.dv_pd = dv_pd
         if srq:

--- a/pyverbs/spec.pyx
+++ b/pyverbs/spec.pyx
@@ -444,7 +444,7 @@ cdef class TcpUdpSpec(Spec):
 
 
 cdef class Ipv6Spec(Spec):
-    EMPTY_IPV6 = [0] * 16
+    EMPTY_IPV6 = '::'
     IPV6_MASK = ("ffff:" * 8)[:-1]
     FLOW_LABEL_MASK = 0xfffff
 
@@ -476,9 +476,21 @@ cdef class Ipv6Spec(Spec):
             self.spec_type |= v.IBV_FLOW_SPEC_INNER
         self.size = sizeof(v.ibv_flow_spec_ipv6)
 
-        self.dst_ip, self.dst_ip_mask = self._set_val_mask(self.IPV6_MASK,
+        if dst_ip is None:
+            def_dst_ip_mask = self.EMPTY_IPV6
+            dst_ip = '::'
+        else:
+            def_dst_ip_mask = self.IPV6_MASK
+
+        if src_ip is None:
+            def_src_ip_mask = self.EMPTY_IPV6
+            src_ip = '::'
+        else:
+            def_src_ip_mask = self.IPV6_MASK
+
+        self.dst_ip, self.dst_ip_mask = self._set_val_mask(def_dst_ip_mask,
                                                            dst_ip, dst_ip_mask)
-        self.src_ip, self.src_ip_mask = self._set_val_mask(self.IPV6_MASK,
+        self.src_ip, self.src_ip_mask = self._set_val_mask(def_src_ip_mask,
                                                            src_ip, src_ip_mask)
         self.val.flow_label, self.mask.flow_label = \
             map(socket.htonl, self._set_val_mask(self.FLOW_LABEL_MASK,
@@ -492,7 +504,7 @@ cdef class Ipv6Spec(Spec):
 
     @property
     def dst_ip(self):
-        return socket.inet_ntop(socket.AF_INET6, self.val.dst_ip)
+        return socket.inet_ntop(socket.AF_INET6, self.val.dst_ip[:16])
 
     @dst_ip.setter
     def dst_ip(self, val):
@@ -500,7 +512,7 @@ cdef class Ipv6Spec(Spec):
 
     @property
     def dst_ip_mask(self):
-        return socket.inet_ntop(socket.AF_INET6, self.mask.dst_ip)
+        return socket.inet_ntop(socket.AF_INET6, self.mask.dst_ip[:16])
 
     @dst_ip_mask.setter
     def dst_ip_mask(self, val):
@@ -508,7 +520,7 @@ cdef class Ipv6Spec(Spec):
 
     @property
     def src_ip(self):
-        return socket.inet_ntop(socket.AF_INET6, self.val.src_ip)
+        return socket.inet_ntop(socket.AF_INET6, self.val.src_ip[:16])
 
     @src_ip.setter
     def src_ip(self, val):
@@ -516,7 +528,7 @@ cdef class Ipv6Spec(Spec):
 
     @property
     def src_ip_mask(self):
-        return socket.inet_ntop(socket.AF_INET6, self.mask.src_ip)
+        return socket.inet_ntop(socket.AF_INET6, self.mask.src_ip[:16])
 
     @src_ip_mask.setter
     def src_ip_mask(self, val):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1492,8 +1492,12 @@ def requires_root():
 def requires_no_sriov():
     def outer(func):
         def inner(instance):
-            path = '/sys/class/infiniband/{instance.dev_name}/device/sriov_totalvfs'
-            if os.path.isfile(path):
+            physfn_path = f'/sys/class/infiniband/{instance.dev_name}/device/physfn'
+            if os.path.isdir(physfn_path):
+                sriov_path = f'{physfn_path}/sriov_totalvfs'
+            else:
+                sriov_path = f'/sys/class/infiniband/{instance.dev_name}/device/sriov_totalvfs'
+            if os.path.isfile(sriov_path):
                 raise unittest.SkipTest('Virtual Functions are present on the device')
             return func(instance)
         return inner


### PR DESCRIPTION
The series includes two small test fixes related to Ipv6Spec class and mlx5 flow tests.
The head of the series consists of a patch adjusting Pyverbs' PD return type to be compatible with Cython 3.x.