### PR TITLE
librdmacm: extend rsocket for Redis, iperf3, memcached and more Linux APIsRsocket upstream

### DIFF
--- a/debian/librdmacm1.symbols
+++ b/debian/librdmacm1.symbols
@@ -11,6 +11,7 @@ librdmacm.so.1 librdmacm1 #MINVER#
  rclose@RDMACM_1.0 1.0.16
  rconnect@RDMACM_1.0 1.0.16
  repoll_create1@RDMACM_1.5 61
+ repoll_ctl@RDMACM_1.5 61
  rdma_accept@RDMACM_1.0 1.0.15
  rdma_ack_cm_event@RDMACM_1.0 1.0.15
  rdma_bind_addr@RDMACM_1.0 1.0.15

--- a/debian/librdmacm1.symbols
+++ b/debian/librdmacm1.symbols
@@ -12,6 +12,7 @@ librdmacm.so.1 librdmacm1 #MINVER#
  rconnect@RDMACM_1.0 1.0.16
  repoll_create1@RDMACM_1.5 61
  repoll_ctl@RDMACM_1.5 61
+ repoll_wait@RDMACM_1.5 61
  rdma_accept@RDMACM_1.0 1.0.15
  rdma_ack_cm_event@RDMACM_1.0 1.0.15
  rdma_bind_addr@RDMACM_1.0 1.0.15

--- a/debian/librdmacm1.symbols
+++ b/debian/librdmacm1.symbols
@@ -5,10 +5,12 @@ librdmacm.so.1 librdmacm1 #MINVER#
  RDMACM_1.2@RDMACM_1.2 23
  RDMACM_1.3@RDMACM_1.3 31
  RDMACM_1.4@RDMACM_1.4 60
+ RDMACM_1.5@RDMACM_1.5 61
  raccept@RDMACM_1.0 1.0.16
  rbind@RDMACM_1.0 1.0.16
  rclose@RDMACM_1.0 1.0.16
  rconnect@RDMACM_1.0 1.0.16
+ repoll_create1@RDMACM_1.5 61
  rdma_accept@RDMACM_1.0 1.0.15
  rdma_ack_cm_event@RDMACM_1.0 1.0.15
  rdma_bind_addr@RDMACM_1.0 1.0.15

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -11,7 +11,7 @@ publish_headers(infiniband
 
 rdma_library(rdmacm librdmacm.map
   # See Documentation/versioning.md
-  1 1.4.${PACKAGE_VERSION}
+  1 1.5.${PACKAGE_VERSION}
   acm.c
   addrinfo.c
   cma.c

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -26,14 +26,16 @@ target_link_libraries(rdmacm LINK_PRIVATE
   )
 
 # When building without LFS (_FILE_OFFSET_BITS != 64), we may need to wrap
-# fcntl64. Only do so if the system libc actually provides them
+# fcntl64/sendfile64. Only do so if the system libc actually provides them
 set(CMAKE_REQUIRED_QUIET 1)
 set(SAVE_DEFS "${CMAKE_REQUIRED_DEFINITIONS}")
 set(CMAKE_REQUIRED_DEFINITIONS "")
 check_c_source_compiles("
 #include <fcntl.h>
+#include <sys/sendfile.h>
 int main(void) {
   (void)&fcntl64;
+  (void)&sendfile64;
   return 0;
 }
 " RDMA_PRELOAD_HAVE_64)
@@ -45,9 +47,10 @@ else()
   set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 0)
 endif()
 
-# Detect at configure time if fcntl64 is declared so we can
+# Detect at configure time if fcntl64/sendfile64 is declared so we can
 # add our forward declarations only when needed.
 set(RDMA_PRELOAD_FCNTL64_IN_HEADER 0)
+set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 0)
 if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS)
   set(CMAKE_REQUIRED_QUIET 1)
   set(SAVE_FLAGS "${CMAKE_REQUIRED_FLAGS}")
@@ -59,6 +62,17 @@ int fcntl64(int socket, int cmd, ...) { (void)socket;(void)cmd; return 0; }
 " RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
   if(RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
     set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
+  endif()
+  check_c_source_compiles("
+#define _GNU_SOURCE
+#include <sys/sendfile.h>
+#include <sys/types.h>
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count) {
+  (void)out_fd;(void)in_fd;(void)offset64;(void)count; return 0;
+}
+" RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
+  if(RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
+    set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 1)
   endif()
   set(CMAKE_REQUIRED_FLAGS "${SAVE_FLAGS}")
   set(CMAKE_REQUIRED_QUIET 0)
@@ -72,7 +86,8 @@ add_library(rspreload MODULE
   )
 target_compile_definitions(rspreload PRIVATE
   RDMA_PRELOAD_HAVE_64=${RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS}
-  RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER})
+  RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER}
+  RDMA_PRELOAD_SENDFILE64_IN_HEADER=${RDMA_PRELOAD_SENDFILE64_IN_HEADER})
 # Even though this is a module we still want to use Wl,--no-undefined
 set_target_properties(rspreload PROPERTIES LINK_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
 set_target_properties(rspreload PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -25,12 +25,54 @@ target_link_libraries(rdmacm LINK_PRIVATE
   ${RT_LIBRARIES}
   )
 
+# When building without LFS (_FILE_OFFSET_BITS != 64), we may need to wrap
+# fcntl64. Only do so if the system libc actually provides them
+set(CMAKE_REQUIRED_QUIET 1)
+set(SAVE_DEFS "${CMAKE_REQUIRED_DEFINITIONS}")
+set(CMAKE_REQUIRED_DEFINITIONS "")
+check_c_source_compiles("
+#include <fcntl.h>
+int main(void) {
+  (void)&fcntl64;
+  return 0;
+}
+" RDMA_PRELOAD_HAVE_64)
+set(CMAKE_REQUIRED_DEFINITIONS "${SAVE_DEFS}")
+set(CMAKE_REQUIRED_QUIET 0)
+if(RDMA_PRELOAD_HAVE_64)
+  set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 1)
+else()
+  set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 0)
+endif()
+
+# Detect at configure time if fcntl64 is declared so we can
+# add our forward declarations only when needed.
+set(RDMA_PRELOAD_FCNTL64_IN_HEADER 0)
+if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS)
+  set(CMAKE_REQUIRED_QUIET 1)
+  set(SAVE_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS}")
+  check_c_source_compiles("
+#define _GNU_SOURCE
+#include <fcntl.h>
+int fcntl64(int socket, int cmd, ...) { (void)socket;(void)cmd; return 0; }
+" RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
+  if(RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
+    set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "${SAVE_FLAGS}")
+  set(CMAKE_REQUIRED_QUIET 0)
+endif()
+
 # The preload library is a bit special, it needs to be open coded
 # Since it is a LD_PRELOAD it has no soname, and is installed in sub dir
 add_library(rspreload MODULE
   preload.c
   indexer.c
   )
+target_compile_definitions(rspreload PRIVATE
+  RDMA_PRELOAD_HAVE_64=${RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS}
+  RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER})
 # Even though this is a module we still want to use Wl,--no-undefined
 set_target_properties(rspreload PROPERTIES LINK_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
 set_target_properties(rspreload PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")

--- a/librdmacm/cma.h
+++ b/librdmacm/cma.h
@@ -96,6 +96,7 @@ int ucma_init(void);
 extern int af_ib_support;
 
 #define RAI_ROUTEONLY		0x01000000
+#define EPOLL_FLAG			0x80000000
 
 void ucma_ib_init(void);
 void ucma_ib_cleanup(void);

--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -99,4 +99,5 @@ RDMACM_1.5 {
 	global:
 		repoll_create1;
 		repoll_ctl;
+		repoll_wait;
 } RDMACM_1.4;

--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -98,4 +98,5 @@ RDMACM_1.4 {
 RDMACM_1.5 {
 	global:
 		repoll_create1;
+		repoll_ctl;
 } RDMACM_1.4;

--- a/librdmacm/librdmacm.map
+++ b/librdmacm/librdmacm.map
@@ -94,3 +94,8 @@ RDMACM_1.4 {
 		rdma_resolve_addrinfo;
 		rdma_write_cm_event;
 } RDMACM_1.3;
+
+RDMACM_1.5 {
+	global:
+		repoll_create1;
+} RDMACM_1.4;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -4,6 +4,7 @@
 	   the signature this will go sideways.. */
 	global:
 		accept;
+		accept4;
 		bind;
 		close;
 		connect;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -24,6 +24,7 @@
 		select;
 		send;
 		sendfile;
+		sendfile64;
 		sendmsg;
 		sendto;
 		setsockopt;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -31,5 +31,6 @@
 		writev;
 		epoll_create;
 		epoll_create1;
+		epoll_ctl;
 	local: *;
 };

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -10,6 +10,7 @@
 		connect;
 		dup2;
 		fcntl;
+		fcntl64;
 		getpeername;
 		getsockname;
 		getsockopt;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -8,6 +8,7 @@
 		bind;
 		close;
 		connect;
+		dup;
 		dup2;
 		fcntl;
 		fcntl64;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -32,5 +32,6 @@
 		epoll_create;
 		epoll_create1;
 		epoll_ctl;
+		epoll_wait;
 	local: *;
 };

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -29,5 +29,7 @@
 		socket;
 		write;
 		writev;
+		epoll_create;
+		epoll_create1;
 	local: *;
 };

