### PR TITLE
verbs: RDMA support for DMA handle

### DIFF
--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -12,6 +12,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  IBVERBS_1.12@IBVERBS_1.12 34
  IBVERBS_1.13@IBVERBS_1.13 35
  IBVERBS_1.14@IBVERBS_1.14 36
+ IBVERBS_1.15@IBVERBS_1.15 37
  (symver)IBVERBS_PRIVATE_57 57
  _ibv_query_gid_ex@IBVERBS_1.11 32
  _ibv_query_gid_table@IBVERBS_1.11 32
@@ -19,6 +20,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_ack_async_event@IBVERBS_1.1 1.1.6
  ibv_ack_cq_events@IBVERBS_1.0 1.1.6
  ibv_ack_cq_events@IBVERBS_1.1 1.1.6
+ ibv_alloc_dmah@IBVERBS_1.15 37
  ibv_alloc_pd@IBVERBS_1.0 1.1.6
  ibv_alloc_pd@IBVERBS_1.1 1.1.6
  ibv_attach_mcast@IBVERBS_1.0 1.1.6
@@ -39,6 +41,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_create_qp@IBVERBS_1.1 1.1.6
  ibv_create_srq@IBVERBS_1.0 1.1.6
  ibv_create_srq@IBVERBS_1.1 1.1.6
+ ibv_dealloc_dmah@IBVERBS_1.15 37
  ibv_dealloc_pd@IBVERBS_1.0 1.1.6
  ibv_dealloc_pd@IBVERBS_1.1 1.1.6
  ibv_dereg_mr@IBVERBS_1.0 1.1.6

--- a/debian/libibverbs1.symbols
+++ b/debian/libibverbs1.symbols
@@ -111,6 +111,7 @@ libibverbs.so.1 libibverbs1 #MINVER#
  ibv_reg_dmabuf_mr@IBVERBS_1.12 34
  ibv_reg_mr@IBVERBS_1.0 1.1.6
  ibv_reg_mr@IBVERBS_1.1 1.1.6
+ ibv_reg_mr_ex@IBVERBS_1.15 37
  ibv_reg_mr_iova@IBVERBS_1.7 25
  ibv_reg_mr_iova2@IBVERBS_1.8 28
  ibv_register_driver@IBVERBS_1.1 1.1.6

