### PR TITLE
Enable ST64B for writes on AArch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,6 +496,7 @@ if (NOT HAVE_SPARSE)
 endif()
 
 RDMA_Check_SSE(HAVE_TARGET_SSE)
+RDMA_Check_LS64(HAVE_LS64)
 
 # Enable development support features
 # Prune unneeded shared libraries during linking
@@ -929,6 +930,9 @@ if (NOT HAVE_GLIBC_UAPI_COMPAT)
 endif()
 if (NOT HAVE_TARGET_SSE)
   message(STATUS " attribute(target(\"sse\")) does NOT work")
+endif()
+if (NOT HAVE_LS64 AND CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+  message(STATUS " AArch64 ST64B intrinsic NOT supported")
 endif()
 if (NOT DRM_INCLUDE_DIRS)
   message(STATUS " DMABUF NOT supported (disabling some tests)")

--- a/buildlib/RDMA_EnableCStd.cmake
+++ b/buildlib/RDMA_EnableCStd.cmake
@@ -127,3 +127,25 @@ int main(int argc, char *argv[])
   endif()
   set(${TO_VAR} "${HAVE_TARGET_SSE}" PARENT_SCOPE)
 endFunction()
+
+function(RDMA_Check_LS64 TO_VAR)
+  set(LS64_CHECK_PROGRAM "
+#include <arm_acle.h>
+int main(void)
+{
+	static char buf[64] __attribute__((aligned(64)));
+
+	__arm_st64b(buf, *(const data512_t *)buf);
+	return 0;
+}
+")
+
+  RDMA_Check_C_Compiles(HAVE_LS64 "${LS64_CHECK_PROGRAM}" "-march=armv8-a+ls64")
+
+  if (HAVE_LS64)
+    set(LS64_FLAGS "-march=armv8-a+ls64" PARENT_SCOPE)
+    set(${TO_VAR} TRUE PARENT_SCOPE)
+  else()
+    set(${TO_VAR} FALSE PARENT_SCOPE)
+  endif()
+endFunction()

--- a/buildlib/config.h.in
+++ b/buildlib/config.h.in
@@ -46,6 +46,8 @@
 
 #cmakedefine HAVE_FUNC_ATTRIBUTE_IFUNC 1
 
+#cmakedefine HAVE_LS64 1
+
 #cmakedefine HAVE_FUNC_ATTRIBUTE_SYMVER 1
 
 #cmakedefine HAVE_WORKING_IF_H 1

--- a/providers/mlx5/CMakeLists.txt
+++ b/providers/mlx5/CMakeLists.txt
@@ -52,6 +52,10 @@ publish_headers(infiniband
   mlx5dv.h
 )
 
+if (LS64_FLAGS)
+  set_source_files_properties(qp.c PROPERTIES COMPILE_FLAGS "${LS64_FLAGS}")
+endif()
+
 rdma_pkg_config("mlx5" "libibverbs" "${CMAKE_THREAD_LIBS_INIT}")
 
 if (ENABLE_LTTNG AND LTTNGUST_FOUND)

--- a/util/mmio.c
+++ b/util/mmio.c
@@ -5,9 +5,13 @@
 
 #include <pthread.h>
 #include <stdbool.h>
+#include <stdlib.h>
+
+#if (defined(__aarch64__) && defined(HAVE_LS64)) || defined(__s390x__)
+#include <sys/auxv.h>
+#endif
 
 #ifdef __s390x__
-#include <sys/auxv.h>
 #include <ccan/minmax.h>
 
 bool s390_is_mio_supported;
@@ -72,6 +76,25 @@ mmio_memcpy_x64_fn_t resolve_mmio_memcpy_x64(uint64_t hwcap)
 		return &s390_mmio_write_syscall;
 }
 #endif /* __s390x__ */
+
+#if defined(__aarch64__) && defined(HAVE_LS64)
+
+/* FEAT_LS64 (ST64B) is exposed as bit 3 of AT_HWCAP3. */
+#ifndef AT_HWCAP3
+#define AT_HWCAP3  29
+#endif
+#ifndef HWCAP3_LS64
+#define HWCAP3_LS64  (1UL << 3)
+#endif
+
+bool aarch64_has_ls64;
+
+static __attribute__((constructor)) void init_aarch64_caps(void)
+{
+	aarch64_has_ls64 = getauxval(AT_HWCAP3) & HWCAP3_LS64;
+}
+
+#endif /* __aarch64__ && HAVE_LS64 */
 
 #if SIZEOF_LONG != 8
 

--- a/util/mmio.h
+++ b/util/mmio.h
@@ -204,16 +204,47 @@ __le64 mmio_read64_le(const void *addr);
 		return le##_SZ_##toh(_NAME_##_le(addr));                       \
 	}
 
