### PR TITLE
dump_fts: Change lft type in dump_fts to uint8_t

### DIFF
--- a/infiniband-diags/dump_fts.c
+++ b/infiniband-diags/dump_fts.c
@@ -296,7 +296,7 @@ static void dump_unicast_tables(ibnd_node_t *node, int startl, int endl,
 				ibnd_fabric_t *fabric)
 {
 	ib_portid_t * portid = &node->path_portid;
-	char lft[IB_SMP_DATA_SIZE] = { 0 };
+	uint8_t lft[IB_SMP_DATA_SIZE] = { 0 };
 	char str[200];
 	uint64_t nodeguid;
 	int block, i, e, top;


### PR DESCRIPTION
Use uint8_t for the LFT type in dump_fts to match the expected data width (127 < port <= 255).

Fixes: 0ca4d899d57e ("infiniband-diags: add dump_fts tool")