--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: ((GPL-2.0 WITH Linux-syscall-note) OR BSD-2-Clause) */
 /*
- * Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2018-2025 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef EFA_ABI_USER_H
@@ -131,6 +131,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_DATA_POLLING_128 = 1 << 4,
 	EFA_QUERY_DEVICE_CAPS_RDMA_WRITE = 1 << 5,
 	EFA_QUERY_DEVICE_CAPS_UNSOLICITED_WRITE_RECV = 1 << 6,
+	EFA_QUERY_DEVICE_CAPS_CQ_WITH_EXT_MEM = 1 << 7,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/kernel-headers/rdma/ib_user_ioctl_cmds.h
+++ b/kernel-headers/rdma/ib_user_ioctl_cmds.h
@@ -55,6 +55,7 @@ enum uverbs_default_objects {
 	UVERBS_OBJECT_DM,
 	UVERBS_OBJECT_COUNTERS,
 	UVERBS_OBJECT_ASYNC_EVENT,
+	UVERBS_OBJECT_DMAH,
 };
 
 enum {
@@ -105,6 +106,10 @@ enum uverbs_attrs_create_cq_cmd_attr_ids {
 	UVERBS_ATTR_CREATE_CQ_FLAGS,
 	UVERBS_ATTR_CREATE_CQ_RESP_CQE,
 	UVERBS_ATTR_CREATE_CQ_EVENT_FD,
+	UVERBS_ATTR_CREATE_CQ_BUFFER_VA,
+	UVERBS_ATTR_CREATE_CQ_BUFFER_LENGTH,
+	UVERBS_ATTR_CREATE_CQ_BUFFER_FD,
+	UVERBS_ATTR_CREATE_CQ_BUFFER_OFFSET,
 };
 
 enum uverbs_attrs_destroy_cq_cmd_attr_ids {
@@ -236,6 +241,22 @@ enum uverbs_methods_dm {
 	UVERBS_METHOD_DM_FREE,
 };
 
+enum uverbs_attrs_alloc_dmah_cmd_attr_ids {
+	UVERBS_ATTR_ALLOC_DMAH_HANDLE,
+	UVERBS_ATTR_ALLOC_DMAH_CPU_ID,
+	UVERBS_ATTR_ALLOC_DMAH_TPH_MEM_TYPE,
+	UVERBS_ATTR_ALLOC_DMAH_PH,
+};
+
+enum uverbs_attrs_free_dmah_cmd_attr_ids {
+	UVERBS_ATTR_FREE_DMA_HANDLE,
+};
+
+enum uverbs_methods_dmah {
+	UVERBS_METHOD_DMAH_ALLOC,
+	UVERBS_METHOD_DMAH_FREE,
+};
+
 enum uverbs_attrs_reg_dm_mr_cmd_attr_ids {
 	UVERBS_ATTR_REG_DM_MR_HANDLE,
 	UVERBS_ATTR_REG_DM_MR_OFFSET,
@@ -253,6 +274,7 @@ enum uverbs_methods_mr {
 	UVERBS_METHOD_ADVISE_MR,
 	UVERBS_METHOD_QUERY_MR,
 	UVERBS_METHOD_REG_DMABUF_MR,
+	UVERBS_METHOD_REG_MR,
 };
 
 enum uverbs_attrs_mr_destroy_ids {
@@ -284,6 +306,20 @@ enum uverbs_attrs_reg_dmabuf_mr_cmd_attr_ids {
 	UVERBS_ATTR_REG_DMABUF_MR_ACCESS_FLAGS,
 	UVERBS_ATTR_REG_DMABUF_MR_RESP_LKEY,
 	UVERBS_ATTR_REG_DMABUF_MR_RESP_RKEY,
+};
+
+enum uverbs_attrs_reg_mr_cmd_attr_ids {
+	UVERBS_ATTR_REG_MR_HANDLE,
+	UVERBS_ATTR_REG_MR_PD_HANDLE,
+	UVERBS_ATTR_REG_MR_DMA_HANDLE,
+	UVERBS_ATTR_REG_MR_IOVA,
+	UVERBS_ATTR_REG_MR_ADDR,
+	UVERBS_ATTR_REG_MR_LENGTH,
+	UVERBS_ATTR_REG_MR_ACCESS_FLAGS,
+	UVERBS_ATTR_REG_MR_FD,
+	UVERBS_ATTR_REG_MR_FD_OFFSET,
+	UVERBS_ATTR_REG_MR_RESP_LKEY,
+	UVERBS_ATTR_REG_MR_RESP_RKEY,
 };
 
 enum uverbs_attrs_create_counters_cmd_attr_ids {

--- a/kernel-headers/rdma/rdma_netlink.h
+++ b/kernel-headers/rdma/rdma_netlink.h
@@ -580,6 +580,8 @@ enum rdma_nldev_attr {
 	RDMA_NLDEV_ATTR_EVENT_TYPE,		/* u8 */
 
 	RDMA_NLDEV_SYS_ATTR_MONITOR_MODE,	/* u8 */