-/* This strictly guarantees the order of TLP generation for the memory copy to
-   be in ascending address order.
-*/
+/* mmio_memcpy_x64 - Copy to MMIO space in 64-byte blocks, strictly in
+ * ascending address order (guarantees TLP generation order).
+ *
+ *   Caller must guarantee:
+ *	assert(bytecnt != 0);
+ *	assert((bytecnt % 64) == 0);
+ *	assert(((uintptr_t)dest) % __alignof__(uintptr_t) == 0);
+ *	assert(((uintptr_t)src) % __alignof__(uintptr_t) == 0);
+ *   When aarch64 ST64B is used:
+ *	assert(((uintptr_t)dest) % 64 == 0);
+ */
 #if defined(__aarch64__) || defined(__arm__)
 #include <arm_neon.h>
 
+/*
+ * When compiled with -march=armv8-a+ls64, the compiler defines
+ * __ARM_FEATURE_LS64 and ST64B is used for single-copy atomic 64-byte
+ * writes. At runtime aarch64_has_ls64 verifies the CPU has FEAT_LS64.
+ *
+ * Files compiled without the above flags get the SIMD-instruction path.
+ */
+#ifdef __ARM_FEATURE_LS64
+#include <arm_acle.h>
+#include <stdbool.h>
+
+extern bool aarch64_has_ls64;
+
+static inline void _mmio_memcpy_x64_64b(void *dest, const void *src)
+{
+	if (aarch64_has_ls64) {
+		__arm_st64b(dest, *(const data512_t *)src);
+		return;
+	}
+	vst4q_u64(dest, vld4q_u64(src));
+}
+#else
 static inline void _mmio_memcpy_x64_64b(void *dest, const void *src)
 {
 	vst4q_u64(dest, vld4q_u64(src));
 }
+#endif /* __ARM_FEATURE_LS64 */
 
 static inline void _mmio_memcpy_x64(void *dest, const void *src, size_t bytecnt)
 {
@@ -235,17 +266,9 @@ static inline void _mmio_memcpy_x64(void *dest, const void *src, size_t bytecnt)
 #elif defined(__s390x__)
 void mmio_memcpy_x64(void *dst, const void *src, size_t bytecnt);
 #else
-/* Transfer is some multiple of 64 bytes */
 static inline void mmio_memcpy_x64(void *dest, const void *src, size_t bytecnt)
 {
 	uintptr_t *dst_p = dest;
-
-	/* Caller must guarantee:
-	    assert(bytecnt != 0);
-	    assert((bytecnt % 64) == 0);
-	    assert(((uintptr_t)dest) % __alignof__(*dst) == 0);
-	    assert(((uintptr_t)src) % __alignof__(*dst) == 0);
-	*/
 
 	/* Use the native word size for the copy */
 	if (sizeof(*dst_p) == 8) {


### PR DESCRIPTION
This series adds support for the ARMv8.7 ST64B instruction (FEAT_LS64) in mmio_memcpy_x64 and enables it for mlx5 BlueFlame
doorbell copies.

Series overview:
Patch 1 extends util/mmio to detect and use ST64B on AArch64:
  - A cmake probe (RDMA_Check_LS64) detects compiler LS64 intrinsic
    support at build time and sets LS64_FLAGS / HAVE_LS64.
  - A constructor function checks AT_HWCAP3 at process start to confirm
    the CPU implements FEAT_LS64 at runtime.
  - mmio_memcpy_x64 gains an ST64B fast path when both conditions are
    met, falling back to the existing NEON path otherwise. Files not
    compiled with -march=armv8-a+ls64 see zero overhead and continue to
    use the NEON path.

Patch 2 opts mlx5 qp.c into the new path by compiling it with LS64_FLAGS.

Further details exist as part of the commit logs.