### PR TITLE
libibverbs: Fix the issue of ibv_ud_pingpong failing in RDMA communic…

### DIFF
--- a/libibverbs/examples/ud_pingpong.c
+++ b/libibverbs/examples/ud_pingpong.c
@@ -109,7 +109,7 @@ static int pp_connect_ctx(struct pingpong_context *ctx, int port, int my_psn,
 
 	if (dest->gid.global.interface_id) {
 		ah_attr.is_global = 1;
-		ah_attr.grh.hop_limit = 1;
+		ah_attr.grh.hop_limit = 64;
 		ah_attr.grh.dgid = dest->gid;
 		ah_attr.grh.sgid_index = sgid_idx;
 	}


### PR DESCRIPTION
…ation environments across three layers of networks (different subnets)

Fixed the issue where, in an RDMA communication environment across three layers of networks (different subnets), when using a global routing header (GRH) to establish an address handle (AH), the data packet could not be transmitted across the router due to the hard coded setting of ah_ attr. grh. hop limit to 1, resulting in RDMA communication failure across network nodes. Now adjust ah_ attr. grh. hop limit to 64