### PR TITLE
libibverbs: Fix create CQ max number of attributes

### DIFF
--- a/libibverbs/cmd_cq.c
+++ b/libibverbs/cmd_cq.c
@@ -40,7 +40,7 @@ static int ibv_icmd_create_cq(struct ibv_context *context, int cqe,
 			      struct ibv_command_buffer *link,
 			      uint32_t cmd_flags)
 {
-	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE, 8, link);
+	DECLARE_FBCMD_BUFFER(cmdb, UVERBS_OBJECT_CQ, UVERBS_METHOD_CQ_CREATE, 11, link);
 	struct verbs_ex_private *priv = get_priv(context);
 	struct ib_uverbs_attr *handle;
 	struct ib_uverbs_attr *async_fd_attr;


### PR DESCRIPTION
With CQ creation with external memory support the max number of attributes was increased but was left unchanged in the cmd declaration.

Fixes: 8d0ce825e0cc ("libibverbs: Add option to pass CQ buffers to kernel")