--- a/librdmacm/man/rsocket.7.in
+++ b/librdmacm/man/rsocket.7.in
@@ -30,7 +30,7 @@ rpoll, rselect
 rgetpeername, rgetsockname
 .P
 rsetsockopt, rgetsockopt, rfcntl
-repoll_create1
+repoll_create1, repoll_ctl
 .P
 Functions take the same parameters as that used for sockets.  The
 follow capabilities and flags are supported at this time:

--- a/librdmacm/man/rsocket.7.in
+++ b/librdmacm/man/rsocket.7.in
@@ -30,7 +30,7 @@ rpoll, rselect
 rgetpeername, rgetsockname
 .P
 rsetsockopt, rgetsockopt, rfcntl
-repoll_create1, repoll_ctl
+repoll_create1, repoll_ctl, repoll_wait
 .P
 Functions take the same parameters as that used for sockets.  The
 follow capabilities and flags are supported at this time:

--- a/librdmacm/man/rsocket.7.in
+++ b/librdmacm/man/rsocket.7.in
@@ -1,5 +1,5 @@
 .\" Licensed under the OpenIB.org BSD license (FreeBSD Variant) - See COPYING.md
-.TH "RSOCKET" 7 "2019-04-16" "librdmacm" "Librdmacm Programmer's Manual" librdmacm
+.TH "RSOCKET" 7 "2024-12-24" "librdmacm" "Librdmacm Programmer's Manual" librdmacm
 .SH NAME
 rsocket \- RDMA socket API
 .SH SYNOPSIS
@@ -30,6 +30,7 @@ rpoll, rselect
 rgetpeername, rgetsockname
 .P
 rsetsockopt, rgetsockopt, rfcntl
+repoll_create1
 .P
 Functions take the same parameters as that used for sockets.  The
 follow capabilities and flags are supported at this time:
@@ -150,6 +151,8 @@ polling_time - default number of microseconds to poll for data before waiting
 wake_up_interval - maximum number of milliseconds to block in poll.
 This value is used to safe guard against potential application hangs
 in rpoll().
+.P
+max_events - maximum number of events for the epoll thread to handle for an epoll_instance.
 .P
 All configuration files should contain a single integer value.  Values may
 be set by issuing a command similar to the following example.

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -90,13 +90,18 @@ struct socket_calls {
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
 	int (*fxstat)(int ver, int fd, struct stat *buf);
+	int (*epoll_create)(int size);
+	int (*epoll_create1)(int flags);
+	int (*epoll_ctl)(int epfd, int op, int fd, struct epoll_event *event);
 };
 
 static struct socket_calls real;
 static struct socket_calls rs;
 
 static struct index_map idm;
+static struct index_map ep_idm;
 static pthread_mutex_t mut = PTHREAD_MUTEX_INITIALIZER;
+static pthread_mutex_t ep_mut = PTHREAD_MUTEX_INITIALIZER;
 
 static int sq_size;
 static int rq_size;
@@ -411,6 +416,9 @@ static void init_preload(void)
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
 	real.fxstat = dlsym(RTLD_NEXT, "__fxstat");
+	real.epoll_create = dlsym(RTLD_NEXT, "epoll_create");
+	real.epoll_create1 = dlsym(RTLD_NEXT, "epoll_create1");
+	real.epoll_ctl = dlsym(RTLD_NEXT, "epoll_ctl");
 
 	rs.socket = dlsym(RTLD_DEFAULT, "rsocket");
 	rs.bind = dlsym(RTLD_DEFAULT, "rbind");
@@ -1194,4 +1202,39 @@ int __fxstat(int ver, int socket, struct stat *buf)
 		ret = real.fxstat(ver, fd, buf);
 	}
 	return ret;
