### PR TITLE
When fd_type is fd_normal, pollfd needs to be replaced with the actual fd instead of the index

### DIFF
--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -972,30 +972,25 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	init_preload();
 
 	rfds = fds_alloc(nfds);
-	if (!rfds) {
+	if (!rfds)
 		return ERR(ENOMEM);
-	}
 
 	for (i = 0; i < nfds; i++) {
 		rfds[i].fd = fd_getd(fds[i].fd);
 		rfds[i].events = fds[i].events;
 		rfds[i].revents = 0;
 
-		if (fd_gett(fds[i].fd) == fd_rsocket) {
+		if (fd_gett(fds[i].fd) == fd_rsocket)
 			has_rsocket = 1;
-		}
 	}
 
-	if (!has_rsocket) {
+	if (!has_rsocket)
 		ret = real.poll(rfds, nfds, timeout);
-	}
-	else {
+	else
 		ret = rpoll(rfds, nfds, timeout);
-	}
 
-	for (i = 0; i < nfds; i++) {
+	for (i = 0; i < nfds; i++)
 		fds[i].revents = rfds[i].revents;
-	}
 
 	return ret;
 }

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -967,7 +967,7 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	struct pollfd *rfds;
 	struct fd_info *fdi;
 	int i, ret;
-	int has_rsocket = 0;
+	int has_rsocket = 0; 
 
 	init_preload();
 

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -964,32 +964,39 @@ static int *fds_r_alloc(nfds_t nfds)
 
 int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
-	struct pollfd *rfds;
+		struct pollfd *rfds;
+	struct fd_info *fdi;
 	int i, ret;
+	int has_rsocket = 0;
 
 	init_preload();
-	for (i = 0; i < nfds; i++) {
-		if (fd_gett(fds[i].fd) == fd_rsocket)
-			goto use_rpoll;
-	}
 
-	return real.poll(fds, nfds, timeout);
-
-use_rpoll:
 	rfds = fds_alloc(nfds);
 	if (!rfds)
+	{
 		return ERR(ENOMEM);
+	}
 
 	for (i = 0; i < nfds; i++) {
 		rfds[i].fd = fd_getd(fds[i].fd);
 		rfds[i].events = fds[i].events;
 		rfds[i].revents = 0;
+
+		if (fd_gett(fds[i].fd) == fd_rsocket) {
+			has_rsocket = 1;
+		}
 	}
 
-	ret = rpoll(rfds, nfds, timeout);
+	if (!has_rsocket) {
+		ret = real.poll(rfds, nfds, timeout);
+	}
+	else {
+		ret = rpoll(rfds, nfds, timeout);
+	}
 
-	for (i = 0; i < nfds; i++)
+	for (i = 0; i < nfds; i++) {
 		fds[i].revents = rfds[i].revents;
+	}
 
 	return ret;
 }

--- a/librdmacm/preload.c
+++ b/librdmacm/preload.c
@@ -964,7 +964,7 @@ static int *fds_r_alloc(nfds_t nfds)
 
 int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 {
-		struct pollfd *rfds;
+	struct pollfd *rfds;
 	struct fd_info *fdi;
 	int i, ret;
 	int has_rsocket = 0;
@@ -972,8 +972,7 @@ int poll(struct pollfd *fds, nfds_t nfds, int timeout)
 	init_preload();
 
 	rfds = fds_alloc(nfds);
-	if (!rfds)
-	{
+	if (!rfds) {
 		return ERR(ENOMEM);
 	}
 


### PR DESCRIPTION
In the socket function, when in fork_support mode, a normal socket is created, and the return value is the index, not the socket fd. When polling, the fd passed in the pollfd parameter must be the index, not the actual socket fd. Before calling real.poll, the fd in pollfd is not replaced with the actual socket fd, so real.poll cannot poll for the correct event.

In the socket function:
if (fork_support && (domain == PF_INET || domain == PF_INET6) &&
     (type == SOCK_STREAM) && (!protocol || protocol == IPPROTO_TCP)) {
  ret = real.socket(domain, type, protocol);
  if (ret < 0)
   return ret;
  fd_store(index, ret, fd_normal, fd_fork);
  return index;     //Here return the index, not real socket fd.
 }

In the poll function:
 for (i = 0; i < nfds; i++) {
  if (fd_gett(fds[i].fd) == fd_rsocket)    // If only fd_normal is present in fds, real.poll will be called, and the fd in fds is not a real socket fd
   goto use_rpoll;
 }
 return real.poll(fds, nfds, timeout);