+
+	RDMA_NLDEV_ATTR_STAT_OPCOUNTER_ENABLED,	/* u8 */
 	/*
 	 * Always the end
 	 */

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -21,7 +21,7 @@ configure_file("libibverbs.map.in"
 
 rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   # See Documentation/versioning.md
-  1 1.14.${PACKAGE_VERSION}
+  1 1.15.${PACKAGE_VERSION}
   all_providers.c
   cmd.c
   cmd_ah.c

--- a/libibverbs/CMakeLists.txt
+++ b/libibverbs/CMakeLists.txt
@@ -29,6 +29,7 @@ rdma_library(ibverbs "${CMAKE_CURRENT_BINARY_DIR}/libibverbs.map"
   cmd_cq.c
   cmd_device.c
   cmd_dm.c
+  cmd_dmah.c
   cmd_fallback.c
   cmd_flow.c
   cmd_flow_action.c

--- a/libibverbs/cmd_dmah.c
+++ b/libibverbs/cmd_dmah.c
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: GPL-2.0 or Linux-OpenIB
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved
+ */
+
+#include <infiniband/cmd_write.h>
+
+int ibv_cmd_alloc_dmah(struct ibv_context *ctx,
+		       struct verbs_dmah *dmah,
+		       struct ibv_dmah_init_attr *attr)
+{
+	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_DMAH, UVERBS_METHOD_DMAH_ALLOC, 4);
+	struct ib_uverbs_attr *handle;
+	int ret;
+
+	handle = fill_attr_out_obj(cmdb, UVERBS_ATTR_ALLOC_DMAH_HANDLE);
+	if (attr->comp_mask & IBV_DMAH_INIT_ATTR_MASK_CPU_ID)
+		fill_attr_in_uint32(cmdb, UVERBS_ATTR_ALLOC_DMAH_CPU_ID,
+				    attr->cpu_id);
+	if (attr->comp_mask & IBV_DMAH_INIT_ATTR_MASK_TPH_MEM_TYPE)
+		fill_attr_in_enum(cmdb, UVERBS_ATTR_ALLOC_DMAH_TPH_MEM_TYPE,
+				  attr->tph_mem_type, NULL, 0);
+	if (attr->comp_mask & IBV_DMAH_INIT_ATTR_MASK_PH)
+		fill_attr_in(cmdb, UVERBS_ATTR_ALLOC_DMAH_PH,
+			     &attr->ph, sizeof(attr->ph));
+	ret = execute_ioctl(ctx, cmdb);
+	if (ret)
+		return errno;
+
+	dmah->handle = read_attr_obj(UVERBS_ATTR_ALLOC_DMAH_HANDLE, handle);
+	dmah->dmah.context = ctx;
+
+	return 0;
+}
+
+int ibv_cmd_free_dmah(struct verbs_dmah *dmah)
+{
+	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_DMAH, UVERBS_METHOD_DMAH_FREE, 1);
+	int ret;
+
+	fill_attr_in_obj(cmdb, UVERBS_ATTR_FREE_DMA_HANDLE, dmah->handle);
+
+	ret = execute_ioctl(dmah->dmah.context, cmdb);
+	if (verbs_is_destroy_err(&ret))
+		return ret;
+
+	return 0;
+}

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -450,6 +450,7 @@ struct verbs_context_ops {
 					int fd, int access);
 	struct ibv_mr *(*reg_mr)(struct ibv_pd *pd, void *addr, size_t length,
 				 uint64_t hca_va, int access);
+	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
 	int (*req_notify_cq)(struct ibv_cq *cq, int solicited_only);
 	int (*rereg_mr)(struct verbs_mr *vmr, int flags, struct ibv_pd *pd,
 			void *addr, size_t length, int access);

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -194,6 +194,11 @@ struct verbs_dmah {
 	uint32_t handle;
 };
 
+static inline struct verbs_dmah *verbs_get_dmah(struct ibv_dmah *dmah)
+{
+	return container_of(dmah, struct verbs_dmah, dmah);
+}
+
 enum {
 	VERBS_MATCH_SENTINEL = 0,
 	VERBS_MATCH_PCI = 1,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -573,6 +573,8 @@ int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 			  uint64_t iova, int fd, int access,
 			  struct verbs_mr *vmr,
 			  struct ibv_command_buffer *driver);
+int ibv_cmd_reg_mr_ex(struct ibv_pd *pd, struct verbs_mr *vmr,
+		      struct ibv_reg_mr_in *in);
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -189,6 +189,11 @@ struct verbs_dm {
 	uint32_t		handle;
 };
 
