### PR TITLE
libibverbs: Rename ibv_reg_mr_in to ibv_mr_init_attr

### DIFF
--- a/libibverbs/cmd_mr.c
+++ b/libibverbs/cmd_mr.c
@@ -158,49 +158,51 @@ int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 }
 
 int ibv_cmd_reg_mr_ex(struct ibv_pd *pd, struct verbs_mr *vmr,
-		      struct ibv_reg_mr_in *in)
+		      struct ibv_mr_init_attr *mr_init_attr)
 {
 	DECLARE_COMMAND_BUFFER(cmdb, UVERBS_OBJECT_MR,
 			       UVERBS_METHOD_REG_MR, 11);
-	bool fd_based = (in->comp_mask & IBV_REG_MR_MASK_FD);
+	bool fd_based = (mr_init_attr->comp_mask & IBV_REG_MR_MASK_FD);
 	struct ib_uverbs_attr *handle;
-	uint64_t length = in->length;
+	uint64_t length = mr_init_attr->length;
 	uint32_t lkey, rkey;
 	int ret;
 
 	if (fd_based) {
-		if (!(in->comp_mask & IBV_REG_MR_MASK_FD_OFFSET) ||
-		    (in->comp_mask & IBV_REG_MR_MASK_ADDR)) {
+		if (!(mr_init_attr->comp_mask & IBV_REG_MR_MASK_FD_OFFSET) ||
+		    (mr_init_attr->comp_mask & IBV_REG_MR_MASK_ADDR)) {
 			errno = EINVAL;
 			return EINVAL;
 		}
-		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_FD_OFFSET, in->fd_offset);
+		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_FD_OFFSET,
+				    mr_init_attr->fd_offset);
 		fill_attr_in_fd(cmdb, UVERBS_ATTR_REG_MR_FD,
-				in->fd);
+				mr_init_attr->fd);
 	} else {
-		if ((in->comp_mask & IBV_REG_MR_MASK_FD_OFFSET) ||
-		    !(in->comp_mask & IBV_REG_MR_MASK_ADDR)) {
+		if ((mr_init_attr->comp_mask & IBV_REG_MR_MASK_FD_OFFSET) ||
+		    !(mr_init_attr->comp_mask & IBV_REG_MR_MASK_ADDR)) {
 			errno = EINVAL;
 			return EINVAL;
 		}
 
-		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_ADDR, (uintptr_t)in->addr);
-		if (in->access & IBV_ACCESS_ON_DEMAND) {
-			if (in->length == SIZE_MAX && in->addr) {
+		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_ADDR,
+				    (uintptr_t) mr_init_attr->addr);
+		if (mr_init_attr->access & IBV_ACCESS_ON_DEMAND) {
+			if (mr_init_attr->length == SIZE_MAX && mr_init_attr->addr) {
 				errno = EINVAL;
 				return EINVAL;
 			}
-			if (in->length == SIZE_MAX)
+			if (mr_init_attr->length == SIZE_MAX)
 				length = UINT64_MAX;
 		}
 	}
 
-	if (in->comp_mask & IBV_REG_MR_MASK_IOVA) {
-		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_IOVA, in->iova);
+	if (mr_init_attr->comp_mask & IBV_REG_MR_MASK_IOVA) {
+		fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_IOVA, mr_init_attr->iova);
 	} else {
 		if (!fd_based) {
 			fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_IOVA,
-					    (uintptr_t)in->addr);
+					    (uintptr_t) mr_init_attr->addr);
 		} else {
 			/* iova is a must from kernel point of view */
 			errno = EINVAL;
@@ -213,11 +215,12 @@ int ibv_cmd_reg_mr_ex(struct ibv_pd *pd, struct verbs_mr *vmr,
 	fill_attr_out_ptr(cmdb, UVERBS_ATTR_REG_MR_RESP_RKEY, &rkey);
 	fill_attr_in_obj(cmdb, UVERBS_ATTR_REG_MR_PD_HANDLE, pd->handle);
 	fill_attr_in_uint64(cmdb, UVERBS_ATTR_REG_MR_LENGTH, length);
-	fill_attr_in_uint32(cmdb, UVERBS_ATTR_REG_MR_ACCESS_FLAGS, in->access);
+	fill_attr_in_uint32(cmdb, UVERBS_ATTR_REG_MR_ACCESS_FLAGS,
+			    mr_init_attr->access);
 
-	if (in->comp_mask & IBV_REG_MR_MASK_DMAH)
+	if (mr_init_attr->comp_mask & IBV_REG_MR_MASK_DMAH)
 		fill_attr_in_obj(cmdb, UVERBS_ATTR_REG_MR_DMA_HANDLE,
-				 verbs_get_dmah(in->dmah)->handle);
+				 verbs_get_dmah(mr_init_attr->dmah)->handle);
 
 	ret = execute_ioctl(pd->context, cmdb);
 	if (ret)

--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -466,7 +466,8 @@ struct verbs_context_ops {
 					int fd, int access);
 	struct ibv_mr *(*reg_mr)(struct ibv_pd *pd, void *addr, size_t length,
 				 uint64_t hca_va, int access);
-	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
+	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd,
+				    struct ibv_mr_init_attr *mr_init_attr);
 	int (*req_notify_cq)(struct ibv_cq *cq, int solicited_only);
 	int (*rereg_mr)(struct verbs_mr *vmr, int flags, struct ibv_pd *pd,
 			void *addr, size_t length, int access);