+}
+
+int epoll_create(int size)
+{
+	if (size <= 0)
+		return ERR(EINVAL);
+
+	return epoll_create1(0);
+}
+
+int epoll_create1(int flags)
+{
+	init_preload();
+
+	int epfd = real.epoll_create1(flags);
+	int ep_reg = real.epoll_create1(flags);
+	struct epoll_event event;
+
+	if (epfd < 0 || ep_reg < 0)
+		return -1;
+
+	event.events = EPOLLIN | EPOLLOUT;
+	event.data.fd = ep_reg;
+
+	(void)real.epoll_ctl(epfd, EPOLL_CTL_ADD, ep_reg, &event);
+	pthread_mutex_lock(&ep_mut);
+	if (idm_set(&ep_idm, epfd, (void *)(uintptr_t)ep_reg) < 0) {
+		pthread_mutex_unlock(&ep_mut);
+		close(epfd);
+		close(ep_reg);
+		return -1;
+	}
+
+	pthread_mutex_unlock(&ep_mut);
+	return repoll_create1(epfd);
 }

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -103,6 +103,7 @@ struct socket_calls {
 	(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
 	int (*fcntl64)(int socket, int cmd, ... /* arg */);
 #endif
+	int (*dup)(int oldfd);
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
 #if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
@@ -441,6 +442,7 @@ static void init_preload(void)
 (!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
 	real.fcntl64 = dlsym(RTLD_NEXT, "fcntl64");
 #endif
+	real.dup = dlsym(RTLD_NEXT, "dup");
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
 #if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
@@ -1233,6 +1235,13 @@ int fcntl64(int socket, int cmd, ... /* arg */)
 	return ret;
 }
 #endif
+
+int dup(int oldfd)
+{
+	int new_fd = fcntl(oldfd, F_DUPFD, 0);
+
+	return dup2(oldfd, new_fd);
+}
 
 /*
  * dup2 is not thread safe

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -885,20 +885,31 @@ ssize_t writev(int socket, const struct iovec *iov, int iovcnt)
 		rwritev(fd, iov, iovcnt) : real.writev(fd, iov, iovcnt);
 }
 
-static struct pollfd *fds_alloc(nfds_t nfds)
+static int fds_alloc(nfds_t nfds, struct pollfd **rfds, int **user_fds)
 {
-	static __thread struct pollfd *rfds;
-	static __thread nfds_t rnfds;
+	static __thread struct pollfd *rfds_buf;
+	static __thread int *user_fds_buf;
+	static __thread nfds_t buf_nfds;
 
-	if (nfds > rnfds) {
-		if (rfds)
-			free(rfds);
-
-		rfds = malloc(sizeof(*rfds) * nfds);
-		rnfds = rfds ? nfds : 0;
+	if (nfds > buf_nfds) {
+		free(rfds_buf);
+		free(user_fds_buf);
+		rfds_buf = malloc(sizeof(*rfds_buf) * nfds);
+		user_fds_buf = malloc(sizeof(*user_fds_buf) * nfds);
+		if (!rfds_buf || !user_fds_buf) {
+			free(rfds_buf);
+			free(user_fds_buf);
+			rfds_buf = NULL;
+			user_fds_buf = NULL;
+			return -ENOMEM;
+		}
+		buf_nfds = nfds;
 	}
 
-	return rfds;
+	*rfds = rfds_buf;
+	if (user_fds)
+		*user_fds = user_fds_buf;
+	return 0;
 }
 
 int poll(struct pollfd *fds, nfds_t nfds, int timeout)
@@ -915,8 +926,8 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	return real.poll(fds, nfds, timeout);
 
 use_rpoll:
-	rfds = fds_alloc(nfds);
-	if (!rfds)
+	ret = fds_alloc(nfds, &rfds, NULL);
+	if (ret)
 		return ERR(ENOMEM);
 
 	for (i = 0; i < nfds; i++) {
@@ -934,7 +945,7 @@ use_rpoll:
 }
 
 static void select_to_rpoll(struct pollfd *fds, int *nfds,
-			    fd_set *readfds, fd_set *writefds, fd_set *exceptfds)
+			    fd_set *readfds, fd_set *writefds, fd_set *exceptfds, int *user_fds)
 {
 	int fd, events, i = 0;
 
@@ -945,7 +956,8 @@ static void select_to_rpoll(struct pollfd *fds, int *nfds,
 
 		if (events || (exceptfds && FD_ISSET(fd, exceptfds))) {
 			fds[i].fd = fd_getd(fd);
-			fds[i++].events = events;
+			fds[i].events = events;
+			user_fds[i++] = fd;
 		}
 	}
 
@@ -953,30 +965,27 @@ static void select_to_rpoll(struct pollfd *fds, int *nfds,
 }
 
 static int rpoll_to_select(struct pollfd *fds, int nfds,
-			   fd_set *readfds, fd_set *writefds, fd_set *exceptfds)
+			   fd_set *readfds, fd_set *writefds, fd_set *exceptfds, int *user_fds)
 {
-	int fd, rfd, i, cnt = 0;
+	int i, cnt = 0;
 
-	for (i = 0, fd = 0; i < nfds; fd++) {
-		rfd = fd_getd(fd);
-		if (rfd != fds[i].fd)
-			continue;
+	for (i = 0; i < nfds; i++) {
+		assert(fds[i].fd == fd_getd(user_fds[i]));
 
 		if (readfds && (fds[i].revents & POLLIN)) {
-			FD_SET(fd, readfds);
+			FD_SET(user_fds[i], readfds);
 			cnt++;
 		}
 
 		if (writefds && (fds[i].revents & POLLOUT)) {
-			FD_SET(fd, writefds);
+			FD_SET(user_fds[i], writefds);
 			cnt++;
 		}
 
 		if (exceptfds && (fds[i].revents & ~(POLLIN | POLLOUT))) {
-			FD_SET(fd, exceptfds);
+			FD_SET(user_fds[i], exceptfds);
 			cnt++;
 		}
-		i++;
 	}
 
 	return cnt;
@@ -991,13 +1000,14 @@ int select(int nfds, fd_set *readfds, fd_set *writefds,
 	   fd_set *exceptfds, struct timeval *timeout)
 {
 	struct pollfd *fds;
+	int *user_fds;
 	int ret;
 
-	fds = fds_alloc(nfds);
-	if (!fds)
+	ret = fds_alloc(nfds, &fds, &user_fds);
+	if (ret)
 		return ERR(ENOMEM);
 
-	select_to_rpoll(fds, &nfds, readfds, writefds, exceptfds);
+	select_to_rpoll(fds, &nfds, readfds, writefds, exceptfds, user_fds);
 	ret = rpoll(fds, nfds, rs_convert_timeout(timeout));
 
 	if (readfds)
@@ -1008,7 +1018,7 @@ int select(int nfds, fd_set *readfds, fd_set *writefds,
 		FD_ZERO(exceptfds);
 
 	if (ret > 0)
-		ret = rpoll_to_select(fds, nfds, readfds, writefds, exceptfds);
+		ret = rpoll_to_select(fds, nfds, readfds, writefds, exceptfds, user_fds);
 
 	return ret;
 }

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -59,6 +59,14 @@
 #include "cma.h"
 #include "indexer.h"
 
+//Whether to compile fcntl64/sendfile64 wrappers. Need both:
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+#if !RDMA_PRELOAD_FCNTL64_IN_HEADER
+int fcntl64(int socket, int cmd, ... /* arg */);
+#endif
+#endif
+
 struct socket_calls {
 	int (*socket)(int domain, int type, int protocol);
 	int (*bind)(int socket, const struct sockaddr *addr, socklen_t addrlen);
@@ -88,6 +96,10 @@ struct socket_calls {
 	int (*getsockopt)(int socket, int level, int optname,
 			  void *optval, socklen_t *optlen);
 	int (*fcntl)(int socket, int cmd, ... /* arg */);
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+	(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+	int (*fcntl64)(int socket, int cmd, ... /* arg */);
+#endif
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
 	int (*fxstat)(int ver, int fd, struct stat *buf);
@@ -418,6 +430,10 @@ static void init_preload(void)
 	real.setsockopt = dlsym(RTLD_NEXT, "setsockopt");
 	real.getsockopt = dlsym(RTLD_NEXT, "getsockopt");
 	real.fcntl = dlsym(RTLD_NEXT, "fcntl");
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+	real.fcntl64 = dlsym(RTLD_NEXT, "fcntl64");
+#endif
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
 	real.fxstat = dlsym(RTLD_NEXT, "__fxstat");
@@ -658,7 +674,6 @@ int accept4(int socket, struct sockaddr *addr, socklen_t *addrlen, int flags)
 		if (cur_flags == -1)
 			goto close;
 	}
-
 	return fd;
 close:
 	close(fd);
@@ -1164,6 +1179,49 @@ int fcntl(int socket, int cmd, ... /* arg */)
 	va_end(args);
 	return ret;
 }
+
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+int fcntl64(int socket, int cmd, ... /* arg */)
+{
+	va_list args;
+	long lparam;
+	void *pparam;
+	int fd, ret;
+
+	init_preload();
+	va_start(args, cmd);
+	switch (cmd) {
+	case F_GETFD:
+	case F_GETFL:
+	case F_GETOWN:
+	case F_GETSIG:
+	case F_GETLEASE:
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd) : real.fcntl64(fd, cmd);
+		break;
+	case F_DUPFD:
+	/*case F_DUPFD_CLOEXEC:*/
+	case F_SETFD:
+	case F_SETFL:
+	case F_SETOWN:
+	case F_SETSIG:
+	case F_SETLEASE:
+	case F_NOTIFY:
+		lparam = va_arg(args, long);
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd, lparam) : real.fcntl64(fd, cmd, lparam);
+		break;
+	default:
+		pparam = va_arg(args, void *);
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd, pparam) : real.fcntl64(fd, cmd, pparam);
+		break;
+	}
+	va_end(args);
+	return ret;
+}
+#endif
 
 /*
  * dup2 is not thread safe

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -65,6 +65,9 @@
 #if !RDMA_PRELOAD_FCNTL64_IN_HEADER
 int fcntl64(int socket, int cmd, ... /* arg */);
 #endif