+struct verbs_dmah {
+	struct ibv_dmah dmah;
+	uint32_t handle;
+};
+
 enum {
 	VERBS_MATCH_SENTINEL = 0,
 	VERBS_MATCH_PCI = 1,
@@ -707,6 +712,9 @@ int ibv_cmd_alloc_dm(struct ibv_context *ctx,
 		     struct verbs_dm *dm,
 		     struct ibv_command_buffer *link);
 int ibv_cmd_free_dm(struct verbs_dm *dm);
+int ibv_cmd_alloc_dmah(struct ibv_context *ctx, struct verbs_dmah *st,
+		       struct ibv_dmah_init_attr *attr);
+int ibv_cmd_free_dmah(struct verbs_dmah *dmah);
 int ibv_cmd_reg_dm_mr(struct ibv_pd *pd, struct verbs_dm *dm,
 		      uint64_t offset, size_t length,
 		      unsigned int access, struct verbs_mr *vmr,

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -316,6 +316,8 @@ struct verbs_context_ops {
 			 uint32_t num_sges);
 	struct ibv_dm *(*alloc_dm)(struct ibv_context *context,
 				   struct ibv_alloc_dm_attr *attr);
+	struct ibv_dmah *(*alloc_dmah)(struct ibv_context *context,
+				       struct ibv_dmah_init_attr *attr);
 	struct ibv_mw *(*alloc_mw)(struct ibv_pd *pd, enum ibv_mw_type type);
 	struct ibv_mr *(*alloc_null_mr)(struct ibv_pd *pd);
 	struct ibv_pd *(*alloc_parent_domain)(
@@ -363,6 +365,7 @@ struct verbs_context_ops {
 		struct ibv_srq_init_attr_ex *srq_init_attr_ex);
 	struct ibv_wq *(*create_wq)(struct ibv_context *context,
 				    struct ibv_wq_init_attr *wq_init_attr);
+	int (*dealloc_dmah)(struct ibv_dmah *dmah);
 	int (*dealloc_mw)(struct ibv_mw *mw);
 	int (*dealloc_pd)(struct ibv_pd *pd);
 	int (*dealloc_td)(struct ibv_td *td);

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -461,6 +461,12 @@ static struct ibv_mr *reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	return NULL;
 }
 
+static struct ibv_mr *reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in)
+{
+	errno = EOPNOTSUPP;
+	return NULL;
+}
+
 static struct ibv_mr *reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 				    size_t length, uint64_t iova,
 				    int fd, int access)
@@ -586,6 +592,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	reg_dm_mr,
 	reg_dmabuf_mr,
 	reg_mr,
+	reg_mr_ex,
 	req_notify_cq,
 	rereg_mr,
 	resize_cq,
@@ -713,6 +720,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_OP(vctx, reg_dm_mr);
 	SET_PRIV_OP_IC(vctx, reg_dmabuf_mr);
 	SET_PRIV_OP(ctx, reg_mr);
+	SET_OP(vctx, reg_mr_ex);
 	SET_OP(ctx, req_notify_cq);
 	SET_PRIV_OP(ctx, rereg_mr);
 	SET_PRIV_OP(ctx, resize_cq);

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -50,6 +50,13 @@ static struct ibv_dm *alloc_dm(struct ibv_context *context,
 	return NULL;
 }
 
