### PR TITLE
infiniband-diags: Fix sa_get_handle to use smi/gsi API

### DIFF
--- a/infiniband-diags/ibdiag_sa.c
+++ b/infiniband-diags/ibdiag_sa.c
@@ -48,6 +48,8 @@
  * the saquery tool and provides it to other utilities.
  */
 
+static struct ibmad_ports_pair *srcports;
+
 struct sa_handle *sa_get_handle(char *ca_name)
 {
 	struct sa_handle *handle;
@@ -57,7 +59,13 @@ struct sa_handle *sa_get_handle(char *ca_name)
 
 	char *name = ca_name ? ca_name : ibd_ca;
 
-	resolve_sm_portid(name, ibd_ca_port, &handle->dport);
+	int mgmt_classes[1] = { IB_SA_CLASS };
+
+	srcports =  mad_rpc_open_port2(name, ibd_ca_port, mgmt_classes, 1, 0);
+	if (!srcports)
+		IBEXIT("Failed to open '%s' port '%d'", name, ibd_ca_port);
+
+	resolve_sm_portid(srcports->gsi.ca_name, ibd_ca_port, &handle->dport);
 	if (!handle->dport.lid) {
 		IBWARN("No SM/SA found on port %s:%d",
 			name ? "" : name,
@@ -69,20 +77,8 @@ struct sa_handle *sa_get_handle(char *ca_name)
 	if (!handle->dport.qkey)
 		handle->dport.qkey = IB_DEFAULT_QP1_QKEY;
 
-	handle->fd = umad_open_port(name, ibd_ca_port);
-	if (handle->fd < 0) {
-		IBWARN("umad_open_port on port %s:%d failed",
-			name ? "" : name,
-			ibd_ca_port);
-		goto err;
-	}
-	if ((handle->agent = umad_register(handle->fd, IB_SA_CLASS, 2, 1, NULL)) < 0) {
-		umad_close_port(handle->fd);
-		IBWARN("umad_register for SA class failed on port %s:%d",
-		       name ? "" : name,
-		       ibd_ca_port);
-		goto err;
-	}
+	handle->fd = mad_rpc_portid(srcports->gsi.port);
+	handle->agent = mad_rpc_class_agent(srcports->gsi.port, IB_SA_CLASS);
 
 	return handle;
 
@@ -94,7 +90,7 @@ err:
 void sa_free_handle(struct sa_handle * h)
 {
 	umad_unregister(h->fd, h->agent);
-	umad_close_port(h->fd);
+	mad_rpc_close_port2(srcports);
 	free(h);
 }
 

--- a/infiniband-diags/ibqueryerrors.c
+++ b/infiniband-diags/ibqueryerrors.c
@@ -1124,10 +1124,12 @@ int main(int argc, char **argv)
 			ibd_ca, ibd_ca_port);
 	}
 
-	smp_mkey_set(ibmad_port, ibd_mkey);
+	smp_mkey_set(ibmad_ports->smi.port, ibd_mkey);
 
-	if (ibd_timeout)
-		mad_rpc_set_timeout(ibmad_port, ibd_timeout);
+	if (ibd_timeout) {
+		mad_rpc_set_timeout(ibmad_ports->smi.port, ibd_timeout);
+		mad_rpc_set_timeout(ibmad_ports->gsi.port, ibd_timeout);
+	}
 
 	if (port_guid_str) {
 		ibnd_port_t *ndport = ibnd_find_port_guid(fabric, port_guid);
@@ -1141,7 +1143,7 @@ int main(int argc, char **argv)
 
 		uint8_t ni[IB_SMP_DATA_SIZE] = { 0 };
 		if (!smp_query_via(ni, &portid, IB_ATTR_NODE_INFO, 0,
-			   ibd_timeout, ibmad_port)) {
+			   ibd_timeout, ibmad_ports->smi.port)) {
 				fprintf(stderr, "Failed to query local Node Info\n");
 				goto close_port;
 		}


### PR DESCRIPTION
 - Use mad_rpc_open_port_2 inside sa_get_handle
 - Update handle members according to gsi port from mad_rpc_open_port2
 - Replace umad_close_port in mad_rpc_close_port_2 inside sa_free_handle

This fixes behavior where we can take smi handle by mistake. mad_rpc_open_port2 does inside umad_open_port and umad_register, so we just need to assign the relevant values to the handle.

Fixes: aaf9f699c10f ("ibqueryerrors: Use API supporting SMI/GSI seperation")