+#if !RDMA_PRELOAD_SENDFILE64_IN_HEADER
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count);
+#endif
 #endif
 
 struct socket_calls {
@@ -102,6 +105,10 @@ struct socket_calls {
 #endif
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+	ssize_t (*sendfile64)(int out_fd, int in_fd, off64_t *offset64, size_t count);
+#endif
 	int (*fxstat)(int ver, int fd, struct stat *buf);
 	int (*epoll_create)(int size);
 	int (*epoll_create1)(int flags);
@@ -436,6 +443,10 @@ static void init_preload(void)
 #endif
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+	real.sendfile64 = dlsym(RTLD_NEXT, "sendfile64");
+#endif
 	real.fxstat = dlsym(RTLD_NEXT, "__fxstat");
 	real.epoll_create = dlsym(RTLD_NEXT, "epoll_create");
 	real.epoll_create1 = dlsym(RTLD_NEXT, "epoll_create1");
@@ -1294,6 +1305,29 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
 	munmap(file_addr, count);
 	return ret;
 }
+
+#if (!defined(_FILE_OFFSET_BITS) || _FILE_OFFSET_BITS != 64) && \
+(!defined(RDMA_PRELOAD_HAVE_64) || RDMA_PRELOAD_HAVE_64)
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count)
+{
+	void *file_addr;
+	int fd;
+	size_t ret;
+
+	if (fd_get(out_fd, &fd) != fd_rsocket)
+		return real.sendfile64(fd, in_fd, offset64, count);
+
+	file_addr = mmap(NULL, count, PROT_READ, 0, in_fd, offset64 ? *offset64 : 0);
+	if (file_addr == (void *) -1)
+		return -1;
+
+	ret = rwrite(fd, file_addr, count);
+	if ((ret > 0) && offset64)
+		lseek(in_fd, ret, SEEK_CUR);
+	munmap(file_addr, count);
+	return ret;
+}
+#endif
 
 int __fxstat(int ver, int socket, struct stat *buf)
 {

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -5109,3 +5109,19 @@ int repoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
 
 	return 0;
 }
+
+int repoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout)
+{
+	struct epoll_inst *instance = get_epins(epfd);
+
+	pthread_spin_lock(&instance->evlock);
+
+	int count = (instance->rdy_cnt > maxevents) ? maxevents : instance->rdy_cnt;
+
+	for (int i = 0; i < count; i++)
+		events[i] = instance->rev[i];
+
+	pthread_spin_unlock(&instance->evlock);
+
+	return count;
+}

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -136,6 +136,7 @@ static uint32_t def_mem = (1 << 17);
 static uint32_t def_wmem = (1 << 17);
 static uint32_t polling_time = 10;
 static int wake_up_interval = 5000;