@@ -590,7 +591,7 @@ int ibv_cmd_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 			  struct verbs_mr *vmr,
 			  struct ibv_command_buffer *driver);
 int ibv_cmd_reg_mr_ex(struct ibv_pd *pd, struct verbs_mr *vmr,
-		      struct ibv_reg_mr_in *in);
+		      struct ibv_mr_init_attr *mr_init_attr);
 int ibv_cmd_alloc_mw(struct ibv_pd *pd, enum ibv_mw_type type,
 		     struct ibv_mw *mw, struct ibv_alloc_mw *cmd,
 		     size_t cmd_size,

--- a/libibverbs/dummy_ops.c
+++ b/libibverbs/dummy_ops.c
@@ -461,7 +461,8 @@ static struct ibv_mr *reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	return NULL;
 }
 
-static struct ibv_mr *reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in)
+static struct ibv_mr *reg_mr_ex(struct ibv_pd *pd,
+				struct ibv_mr_init_attr *mr_init_attr)
 {
 	errno = EOPNOTSUPP;
 	return NULL;

--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -19,7 +19,7 @@ ibv_reg_mr, ibv_reg_mr_iova, ibv_reg_dmabuf_mr, ibv_reg_mr_ex, ibv_dereg_mr \- r
 .BI "                                 size_t " "length" ", uint64_t " "iova" ,
 .BI "                                 int " "fd" ", int " "access" );
 .sp
-.BI "struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd " "*pd" ", struct ibv_reg_mr_in " in" );
+.BI "struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd " "*pd" ", struct ibv_mr_init_attr "*mr_init_attr" );
 .sp
 .BI "int ibv_dereg_mr(struct ibv_mr " "*mr" );
 .fi

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -681,7 +681,7 @@ struct ibv_mr {
 	uint32_t		rkey;
 };
 
-enum  ibv_reg_mr_in_mask {
+enum ibv_mr_init_attr_mask {
 	IBV_REG_MR_MASK_IOVA = 1 << 0,
 	IBV_REG_MR_MASK_ADDR = 1 << 1,
 	IBV_REG_MR_MASK_FD = 1 << 2,
@@ -689,10 +689,10 @@ enum  ibv_reg_mr_in_mask {
 	IBV_REG_MR_MASK_DMAH = 1 << 4,
 };
 
-struct ibv_reg_mr_in {
+struct ibv_mr_init_attr {
 	size_t length;
 	int access;
-	uint64_t comp_mask; /* Use enum ibv_reg_mr_in_mask */
+	uint64_t comp_mask; /* Use enum ibv_mr_init_attr_mask */
 	uint64_t iova;
 	void *addr;
 	int fd;
@@ -2181,7 +2181,8 @@ struct ibv_values_ex {
 
 struct verbs_context {
 	/*  "grows up" - new fields go here */
-	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
+	struct ibv_mr *(*reg_mr_ex)(struct ibv_pd *pd,
+				    struct ibv_mr_init_attr *mr_init_attr);
 	int (*dealloc_dmah)(struct ibv_dmah *dmah);
 	struct ibv_dmah *(*alloc_dmah)(struct ibv_context *context,
 				       struct ibv_dmah_init_attr *attr);
@@ -2677,7 +2678,7 @@ __ibv_reg_mr_iova(struct ibv_pd *pd, void *addr, size_t length, uint64_t iova,
 struct ibv_mr *ibv_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 				 uint64_t iova, int fd, int access);
 
-struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
+struct ibv_mr *ibv_reg_mr_ex(struct ibv_pd *pd, struct ibv_mr_init_attr *mr_init_attr);
 
 enum ibv_rereg_mr_err_code {
 	/* Old MR is valid, invalid input */

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -1143,7 +1143,7 @@ struct ibv_mr *mlx5_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 			   uint64_t hca_va, int access);
 struct ibv_mr *mlx5_reg_dmabuf_mr(struct ibv_pd *pd, uint64_t offset, size_t length,
 				  uint64_t iova, int fd, int access);
-struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in);
+struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_mr_init_attr *mr_init_attr);
 int mlx5_rereg_mr(struct verbs_mr *mr, int flags, struct ibv_pd *pd, void *addr,
 		  size_t length, int access);
 int mlx5_dereg_mr(struct verbs_mr *mr);

--- a/providers/mlx5/verbs.c
+++ b/providers/mlx5/verbs.c
@@ -651,7 +651,7 @@ struct ibv_mr *mlx5_reg_mr(struct ibv_pd *pd, void *addr, size_t length,
 	return &mr->vmr.ibv_mr;
 }
 
-struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in)
+struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_mr_init_attr *mr_init_attr)
 {
 	struct mlx5_mr *mr;
 	int ret;
@@ -660,12 +660,12 @@ struct ibv_mr *mlx5_reg_mr_ex(struct ibv_pd *pd, struct ibv_reg_mr_in *in)
 	if (!mr)
 		return NULL;
 
-	ret = ibv_cmd_reg_mr_ex(pd, &mr->vmr, in);
+	ret = ibv_cmd_reg_mr_ex(pd, &mr->vmr, mr_init_attr);
 	if (ret) {
 		free(mr);
 		return NULL;
 	}
-	mr->alloc_flags = in->access;
+	mr->alloc_flags = mr_init_attr->access;
 
 	return &mr->vmr.ibv_mr;
 }


### PR DESCRIPTION
Rename the structure and input parameter to align with other libibverbs API calls.

This change should be renames only, plus 1 comment.