+static struct ibv_dmah *alloc_dmah(struct ibv_context *context,
+				   struct ibv_dmah_init_attr *attr)
+{
+	errno = EOPNOTSUPP;
+	return NULL;
+}
+
 static struct ibv_mw *alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type)
 {
 	errno = EOPNOTSUPP;
@@ -200,6 +207,11 @@ static struct ibv_wq *create_wq(struct ibv_context *context,
 {
 	errno = EOPNOTSUPP;
 	return NULL;
+}
+
+static int dealloc_dmah(struct ibv_dmah *st)
+{
+	return EOPNOTSUPP;
 }
 
 static int dealloc_mw(struct ibv_mw *mw)
@@ -505,6 +517,7 @@ static void unimport_pd(struct ibv_pd *pd)
 const struct verbs_context_ops verbs_dummy_ops = {
 	advise_mr,
 	alloc_dm,
+	alloc_dmah,
 	alloc_mw,
 	alloc_null_mr,
 	alloc_parent_domain,
@@ -528,6 +541,7 @@ const struct verbs_context_ops verbs_dummy_ops = {
 	create_srq,
 	create_srq_ex,
 	create_wq,
+	dealloc_dmah,
 	dealloc_mw,
 	dealloc_pd,
 	dealloc_td,
@@ -630,6 +644,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 
 	SET_OP(vctx, advise_mr);
 	SET_OP(vctx, alloc_dm);
+	SET_OP(vctx, alloc_dmah);
 	SET_OP(ctx, alloc_mw);
 	SET_OP(vctx, alloc_null_mr);
 	SET_PRIV_OP(ctx, alloc_pd);
@@ -653,6 +668,7 @@ void verbs_set_ops(struct verbs_context *vctx,
 	SET_PRIV_OP(ctx, create_srq);
 	SET_OP(vctx, create_srq_ex);
 	SET_OP(vctx, create_wq);
+	SET_OP(vctx, dealloc_dmah);
 	SET_OP(ctx, dealloc_mw);
 	SET_PRIV_OP(ctx, dealloc_pd);
 	SET_OP(vctx, dealloc_td);

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -164,6 +164,12 @@ IBVERBS_1.14 {
 		ibv_query_qp_data_in_order;
 } IBVERBS_1.13;
 
+IBVERBS_1.15 {
+	global:
+		ibv_alloc_dmah;
+		ibv_dealloc_dmah;
+} IBVERBS_1.14;
+
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
    version. See the top level CMakeLists.txt for this setting. */
 

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -182,6 +182,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		execute_ioctl;
 		ibv_cmd_advise_mr;
 		ibv_cmd_alloc_dm;
+		ibv_cmd_alloc_dmah;
 		ibv_cmd_alloc_mw;
 		ibv_cmd_alloc_pd;
 		ibv_cmd_attach_mcast;
@@ -214,6 +215,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_destroy_wq;
 		ibv_cmd_detach_mcast;
 		ibv_cmd_free_dm;
+		ibv_cmd_free_dmah;
 		ibv_cmd_get_context;
 		ibv_cmd_modify_cq;
 		ibv_cmd_modify_flow_action_esp;

--- a/libibverbs/libibverbs.map.in
+++ b/libibverbs/libibverbs.map.in
@@ -168,6 +168,7 @@ IBVERBS_1.15 {
 	global:
 		ibv_alloc_dmah;
 		ibv_dealloc_dmah;
+		ibv_reg_mr_ex;
 } IBVERBS_1.14;
 
 /* If any symbols in this stanza change ABI then the entire staza gets a new symbol
@@ -239,6 +240,7 @@ IBVERBS_PRIVATE_@IBVERBS_PABI_VERSION@ {
 		ibv_cmd_reg_dm_mr;
 		ibv_cmd_reg_dmabuf_mr;
 		ibv_cmd_reg_mr;
+		ibv_cmd_reg_mr_ex;
 		ibv_cmd_req_notify_cq;
 		ibv_cmd_rereg_mr;
 		ibv_cmd_resize_cq;

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -118,6 +118,7 @@ rdma_alias_man_pages(
   ibv_rate_to_mbps.3 mbps_to_ibv_rate.3
   ibv_rate_to_mult.3 mult_to_ibv_rate.3
   ibv_reg_mr.3 ibv_dereg_mr.3
+  ibv_reg_mr.3 ibv_reg_mr_ex.3
   ibv_wr_post.3 ibv_wr_abort.3
   ibv_wr_post.3 ibv_wr_complete.3
   ibv_wr_post.3 ibv_wr_start.3

--- a/libibverbs/man/CMakeLists.txt
+++ b/libibverbs/man/CMakeLists.txt
@@ -1,6 +1,7 @@
 rdma_man_pages(
   ibv_advise_mr.3.md
   ibv_alloc_dm.3
+  ibv_alloc_dmah.3.md
   ibv_alloc_mw.3
   ibv_alloc_null_mr.3.md
   ibv_alloc_parent_domain.3
@@ -87,6 +88,7 @@ rdma_alias_man_pages(
   ibv_alloc_dm.3 ibv_reg_dm_mr.3
   ibv_alloc_dm.3 ibv_memcpy_to_dm.3
   ibv_alloc_dm.3 ibv_memcpy_from_dm.3
+  ibv_alloc_dmah.3 ibv_dealloc_dmah.3
   ibv_alloc_mw.3 ibv_dealloc_mw.3
   ibv_alloc_pd.3 ibv_dealloc_pd.3
   ibv_alloc_td.3 ibv_dealloc_td.3

--- a/libibverbs/man/ibv_alloc_dmah.3.md
+++ b/libibverbs/man/ibv_alloc_dmah.3.md
@@ -1,0 +1,88 @@
+---
+date: 2025-5-8
+footer: libibverbs
+header: "Libibverbs Programmer's Manual"
+layout: page
+license: 'Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md'
+section: 3
+title: ibv_alloc_dmah
+---
+
+# NAME
+
+ibv_alloc_dmah - allocate a dma handle
+
+int ibv_dealloc_dmah - deallocate a dma handle
+
+# SYNOPSIS
+
+```c
+#include <infiniband/verbs.h>
+
+struct ibv_dmah *ibv_alloc_dmah(struct ibv_context *context, struct ibv_dmah_init_attr *attr);
+
+int ibv_dealloc_dmah(struct ibv_dmah *dmah);
+
+```
+
+# DESCRIPTION
+
+**ibv_alloc_dmah()** allocates an *ibv_dmah* object that is associated with the given
+*context* and the input *attr* parameter.
+
+The allocated handle can be later used for optimizing DMA and RDMA operations associated
+with a registered memory region.
+
+Once the *ibv_dmah* usage has been ended *ibv_dealloc_dmah()* should be called.
+
+This call will release resources that were earlier allocated using the **ibv_alloc_dmah()** API.
+
+# ARGUMENTS
+
+## attr
+
+```c
+
+enum ibv_tph_mem_type {
+	IBV_TPH_MEM_TYPE_VM, /* volatile memory */
+	IBV_TPH_MEM_TYPE_PM, /* persistent memory */
+};
+
+enum ibv_dmah_init_attr_mask {
+	IBV_DMAH_INIT_ATTR_MASK_CPU_ID = 1 << 0,
+	IBV_DMAH_INIT_ATTR_MASK_PH = 1 << 1,
+	IBV_DMAH_INIT_ATTR_MASK_TPH_MEM_TYPE = 1 << 2,
+};
+
+struct ibv_dmah_init_attr {
+	uint32_t comp_mask; /* From ibv_dmah_init_attr_mask */
+	uint32_t cpu_id;
+	uint8_t ph;
+	uint8_t tph_mem_type; /* From enum ibv_tph_mem_type */
+};
+```
+*comp_mask*
+:	Bitmask specifying what fields in the structure are valid.
+
+*cpu_id*
+:	The cpu id that the dma handle refers to.
+
+*ph*
+:	 Processing hints, used to aid in optimizing the handling of transactions over PCIe.
+
+*tph_mem_type*
+:	The target memory type, one among *enum ibv_tph_mem_type*.
+
+# RETURN VALUE
+
+**ibv_alloc_dmah()** returns a pointer to the allocated dma handle object, or NULL if the request fails.
+
+**ibv_dealloc_dmah()** returns 0 upon success, otherwise the errno value.
+
+# SEE ALSO
+
+**ibv_reg_mr_ex**(3)
+
+# AUTHOR
+
+Yishai Hadas <yishaih@nvidia.com>

--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -3,7 +3,7 @@
 .\"
 .TH IBV_REG_MR 3 2006-10-31 libibverbs "Libibverbs Programmer's Manual"
 .SH "NAME"
-ibv_reg_mr, ibv_reg_mr_iova, ibv_reg_dmabuf_mr, ibv_dereg_mr \- register or deregister a memory region (MR)
+ibv_reg_mr, ibv_reg_mr_iova, ibv_reg_dmabuf_mr, ibv_reg_mr_ex, ibv_dereg_mr \- register or deregister a memory region (MR)
 .SH "SYNOPSIS"
 .nf
 .B #include <infiniband/verbs.h>
@@ -18,6 +18,8 @@ ibv_reg_mr, ibv_reg_mr_iova, ibv_reg_dmabuf_mr, ibv_dereg_mr \- register or dere
 .BI "struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd " "*pd" ", uint64_t " "offset" ,
 .BI "                                 size_t " "length" ", uint64_t " "iova" ,
 .BI "                                 int " "fd" ", int " "access" );
+.sp
+.BI "struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd " "*pd" ", struct ibv_reg_mr_in " in" );
 .sp
 .BI "int ibv_dereg_mr(struct ibv_mr " "*mr" );
 .fi
@@ -119,11 +121,21 @@ The argument
 describes the desired memory protection attributes; it is similar to the ibv_reg_mr case except that only the following flags are supported:
 .B IBV_ACCESS_LOCAL_WRITE, IBV_ACCESS_REMOTE_WRITE, IBV_ACCESS_REMOTE_READ, IBV_ACCESS_REMOTE_ATOMIC, IBV_ACCESS_RELAXED_ORDERING.
 .PP
+.B ibv_reg_mr_ex()
+ibv_reg_mr_ex is a an API that enables all the variants of the other ibv_reg_mr_xxx() that desecibed in that man page.
+It has the
+.I in->comp_mask
+field to let application mark which fields are applicable.
+In addition, it includes the
+.I in->dmah
+which can be used to include an ibv_dmah object that will be used for that MR.
+The other fields on the input pointer have the same meaning as of the fields that described in that man page for the other verbs.
+.PP
 .B ibv_dereg_mr()
 deregisters the MR
 .I mr\fR.
 .SH "RETURN VALUE"
-.B ibv_reg_mr() / ibv_reg_mr_iova() / ibv_reg_dmabuf_mr()
+.B ibv_reg_mr() / ibv_reg_mr_iova() / ibv_reg_dmabuf_mr() / ibv_reg_mr_ex()
 returns a pointer to the registered MR, or NULL if the request fails.
 The local key (\fBL_Key\fR) field
 .B lkey
@@ -140,6 +152,8 @@ returns 0 on success, or the value of errno on failure (which indicates the fail
 .SH "NOTES"
 .B ibv_dereg_mr()
 fails if any memory window is still bound to this MR.
+.B ibv_dereg_mr_ex()
+One among in->fd and in->addr is required, both can't come together.
 .SH "SEE ALSO"
 .BR ibv_alloc_pd (3),
 .BR ibv_post_send (3),

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -395,6 +395,23 @@ void ibv_unimport_dm(struct ibv_dm *dm)
 	get_ops(dm->context)->unimport_dm(dm);
 }
 
+/**
+ * ibv_alloc_dmah - Allocate a dma handle
+ */
+struct ibv_dmah *ibv_alloc_dmah(struct ibv_context *context,
+				struct ibv_dmah_init_attr *attr)
+{
+	return get_ops(context)->alloc_dmah(context, attr);
+}
+
+/**
+ * ibv_dealloc_dmah - Free a dma handle
+ */
+int ibv_dealloc_dmah(struct ibv_dmah *dmah)
+{
+	return get_ops(dmah->context)->dealloc_dmah(dmah);
+}
+
 struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset,
 				 size_t length, uint64_t iova, int fd,
 				 int access)

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -681,6 +681,25 @@ struct ibv_mr {
 	uint32_t		rkey;
 };
 
+enum  ibv_reg_mr_in_mask {
+	IBV_REG_MR_MASK_IOVA = 1 << 0,
+	IBV_REG_MR_MASK_ADDR = 1 << 1,
+	IBV_REG_MR_MASK_FD = 1 << 2,
+	IBV_REG_MR_MASK_FD_OFFSET = 1 << 3,
+	IBV_REG_MR_MASK_DMAH = 1 << 4,
+};
+
+struct ibv_reg_mr_in {
+	size_t length;
+	int access;
+	uint64_t comp_mask; /* Use enum ibv_reg_mr_in_mask */
+	uint64_t iova;
+	void *addr;
+	int fd;
+	uint64_t fd_offset;
+	struct ibv_dmah *dmah;
+};
+
 enum ibv_mw_type {
 	IBV_MW_TYPE_1			= 1,
 	IBV_MW_TYPE_2			= 2
@@ -2162,6 +2181,7 @@ struct ibv_values_ex {
 
 struct verbs_context {
 	/*  "grows up" - new fields go here */
+	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
 	int (*dealloc_dmah)(struct ibv_dmah *dmah);
 	struct ibv_dmah *(*alloc_dmah)(struct ibv_context *context,
 				       struct ibv_dmah_init_attr *attr);
@@ -2656,6 +2676,8 @@ __ibv_reg_mr_iova(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova,
  */
 struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 				 uint64_t iova, int fd, int access);
+
+struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
 
 enum ibv_rereg_mr_err_code {
 	/* Old MR is valid, invalid input */

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -173,6 +173,8 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.unimport_mr = mlx5_unimport_mr,
 	.unimport_pd = mlx5_unimport_pd,
 	.query_qp_data_in_order = mlx5_query_qp_data_in_order,
+	.alloc_dmah = mlx5_alloc_dmah,
+	.dealloc_dmah = mlx5_dealloc_dmah,
 };
 
 static const struct verbs_context_ops mlx5_ctx_cqev1_ops = {

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -175,6 +175,7 @@ static const struct verbs_context_ops mlx5_ctx_common_ops = {
 	.query_qp_data_in_order = mlx5_query_qp_data_in_order,
 	.alloc_dmah = mlx5_alloc_dmah,
 	.dealloc_dmah = mlx5_dealloc_dmah,
+	.reg_mr_ex = mlx5_reg_mr_ex,
 };
 
 static const struct verbs_context_ops mlx5_ctx_cqev1_ops = {

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1276,6 +1276,9 @@ int mlx5_dealloc_td(struct ibv_td *td);
 struct ibv_pd *mlx5_alloc_parent_domain(struct ibv_context *context,
 					struct ibv_parent_domain_init_attr *attr);
 
+struct ibv_dmah *mlx5_alloc_dmah(struct ibv_context *context,
+				 struct ibv_dmah_init_attr *attr);
+int mlx5_dealloc_dmah(struct ibv_dmah *dmah);
 
 void *mlx5_mmap(struct mlx5_uar_info *uar, int index,
 		int cmd_fd, int page_size, int uar_type);

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1143,6 +1143,7 @@ struct ibv_mr *mlx5_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 			   uint64_t hca_va, int access);
 struct ibv_mr *mlx5_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 				  uint64_t iova, int fd, int access);
+struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
 int mlx5_rereg_mr(struct verbs_mr *mr, int flags, struct ibv_pd *pd, void *addr,
 		  size_t length, int access);
 int mlx5_dereg_mr(struct verbs_mr *mr);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -651,6 +651,25 @@ struct ibv_mr *mlx5_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	return &mr->vmr.ibv_mr;
 }
 
+struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in)
+{
+	struct mlx5_mr *mr;
+	int ret;
+
+	mr = calloc(1, sizeof(*mr));
+	if (!mr)
+		return NULL;
+
+	ret = ibv_cmd_reg_mr_ex(pd, &mr->vmr, in);
+	if (ret) {
+		free(mr);
+		return NULL;
+	}
+	mr->alloc_flags = in->access;
+
+	return &mr->vmr.ibv_mr;
+}
+
 struct ibv_mr *mlx5_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 				  uint64_t iova, int fd, int acc)
 {


### PR DESCRIPTION
This patch series introduces a new DMA Handle (DMAH) object, along with its corresponding verbs for allocation and deallocation. (i.e. ibv_alloc_dmah(), ibv_dealloc_dmah())

The DMAH object encapsulates attributes relevant for DMA transactions.

While initially intended to support TLP Processing Hints (TPH) [1], the design is extensible to accommodate future features such as PCI multipath for DMA, PCI UIO configurations, traffic class selection, and more.

This addition enables applications to allocate an opaque DMA handle that can be used to optimize DMA and RDMA operations associated with a registered memory region.

Additionally, we introduce a new verb named ibv_reg_mr_ex() with its corresponding ioctl (i.e. UVERBS_METHOD_REG_MR) on the MR object.

This verb consolidates multiple reg_mr variants under a single user-space ioctl interface, supporting: ibv_reg_mr(), ibv_reg_mr_iova(), ibv_reg_mr_iova2() and ibv_reg_dmabuf_mr().

It also enables passing a DMA handle as part of the registration process to associate it with the registered MR. 

The series includes the implementation of the new functionality in the mlx5 driver.

Detailed man pages exist to describe the expected usage.

The matching kernel series was sent to rdma-next.

[1] Background, from PCIe specification 6.2.
TLP Processing Hints (TPH)
------------------------------
TLP Processing Hints is an optional feature that provides hints in Request TLP headers to facilitate optimized processing of Requests that target Memory Space.  These Processing Hints enable the system hardware (e.g., the Root Complex and/ or Endpoints) to optimize platform resources such as system and memory interconnect on a per TLP basis.