+static int max_events = 40000;
 
 /*
  * Immediate data format is determined by the upper bits
@@ -423,6 +424,46 @@ struct ds_udp_header {
 	} addr;
 };
 
+struct rfd_nd {
+	int fd;
+	uint32_t events;
+	struct rfd_nd *next;
+	struct rfd_nd *prev;
+};
+
+struct epoll_inst {
+	int epfd;
+	struct rfd_nd *fds;
+	int rdy_cnt;
+	int fd_cnt;
+	int wakeup;
+	pthread_t thread;
+	pthread_spinlock_t evlock;
+	pthread_spinlock_t fdlock;
+	struct epoll_event *rev;
+};
+
+struct fdm_entry {
+	int key;
+	struct epoll_inst *ep;
+};
+
+static int wake_pipe[2];
+static int pipe_init;
+
+static pthread_t glep_thread;
+static pthread_mutex_t glep_lock = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t glep_cond = PTHREAD_COND_INITIALIZER;
+static struct index_map evidm;
+
+struct eplist {
+	struct epoll_inst **ep;
+	int cnt;
+	int cap;
+	int idx;
+};
+static struct eplist glep_list = {NULL, 0, 0, 0};
+
 #define DS_UDP_IPV4_HDR_LEN 16
 #define DS_UDP_IPV6_HDR_LEN 28
 
@@ -584,6 +625,13 @@ static void rs_configure(void)
 		failable_fscanf(f, "%d", &wake_up_interval);
 		fclose(f);
 	}
+
+	f = fopen(RS_CONF_DIR "/max_events", "r");
+	if (f) {
+		failable_fscanf(f, "%d", &max_events);
+		fclose(f);
+	}
+
 	if ((f = fopen(RS_CONF_DIR "/inline_default", "r"))) {
 		failable_fscanf(f, "%hu", &def_inline);
 		fclose(f);
@@ -4565,7 +4613,7 @@ static void tcp_svc_send_keepalive(struct rsocket *rs)
 			      0, (uintptr_t) NULL, (uintptr_t) NULL);
 	}
 	fastlock_release(&rs->cq_lock);
-}	
+}
 
 static void *tcp_svc_run(void *arg)
 {
@@ -4696,4 +4744,261 @@ static void *cm_svc_run(void *arg)
 	} while (svc->cnt >= 1);
 
 	return NULL;
+}
+
+static uint32_t epoll_rs(int fd, uint32_t events);
+
+uint32_t epoll_rs(int fd, uint32_t events)
+{
+	struct pollfd fds;
+	uint32_t revents = 0;
+	int ret;
+	struct rsocket *rs = idm_lookup(&idm, fd);
+
+check_cq:
+	if ((rs->type & SOCK_STREAM) && ((rs->state & rs_connected) ||
+	     (rs->state == rs_disconnected) || (rs->state & rs_error))) {
+		rs_process_cq(rs, 1, rs_poll_all);
+
+		if ((events & EPOLLIN) && rs_conn_have_rdata(rs))
+			revents |= EPOLLIN;
+		if ((events & EPOLLOUT) && rs_can_send(rs))
+			revents |= EPOLLOUT;
+		if (!(rs->state & rs_connected)) {
+			if (rs->state == rs_disconnected)
+				revents |= EPOLLHUP;
+			else
+				revents |= EPOLLERR;
+		}
+
+		return revents;
+	} else if (rs->type & SOCK_DGRAM) {
+		ds_process_cqs(rs, 1, rs_poll_all);
+
+		if ((events & EPOLLIN) && rs_have_rdata(rs))
+			revents |= EPOLLIN;
+		if ((events & EPOLLOUT) && ds_can_send(rs))
+			revents |= EPOLLOUT;
+
+		return revents;
+	}
+
+	if (rs->state == rs_listening) {
+		fds.fd = rs->accept_queue[0];
+		fds.revents = 0;
+			if (events & EPOLLIN)
+				fds.events |= POLLIN;
+			if (events & EPOLLOUT)
+				fds.events |= POLLOUT;
+			if (events & EPOLLERR)
+				fds.events |= POLLERR;
+			if (events & EPOLLHUP)
+				fds.events |= POLLHUP;
+
+
+		poll(&fds, 1, 0);
+		if (fds.revents & POLLIN)
+			revents |= EPOLLIN;
+		if (fds.revents & POLLOUT)
+			revents |= EPOLLOUT;
+		if (fds.revents & POLLERR)
+			revents |= EPOLLERR;
+		if (fds.revents & POLLHUP)
+			revents |= EPOLLHUP;
+
+		return revents;
+	}
+
+	if (rs->state & rs_opening) {
+		ret = rs_do_connect(rs);
+		if (ret && (errno == EINPROGRESS))
+			errno = 0;
+		else
+			goto check_cq;
+	}
+
+	if (rs->state == rs_connect_error) {
+		if (events & EPOLLOUT)
+			revents |= EPOLLOUT;
+		if (events & EPOLLIN)
+			revents |= EPOLLIN;
+		revents |= EPOLLERR;
+		return revents;
+	}
+
+	return 0;
+}
+
+static void get_pipe(void)
+{
+	uint64_t u = 1;
+
+	if (!pipe_init) {
+		if (pipe(wake_pipe) != 0)
+			return;
+		if (write(wake_pipe[1], &u, sizeof(u)) != (ssize_t)sizeof(u))
+			return;
+		pipe_init = 1;
+	}
+
+}
+
+static void update_wakeup(struct epoll_inst *instance, int count)
+{
+	struct epoll_event eve;
+
+	eve.events = EPOLLIN | EPOLLET;
+	eve.data.fd = wake_pipe[0];
+
+	if (count && !instance->wakeup) {
+		(void)epoll_ctl(instance->epfd, EPOLL_CTL_ADD | EPOLL_FLAG, wake_pipe[0], &eve);
+		instance->wakeup = 1;
+	} else if (!count && instance->wakeup) {
+		(void)epoll_ctl(instance->epfd, EPOLL_CTL_DEL | EPOLL_FLAG, wake_pipe[0], NULL);
+		instance->wakeup = 0;
+	}
+
+}
+
+static int add_epins(int fd, struct epoll_inst *instance)
+{
+	struct fdm_entry *entry = malloc(sizeof(struct fdm_entry));
+
+	if (!entry)
+		return ERR(ENOMEM);
+
+	entry->key = fd;
+	entry->ep = instance;
+	idm_set(&evidm, fd, entry);
+
+	return fd;
+}
+
+static void *epoll_thread(void *arg)
+{
+	struct eplist *list = &glep_list;
+	struct epoll_event *temp_revents2;
+	struct rfd_nd *curr;
+	struct epoll_inst *instance;
+	int count, revent;
+
+	temp_revents2 = malloc(max_events * sizeof(struct epoll_event));
+	if (!temp_revents2)
+		return NULL;
+
+	while (1) {
+		pthread_mutex_lock(&glep_lock);
+		while (list->cnt == 0 || list->idx >= list->cnt)
+			pthread_cond_wait(&glep_cond, &glep_lock);
+
+		instance = list->ep[list->idx];
+		list->idx = (list->idx + 1) % list->cnt;
+		pthread_mutex_unlock(&glep_lock);
+
+		memset(temp_revents2, 0, max_events * sizeof(struct epoll_event));
+
+		count = 0;
+		pthread_spin_lock(&instance->fdlock);
+		curr = instance->fds;
+		while (curr != NULL) {
+			if (count >= max_events)
+				break;
+
+			revent = epoll_rs(curr->fd, curr->events);
+			if (revent) {
+				temp_revents2[count].data.fd = curr->fd;
+				temp_revents2[count].events = revent;
+				count++;
+			}
+			curr = curr->next;
+		}
+
+		pthread_spin_unlock(&instance->fdlock);
+
+		pthread_spin_lock(&instance->evlock);
+		memset(instance->rev, 0, max_events * sizeof(struct epoll_event));
+		memcpy(instance->rev, temp_revents2, count * sizeof(struct epoll_event));
+
+		instance->rdy_cnt = count;
+		update_wakeup(instance, count);
+
+		pthread_spin_unlock(&instance->evlock);
+
+	}
+
+	return NULL;
+}
+
+static int mng_epfd_thread(struct epoll_inst *instance)
+{
+	struct epoll_inst **new_instances;
+	int ret, new_capacity;
+
+	pthread_mutex_lock(&glep_lock);
+
+	// Check if we need to expand the global instance list
+	if (glep_list.cnt == glep_list.cap) {
+		new_capacity = glep_list.cap ? glep_list.cap * 2 : 4;
+		new_instances = realloc(glep_list.ep,
+					new_capacity * sizeof(struct epoll_inst *));
+		if (!new_instances) {
+			pthread_mutex_unlock(&glep_lock);
+			return ERR(ENOMEM);
+		}
+
+		glep_list.ep = new_instances;
+		glep_list.cap = new_capacity;
+	}
+
+	// Add the new instance to the global instance list
+	glep_list.ep[glep_list.cnt++] = instance;
+
+	// Create the global epoll thread if it doesn't exist
+	if (glep_list.cnt > 0 && !glep_thread) {
+		ret = pthread_create(&glep_thread, NULL, epoll_thread, NULL);
+		if (ret) {
+			pthread_mutex_unlock(&glep_lock);
+			// TODO: Handle the thread creation error properly
+			return ERR(EAGAIN);
+		}
+	}
+
+	// Signal the global thread to start or resume processing
+	glep_list.idx = 0; // Start from the beginning
+	pthread_cond_signal(&glep_cond);
+	pthread_mutex_unlock(&glep_lock);
+
+	return 0;
+}
+
+int repoll_create1(int flags)
+{
+	get_pipe();
+	int ret, epfd = flags;
+	struct epoll_inst *instance;
+
+	instance = malloc(sizeof(struct epoll_inst));
+	if (!instance)
+		goto error;
+
+	instance->epfd = epfd;
+	instance->fds = NULL;
+	instance->rdy_cnt = 0;
+	instance->fd_cnt = 0;
+	instance->wakeup = 0;
+	instance->rev = (struct epoll_event *)malloc(max_events * sizeof(struct epoll_event));
+
+	pthread_spin_init(&instance->evlock, PTHREAD_PROCESS_PRIVATE);
+	pthread_spin_init(&instance->fdlock, PTHREAD_PROCESS_PRIVATE);
+
+	ret = mng_epfd_thread(instance);
+	if (ret)
+		goto free_instance;
+
+	return add_epins(epfd, instance);
+
+free_instance:
+	free(instance);
+error:
+	return ERR(ENOMEM);
 }

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -135,7 +135,7 @@ static uint16_t def_rqsize = 384;
 static uint32_t def_mem = (1 << 17);
 static uint32_t def_wmem = (1 << 17);
 static uint32_t polling_time = 10;
-static int wake_up_interval = 5000;
+static int wake_up_interval = 500;
 static int max_events = 40000;
 
 /*

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -3415,8 +3415,10 @@ int rpoll(struct pollfd *fds, nfds_t nfds, int timeout)
 
 		if (timeout >= 0) {
 			timeout -= (int) ((rs_time_us() - start_time) / 1000);
-			if (timeout <= 0)
+			if (timeout <= 0) {
+				rs_poll_exit();
 				return 0;
+			}
 			pollsleep = min(timeout, wake_up_interval);
 		} else {
 			pollsleep = wake_up_interval;

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -378,6 +378,7 @@ struct rsocket {
 
 	int		  opts;
 	int		  fd_flags;
+	int		  fs_flags;
 	int		  ipv4_opts;
 	uint64_t	  so_opts;
 	uint64_t	  ipv6_opts;
@@ -895,7 +896,7 @@ static int rs_create_cq(struct rsocket *rs, struct rdma_cm_id *cm_id)
 	if (!cm_id->recv_cq)
 		goto err1;
 
-	if (rs->fd_flags & O_NONBLOCK) {
+	if (rs->fs_flags & O_NONBLOCK) {
 		if (set_fd_nonblock(cm_id->recv_cq_channel->fd, true))
 			goto err2;
 	}
@@ -1327,7 +1328,7 @@ int rlisten(int socket, int backlog)
 	if (ret)
 		return ret;
 
-	if (rs->fd_flags & O_NONBLOCK) {
+	if (rs->fs_flags & O_NONBLOCK) {
 		ret = set_fd_nonblock(rs->accept_queue[0], true);
 		if (ret)
 			return ret;
@@ -1519,7 +1520,7 @@ connected:
 		rs->state = rs_connect_rdwr;
 		break;
 	case rs_accepting:
-		if (!(rs->fd_flags & O_NONBLOCK))
+		if (!(rs->fs_flags & O_NONBLOCK))
 			set_fd_nonblock(rs->cm_id->channel->fd, true);
 
 		ret = ucma_complete(rs->cm_id);
@@ -2394,7 +2395,7 @@ static int ds_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsoc
 
 static int rs_nonblocking(struct rsocket *rs, int flags)
 {
-	return (rs->fd_flags & O_NONBLOCK) || (flags & MSG_DONTWAIT);
+	return (rs->fs_flags & O_NONBLOCK) || (flags & MSG_DONTWAIT);
 }
 
 static int rs_is_cq_armed(struct rsocket *rs)
@@ -3543,7 +3544,7 @@ int rshutdown(int socket, int how)
 	if (rs->opts & RS_OPT_KEEPALIVE)
 		rs_notify_svc(&tcp_svc, rs, RS_SVC_REM_KEEPALIVE);
 
-	if (rs->fd_flags & O_NONBLOCK)
+	if (rs->fs_flags & O_NONBLOCK)
 		rs_set_nonblocking(rs, 0);
 
 	if (rs->state & rs_connected) {
@@ -3576,8 +3577,8 @@ int rshutdown(int socket, int how)
 		rs_process_cq(rs, 0, rs_conn_all_sends_done);
 
 out:
-	if ((rs->fd_flags & O_NONBLOCK) && (rs->state & rs_connected))
-		rs_set_nonblocking(rs, rs->fd_flags);
+	if ((rs->fs_flags & O_NONBLOCK) && (rs->state & rs_connected))
+		rs_set_nonblocking(rs, rs->fs_flags);
 
 	if (rs->state & rs_disconnected) {
 		/* Generate event by flushing receives to unblock rpoll */
