### PR TITLE
efa: Extend DV query CQ to return doorbell

### DIFF
--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -127,6 +127,7 @@ struct efadv_cq_attr {
 	uint8_t *buffer;
 	uint32_t entry_size;
 	uint32_t num_entries;
+	uint32_t *doorbell;
 };
 
 int efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t inlen);

--- a/providers/efa/man/efadv_query_cq.3.md
+++ b/providers/efa/man/efadv_query_cq.3.md
@@ -33,6 +33,7 @@ struct efadv_cq_attr {
 	uint8_t *buffer;
 	uint32_t entry_size;
 	uint32_t num_entries;
+	uint32_t *doorbell;
 };
 ```
 
@@ -50,6 +51,10 @@ struct efadv_cq_attr {
 
 *num_entries*
 :	Maximal number of entries in the completion queue.
+
+*doorbell*
+:	Reverse doorbell used to update the device of polled entries and to
+	request notifications. NULL when not in use for this Completion Queue.
 
 # RETURN VALUE
 

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -1326,6 +1326,9 @@ int efadv_query_cq(struct ibv_cq *ibvcq, struct efadv_cq_attr *attr, uint32_t in
 	attr->entry_size = cq->cqe_size;
 	attr->num_entries = ibvcq->cqe;
 
+	if (vext_field_avail(typeof(*attr), doorbell, inlen))
+		attr->doorbell = cq->db;
+
 	return 0;
 }
 


### PR DESCRIPTION
Return the CQ reverse doorbell to give external data path implementations (GPU, etc.) an option to notify the device of polled entries.