### PR TITLE
mlx5: Misc. improvements

### DIFF
--- a/providers/mlx5/dr_action.c
+++ b/providers/mlx5/dr_action.c
@@ -975,8 +975,7 @@ out_errno:
 int dr_actions_build_attr(struct mlx5dv_dr_matcher *matcher,
 			  struct mlx5dv_dr_action *actions[],
 			  size_t num_actions,
-			  struct mlx5dv_flow_action_attr *attr,
-			  struct mlx5_flow_action_attr_aux *attr_aux)
+			  struct mlx5dv_flow_action_attr *attr)
 {
 	struct mlx5dv_dr_domain *dmn = matcher->tbl->dmn;
 	int i;
@@ -1026,8 +1025,8 @@ int dr_actions_build_attr(struct mlx5dv_dr_matcher *matcher,
 			attr[i].obj = actions[i]->ctr.devx_obj;
 
 			if (actions[i]->ctr.offset) {
-				attr_aux[i].type = MLX5_FLOW_ACTION_COUNTER_OFFSET;
-				attr_aux[i].offset = actions[i]->ctr.offset;
+				attr[i].type = MLX5DV_FLOW_ACTION_COUNTERS_DEVX_WITH_OFFSET;
+				attr[i].bulk_obj.offset = actions[i]->ctr.offset;
 			}
 			break;
 		case DR_ACTION_TYP_TAG:

--- a/providers/mlx5/dr_rule.c
+++ b/providers/mlx5/dr_rule.c
@@ -1552,7 +1552,6 @@ dr_rule_create_rule_root(struct mlx5dv_dr_matcher *matcher,
 			 struct mlx5dv_dr_action *actions[])
 {
 	struct mlx5dv_flow_action_attr *attr;
-	struct mlx5_flow_action_attr_aux *attr_aux;
 	struct mlx5dv_dr_rule *rule;
 	int ret;
 
@@ -1570,37 +1569,27 @@ dr_rule_create_rule_root(struct mlx5dv_dr_matcher *matcher,
 		goto free_rule;
 	}
 
-	attr_aux = calloc(num_actions, sizeof(*attr_aux));
-	if (!attr_aux) {
-		errno = ENOMEM;
-		goto free_attr;
-	}
-
-	ret = dr_actions_build_attr(matcher, actions, num_actions, attr, attr_aux);
+	ret = dr_actions_build_attr(matcher, actions, num_actions, attr);
 	if (ret)
-		goto free_attr_aux;
+		goto free_attr;
 
 	ret = dr_rule_add_action_members(rule, num_actions, actions);
 	if (ret)
-		goto free_attr_aux;
+		goto free_attr;
 
-	rule->flow = _mlx5dv_create_flow(matcher->dv_matcher,
+	rule->flow = mlx5dv_create_flow(matcher->dv_matcher,
 					 value,
 					 num_actions,
-					 attr,
-					 attr_aux);
+					 attr);
 	if (!rule->flow)
 		goto remove_action_members;
 
 	free(attr);
-	free(attr_aux);
 
 	return rule;
 
 remove_action_members:
 	dr_rule_remove_action_members(rule);
-free_attr_aux:
-	free(attr_aux);
 free_attr:
 	free(attr);
 free_rule:

--- a/providers/mlx5/man/mlx5dv_create_flow.3.md
+++ b/providers/mlx5/man/mlx5dv_create_flow.3.md
@@ -46,6 +46,10 @@ struct mlx5dv_flow_action_attr {
 		struct ibv_flow_action *action;
 		uint32_t tag_value;
 		struct mlx5dv_devx_obj *obj;
+		struct {
+			struct mlx5dv_devx_obj *obj;
+			uint32_t offset;
+		} bulk_obj;
 	};
 };
 ```
@@ -65,6 +69,8 @@ struct mlx5dv_flow_action_attr {
 		Steer the packet to the default miss destination.
 	MLX5DV_FLOW_ACTION_DROP
 		Action is dropping the matched packet.
+	MLX5DV_FLOW_ACTION_COUNTERS_DEVX_WITH_OFFSET
+		The DEVX bulk counter object and its counter offset for the matched packets.
 
 *qp*
 :	QP passed, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_IBV_QP*.
@@ -78,7 +84,12 @@ struct mlx5dv_flow_action_attr {
 	*MLX5DV_FLOW_ACTION_TAG* see *ibv_create_cq_ex(3)*.
 
 *obj*
-:	DEVX object, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_DEVX* or by *MLX5DV_FLOW_ACTION_COUNTERS_DEVX*.
+:	DEVX object, to be used with *type* *MLX5DV_FLOW_ACTION_DEST_DEVX* or by *MLX5DV_FLOW_ACTION_COUNTERS_DEVX*
+	or by *MLX5DV_FLOW_ACTION_COUNTERS_DEVX_WITH_OFFSET*.
+
+*offset*
+:	offset to the target counter within a bulk DEVX object, to be used with *type*
+	*MLX5DV_FLOW_ACTION_COUNTERS_DEVX_WITH_OFFSET*
 
 # RETURN VALUE
 

--- a/providers/mlx5/mlx5.h
+++ b/providers/mlx5/mlx5.h
@@ -962,8 +962,7 @@ struct ibv_flow *
 _mlx5dv_create_flow(struct mlx5dv_flow_matcher *flow_matcher,
 		    struct mlx5dv_flow_match_parameters *match_value,
 		    size_t num_actions,
-		    struct mlx5dv_flow_action_attr actions_attr[],
-		    struct mlx5_flow_action_attr_aux actions_attr_aux[]);
+		    struct mlx5dv_flow_action_attr actions_attr[]);
 
 extern int mlx5_stall_num_loop;
 extern int mlx5_stall_cq_poll_min;
@@ -1586,11 +1585,11 @@ struct mlx5_dv_context_ops {
 	struct mlx5dv_flow_matcher *(*create_flow_matcher)(struct ibv_context *context,
 							   struct mlx5dv_flow_matcher_attr *attr);
 	int (*destroy_flow_matcher)(struct mlx5dv_flow_matcher *flow_matcher);
-	struct ibv_flow *(*create_flow)(struct mlx5dv_flow_matcher *flow_matcher,
-					struct mlx5dv_flow_match_parameters *match_value,
-					size_t num_actions,
-					struct mlx5dv_flow_action_attr actions_attr[],
-					struct mlx5_flow_action_attr_aux actions_attr_aux[]);
+	struct ibv_flow *(*create_flow)(
+		struct mlx5dv_flow_matcher *flow_matcher,
+		struct mlx5dv_flow_match_parameters *match_value,
+		size_t num_actions,
+		struct mlx5dv_flow_action_attr actions_attr[]);
 
 	struct mlx5dv_steering_anchor *(*create_steering_anchor)(struct ibv_context *conterxt,
 								 struct mlx5dv_steering_anchor_attr *attr);

--- a/providers/mlx5/mlx5dv.h
+++ b/providers/mlx5/mlx5dv.h
@@ -783,6 +783,7 @@ enum mlx5dv_flow_action_type {
 	MLX5DV_FLOW_ACTION_DEST_DEVX,
 	MLX5DV_FLOW_ACTION_COUNTERS_DEVX,
 	MLX5DV_FLOW_ACTION_DEFAULT_MISS,
+	MLX5DV_FLOW_ACTION_COUNTERS_DEVX_WITH_OFFSET,
 };
 
 struct mlx5dv_flow_action_attr {
@@ -793,6 +794,10 @@ struct mlx5dv_flow_action_attr {
 		struct ibv_flow_action *action;
 		uint32_t tag_value;
 		struct mlx5dv_devx_obj *obj;
+		struct {
+			struct mlx5dv_devx_obj *obj;
+			uint32_t offset;
+		} bulk_obj;
 	};
 };
 

--- a/providers/mlx5/mlx5dv_dr.h
+++ b/providers/mlx5/mlx5dv_dr.h
@@ -691,8 +691,7 @@ int dr_actions_build_ste_arr(struct mlx5dv_dr_matcher *matcher,
 int dr_actions_build_attr(struct mlx5dv_dr_matcher *matcher,
 			  struct mlx5dv_dr_action *actions[],
 			  size_t num_actions,
-			  struct mlx5dv_flow_action_attr *attr,
-			  struct mlx5_flow_action_attr_aux *attr_aux);
+			  struct mlx5dv_flow_action_attr *attr);
 
 uint32_t dr_actions_reformat_get_id(struct mlx5dv_dr_action *action);
 


### PR DESCRIPTION
This series for the mlx5 provider introduces the below 2 improvements:

- Add support for bulk flow counters in mlx5dv_create_flow().
- Implement UAR fallback for TD allocation.

Additional details can be found in the corresponding commit logs.