@@ -3593,14 +3594,14 @@ static void ds_shutdown(struct rsocket *rs)
 	if (rs->opts & RS_OPT_UDP_SVC)
 		rs_notify_svc(&udp_svc, rs, RS_SVC_REM_DGRAM);
 
-	if (rs->fd_flags & O_NONBLOCK)
+	if (rs->fs_flags & O_NONBLOCK)
 		rs_set_nonblocking(rs, 0);
 
 	rs->state &= ~(rs_readable | rs_writable);
 	ds_process_cqs(rs, 0, ds_all_sends_done);
 
-	if (rs->fd_flags & O_NONBLOCK)
-		rs_set_nonblocking(rs, rs->fd_flags);
+	if (rs->fs_flags & O_NONBLOCK)
+		rs_set_nonblocking(rs, rs->fs_flags);
 }
 
 int rclose(int socket)
@@ -4078,15 +4079,22 @@ int rfcntl(int socket, int cmd, ... /* arg */ )
 	va_start(args, cmd);
 	switch (cmd) {
 	case F_GETFL:
-		ret = rs->fd_flags;
+		ret = rs->fs_flags;
 		break;
 	case F_SETFL:
 		param = va_arg(args, int);
-		if ((rs->fd_flags & O_NONBLOCK) != (param & O_NONBLOCK))
+		if ((rs->fs_flags & O_NONBLOCK) != (param & O_NONBLOCK))
 			ret = rs_set_nonblocking(rs, param & O_NONBLOCK);
 
 		if (!ret)
-			rs->fd_flags = param;
+			rs->fs_flags = param;
+		break;
+	case F_GETFD:
+		ret = rs->fd_flags;
+		break;
+	case F_SETFD:
+		param = va_arg(args, int);
+		rs->fd_flags = param;
 		break;
 	default:
 		ret = ERR(ENOTSUP);

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -4874,6 +4874,13 @@ static int add_epins(int fd, struct epoll_inst *instance)
 	return fd;
 }
 
