### PR TITLE
librdmacm: extend rsocket for Redis, iperf3, memcached and more Linux APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,7 +453,7 @@ endif()
 # preload should implement the fcntl64/sendfile64 wrapper (see RDMA_PRELOAD_WRAP_LFS64 below).
 set(CMAKE_REQUIRED_QUIET 1)
 set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
-set(CMAKE_REQUIRED_DEFINITIONS "")
+set(CMAKE_REQUIRED_DEFINITIONS "-D_GNU_SOURCE")
 CHECK_C_SOURCE_COMPILES("
 #include <fcntl.h>
 #include <sys/sendfile.h>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,15 +449,17 @@ if (NOT HAVE_LARGE_FILES)
   add_definitions("-D_FILE_OFFSET_BITS=64")
 endif()
 
-# librspreload: probe libc for fcntl64; CMake sets RDMA_PRELOAD_WRAP_LFS64 when
-# preload should implement the fcntl64 wrapper (see RDMA_PRELOAD_WRAP_LFS64 below).
+# librspreload: probe libc for fcntl64/sendfile64; CMake sets RDMA_PRELOAD_WRAP_LFS64 when
+# preload should implement the fcntl64/sendfile64 wrapper (see RDMA_PRELOAD_WRAP_LFS64 below).
 set(CMAKE_REQUIRED_QUIET 1)
 set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
 set(CMAKE_REQUIRED_DEFINITIONS "")
 CHECK_C_SOURCE_COMPILES("
 #include <fcntl.h>
+#include <sys/sendfile.h>
 int main(void) {
   (void)&fcntl64;
+  (void)&sendfile64;
   return 0;
 }
 " RDMA_PRELOAD_LIBC_HAS_FCNTL64_SENDFILE64)
@@ -469,8 +471,8 @@ else()
   set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 0)
 endif()
 
-# Single gate for preload.c fcntl64 wrapper: need libc symbol and must not compile
-# preload with _FILE_OFFSET_BITS=64 (CMake adds that when HAVE_LARGE_FILES is false).
+# Single gate for preload.c fcntl64/sendfile64 wrappers: need libc symbols and must
+# not compile preload with _FILE_OFFSET_BITS=64 (CMake adds that when HAVE_LARGE_FILES is false).
 if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS AND HAVE_LARGE_FILES)
   set(RDMA_PRELOAD_WRAP_LFS64 1)
 else()
@@ -490,6 +492,17 @@ int fcntl64(int socket, int cmd, ...) { (void)socket;(void)cmd; return 0; }
 " RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
   if(RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
     set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
+  endif()
+  CHECK_C_SOURCE_COMPILES("
+#define _GNU_SOURCE
+#include <sys/sendfile.h>
+#include <sys/types.h>
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count) {
+  (void)out_fd;(void)in_fd;(void)offset64;(void)count; return 0;
+}
+" RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
+  if(RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
+    set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 1)
   endif()
   set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
   set(CMAKE_REQUIRED_QUIET 0)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -479,33 +479,14 @@ else()
   set(RDMA_PRELOAD_WRAP_LFS64 0)
 endif()
 
-set(RDMA_PRELOAD_FCNTL64_IN_HEADER 0)
-set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 0)
+# If the first test found fcntl64/sendfile64 with _GNU_SOURCE, the headers
+# must declare them -- no separate check needed.
 if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS)
-  set(CMAKE_REQUIRED_QUIET 1)
-  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
-  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS}")
-  CHECK_C_SOURCE_COMPILES("
-#define _GNU_SOURCE
-#include <fcntl.h>
-int fcntl64(int socket, int cmd, ...) { (void)socket;(void)cmd; return 0; }
-" RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
-  if(RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
-    set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
-  endif()
-  CHECK_C_SOURCE_COMPILES("
-#define _GNU_SOURCE
-#include <sys/sendfile.h>
-#include <sys/types.h>
-ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count) {
-  (void)out_fd;(void)in_fd;(void)offset64;(void)count; return 0;
-}
-" RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
-  if(RDMA_PRELOAD_SENDFILE64_DECLARED_IN_HEADER)
-    set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 1)
-  endif()
-  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
-  set(CMAKE_REQUIRED_QUIET 0)
+  set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
+  set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 1)
+else()
+  set(RDMA_PRELOAD_FCNTL64_IN_HEADER 0)
+  set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 0)
 endif()
 
 # Provide a shim if C11 stdatomic.h is not supported.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -449,6 +449,52 @@ if (NOT HAVE_LARGE_FILES)
   add_definitions("-D_FILE_OFFSET_BITS=64")
 endif()
 
+# librspreload: probe libc for fcntl64; CMake sets RDMA_PRELOAD_WRAP_LFS64 when
+# preload should implement the fcntl64 wrapper (see RDMA_PRELOAD_WRAP_LFS64 below).
+set(CMAKE_REQUIRED_QUIET 1)
+set(SAFE_CMAKE_REQUIRED_DEFINITIONS "${CMAKE_REQUIRED_DEFINITIONS}")
+set(CMAKE_REQUIRED_DEFINITIONS "")
+CHECK_C_SOURCE_COMPILES("
+#include <fcntl.h>
+int main(void) {
+  (void)&fcntl64;
+  return 0;
+}
+" RDMA_PRELOAD_LIBC_HAS_FCNTL64_SENDFILE64)
+set(CMAKE_REQUIRED_DEFINITIONS "${SAFE_CMAKE_REQUIRED_DEFINITIONS}")
+set(CMAKE_REQUIRED_QUIET 0)
+if(RDMA_PRELOAD_LIBC_HAS_FCNTL64_SENDFILE64)
+  set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 1)
+else()
+  set(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS 0)
+endif()
+
+# Single gate for preload.c fcntl64 wrapper: need libc symbol and must not compile
+# preload with _FILE_OFFSET_BITS=64 (CMake adds that when HAVE_LARGE_FILES is false).
+if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS AND HAVE_LARGE_FILES)
+  set(RDMA_PRELOAD_WRAP_LFS64 1)
+else()
+  set(RDMA_PRELOAD_WRAP_LFS64 0)
+endif()
+
+set(RDMA_PRELOAD_FCNTL64_IN_HEADER 0)
+set(RDMA_PRELOAD_SENDFILE64_IN_HEADER 0)
+if(RDMA_PRELOAD_HAVE_LFS_WRAPPER_SYMS)
+  set(CMAKE_REQUIRED_QUIET 1)
+  set(SAFE_CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_FLAGS "${CMAKE_C_FLAGS}")
+  CHECK_C_SOURCE_COMPILES("
+#define _GNU_SOURCE
+#include <fcntl.h>
+int fcntl64(int socket, int cmd, ...) { (void)socket;(void)cmd; return 0; }
+" RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
+  if(RDMA_PRELOAD_FCNTL64_DECLARED_IN_HEADER)
+    set(RDMA_PRELOAD_FCNTL64_IN_HEADER 1)
+  endif()
+  set(CMAKE_REQUIRED_FLAGS "${SAFE_CMAKE_REQUIRED_FLAGS}")
+  set(CMAKE_REQUIRED_QUIET 0)
+endif()
+
 # Provide a shim if C11 stdatomic.h is not supported.
 if (NOT HAVE_SPARSE)
   CHECK_INCLUDE_FILE("stdatomic.h" HAVE_STDATOMIC)

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -120,6 +120,18 @@ function(rdma_library DEST VERSION_SCRIPT SOVERSION VERSION)
   install(TARGETS ${DEST} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 endfunction()
 
+# rsocket LD_PRELOAD module. Requires RDMA_PRELOAD_* variables from top-level
+# CMakeLists.txt (RDMA_PRELOAD_WRAP_LFS64 and fcntl64 header probe).
+function(rdma_rspreload_module DEST VERSION_SCRIPT)
+  add_library(${DEST} MODULE ${ARGN})
+  target_compile_definitions(${DEST} PRIVATE
+    RDMA_PRELOAD_WRAP_LFS64=${RDMA_PRELOAD_WRAP_LFS64}
+    RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER})
+  set_target_properties(${DEST} PROPERTIES LINK_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
+  set_target_properties(${DEST} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")
+  rdma_set_library_map(${DEST} ${VERSION_SCRIPT})
+endfunction()
+
 # Create a special provider with exported symbols in it The shared provider
 # exists as a normal system library with the normal shared library SONAME and
 # other convections. The system library is symlinked into the

--- a/buildlib/rdma_functions.cmake
+++ b/buildlib/rdma_functions.cmake
@@ -121,12 +121,13 @@ function(rdma_library DEST VERSION_SCRIPT SOVERSION VERSION)
 endfunction()
 
 # rsocket LD_PRELOAD module. Requires RDMA_PRELOAD_* variables from top-level
-# CMakeLists.txt (RDMA_PRELOAD_WRAP_LFS64 and fcntl64 header probe).
+# CMakeLists.txt (RDMA_PRELOAD_WRAP_LFS64 and fcntl64/sendfile64 header probe).
 function(rdma_rspreload_module DEST VERSION_SCRIPT)
   add_library(${DEST} MODULE ${ARGN})
   target_compile_definitions(${DEST} PRIVATE
     RDMA_PRELOAD_WRAP_LFS64=${RDMA_PRELOAD_WRAP_LFS64}
-    RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER})
+    RDMA_PRELOAD_FCNTL64_IN_HEADER=${RDMA_PRELOAD_FCNTL64_IN_HEADER}
+    RDMA_PRELOAD_SENDFILE64_IN_HEADER=${RDMA_PRELOAD_SENDFILE64_IN_HEADER})
   set_target_properties(${DEST} PROPERTIES LINK_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
   set_target_properties(${DEST} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")
   rdma_set_library_map(${DEST} ${VERSION_SCRIPT})

--- a/librdmacm/CMakeLists.txt
+++ b/librdmacm/CMakeLists.txt
@@ -27,14 +27,10 @@ target_link_libraries(rdmacm LINK_PRIVATE
 
 # The preload library is a bit special, it needs to be open coded
 # Since it is a LD_PRELOAD it has no soname, and is installed in sub dir
-add_library(rspreload MODULE
+rdma_rspreload_module(rspreload librspreload.map
   preload.c
   indexer.c
   )
-# Even though this is a module we still want to use Wl,--no-undefined
-set_target_properties(rspreload PROPERTIES LINK_FLAGS ${CMAKE_SHARED_LINKER_FLAGS})
-set_target_properties(rspreload PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${BUILD_LIB}")
-rdma_set_library_map(rspreload librspreload.map)
 target_link_libraries(rspreload LINK_PRIVATE
   rdmacm
   ${CMAKE_THREAD_LIBS_INIT}

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -4,6 +4,7 @@
 	   the signature this will go sideways.. */
 	global:
 		accept;
+		accept4;
 		bind;
 		close;
 		connect;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -24,6 +24,7 @@
 		select;
 		send;
 		sendfile;
+		sendfile64;
 		sendmsg;
 		sendto;
 		setsockopt;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -10,6 +10,7 @@
 		connect;
 		dup2;
 		fcntl;
+		fcntl64;
 		getpeername;
 		getsockname;
 		getsockopt;

--- a/librdmacm/librspreload.map
+++ b/librdmacm/librspreload.map
@@ -8,6 +8,7 @@
 		bind;
 		close;
 		connect;
+		dup;
 		dup2;
 		fcntl;
 		fcntl64;

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -59,6 +59,12 @@
 #include "cma.h"
 #include "indexer.h"
 
+#if RDMA_PRELOAD_WRAP_LFS64
+#if !RDMA_PRELOAD_FCNTL64_IN_HEADER
+int fcntl64(int socket, int cmd, ... /* arg */);
+#endif
+#endif
+
 struct socket_calls {
 	int (*socket)(int domain, int type, int protocol);
 	int (*bind)(int socket, const struct sockaddr *addr, socklen_t addrlen);
@@ -88,6 +94,9 @@ struct socket_calls {
 	int (*getsockopt)(int socket, int level, int optname,
 			  void *optval, socklen_t *optlen);
 	int (*fcntl)(int socket, int cmd, ... /* arg */);
+#if RDMA_PRELOAD_WRAP_LFS64
+	int (*fcntl64)(int socket, int cmd, ... /* arg */);
+#endif
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
 	int (*fxstat)(int ver, int fd, struct stat *buf);
@@ -410,6 +419,9 @@ static void init_preload(void)
 	real.setsockopt = dlsym(RTLD_NEXT, "setsockopt");
 	real.getsockopt = dlsym(RTLD_NEXT, "getsockopt");
 	real.fcntl = dlsym(RTLD_NEXT, "fcntl");
+#if RDMA_PRELOAD_WRAP_LFS64
+	real.fcntl64 = dlsym(RTLD_NEXT, "fcntl64");
+#endif
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
 	real.fxstat = dlsym(RTLD_NEXT, "__fxstat");
@@ -647,7 +659,6 @@ int accept4(int socket, struct sockaddr *addr, socklen_t *addrlen, int flags)
 		if (cur_flags == -1)
 			goto close;
 	}
-
 	return fd;
 close:
 	close(fd);
@@ -1162,6 +1173,48 @@ int fcntl(int socket, int cmd, ... /* arg */)
 	va_end(args);
 	return ret;
 }
+
+#if RDMA_PRELOAD_WRAP_LFS64
+int fcntl64(int socket, int cmd, ... /* arg */)
+{
+	va_list args;
+	long lparam;
+	void *pparam;
+	int fd, ret;
+
+	init_preload();
+	va_start(args, cmd);
+	switch (cmd) {
+	case F_GETFD:
+	case F_GETFL:
+	case F_GETOWN:
+	case F_GETSIG:
+	case F_GETLEASE:
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd) : real.fcntl64(fd, cmd);
+		break;
+	case F_DUPFD:
+	/*case F_DUPFD_CLOEXEC:*/
+	case F_SETFD:
+	case F_SETFL:
+	case F_SETOWN:
+	case F_SETSIG:
+	case F_SETLEASE:
+	case F_NOTIFY:
+		lparam = va_arg(args, long);
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd, lparam) : real.fcntl64(fd, cmd, lparam);
+		break;
+	default:
+		pparam = va_arg(args, void *);
+		ret = (fd_get(socket, &fd) == fd_rsocket) ?
+			rfcntl(fd, cmd, pparam) : real.fcntl64(fd, cmd, pparam);
+		break;
+	}
+	va_end(args);
+	return ret;
+}
+#endif
 
 /*
  * dup2 is not thread safe

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -64,6 +64,7 @@ struct socket_calls {
 	int (*bind)(int socket, const struct sockaddr *addr, socklen_t addrlen);
 	int (*listen)(int socket, int backlog);
 	int (*accept)(int socket, struct sockaddr *addr, socklen_t *addrlen);
+	int (*accept4)(int socket, struct sockaddr *addr, socklen_t *addrlen, int flags);
 	int (*connect)(int socket, const struct sockaddr *addr, socklen_t addrlen);
 	ssize_t (*recv)(int socket, void *buf, size_t len, int flags);
 	ssize_t (*recvfrom)(int socket, void *buf, size_t len, int flags,
@@ -389,6 +390,7 @@ static void init_preload(void)
 	real.bind = dlsym(RTLD_NEXT, "bind");
 	real.listen = dlsym(RTLD_NEXT, "listen");
 	real.accept = dlsym(RTLD_NEXT, "accept");
+	real.accept4 = dlsym(RTLD_NEXT, "accept4");
 	real.connect = dlsym(RTLD_NEXT, "connect");
 	real.recv = dlsym(RTLD_NEXT, "recv");
 	real.recvfrom = dlsym(RTLD_NEXT, "recvfrom");
@@ -619,6 +621,39 @@ int accept(int socket, struct sockaddr *addr, socklen_t *addrlen)
 		return real.accept(fd, addr, addrlen);
 	}
 }
+
+int accept4(int socket, struct sockaddr *addr, socklen_t *addrlen, int flags)
+{
+	int cur_flags = 0;
+	int fd;
+
+	fd = accept(socket, addr, addrlen);
+	if (fd < 0)
+		return fd;
+	if (flags & SOCK_NONBLOCK) {
+		cur_flags = fcntl(fd, F_GETFL);
+
+		if (cur_flags != -1)
+			cur_flags = fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+
+		if (cur_flags == -1)
+			goto close;
+	}
+
+	if (flags & SOCK_CLOEXEC) {
+		cur_flags = fcntl(fd, F_GETFD);
+		if (cur_flags != -1)
+			cur_flags = fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
+		if (cur_flags == -1)
+			goto close;
+	}
+
+	return fd;
+close:
+	close(fd);
+	return -1;
+}
+
 
 /*
  * We can't fork RDMA connections and pass them from the parent to the child

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -100,6 +100,7 @@ struct socket_calls {
 #if RDMA_PRELOAD_WRAP_LFS64
 	int (*fcntl64)(int socket, int cmd, ... /* arg */);
 #endif
+	int (*dup)(int oldfd);
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
 #if RDMA_PRELOAD_WRAP_LFS64
@@ -428,6 +429,7 @@ static void init_preload(void)
 #if RDMA_PRELOAD_WRAP_LFS64
 	real.fcntl64 = dlsym(RTLD_NEXT, "fcntl64");
 #endif
+	real.dup = dlsym(RTLD_NEXT, "dup");
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
 #if RDMA_PRELOAD_WRAP_LFS64
@@ -1224,6 +1226,17 @@ int fcntl64(int socket, int cmd, ... /* arg */)
 	return ret;
 }
 #endif
+
+int dup(int oldfd)
+{
+	int new_fd;
+
+	new_fd = fcntl(oldfd, F_DUPFD, 0);
+	if (new_fd < 0)
+		return new_fd;
+
+	return dup2(oldfd, new_fd);
+}
 
 /*
  * dup2 is not thread safe

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -889,6 +889,22 @@ static struct pollfd *fds_alloc(nfds_t nfds)
 	return rfds;
 }
 
+static int *fds_r_alloc(nfds_t nfds)
+{
+	static __thread int *rfds_r;
+	static __thread nfds_t rnfds;
+
+	if (nfds > rnfds) {
+		if (rfds_r)
+			free(rfds_r);
+
+		rfds_r = malloc(sizeof(*rfds_r) * nfds);
+		rnfds = rfds_r ? nfds : 0;
+	}
+
+	return rfds_r;
+}
+
 int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
 	struct pollfd *rfds;
@@ -922,7 +938,7 @@ use_rpoll:
 }
 
 static void select_to_rpoll(struct pollfd *fds, int *nfds,
-			    fd_set *readfds, fd_set *writefds, fd_set *exceptfds)
+			    fd_set *readfds, fd_set *writefds, fd_set *exceptfds, int *user_fds)
 {
 	int fd, events, i = 0;
 
@@ -933,7 +949,8 @@ static void select_to_rpoll(struct pollfd *fds, int *nfds,
 
 		if (events || (exceptfds && FD_ISSET(fd, exceptfds))) {
 			fds[i].fd = fd_getd(fd);
-			fds[i++].events = events;
+			fds[i].events = events;
+			user_fds[i++] = fd;
 		}
 	}
 
@@ -941,30 +958,27 @@ static void select_to_rpoll(struct pollfd *fds, int *nfds,
 }
 
 static int rpoll_to_select(struct pollfd *fds, int nfds,
-			   fd_set *readfds, fd_set *writefds, fd_set *exceptfds)
+			   fd_set *readfds, fd_set *writefds, fd_set *exceptfds, int *user_fds)
 {
-	int fd, rfd, i, cnt = 0;
+	int i, cnt = 0;
 
-	for (i = 0, fd = 0; i < nfds; fd++) {
-		rfd = fd_getd(fd);
-		if (rfd != fds[i].fd)
-			continue;
+	for (i = 0; i < nfds; i++) {
+		assert(fds[i].fd == fd_getd(user_fds[i]));
 
 		if (readfds && (fds[i].revents & POLLIN)) {
-			FD_SET(fd, readfds);
+			FD_SET(user_fds[i], readfds);
 			cnt++;
 		}
 
 		if (writefds && (fds[i].revents & POLLOUT)) {
-			FD_SET(fd, writefds);
+			FD_SET(user_fds[i], writefds);
 			cnt++;
 		}
 
 		if (exceptfds && (fds[i].revents & ~(POLLIN | POLLOUT))) {
-			FD_SET(fd, exceptfds);
+			FD_SET(user_fds[i], exceptfds);
 			cnt++;
 		}
-		i++;
 	}
 
 	return cnt;
@@ -980,12 +994,17 @@ int select(int nfds, fd_set *readfds, fd_set *writefds,
 {
 	struct pollfd *fds;
 	int ret;
+	int *user_fds;
 
 	fds = fds_alloc(nfds);
 	if (!fds)
 		return ERR(ENOMEM);
 
-	select_to_rpoll(fds, &nfds, readfds, writefds, exceptfds);
+	user_fds = fds_r_alloc(nfds);
+	if (!user_fds)
+		return ERR(ENOMEM);
+
+	select_to_rpoll(fds, &nfds, readfds, writefds, exceptfds, user_fds);
 	ret = rpoll(fds, nfds, rs_convert_timeout(timeout));
 
 	if (readfds)
@@ -996,7 +1015,7 @@ int select(int nfds, fd_set *readfds, fd_set *writefds,
 		FD_ZERO(exceptfds);
 
 	if (ret > 0)
-		ret = rpoll_to_select(fds, nfds, readfds, writefds, exceptfds);
+		ret = rpoll_to_select(fds, nfds, readfds, writefds, exceptfds, user_fds);
 
 	return ret;
 }

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -63,6 +63,9 @@
 #if !RDMA_PRELOAD_FCNTL64_IN_HEADER
 int fcntl64(int socket, int cmd, ... /* arg */);
 #endif
+#if !RDMA_PRELOAD_SENDFILE64_IN_HEADER
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count);
+#endif
 #endif
 
 struct socket_calls {
@@ -99,6 +102,9 @@ struct socket_calls {
 #endif
 	int (*dup2)(int oldfd, int newfd);
 	ssize_t (*sendfile)(int out_fd, int in_fd, off_t *offset, size_t count);
+#if RDMA_PRELOAD_WRAP_LFS64
+	ssize_t (*sendfile64)(int out_fd, int in_fd, off64_t *offset64, size_t count);
+#endif
 	int (*fxstat)(int ver, int fd, struct stat *buf);
 };
 
@@ -424,6 +430,9 @@ static void init_preload(void)
 #endif
 	real.dup2 = dlsym(RTLD_NEXT, "dup2");
 	real.sendfile = dlsym(RTLD_NEXT, "sendfile");
+#if RDMA_PRELOAD_WRAP_LFS64
+	real.sendfile64 = dlsym(RTLD_NEXT, "sendfile64");
+#endif
 	real.fxstat = dlsym(RTLD_NEXT, "__fxstat");
 
 	rs.socket = dlsym(RTLD_DEFAULT, "rsocket");
@@ -1287,6 +1296,28 @@ ssize_t sendfile(int out_fd, int in_fd, off_t *offset, size_t count)
 	munmap(file_addr, count);
 	return ret;
 }
+
+#if RDMA_PRELOAD_WRAP_LFS64
+ssize_t sendfile64(int out_fd, int in_fd, off64_t *offset64, size_t count)
+{
+	void *file_addr;
+	int fd;
+	size_t ret;
+
+	if (fd_get(out_fd, &fd) != fd_rsocket)
+		return real.sendfile64(fd, in_fd, offset64, count);
+
+	file_addr = mmap(NULL, count, PROT_READ, 0, in_fd, offset64 ? *offset64 : 0);
+	if (file_addr == (void *) -1)
+		return -1;
+
+	ret = rwrite(fd, file_addr, count);
+	if ((ret > 0) && offset64)
+		lseek(in_fd, ret, SEEK_CUR);
+	munmap(file_addr, count);
+	return ret;
+}
+#endif
 
 int __fxstat(int ver, int socket, struct stat *buf)
 {

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -3367,8 +3367,10 @@ int rpoll(struct pollfd *fds, nfds_t nfds, int timeout)
 
 		if (timeout >= 0) {
 			timeout -= (int) ((rs_time_us() - start_time) / 1000);
-			if (timeout <= 0)
+			if (timeout <= 0) {
+				rs_poll_exit();
 				return 0;
+			}
 			pollsleep = min(timeout, wake_up_interval);
 		} else {
 			pollsleep = wake_up_interval;

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -377,6 +377,7 @@ struct rsocket {
 
 	int		  opts;
 	int		  fd_flags;
+	int		  fs_flags;
 	int		  ipv4_opts;
 	uint64_t	  so_opts;
 	uint64_t	  ipv6_opts;
@@ -847,7 +848,7 @@ static int rs_create_cq(struct rsocket *rs, struct rdma_cm_id *cm_id)
 	if (!cm_id->recv_cq)
 		goto err1;
 
-	if (rs->fd_flags & O_NONBLOCK) {
+	if (rs->fs_flags & O_NONBLOCK) {
 		if (set_fd_nonblock(cm_id->recv_cq_channel->fd, true))
 			goto err2;
 	}
@@ -1279,7 +1280,7 @@ int rlisten(int socket, int backlog)
 	if (ret)
 		return ret;
 
-	if (rs->fd_flags & O_NONBLOCK) {
+	if (rs->fs_flags & O_NONBLOCK) {
 		ret = set_fd_nonblock(rs->accept_queue[0], true);
 		if (ret)
 			return ret;
@@ -1471,7 +1472,7 @@ connected:
 		rs->state = rs_connect_rdwr;
 		break;
 	case rs_accepting:
-		if (!(rs->fd_flags & O_NONBLOCK))
+		if (!(rs->fs_flags & O_NONBLOCK))
 			set_fd_nonblock(rs->cm_id->channel->fd, true);
 
 		ret = ucma_complete(rs->cm_id);
@@ -2346,7 +2347,7 @@ static int ds_get_comp(struct rsocket *rs, int nonblock, int (*test)(struct rsoc
 
 static int rs_nonblocking(struct rsocket *rs, int flags)
 {
-	return (rs->fd_flags & O_NONBLOCK) || (flags & MSG_DONTWAIT);
+	return (rs->fs_flags & O_NONBLOCK) || (flags & MSG_DONTWAIT);
 }
 
 static int rs_is_cq_armed(struct rsocket *rs)
@@ -3495,7 +3496,7 @@ int rshutdown(int socket, int how)
 	if (rs->opts & RS_OPT_KEEPALIVE)
 		rs_notify_svc(&tcp_svc, rs, RS_SVC_REM_KEEPALIVE);
 
-	if (rs->fd_flags & O_NONBLOCK)
+	if (rs->fs_flags & O_NONBLOCK)
 		rs_set_nonblocking(rs, 0);
 
 	if (rs->state & rs_connected) {
@@ -3528,8 +3529,8 @@ int rshutdown(int socket, int how)
 		rs_process_cq(rs, 0, rs_conn_all_sends_done);
 
 out:
-	if ((rs->fd_flags & O_NONBLOCK) && (rs->state & rs_connected))
-		rs_set_nonblocking(rs, rs->fd_flags);
+	if ((rs->fs_flags & O_NONBLOCK) && (rs->state & rs_connected))
+		rs_set_nonblocking(rs, rs->fs_flags);
 
 	if (rs->state & rs_disconnected) {
 		/* Generate event by flushing receives to unblock rpoll */
@@ -3545,14 +3546,14 @@ static void ds_shutdown(struct rsocket *rs)
 	if (rs->opts & RS_OPT_UDP_SVC)
 		rs_notify_svc(&udp_svc, rs, RS_SVC_REM_DGRAM);
 
-	if (rs->fd_flags & O_NONBLOCK)
+	if (rs->fs_flags & O_NONBLOCK)
 		rs_set_nonblocking(rs, 0);
 
 	rs->state &= ~(rs_readable | rs_writable);
 	ds_process_cqs(rs, 0, ds_all_sends_done);
 
-	if (rs->fd_flags & O_NONBLOCK)
-		rs_set_nonblocking(rs, rs->fd_flags);
+	if (rs->fs_flags & O_NONBLOCK)
+		rs_set_nonblocking(rs, rs->fs_flags);
 }
 
 int rclose(int socket)
@@ -4030,15 +4031,22 @@ int rfcntl(int socket, int cmd, ... /* arg */ )
 	va_start(args, cmd);
 	switch (cmd) {
 	case F_GETFL:
-		ret = rs->fd_flags;
+		ret = rs->fs_flags;
 		break;
 	case F_SETFL:
 		param = va_arg(args, int);
-		if ((rs->fd_flags & O_NONBLOCK) != (param & O_NONBLOCK))
+		if ((rs->fs_flags & O_NONBLOCK) != (param & O_NONBLOCK))
 			ret = rs_set_nonblocking(rs, param & O_NONBLOCK);
 
 		if (!ret)
-			rs->fd_flags = param;
+			rs->fs_flags = param;
+		break;
+	case F_GETFD:
+		ret = rs->fd_flags;
+		break;
+	case F_SETFD:
+		param = va_arg(args, int);
+		rs->fd_flags = param;
 		break;
 	default:
 		ret = ERR(ENOTSUP);

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -135,7 +135,7 @@ static uint16_t def_rqsize = 384;
 static uint32_t def_mem = (1 << 17);
 static uint32_t def_wmem = (1 << 17);
 static uint32_t polling_time = 10;
-static int wake_up_interval = 5000;
+static int wake_up_interval = 500;
 
 /*
  * Immediate data format is determined by the upper bits

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -317,7 +317,7 @@ struct ds_qp {
 };
 
 struct rsocket {
-	int		  type;
+	int		  type;  /* SOCK_STREAM or SOCK_DGRAM only; flags in fd_flags/fs_flags */
 	int		  index;
 	fastlock_t	  slock;
 	fastlock_t	  rlock;
@@ -654,6 +654,7 @@ static struct rsocket *rs_alloc(struct rsocket *inherited_rs, int type)
 		return NULL;
 
 	rs->type = type;
+
 	rs->index = -1;
 	if (type == SOCK_DGRAM) {
 		rs->udp_sock = -1;
@@ -1199,19 +1200,23 @@ int rsocket(int domain, int type, int protocol)
 {
 	struct rsocket *rs;
 	int index, ret;
+	int socket_type = type & ~(SOCK_CLOEXEC | SOCK_NONBLOCK);
 
 	if ((domain != AF_INET && domain != AF_INET6 && domain != AF_IB) ||
-	    ((type != SOCK_STREAM) && (type != SOCK_DGRAM)) ||
-	    (type == SOCK_STREAM && protocol && protocol != IPPROTO_TCP) ||
-	    (type == SOCK_DGRAM && protocol && protocol != IPPROTO_UDP))
+	    (socket_type != SOCK_STREAM && socket_type != SOCK_DGRAM) ||
+	    ((socket_type == SOCK_STREAM) && protocol && protocol != IPPROTO_TCP) ||
+	    ((socket_type == SOCK_DGRAM) && protocol && protocol != IPPROTO_UDP))
 		return ERR(ENOTSUP);
 
 	rs_configure();
-	rs = rs_alloc(NULL, type);
+	rs = rs_alloc(NULL, socket_type);
 	if (!rs)
 		return ERR(ENOMEM);
 
-	if (type == SOCK_STREAM) {
+	rs->fd_flags = (type & SOCK_CLOEXEC) ? FD_CLOEXEC : 0;
+	rs->fs_flags = (type & SOCK_NONBLOCK) ? O_NONBLOCK : 0;
+
+	if (socket_type == SOCK_STREAM) {
 		ret = rdma_create_id(NULL, &rs->cm_id, rs, RDMA_PS_TCP);
 		if (ret)
 			goto err;
@@ -1222,7 +1227,6 @@ int rsocket(int domain, int type, int protocol)
 		ret = ds_init(rs, domain);
 		if (ret)
 			goto err;
-
 		index = rs->udp_sock;
 	}
 
@@ -1315,6 +1319,8 @@ static void rs_accept(struct rsocket *rs)
 	if (!new_rs)
 		goto err;
 	new_rs->cm_id = cm_id;
+	new_rs->fd_flags = rs->fd_flags;
+	new_rs->fs_flags = rs->fs_flags;
 
 	ret = rs_insert(new_rs, new_rs->cm_id->channel->fd);
 	if (ret < 0)
@@ -3664,7 +3670,7 @@ int rsetsockopt(int socket, int level, int optname,
 	rs = idm_lookup(&idm, socket);
 	if (!rs)
 		return ERR(EBADF);
-	if (rs->type == SOCK_DGRAM && level != SOL_RDMA) {
+	if ((rs->type == SOCK_DGRAM) && level != SOL_RDMA) {
 		ret = setsockopt(rs->udp_sock, level, optname, optval, optlen);
 		if (ret)
 			return ret;
@@ -3687,8 +3693,8 @@ int rsetsockopt(int socket, int level, int optname,
 			opt_on = *(int *) optval;
 			break;
 		case SO_RCVBUF:
-			if ((rs->type == SOCK_STREAM && !rs->rbuf) ||
-			    (rs->type == SOCK_DGRAM && !rs->qp_list))
+			if (((rs->type == SOCK_STREAM) && !rs->rbuf) ||
+			    ((rs->type == SOCK_DGRAM) && !rs->qp_list))
 				rs->rbuf_size = (*(uint32_t *) optval) << 1;
 			ret = 0;
 			break;

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -377,6 +377,7 @@ struct rsocket {
 
 	int		  opts;
 	int		  fd_flags;
+	int		  ipv4_opts;
 	uint64_t	  so_opts;
 	uint64_t	  ipv6_opts;
 	void		  *optval;
@@ -3712,6 +3713,18 @@ int rsetsockopt(int socket, int level, int optname,
 			break;
 		}
 		break;
+	case IPPROTO_IP:
+		switch (optname) {
+		case IP_TOS:
+			rs->ipv4_opts = *(int *)optval;
+			ret = rdma_set_option(rs->cm_id, RDMA_OPTION_ID,
+						      RDMA_OPTION_ID_TOS,
+						      (void *) optval, optlen);
+			break;
+		default:
+			break;
+		}
+		break;
 	case IPPROTO_TCP:
 		opts = &rs->tcp_opts;
 		switch (optname) {
@@ -3733,6 +3746,7 @@ int rsetsockopt(int socket, int level, int optname,
 			ret = 0;
 			break;
 		case TCP_MAXSEG:
+		case TCP_CONGESTION:
 			ret = 0;
 			break;
 		default:
@@ -3836,6 +3850,7 @@ int rgetsockopt(int socket, int level, int optname,
 	struct rsocket *rs;
 	void *opt;
 	struct ibv_sa_path_rec *path_rec;
+	struct tcp_info *info;
 	struct ibv_path_data path_data;
 	socklen_t len;
 	int ret = 0;
@@ -3873,6 +3888,21 @@ int rgetsockopt(int socket, int level, int optname,
 			*optlen = sizeof(int);
 			rs->err = 0;
 			break;
+		case SO_BROADCAST:
+			ret = 0;
+			break;
+		default:
+			ret = ENOTSUP;
+			break;
+		}
+		break;
+	case IPPROTO_IP:
+		switch (optname) {
+		case IP_TOS:
+			*((int *) optval) = rs->ipv4_opts;
+			*optlen = sizeof(int);
+			break;
+
 		default:
 			ret = ENOTSUP;
 			break;
@@ -3880,6 +3910,7 @@ int rgetsockopt(int socket, int level, int optname,
 		break;
 	case IPPROTO_TCP:
 		switch (optname) {
+		case TCP_CONGESTION:
 		case TCP_KEEPCNT:
 		case TCP_KEEPINTVL:
 			*((int *) optval) = 1;   /* N/A */
@@ -3898,6 +3929,17 @@ int rgetsockopt(int socket, int level, int optname,
 					    2048;
 			*optlen = sizeof(int);
 			break;
+		case TCP_INFO:
+			//TODO: support other tcp_info fields.
+			info = (struct tcp_info *) optval;
+			memset(info, 0, sizeof(struct tcp_info));
+			info->tcpi_state = (rs->state == rs_connected) ?
+				TCP_ESTABLISHED : TCP_CLOSE;
+			info->tcpi_snd_cwnd = rs->sq_size;
+
+			*optlen = sizeof(struct tcp_info);
+			break;
+
 		default:
 			ret = ENOTSUP;
 			break;

--- a/librdmacm/rsocket.c
+++ b/librdmacm/rsocket.c
@@ -1727,9 +1727,11 @@ int rconnect(int socket, const struct sockaddr *addr, socklen_t addrlen)
 	if (rs->type == SOCK_STREAM) {
 		memcpy(&rs->cm_id->route.addr.dst_addr, addr, addrlen);
 		ret = rs_do_connect(rs);
-		if (ret == -1 && errno == EINPROGRESS) {
+		if (ret == 0 || (ret == -1 && errno == EINPROGRESS)) {
 			save_errno = errno;
-			/* The app can still drive the CM state on failure */
+			/* Add rsocket to internal thread that drives CM progress
+			 * so the app can drive state and respond to disconnect requests.
+			 */
 			rs_notify_svc(&connect_svc, rs, RS_SVC_ADD_CM);
 			errno = save_errno;
 		}


### PR DESCRIPTION
Extend the rsocket implementation in librdmacm so that applications such as Redis, iperf3, and memcached can use rsocket transparently via LD_PRELOAD (librspreload), and so rsocket aligns with more standard Linux socket and I/O behavior.

**Motivation**
The rsocket library did not fully support several POSIX/Linux interfaces (epoll, select, accept4, sendfile, fcntl64, and various socket options). Applications that rely on these either failed or fell back to TCP. This change extends the rsocket implementation to implement or fix those interfaces, so the preload can intercept them and route traffic over RDMA.

**Changes**
fix rpoll timeout handling and select,
fix cm_svc_run
add accept4, dup, fcntl64, sendfile64;
fix rfcntl
extend getsockopt/setsockopt;
fix SOCK_STREAM/SOCK_DGRAM handling and connect service/TCP behavior;
adjust wake-up timeout from rpoll.