+static struct epoll_inst *get_epins(int fd)
+{
+	struct fdm_entry *entry = idm_lookup(&evidm, fd);
+
+	return entry ? entry->ep : NULL;
+}
+
 static void *epoll_thread(void *arg)
 {
 	struct eplist *list = &glep_list;
@@ -4971,6 +4978,69 @@ static int mng_epfd_thread(struct epoll_inst *instance)
 	return 0;
 }
 
+static int epoll_add(struct epoll_inst *instance, int fd, struct epoll_event *event)
+{
+	struct rfd_nd *node = (struct rfd_nd *)malloc(sizeof(struct rfd_nd));
+
+	if (!node)
+		return ERR(ENOMEM);
+
+	node->fd = fd;
+	node->events = event->events;
+	node->prev = NULL;
+
+	pthread_spin_lock(&instance->fdlock);
+
+	node->next = instance->fds;
+	if (instance->fds)
+		instance->fds->prev = node;
+
+	instance->fds = node;
+	instance->fd_cnt++;
+
+	pthread_spin_unlock(&instance->fdlock);
+
+	return 0;
+}
+
+static void epoll_mod(struct epoll_inst *instance, struct epoll_event *event, struct rfd_nd *node)
+{
+	pthread_spin_lock(&instance->fdlock);
+	node->events = event->events;
+	pthread_spin_unlock(&instance->fdlock);
+}
+
+static void epoll_del(struct epoll_inst *instance, struct rfd_nd *node)
+{
+	pthread_spin_lock(&instance->fdlock);
+	instance->fd_cnt--;
+	if (!node->prev)
+		instance->fds = node->next;
+	else
+		node->prev->next = node->next;
+
+	if (node->next)
+		node->next->prev = node->prev;
+
+	pthread_spin_unlock(&instance->fdlock);
+
+	free(node);
+}
+
+static struct rfd_nd *find_rfd(struct epoll_inst *instance, int fd)
+{
+	struct rfd_nd *curr = instance->fds;
+
+	while (curr != NULL) {
+		if (curr->fd == fd)
+			return curr;
+
+		curr = curr->next;
+	}
+
+	return NULL;
+}
+
 int repoll_create1(int flags)
 {
 	get_pipe();
@@ -5001,4 +5071,41 @@ free_instance:
 	free(instance);
 error:
 	return ERR(ENOMEM);
+}
+
+int repoll_ctl(int epfd, int op, int fd, struct epoll_event *event)
+{
+	struct epoll_inst *instance = get_epins(epfd);
+
+	if (!instance)
+		return ERR(EBADF);
+
+	struct rfd_nd *nd_fd = find_rfd(instance, fd);
+
+	switch (op) {
+	case EPOLL_CTL_ADD:
+		if (nd_fd)
+			return ERR(EEXIST);
+
+		return epoll_add(instance, fd, event);
+
+	case EPOLL_CTL_MOD:
+		if (!nd_fd)
+			return ERR(ENOENT);
+
+		epoll_mod(instance, event, nd_fd);
+		break;
+
+	case EPOLL_CTL_DEL:
+		if (!nd_fd)
+			return ERR(ENOENT);
+
+		epoll_del(instance, nd_fd);
+		break;
+
+	default:
+		return ERR(EINVAL);
+	}
+
+	return 0;
 }

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -318,7 +318,7 @@ struct ds_qp {
 };
 
 struct rsocket {
-	int		  type;
+	int		  type;  /* SOCK_STREAM or SOCK_DGRAM only; flags in fd_flags/fs_flags */
 	int		  index;
 	fastlock_t	  slock;
 	fastlock_t	  rlock;
@@ -702,6 +702,7 @@ static struct rsocket *rs_alloc(struct rsocket *inherited_rs, int type)
 		return NULL;
 
 	rs->type = type;
+
 	rs->index = -1;
 	if (type == SOCK_DGRAM) {
 		rs->udp_sock = -1;
@@ -1247,19 +1248,23 @@ int rsocket(int domain, int type, int protocol)
 {
 	struct rsocket *rs;
 	int index, ret;
+	int socket_type = type & ~(SOCK_CLOEXEC | SOCK_NONBLOCK);
 
 	if ((domain != AF_INET && domain != AF_INET6 && domain != AF_IB) ||
-	    ((type != SOCK_STREAM) && (type != SOCK_DGRAM)) ||
-	    (type == SOCK_STREAM && protocol && protocol != IPPROTO_TCP) ||
-	    (type == SOCK_DGRAM && protocol && protocol != IPPROTO_UDP))
+	    (socket_type != SOCK_STREAM && socket_type != SOCK_DGRAM) ||
+	    ((socket_type == SOCK_STREAM) && protocol && protocol != IPPROTO_TCP) ||
+	    ((socket_type == SOCK_DGRAM) && protocol && protocol != IPPROTO_UDP))
 		return ERR(ENOTSUP);
 
 	rs_configure();
-	rs = rs_alloc(NULL, type);
+	rs = rs_alloc(NULL, socket_type);
 	if (!rs)
 		return ERR(ENOMEM);
 
-	if (type == SOCK_STREAM) {
+	rs->fd_flags = (type & SOCK_CLOEXEC) ? FD_CLOEXEC : 0;
+	rs->fs_flags = (type & SOCK_NONBLOCK) ? O_NONBLOCK : 0;
+
+	if (socket_type == SOCK_STREAM) {
 		ret = rdma_create_id(NULL, &rs->cm_id, rs, RDMA_PS_TCP);
 		if (ret)
 			goto err;
@@ -1270,7 +1275,6 @@ int rsocket(int domain, int type, int protocol)
 		ret = ds_init(rs, domain);
 		if (ret)
 			goto err;
-
 		index = rs->udp_sock;
 	}
 
@@ -1363,6 +1367,8 @@ static void rs_accept(struct rsocket *rs)
 	if (!new_rs)
 		goto err;
 	new_rs->cm_id = cm_id;
+	new_rs->fd_flags = rs->fd_flags;
+	new_rs->fs_flags = rs->fs_flags;
 
 	ret = rs_insert(new_rs, new_rs->cm_id->channel->fd);
 	if (ret < 0)
@@ -3712,7 +3718,7 @@ int rsetsockopt(int socket, int level, int optname,
 	rs = idm_lookup(&idm, socket);
 	if (!rs)
 		return ERR(EBADF);
-	if (rs->type == SOCK_DGRAM && level != SOL_RDMA) {
+	if ((rs->type == SOCK_DGRAM) && level != SOL_RDMA) {
 		ret = setsockopt(rs->udp_sock, level, optname, optval, optlen);
 		if (ret)
 			return ret;
@@ -3735,8 +3741,8 @@ int rsetsockopt(int socket, int level, int optname,
 			opt_on = *(int *) optval;
 			break;
 		case SO_RCVBUF:
-			if ((rs->type == SOCK_STREAM && !rs->rbuf) ||
-			    (rs->type == SOCK_DGRAM && !rs->qp_list))
+			if (((rs->type == SOCK_STREAM) && !rs->rbuf) ||
+			    ((rs->type == SOCK_DGRAM) && !rs->qp_list))
 				rs->rbuf_size = (*(uint32_t *) optval) << 1;
 			ret = 0;
 			break;
@@ -4810,7 +4816,7 @@ uint32_t epoll_rs(int fd, uint32_t events)
 	struct rsocket *rs = idm_lookup(&idm, fd);
 
 check_cq:
-	if ((rs->type & SOCK_STREAM) && ((rs->state & rs_connected) ||
+	if ((rs->type == SOCK_STREAM) && ((rs->state & rs_connected) ||
 	     (rs->state == rs_disconnected) || (rs->state & rs_error))) {
 		rs_process_cq(rs, 1, rs_poll_all);
 
@@ -4826,7 +4832,7 @@ check_cq:
 		}
 
 		return revents;
-	} else if (rs->type & SOCK_DGRAM) {
+	} else if (rs->type == SOCK_DGRAM) {
 		ds_process_cqs(rs, 1, rs_poll_all);
 
 		if ((events & EPOLLIN) && rs_have_rdata(rs))

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -1775,9 +1775,11 @@ int rconnect(int socket, const struct sockaddr *addr, socklen_t addrlen)
 	if (rs->type == SOCK_STREAM) {
 		memcpy(&rs->cm_id->route.addr.dst_addr, addr, addrlen);
 		ret = rs_do_connect(rs);
-		if (ret == -1 && errno == EINPROGRESS) {
+		if (ret == 0 || (ret == -1 && errno == EINPROGRESS)) {
 			save_errno = errno;
-			/* The app can still drive the CM state on failure */
+			/* Add rsocket to internal thread that drives CM progress
+			 * so the app can drive state and respond to disconnect requests.
+			 */
 			rs_notify_svc(&connect_svc, rs, RS_SVC_ADD_CM);
 			errno = save_errno;
 		}

--- a/librdmacm/rsocket.h
+++ b/librdmacm/rsocket.h
@@ -72,6 +72,7 @@ int rselect(int nfds, fd_set *readfds, fd_set *writefds,
 	    fd_set *exceptfds, struct timeval *timeout);
 
 int repoll_create1(int flags);
+int repoll_ctl(int epfd, int op, int fd, struct epoll_event *event);
 
 int rgetpeername(int socket, struct sockaddr *addr, socklen_t *addrlen);
 int rgetsockname(int socket, struct sockaddr *addr, socklen_t *addrlen);

--- a/librdmacm/rsocket.h
+++ b/librdmacm/rsocket.h
@@ -40,6 +40,7 @@
 #include <poll.h>
 #include <sys/select.h>
 #include <sys/mman.h>
+#include <sys/epoll.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -69,6 +70,8 @@ ssize_t rwritev(int socket, const struct iovec *iov, int iovcnt);
 int rpoll(struct pollfd *fds, nfds_t nfds, int timeout);
 int rselect(int nfds, fd_set *readfds, fd_set *writefds,
 	    fd_set *exceptfds, struct timeval *timeout);
+
+int repoll_create1(int flags);
 
 int rgetpeername(int socket, struct sockaddr *addr, socklen_t *addrlen);
 int rgetsockname(int socket, struct sockaddr *addr, socklen_t *addrlen);

--- a/librdmacm/rsocket.h
+++ b/librdmacm/rsocket.h
@@ -73,6 +73,7 @@ int rselect(int nfds, fd_set *readfds, fd_set *writefds,
 
 int repoll_create1(int flags);
 int repoll_ctl(int epfd, int op, int fd, struct epoll_event *event);
+int repoll_wait(int epfd, struct epoll_event *events, int maxevents, int timeout);
 
 int rgetpeername(int socket, struct sockaddr *addr, socklen_t *addrlen);
 int rgetsockname(int socket, struct sockaddr *addr, socklen_t *addrlen);


### PR DESCRIPTION
### Summary
Extend the rsocket implementation in librdmacm so that applications such as Redis, iperf3, and memcached can use rsocket transparently via LD_PRELOAD (librspreload), and so rsocket aligns with more standard Linux socket and I/O behavior.

### Motivation
The rsocket library did not fully support several POSIX/Linux interfaces (epoll, select, accept4, sendfile, fcntl64, and various socket options). Applications that rely on these either failed or fell back to TCP. This change extends the rsocket implementation to implement or fix those interfaces, so the preload can intercept them and route traffic over RDMA.

### Changes

- Add/fix epoll (epoll_create, epoll_create1, epoll_ctl, epoll_wait)
- fix rpoll timeout handling and select,
- fix cm_svc_run
- add accept4, dup, fcntl64, sendfile64;
- fix rfcntl
- extend getsockopt/setsockopt;
- fix SOCK_STREAM/SOCK_DGRAM handling and connect service/TCP behavior;
- adjust wake-up timeout from rpoll.