### PR TITLE
 ionic: Add Reorder Completion Queue (RCQ) support

### DIFF
--- a/debian/ibverbs-providers.symbols
+++ b/debian/ibverbs-providers.symbols
@@ -222,3 +222,5 @@ libionic.so.1 ibverbs-providers #MINVER#
  ionic_dv_pd_set_udma_mask@IONIC_1.0 59
  ionic_dv_pd_set_sqcmb@IONIC_1.0 59
  ionic_dv_pd_set_rqcmb@IONIC_1.0 59
+ IONIC_1.1@IONIC_1.1 65
+ ionic_dv_create_qp_ex@IONIC_1.1 65

--- a/kernel-headers/rdma/ionic-abi.h
+++ b/kernel-headers/rdma/ionic-abi.h
@@ -46,8 +46,9 @@ struct ionic_ctx_resp {
 	__u8 udma_count;
 	__u8 expdb_mask;
 	__u8 expdb_qtypes;
+	__u8 rcq_sign_bit;
 
-	__u8 rsvd2[3];
+	__u8 rsvd2[2];
 };
 
 struct ionic_qdesc {
@@ -84,6 +85,7 @@ struct ionic_qp_req {
 	__u8 rq_cmb;
 	__u8 udma_mask;
 	__u8 rsvd[3];
+	__u32 ionic_flags;
 };
 
 struct ionic_qp_resp {

--- a/kernel-headers/rdma/ionic-abi.h
+++ b/kernel-headers/rdma/ionic-abi.h
@@ -22,6 +22,10 @@
 #define IONIC_CMB_WC		8
 #define IONIC_CMB_UC		16
 
+enum ionic_ctx_resp_comp_mask {
+	IONIC_CTX_CMASK_IONIC_FLAGS = 1 << 0,
+};
+
 struct ionic_ctx_req {
 	__u32 rsvd[2];
 };
@@ -46,8 +50,9 @@ struct ionic_ctx_resp {
 	__u8 udma_count;
 	__u8 expdb_mask;
 	__u8 expdb_qtypes;
+	__u8 rcq_sign_bit;
 
-	__u8 rsvd2[3];
+	__u16 comp_mask;
 	__aligned_u64 phc_offset;
 };
 
@@ -85,6 +90,8 @@ struct ionic_qp_req {
 	__u8 rq_cmb;
 	__u8 udma_mask;
 	__u8 rsvd[3];
+	__u32 ionic_flags;
+	__u32 rsvd_pad;
 };
 
 struct ionic_qp_resp {

--- a/providers/ionic/CMakeLists.txt
+++ b/providers/ionic/CMakeLists.txt
@@ -1,5 +1,5 @@
 rdma_shared_provider(ionic libionic.map
-	1 1.0.${PACKAGE_VERSION}
+	1 1.1.${PACKAGE_VERSION}
 	ionic.c
 	ionic_verbs.c
 	ionic_memory.c

--- a/providers/ionic/ionic.c
+++ b/providers/ionic/ionic.c
@@ -79,6 +79,7 @@ static struct verbs_context *ionic_alloc_context(struct ibv_device *ibdev,
 
 	ctx->robust_udata = !!(verbs_get_device(ibdev)->core_support &
 			       IB_UVERBS_CORE_SUPPORT_ROBUST_UDATA);
+	ctx->rcq_sign_bit = resp.rcq_sign_bit;
 
 	mask = (1u << ctx->pg_shift) - 1;
 	ctx->dbpage_page = ionic_map_device(1u << ctx->pg_shift, cmd_fd,

--- a/providers/ionic/ionic.c
+++ b/providers/ionic/ionic.c
@@ -77,6 +77,9 @@ static struct verbs_context *ionic_alloc_context(struct ibv_device *ibdev,
 	ctx->sq_expdb = !!(resp.expdb_qtypes & IONIC_EXPDB_SQ);
 	ctx->rq_expdb = !!(resp.expdb_qtypes & IONIC_EXPDB_RQ);
 
+	ctx->robust_udata = !!(verbs_get_device(ibdev)->core_support &
+			       IB_UVERBS_CORE_SUPPORT_ROBUST_UDATA);
+
 	mask = (1u << ctx->pg_shift) - 1;
 	ctx->dbpage_page = ionic_map_device(1u << ctx->pg_shift, cmd_fd,
 					    resp.dbell_offset & ~mask);

--- a/providers/ionic/ionic.c
+++ b/providers/ionic/ionic.c
@@ -78,6 +78,9 @@ static struct verbs_context *ionic_alloc_context(struct ibv_device *ibdev,
 	ctx->sq_expdb = !!(resp.expdb_qtypes & IONIC_EXPDB_SQ);
 	ctx->rq_expdb = !!(resp.expdb_qtypes & IONIC_EXPDB_RQ);
 
+	ctx->robust_udata = !!(verbs_get_device(ibdev)->core_support &
+			       IB_UVERBS_CORE_SUPPORT_ROBUST_UDATA);
+
 	mask = (1u << ctx->pg_shift) - 1;
 	ctx->dbpage_page = ionic_map_device(1u << ctx->pg_shift, cmd_fd,
 					    resp.dbell_offset & ~mask);

--- a/providers/ionic/ionic.c
+++ b/providers/ionic/ionic.c
@@ -80,6 +80,8 @@ static struct verbs_context *ionic_alloc_context(struct ibv_device *ibdev,
 
 	ctx->robust_udata = !!(verbs_get_device(ibdev)->core_support &
 			       IB_UVERBS_CORE_SUPPORT_ROBUST_UDATA);
+	ctx->ionic_flags_supported = !!(resp.comp_mask & IONIC_CTX_CMASK_IONIC_FLAGS);
+	ctx->rcq_sign_bit = resp.rcq_sign_bit;
 
 	mask = (1u << ctx->pg_shift) - 1;
 	ctx->dbpage_page = ionic_map_device(1u << ctx->pg_shift, cmd_fd,

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -22,6 +22,7 @@
 #include "ionic_memory.h"
 #include "ionic_queue.h"
 #include "ionic_table.h"
+#include "ionic_dv.h"
 
 #include <stdio.h>
 #include <inttypes.h>
@@ -45,6 +46,13 @@
 #define IONIC_PD_TAG_CQ	(IONIC_PD_TAG | 1)
 #define IONIC_PD_TAG_SQ	(IONIC_PD_TAG | 2)
 #define IONIC_PD_TAG_RQ	(IONIC_PD_TAG | 3)
+#define IONIC_PD_TAG_RCQ (IONIC_PD_TAG | 4)
+
+#define IONIC_SET_UDATA(ctx, req, field, val)			\
+	do {							\
+		if ((ctx)->robust_udata)			\
+			(req)->field = (val);			\
+	} while (0)
 
 enum {
 	IONIC_CQ_SUPPORTED_WC_FLAGS =
@@ -55,6 +63,18 @@ enum {
 	    IBV_WC_EX_WITH_SLID           |
 	    IBV_WC_EX_WITH_SL             |
 	    IBV_WC_EX_WITH_DLID_PATH_BITS
+};
+
+enum {
+	IONIC_DV_QP_SUPPORTED_COMP_MASK =
+		IONIC_DV_QP_INIT_ATTR_MASK_FLAGS,
+
+	IONIC_DV_QP_SUPPORTED_EXT_FLAGS =
+		IONIC_DV_CREATE_QP_TYPE_RCCL		|
+		IONIC_DV_CREATE_QP_RCCL_DATA		|
+		IONIC_DV_CREATE_QP_RCCL_RDFENCE		|
+		IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD	|
+		IONIC_DV_CREATE_QP_RCCL_RCQ,
 };
 
 struct ionic_ctx {
@@ -204,6 +224,7 @@ struct ionic_qp {
 	struct ionic_sq		sq;
 	struct ionic_rq		rq;
 	bool			sig_all;
+	bool			rcq;
 };
 
 struct ionic_ah {
@@ -309,5 +330,9 @@ static inline void ionic_dbg_xdump(struct ionic_ctx *ctx, const char *str,
 
 /* ionic_verbs.h */
 void ionic_verbs_set_ops(struct ionic_ctx *ctx);
+
+struct ibv_qp *ionic_create_qp_ex_common(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex,
+					 struct ionic_dv_qp_init_attr_ex *ionic_ex);
 
 #endif /* IONIC_H */

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -76,6 +76,7 @@ struct ionic_ctx {
 	uint8_t			expdb_mask;
 	bool			sq_expdb;
 	bool			rq_expdb;
+	bool			robust_udata;
 
 	void			*dbpage_page;
 	uint64_t		*dbpage;

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -169,6 +169,16 @@ struct ionic_sq_meta {
 struct ionic_rq_meta {
 	struct ionic_rq_meta	*next;
 	uint64_t		wrid;
+	struct {
+		uint64_t	timestamp;
+		uint32_t	seq;
+		uint32_t	imm_rkey;
+		uint32_t	sts_len;
+		uint8_t		valid:1;
+		uint8_t		ready:1;
+		uint8_t		error:1;
+		uint8_t		op;
+	} rcqe;
 };
 
 struct ionic_rq {

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -77,6 +77,7 @@ struct ionic_ctx {
 	bool			sq_expdb;
 	bool			rq_expdb;
 	bool			robust_udata;
+	uint8_t			rcq_sign_bit;
 
 	void			*dbpage_page;
 	uint64_t		*dbpage;

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -22,6 +22,7 @@
 #include "ionic_memory.h"
 #include "ionic_queue.h"
 #include "ionic_table.h"
+#include "ionic_dv.h"
 
 #include <stdio.h>
 #include <inttypes.h>
@@ -45,6 +46,17 @@
 #define IONIC_PD_TAG_CQ	(IONIC_PD_TAG | 1)
 #define IONIC_PD_TAG_SQ	(IONIC_PD_TAG | 2)
 #define IONIC_PD_TAG_RQ	(IONIC_PD_TAG | 3)
+#define IONIC_PD_TAG_RCQ (IONIC_PD_TAG | 4)
+
+#define IONIC_SET_UDATA(ctx, req, field, val)			\
+	({							\
+		int __rc = 0;					\
+		if ((ctx)->robust_udata)			\
+			(req)->field = (val);			\
+		else						\
+			__rc = ENOTSUP;				\
+		__rc;						\
+	})
 
 enum {
 	IONIC_CQ_SUPPORTED_WC_FLAGS =
@@ -81,6 +93,18 @@ enum {
 		IBV_QP_EX_WITH_LOCAL_INV		|
 		IBV_QP_EX_WITH_BIND_MW			|
 		IBV_QP_EX_WITH_SEND_WITH_INV,
+};
+
+enum {
+	IONIC_DV_QP_SUPPORTED_COMP_MASK =
+		IONIC_DV_QP_INIT_ATTR_MASK_FLAGS,
+
+	IONIC_DV_QP_SUPPORTED_EXT_FLAGS =
+		IONIC_DV_CREATE_QP_TYPE_RCCL		|
+		IONIC_DV_CREATE_QP_RCCL_DATA		|
+		IONIC_DV_CREATE_QP_RCCL_RDFENCE		|
+		IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD	|
+		IONIC_DV_CREATE_QP_RCCL_RCQ,
 };
 
 struct ionic_ctx {
@@ -256,6 +280,7 @@ struct ionic_qp {
 	struct ibv_send_wr	ex_wr;
 	int			ex_rc;
 	bool			sig_all;
+	bool			rcq;
 };
 
 struct ionic_ah {
@@ -376,5 +401,9 @@ static inline void ionic_dbg_xdump(struct ionic_ctx *ctx, const char *str,
 
 /* ionic_verbs.h */
 void ionic_verbs_set_ops(struct ionic_ctx *ctx);
+
+struct ibv_qp *ionic_create_qp_ex_common(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex,
+					 struct ionic_dv_qp_init_attr_ex *ionic_ex);
 
 #endif /* IONIC_H */

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -103,6 +103,8 @@ struct ionic_ctx {
 	bool			sq_expdb;
 	bool			rq_expdb;
 	bool			robust_udata;
+	bool			ionic_flags_supported;
+	uint8_t			rcq_sign_bit;
 
 	void			*dbpage_page;
 	uint64_t		*dbpage;

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -223,6 +223,16 @@ struct ionic_sq_meta {
 struct ionic_rq_meta {
 	struct ionic_rq_meta	*next;
 	uint64_t		wrid;
+	struct {
+		uint64_t	timestamp;
+		uint32_t	seq;
+		uint32_t	imm_rkey;
+		uint32_t	sts_len;
+		uint8_t		valid:1;
+		uint8_t		ready:1;
+		uint8_t		error:1;
+		uint8_t		op;
+	} rcqe;
 };
 
 struct ionic_rq {

--- a/providers/ionic/ionic.h
+++ b/providers/ionic/ionic.h
@@ -102,6 +102,7 @@ struct ionic_ctx {
 	uint8_t			expdb_mask;
 	bool			sq_expdb;
 	bool			rq_expdb;
+	bool			robust_udata;
 
 	void			*dbpage_page;
 	uint64_t		*dbpage;

--- a/providers/ionic/ionic_dv.c
+++ b/providers/ionic/ionic_dv.c
@@ -105,3 +105,15 @@ int ionic_dv_pd_set_rqcmb(struct ibv_pd *ibpd, bool enable, bool expdb, bool req
 
 	return 0;
 }
+
+struct ibv_qp *ionic_dv_create_qp_ex(struct ibv_context *ibctx,
+				     struct ibv_qp_init_attr_ex *ex,
+				     struct ionic_dv_qp_init_attr_ex *ionic_ex)
+{
+	if (!is_ionic_ctx(ibctx)) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	return ionic_create_qp_ex_common(ibctx, ex, ionic_ex);
+}

--- a/providers/ionic/ionic_dv.h
+++ b/providers/ionic/ionic_dv.h
@@ -68,6 +68,34 @@ int ionic_dv_pd_set_sqcmb(struct ibv_pd *ibpd, bool enable, bool expdb, bool req
  */
 int ionic_dv_pd_set_rqcmb(struct ibv_pd *ibpd, bool enable, bool expdb, bool require);
 
+enum ionic_dv_qp_init_attr_mask {
+	IONIC_DV_QP_INIT_ATTR_MASK_FLAGS		= (1 << 0),
+};
+
+enum ionic_dv_qp_init_attr_flags {
+	IONIC_DV_CREATE_QP_TYPE_RCCL		= 1 << 16,
+	IONIC_DV_CREATE_QP_RCCL_DATA		= 1 << 17,
+	IONIC_DV_CREATE_QP_RCCL_RDFENCE		= 1 << 18,
+	IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD	= 1 << 19,
+	IONIC_DV_CREATE_QP_RCCL_RCQ			= 1 << 24,
+};
+
+struct ionic_dv_qp_init_attr_ex {
+	uint64_t comp_mask;
+	uint32_t ionic_flags;
+};
+
+/**
+ * ionic_dv_create_qp_ex - Create a queue pair with ionic-specific attributes.
+ *
+ * @ibctx - Device context.
+ * @ex - Standard QP init attributes.
+ * @ionic_ex - Ionic-specific QP init attributes (transport mode, rcq paths).
+ */
+struct ibv_qp *ionic_dv_create_qp_ex(struct ibv_context *ibctx,
+				     struct ibv_qp_init_attr_ex *ex,
+				     struct ionic_dv_qp_init_attr_ex *ionic_ex);
+
 #ifdef __cplusplus
 }
 #endif

--- a/providers/ionic/ionic_fw.h
+++ b/providers/ionic/ionic_fw.h
@@ -217,4 +217,6 @@ static inline int ionic_v1_use_spec_sge(int min_sge, int spec)
 	return spec;
 }
 
+#define IONIC_RCQ_SIZE 4096
+
 #endif /* IONIC_FW_H */

--- a/providers/ionic/ionic_fw.h
+++ b/providers/ionic/ionic_fw.h
@@ -217,6 +217,48 @@ static inline int ionic_v1_use_spec_sge(int min_sge, int spec)
 	return spec;
 }
 
+static inline uint32_t ionic_v1_rcqe_seq(uint32_t seq_opf)
+{
+	return seq_opf & IONIC_V1_CQE_RCQE_SEQ_MASK;
+}
+
+static inline uint8_t ionic_v1_rcqe_op(uint32_t seq_opf)
+{
+	return seq_opf >> IONIC_V1_CQE_RCQE_OP_SHIFT;
+}
+
+static inline bool ionic_v1_rcqe_valid(uint32_t seq_opf)
+{
+	return seq_opf & IONIC_V1_CQE_RCQE_FLAG_V;
+}
+
+static inline bool ionic_v1_rcqe_ready(uint32_t seq_opf)
+{
+	return seq_opf & IONIC_V1_CQE_RCQE_FLAG_I;
+}
+
 #define IONIC_RCQ_SIZE 4096
+
+struct ionic_rcq_hdr {
+	__be32 seq;
+	__be32 ack;
+};
+
+struct ionic_rcq {
+	union {
+		uint8_t bytes[IONIC_RCQ_SIZE];
+		struct ionic_rcq_hdr hdr;
+	};
+};
+
+static inline uint32_t ionic_rcq_seq(struct ionic_rcq *rcq)
+{
+	return be32toh(rcq->hdr.seq) & IONIC_V1_CQE_RCQE_SEQ_MASK;
+}
+
+static inline void ionic_rcq_ack(struct ionic_rcq *rcq, uint32_t ack)
+{
+	rcq->hdr.ack = htobe32(ack);
+}
 
 #endif /* IONIC_FW_H */

--- a/providers/ionic/ionic_fw_types.h
+++ b/providers/ionic/ionic_fw_types.h
@@ -70,22 +70,34 @@ union ionic_v1_pld {
 	__u8			data[32];
 };
 
+struct ionic_v1_cqe_send {
+	__u8			rsvd[4];
+	__be32			msg_msn;
+	__u8			rsvd2[8];
+	__le64			npg_wqe_idx;
+};
+
+struct ionic_v1_cqe_recv {
+	__le64			wqe_idx;
+	__be32			src_qpn_op;
+	__u8			src_mac[6];
+	__be16			vlan_tag;
+	__be32			imm_data_rkey;
+};
+
+struct ionic_v1_cqe_rcqe {
+	__be64			wqe_idx;
+	__u8			rsvd[8];
+	__be32			seq_op_flags;
+	__be32			imm_data_rkey;
+};
+
 /* completion queue v1 cqe */
 struct ionic_v1_cqe {
 	union {
-		struct {
-			__le64		wqe_idx;
-			__be32		src_qpn_op;
-			__u8		src_mac[6];
-			__be16		vlan_tag;
-			__be32		imm_data_rkey;
-		} recv;
-		struct {
-			__u8		rsvd[4];
-			__be32		msg_msn;
-			__u8		rsvd2[8];
-			__le64		npg_wqe_idx;
-		} send;
+		struct ionic_v1_cqe_send send;
+		struct ionic_v1_cqe_recv recv;
+		struct ionic_v1_cqe_rcqe rcqe;
 	};
 	__be32				status_length;
 	__be32				qid_type_flags;
@@ -94,6 +106,14 @@ struct ionic_v1_cqe {
 /* bits for cqe wqe_idx */
 enum ionic_v1_cqe_wqe_idx_bits {
 	IONIC_V1_CQE_WQE_IDX_MASK	= 0xffff,
+};
+
+/* bits for rcqe seq_op_flags */
+enum ionic_v1_cqe_rcqe_op_flag_bits {
+	IONIC_V1_CQE_RCQE_SEQ_MASK	= 0xffffff,
+	IONIC_V1_CQE_RCQE_FLAG_V	= 1u << 24,
+	IONIC_V1_CQE_RCQE_FLAG_I	= 1u << 25,
+	IONIC_V1_CQE_RCQE_OP_SHIFT	= 28,
 };
 
 /* bits for cqe recv */

--- a/providers/ionic/ionic_fw_types.h
+++ b/providers/ionic/ionic_fw_types.h
@@ -125,7 +125,7 @@ enum ionic_v1_cqe_qtf_bits {
 	IONIC_V1_CQE_TYPE_RECV		= 1,
 	IONIC_V1_CQE_TYPE_SEND_MSN	= 2,
 	IONIC_V1_CQE_TYPE_SEND_NPG	= 3,
-	IONIC_V1_CQE_TYPE_RECV_INDIR	= 4,
+	IONIC_V1_CQE_TYPE_RECV_RCQE	= 4,
 };
 
 /* v1 base wqe header */

--- a/providers/ionic/ionic_fw_types.h
+++ b/providers/ionic/ionic_fw_types.h
@@ -126,7 +126,7 @@ enum ionic_v1_cqe_qtf_bits {
 	IONIC_V1_CQE_TYPE_RECV		= 1,
 	IONIC_V1_CQE_TYPE_SEND_MSN	= 2,
 	IONIC_V1_CQE_TYPE_SEND_NPG	= 3,
-	IONIC_V1_CQE_TYPE_RECV_INDIR	= 4,
+	IONIC_V1_CQE_TYPE_RECV_RCQE	= 4,
 };
 
 /* v1 base wqe header */

--- a/providers/ionic/ionic_fw_types.h
+++ b/providers/ionic/ionic_fw_types.h
@@ -70,22 +70,34 @@ union ionic_v1_pld {
 	__u8			data[32];
 };
 
+struct ionic_v1_cqe_send {
+	__u8			rsvd[4];
+	__be32			msg_msn;
+	__u8			rsvd2[8];
+	__le64			npg_wqe_idx_timestamp;
+};
+
+struct ionic_v1_cqe_recv {
+	__le64			wqe_idx_timestamp;
+	__be32			src_qpn_op;
+	__u8			src_mac[6];
+	__be16			vlan_tag;
+	__be32			imm_data_rkey;
+};
+
+struct ionic_v1_cqe_rcqe {
+	__be64			wqe_idx_timestamp;
+	__u8			rsvd[8];
+	__be32			seq_op_flags;
+	__be32			imm_data_rkey;
+};
+
 /* completion queue v1 cqe */
 struct ionic_v1_cqe {
 	union {
-		struct {
-			__le64		wqe_idx_timestamp;
-			__be32		src_qpn_op;
-			__u8		src_mac[6];
-			__be16		vlan_tag;
-			__be32		imm_data_rkey;
-		} recv;
-		struct {
-			__u8		rsvd[4];
-			__be32		msg_msn;
-			__u8		rsvd2[8];
-			__le64		npg_wqe_idx_timestamp;
-		} send;
+		struct ionic_v1_cqe_send send;
+		struct ionic_v1_cqe_recv recv;
+		struct ionic_v1_cqe_rcqe rcqe;
 	};
 	__be32				status_length;
 	__be32				qid_type_flags;
@@ -95,6 +107,14 @@ struct ionic_v1_cqe {
 enum ionic_v1_cqe_wqe_idx_timestamp_bits {
 	IONIC_V1_CQE_WQE_IDX_MASK	= 0xffff,
 	IONIC_V1_CQE_TIMESTAMP_SHIFT	= 16,
+};
+
+/* bits for rcqe seq_op_flags */
+enum ionic_v1_cqe_rcqe_op_flag_bits {
+	IONIC_V1_CQE_RCQE_SEQ_MASK	= 0xffffff,
+	IONIC_V1_CQE_RCQE_FLAG_V	= 1u << 24,
+	IONIC_V1_CQE_RCQE_FLAG_I	= 1u << 25,
+	IONIC_V1_CQE_RCQE_OP_SHIFT	= 28,
 };
 
 /* bits for cqe recv */

--- a/providers/ionic/ionic_queue.c
+++ b/providers/ionic/ionic_queue.c
@@ -9,6 +9,7 @@
 #include "ionic.h"
 #include "ionic_queue.h"
 #include "ionic_memory.h"
+#include "ionic_fw.h"
 
 static void ionic_queue_map(struct ionic_queue *q, struct ionic_pd *pd, uint64_t pd_tag, int stride)
 {
@@ -64,6 +65,9 @@ int ionic_queue_init(struct ionic_queue *q, struct ionic_pd *pd,
 
 	q->size = BIT_ULL(q->depth_log2 + q->stride_log2);
 	q->mask = BIT(q->depth_log2) - 1;
+
+	if (pd_tag == IONIC_PD_TAG_RCQ)
+		q->size += IONIC_RCQ_SIZE;
 
 	ionic_queue_map(q, pd, pd_tag, stride);
 	if (!q->ptr)

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1330,7 +1330,7 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 
 			break;
 
-		case IONIC_V1_CQE_TYPE_RECV_INDIR:
+		case IONIC_V1_CQE_TYPE_RECV_RCQE:
 			list_del(&qp->cq_poll_rq);
 			list_add_tail(&cq->poll_rq, &qp->cq_poll_rq);
 			break;
@@ -1612,7 +1612,12 @@ static int ionic_qp_rq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 	if (max_sge > ionic_v1_recv_wqe_max_sge(ctx->max_stride, 0, false))
 		return EINVAL;
 
-	pd_tag = IONIC_PD_TAG_RQ;
+	if (qp->rcq) {
+		pd_tag = IONIC_PD_TAG_RCQ;
+		qp->rq.cmb = 0;
+	} else {
+		pd_tag = IONIC_PD_TAG_RQ;
+	}
 	qp->rq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
 	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
@@ -1672,8 +1677,9 @@ static void ionic_qp_rq_destroy(struct ionic_qp *qp)
 	ionic_queue_destroy(&qp->rq.queue);
 }
 
-static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
-					 struct ibv_qp_init_attr_ex *ex)
+struct ibv_qp *ionic_create_qp_ex_common(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex,
+					 struct ionic_dv_qp_init_attr_ex *ionic_ex)
 {
 	struct ionic_ctx *ctx = to_ionic_ctx(ibctx);
 	struct ionic_pd *pd = to_ionic_pd(ex->pd);
@@ -1682,6 +1688,30 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 	struct ionic_qp *qp;
 	struct ionic_cq *cq;
 	int rc;
+
+	if (ionic_ex) {
+		if (!check_comp_mask(ionic_ex->comp_mask,
+				     IONIC_DV_QP_SUPPORTED_COMP_MASK)) {
+			rc = ENOTSUP;
+			goto err_qp;
+		}
+
+		if (ionic_ex->comp_mask & IONIC_DV_QP_INIT_ATTR_MASK_FLAGS) {
+			if (!check_comp_mask(ionic_ex->ionic_flags,
+					     IONIC_DV_QP_SUPPORTED_EXT_FLAGS)) {
+				rc = ENOTSUP;
+				goto err_qp;
+			}
+
+			if ((ionic_ex->ionic_flags & IONIC_DV_CREATE_QP_RCCL_RCQ) &&
+			     !ctx->rcq_sign_bit) {
+				rc = EINVAL;
+				goto err_qp;
+			}
+
+			IONIC_SET_UDATA(ctx, &req, ionic_flags, ionic_ex->ionic_flags);
+		}
+	}
 
 	qp = calloc(1, sizeof(*qp));
 	if (!qp) {
@@ -1694,6 +1724,7 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 	qp->has_rq = true;
 	qp->lockfree = false;
 	qp->sig_all = ex->sq_sig_all;
+	qp->rcq = ctx->rcq_sign_bit && (req.ionic_flags & IONIC_DV_CREATE_QP_RCCL_RCQ);
 
 	list_node_init(&qp->cq_poll_sq);
 	list_node_init(&qp->cq_poll_rq);
@@ -1809,6 +1840,12 @@ err_sq:
 err_qp:
 	errno = rc;
 	return NULL;
+}
+
+static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex)
+{
+	return ionic_create_qp_ex_common(ibctx, ex, NULL);
 }
 
 static void ionic_flush_qp(struct ionic_ctx *ctx, struct ionic_qp *qp)

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1674,17 +1674,18 @@ static int ionic_qp_sq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 
 	qp->sq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
-	if (qp->sq.cmb & IONIC_CMB_EXPDB) {
-		wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
-						      qp->sq.spec, true);
+	wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
+					      qp->sq.spec, false);
 
-		if (!ionic_expdb_wqe_size_supported(ctx, wqe_size))
+	if (qp->sq.cmb & IONIC_CMB_EXPDB) {
+		uint32_t expdb_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
+								 qp->sq.spec, true);
+
+		if (ionic_expdb_wqe_size_supported(ctx, expdb_size))
+			wqe_size = expdb_size;
+		else
 			qp->sq.cmb &= ~IONIC_CMB_EXPDB;
 	}
-
-	if (!(qp->sq.cmb & IONIC_CMB_EXPDB))
-		wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
-						      qp->sq.spec, false);
 
 	rc = ionic_queue_init(&qp->sq.queue, pd, IONIC_PD_TAG_SQ,
 			      ctx->pg_shift, max_wr, wqe_size);
@@ -1754,15 +1755,16 @@ static int ionic_qp_rq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 	}
 	qp->rq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
-	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
-		wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, true);
+	wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, false);
 
-		if (!ionic_expdb_wqe_size_supported(ctx, wqe_size))
+	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
+		uint32_t expdb_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, true);
+
+		if (ionic_expdb_wqe_size_supported(ctx, expdb_size))
+			wqe_size = expdb_size;
+		else
 			qp->rq.cmb &= ~IONIC_CMB_EXPDB;
 	}
-
-	if (!(qp->rq.cmb & IONIC_CMB_EXPDB))
-		wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, false);
 
 	rc = ionic_queue_init(&qp->rq.queue, pd, pd_tag, ctx->pg_shift, max_wr, wqe_size);
 	if (rc)

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1215,6 +1215,118 @@ static void ionic_reserve_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 	}
 }
 
+static int ionic_validate_rcq_wqe_idx(uint16_t prod, uint16_t cons,
+				      uint16_t idx, uint16_t mask)
+{
+	return ((idx - cons) & mask) < ((prod - cons) & mask) ? 0 : -EIO;
+}
+
+static void ionic_comp_rcqe(struct ionic_ctx *ctx,
+			    struct ionic_qp *qp,
+			    struct ionic_v1_cqe *cqe)
+{
+	struct ionic_rq_meta *meta;
+	uint16_t wqe_idx;
+	uint32_t seq_opf;
+	bool error;
+	int rc;
+
+	seq_opf = be32toh(cqe->rcqe.seq_op_flags);
+
+	if (!ionic_v1_rcqe_valid(seq_opf))
+		return;
+
+	wqe_idx = be64toh(cqe->rcqe.wqe_idx) & IONIC_V1_CQE_WQE_IDX_MASK;
+
+	if (unlikely(wqe_idx >> qp->rq.queue.depth_log2)) {
+		verbs_err(&ctx->vctx, "invalid wqe_idx %#x", wqe_idx);
+		return;
+	}
+
+	rc = ionic_validate_rcq_wqe_idx(qp->rq.queue.prod,
+					qp->rq.queue.cons,
+					wqe_idx,
+					qp->rq.queue.mask);
+	if (rc) {
+		struct ionic_cq *cq =
+			to_ionic_vcq_cq(qp->vqp.qp.recv_cq, qp->udma_idx);
+
+		verbs_err(&ctx->vctx, "wqe is not posted for rcqe seq %u rcqe idx %u qpid %u prod %u cons %u cqid %u",
+			  ionic_v1_rcqe_seq(seq_opf), wqe_idx,
+			  qp->qpid, qp->rq.queue.prod, qp->rq.queue.cons, cq->cqid);
+		return;
+	}
+
+	meta = &qp->rq.meta[qp->rq.meta_idx[wqe_idx]];
+	error = ionic_v1_cqe_error(cqe);
+
+	meta->rcqe.valid = true;
+	meta->rcqe.error = error;
+	meta->rcqe.ready = ionic_v1_rcqe_ready(seq_opf);
+	meta->rcqe.op = ionic_v1_rcqe_op(seq_opf);
+	meta->rcqe.seq = ionic_v1_rcqe_seq(seq_opf);
+	meta->rcqe.imm_rkey = be32toh(cqe->rcqe.imm_data_rkey);
+	meta->rcqe.sts_len = be32toh(cqe->status_length);
+
+	verbs_debug(&ctx->vctx, "received rcq_seq %u wqe idx %u", meta->rcqe.seq, wqe_idx);
+}
+
+static int ionic_poll_rcq_recv(struct ionic_ctx *ctx,
+			       struct ionic_cq *cq,
+			       struct ionic_qp *qp,
+			       struct ibv_wc *wc)
+{
+	struct ionic_v1_cqe cqe = {};
+	struct ionic_rq_meta *meta;
+	struct ionic_rcq *rcq;
+	uint32_t rcq_seq;
+
+	if (qp->rq.flush)
+		return 0;
+
+	rcq = qp->rq.queue.ptr + qp->rq.queue.size - IONIC_RCQ_SIZE;
+
+	rcq_seq = ionic_rcq_seq(rcq);
+	ionic_rcq_ack(rcq, rcq_seq);
+
+	if (ionic_queue_empty(&qp->rq.queue))
+		return 0;
+
+	meta = &qp->rq.meta[qp->rq.meta_idx[qp->rq.queue.cons]];
+	if (!meta->rcqe.valid)
+		return 0;
+
+	if (!meta->rcqe.ready && ((rcq_seq - meta->rcqe.seq) & BIT(ctx->rcq_sign_bit)))
+		return -EAGAIN;
+
+	verbs_debug(&ctx->vctx, "polled rcq_seq %u rcqe_seq %u sign %lu cons %u",
+		    rcq_seq, meta->rcqe.seq, BIT(ctx->rcq_sign_bit), qp->rq.queue.cons);
+
+	cqe.recv.wqe_idx = htole64(qp->rq.queue.cons);
+	cqe.recv.src_qpn_op = htobe32(meta->rcqe.op << IONIC_V1_CQE_RECV_OP_SHIFT);
+	cqe.recv.imm_data_rkey = htobe32(meta->rcqe.imm_rkey);
+	cqe.status_length = htobe32(meta->rcqe.sts_len);
+
+	return ionic_poll_recv(ctx, cq, qp, &cqe, wc);
+}
+
+static int ionic_poll_rcq_recv_many(struct ionic_ctx *ctx, struct ionic_cq *cq,
+				    struct ionic_qp *qp,
+				    struct ibv_wc *wc, int nwc)
+{
+	int rc = 0, npolled = 0;
+
+	while (npolled < nwc) {
+		rc = ionic_poll_rcq_recv(ctx, cq, qp, wc + npolled);
+		if (rc <= 0)
+			break;
+
+		npolled += rc;
+	}
+
+	return npolled ?: rc;
+}
+
 static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 			     int nwc, struct ibv_wc *wc)
 {
@@ -1331,6 +1443,8 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 			break;
 
 		case IONIC_V1_CQE_TYPE_RECV_RCQE:
+			ionic_comp_rcqe(ctx, qp, cqe);
+
 			list_del(&qp->cq_poll_rq);
 			list_add_tail(&cq->poll_rq, &qp->cq_poll_rq);
 			break;
@@ -1344,6 +1458,26 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 cq_next:
 		ionic_queue_produce(&cq->q);
 		cq->color = ionic_color_wrap(cq->q.prod, cq->color);
+	}
+
+	/* poll out-of-order rcq completions for recv queue */
+	list_for_each_safe(&cq->poll_rq, qp, qp_next, cq_poll_rq) {
+		if (npolled == nwc)
+			goto out;
+
+		ionic_rq_spin_lock(qp);
+		rc = ionic_poll_rcq_recv_many(ctx, cq, qp,
+					      wc + npolled, nwc - npolled);
+		ionic_rq_spin_unlock(qp);
+
+		if (rc == 0)
+			list_del_init(&qp->cq_poll_rq);
+		else if (rc == -EAGAIN)
+			rc = 0;
+		else if (rc < 0)
+			goto out;
+
+		npolled += rc;
 	}
 
 	/* lastly, flush send and recv queues */
@@ -2749,6 +2883,7 @@ static int ionic_v1_prep_recv(struct ionic_qp *qp,
 
 	wqe->base.wqe_idx = htole64(qp->rq.queue.prod);
 	wqe->base.num_sge_key = wr->num_sge;
+	memset(&meta->rcqe, 0, sizeof(meta->rcqe));
 
 	qp->rq.meta_idx[qp->rq.queue.prod] = meta - qp->rq.meta;
 

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1677,8 +1677,8 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 {
 	struct ionic_ctx *ctx = to_ionic_ctx(ibctx);
 	struct ionic_pd *pd = to_ionic_pd(ex->pd);
-	struct uionic_qp_resp resp;
-	struct uionic_qp req;
+	struct uionic_qp_resp resp = {};
+	struct uionic_qp req = {};
 	struct ionic_qp *qp;
 	struct ionic_cq *cq;
 	int rc;
@@ -2869,7 +2869,7 @@ static struct ibv_ah *ionic_create_ah(struct ibv_pd *ibpd,
 				      struct ibv_ah_attr *attr)
 {
 	struct ibv_pd *root_ibpd = to_ionic_root_ibpd(ibpd);
-	struct uionic_ah_resp resp;
+	struct uionic_ah_resp resp = {};
 	struct ionic_ah *ah;
 	int rc;
 

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1516,7 +1516,7 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 
 			break;
 
-		case IONIC_V1_CQE_TYPE_RECV_INDIR:
+		case IONIC_V1_CQE_TYPE_RECV_RCQE:
 			list_del(&qp->cq_poll_rq);
 			list_add_tail(&cq->poll_rq, &qp->cq_poll_rq);
 			break;
@@ -1798,7 +1798,12 @@ static int ionic_qp_rq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 	if (max_sge > ionic_v1_recv_wqe_max_sge(ctx->max_stride, 0, false))
 		return EINVAL;
 
-	pd_tag = IONIC_PD_TAG_RQ;
+	if (qp->rcq) {
+		pd_tag = IONIC_PD_TAG_RCQ;
+		qp->rq.cmb = 0;
+	} else {
+		pd_tag = IONIC_PD_TAG_RQ;
+	}
 	qp->rq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
 	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
@@ -2135,8 +2140,9 @@ static void ionic_wr_local_inv(struct ibv_qp_ex *ibqp_ex, uint32_t invalidate_rk
 	ionic_wr_set(qp, 0, 0, NULL);
 }
 
-static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
-					 struct ibv_qp_init_attr_ex *ex)
+struct ibv_qp *ionic_create_qp_ex_common(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex,
+					 struct ionic_dv_qp_init_attr_ex *ionic_ex)
 {
 	struct ionic_ctx *ctx = to_ionic_ctx(ibctx);
 	struct ionic_pd *pd = to_ionic_pd(ex->pd);
@@ -2145,6 +2151,33 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 	struct ionic_qp *qp;
 	struct ionic_cq *cq;
 	int rc;
+
+	if (ionic_ex) {
+		if (!check_comp_mask(ionic_ex->comp_mask,
+				     IONIC_DV_QP_SUPPORTED_COMP_MASK)) {
+			rc = ENOTSUP;
+			goto err_qp;
+		}
+
+		if (ionic_ex->comp_mask & IONIC_DV_QP_INIT_ATTR_MASK_FLAGS) {
+			if (!ctx->ionic_flags_supported ||
+			    !check_comp_mask(ionic_ex->ionic_flags,
+					     IONIC_DV_QP_SUPPORTED_EXT_FLAGS)) {
+				rc = ENOTSUP;
+				goto err_qp;
+			}
+
+			if ((ionic_ex->ionic_flags & IONIC_DV_CREATE_QP_RCCL_RCQ) &&
+			     !ctx->rcq_sign_bit) {
+				rc = EINVAL;
+				goto err_qp;
+			}
+
+			rc = IONIC_SET_UDATA(ctx, &req, ionic_flags, ionic_ex->ionic_flags);
+			if (rc)
+				goto err_qp;
+		}
+	}
 
 	if ((ex->comp_mask & IONIC_QP_REQUIRED_COMP_MASK) !=
 	    IONIC_QP_REQUIRED_COMP_MASK) {
@@ -2186,6 +2219,7 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 	qp->has_rq = true;
 	qp->lockfree = ex->pd ? ionic_pd_lockfree(ex->pd) : false;
 	qp->sig_all = ex->sq_sig_all;
+	qp->rcq = ctx->rcq_sign_bit && (req.ionic_flags & IONIC_DV_CREATE_QP_RCCL_RCQ);
 
 	list_node_init(&qp->cq_poll_sq);
 	list_node_init(&qp->cq_poll_rq);
@@ -2326,6 +2360,12 @@ err_sq:
 err_qp:
 	errno = rc;
 	return NULL;
+}
+
+static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
+					 struct ibv_qp_init_attr_ex *ex)
+{
+	return ionic_create_qp_ex_common(ibctx, ex, NULL);
 }
 
 static void ionic_flush_qp(struct ionic_ctx *ctx, struct ionic_qp *qp)

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -2140,8 +2140,8 @@ static struct ibv_qp *ionic_create_qp_ex(struct ibv_context *ibctx,
 {
 	struct ionic_ctx *ctx = to_ionic_ctx(ibctx);
 	struct ionic_pd *pd = to_ionic_pd(ex->pd);
-	struct uionic_qp_resp resp;
-	struct uionic_qp req;
+	struct uionic_qp_resp resp = {};
+	struct uionic_qp req = {};
 	struct ionic_qp *qp;
 	struct ionic_cq *cq;
 	int rc;
@@ -3386,7 +3386,7 @@ static struct ibv_ah *ionic_create_ah(struct ibv_pd *ibpd,
 				      struct ibv_ah_attr *attr)
 {
 	struct ibv_pd *root_ibpd = to_ionic_root_ibpd(ibpd);
-	struct uionic_ah_resp resp;
+	struct uionic_ah_resp resp = {};
 	struct ionic_ah *ah;
 	int rc;
 

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1866,17 +1866,18 @@ static int ionic_qp_sq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 
 	qp->sq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
-	if (qp->sq.cmb & IONIC_CMB_EXPDB) {
-		wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
-						      qp->sq.spec, true);
+	wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
+					      qp->sq.spec, false);
 
-		if (!ionic_expdb_wqe_size_supported(ctx, wqe_size))
+	if (qp->sq.cmb & IONIC_CMB_EXPDB) {
+		uint32_t expdb_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
+								 qp->sq.spec, true);
+
+		if (ionic_expdb_wqe_size_supported(ctx, expdb_size))
+			wqe_size = expdb_size;
+		else
 			qp->sq.cmb &= ~IONIC_CMB_EXPDB;
 	}
-
-	if (!(qp->sq.cmb & IONIC_CMB_EXPDB))
-		wqe_size = ionic_v1_send_wqe_min_size(max_sge, max_data,
-						      qp->sq.spec, false);
 
 	rc = ionic_queue_init(&qp->sq.queue, pd, IONIC_PD_TAG_SQ,
 			      ctx->pg_shift, max_wr, wqe_size);
@@ -1946,15 +1947,16 @@ static int ionic_qp_rq_init(struct ionic_ctx *ctx, struct ionic_qp *qp, struct i
 	}
 	qp->rq.spec = ionic_v1_use_spec_sge(max_sge, ctx->spec);
 
-	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
-		wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, true);
+	wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, false);
 
-		if (!ionic_expdb_wqe_size_supported(ctx, wqe_size))
+	if (qp->rq.cmb & IONIC_CMB_EXPDB) {
+		uint32_t expdb_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, true);
+
+		if (ionic_expdb_wqe_size_supported(ctx, expdb_size))
+			wqe_size = expdb_size;
+		else
 			qp->rq.cmb &= ~IONIC_CMB_EXPDB;
 	}
-
-	if (!(qp->rq.cmb & IONIC_CMB_EXPDB))
-		wqe_size = ionic_v1_recv_wqe_min_size(max_sge, qp->rq.spec, false);
 
 	rc = ionic_queue_init(&qp->rq.queue, pd, pd_tag, ctx->pg_shift, max_wr, wqe_size);
 	if (rc)

--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -1401,6 +1401,124 @@ static void ionic_reserve_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 	}
 }
 
+static int ionic_validate_rcq_wqe_idx(uint16_t prod, uint16_t cons,
+				      uint16_t idx, uint16_t mask)
+{
+	return ((idx - cons) & mask) < ((prod - cons) & mask) ? 0 : -EIO;
+}
+
+static void ionic_comp_rcqe(struct ionic_ctx *ctx,
+			    struct ionic_qp *qp,
+			    struct ionic_v1_cqe *cqe)
+{
+	struct ionic_rq_meta *meta;
+	uint16_t wqe_idx_timestamp;
+	uint32_t wqe_idx;
+	uint32_t seq_opf;
+	bool error;
+	int rc;
+
+	seq_opf = be32toh(cqe->rcqe.seq_op_flags);
+
+	if (!ionic_v1_rcqe_valid(seq_opf))
+		return;
+
+	wqe_idx_timestamp = be64toh(cqe->rcqe.wqe_idx_timestamp);
+	wqe_idx = wqe_idx_timestamp & IONIC_V1_CQE_WQE_IDX_MASK;
+
+	if (unlikely(wqe_idx >> qp->rq.queue.depth_log2)) {
+		verbs_err(&ctx->vctx, "invalid wqe_idx %#x", wqe_idx);
+		return;
+	}
+
+	rc = ionic_validate_rcq_wqe_idx(qp->rq.queue.prod,
+					qp->rq.queue.cons,
+					wqe_idx,
+					qp->rq.queue.mask);
+	if (rc) {
+		struct ionic_cq *cq =
+			to_ionic_vcq_cq(qp->vqp.qp.recv_cq, qp->udma_idx);
+
+		verbs_err(&ctx->vctx, "wqe is not posted for rcqe seq %u rcqe idx %u qpid %u prod %u cons %u cqid %u",
+			  ionic_v1_rcqe_seq(seq_opf), wqe_idx,
+			  qp->qpid, qp->rq.queue.prod, qp->rq.queue.cons, cq->cqid);
+		return;
+	}
+
+	meta = &qp->rq.meta[qp->rq.meta_idx[wqe_idx]];
+	error = ionic_v1_cqe_error(cqe);
+
+	meta->rcqe.valid = true;
+	meta->rcqe.error = error;
+	meta->rcqe.ready = ionic_v1_rcqe_ready(seq_opf);
+	meta->rcqe.op = ionic_v1_rcqe_op(seq_opf);
+	meta->rcqe.seq = ionic_v1_rcqe_seq(seq_opf);
+	meta->rcqe.imm_rkey = be32toh(cqe->rcqe.imm_data_rkey);
+	meta->rcqe.sts_len = be32toh(cqe->status_length);
+	meta->rcqe.timestamp = wqe_idx_timestamp >> IONIC_V1_CQE_TIMESTAMP_SHIFT;
+
+	verbs_debug(&ctx->vctx, "received rcq_seq %u wqe idx %u", meta->rcqe.seq, wqe_idx);
+}
+
+static int ionic_poll_rcq_recv(struct ionic_ctx *ctx,
+			       struct ionic_cq *cq,
+			       struct ionic_qp *qp,
+			       struct ibv_wc *wc)
+{
+	struct ionic_v1_cqe cqe = {};
+	struct ionic_rq_meta *meta;
+	uint64_t wqe_idx_timestamp;
+	struct ionic_rcq *rcq;
+	uint32_t rcq_seq;
+
+	if (qp->rq.flush)
+		return 0;
+
+	rcq = qp->rq.queue.ptr + qp->rq.queue.size - IONIC_RCQ_SIZE;
+
+	rcq_seq = ionic_rcq_seq(rcq);
+	ionic_rcq_ack(rcq, rcq_seq);
+
+	if (ionic_queue_empty(&qp->rq.queue))
+		return 0;
+
+	meta = &qp->rq.meta[qp->rq.meta_idx[qp->rq.queue.cons]];
+	if (!meta->rcqe.valid)
+		return 0;
+
+	if (!meta->rcqe.ready && ((rcq_seq - meta->rcqe.seq) & BIT(ctx->rcq_sign_bit)))
+		return -EAGAIN;
+
+	verbs_debug(&ctx->vctx, "polled rcq_seq %u rcqe_seq %u sign %lu cons %u",
+		    rcq_seq, meta->rcqe.seq, BIT(ctx->rcq_sign_bit), qp->rq.queue.cons);
+
+	wqe_idx_timestamp = qp->rq.queue.cons |
+		(meta->rcqe.timestamp << IONIC_V1_CQE_TIMESTAMP_SHIFT);
+	cqe.recv.wqe_idx_timestamp = htole64(wqe_idx_timestamp);
+	cqe.recv.src_qpn_op = htobe32(meta->rcqe.op << IONIC_V1_CQE_RECV_OP_SHIFT);
+	cqe.recv.imm_data_rkey = htobe32(meta->rcqe.imm_rkey);
+	cqe.status_length = htobe32(meta->rcqe.sts_len);
+
+	return ionic_poll_recv(ctx, cq, qp, &cqe, wc);
+}
+
+static int ionic_poll_rcq_recv_many(struct ionic_ctx *ctx, struct ionic_cq *cq,
+				    struct ionic_qp *qp,
+				    struct ibv_wc *wc, int nwc)
+{
+	int rc = 0, npolled = 0;
+
+	while (npolled < nwc) {
+		rc = ionic_poll_rcq_recv(ctx, cq, qp, wc + npolled);
+		if (rc <= 0)
+			break;
+
+		npolled += rc;
+	}
+
+	return npolled ?: rc;
+}
+
 static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 			     int nwc, struct ibv_wc *wc)
 {
@@ -1517,6 +1635,8 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 			break;
 
 		case IONIC_V1_CQE_TYPE_RECV_RCQE:
+			ionic_comp_rcqe(ctx, qp, cqe);
+
 			list_del(&qp->cq_poll_rq);
 			list_add_tail(&cq->poll_rq, &qp->cq_poll_rq);
 			break;
@@ -1530,6 +1650,26 @@ static int ionic_poll_vcq_cq(struct ionic_ctx *ctx, struct ionic_cq *cq,
 cq_next:
 		ionic_queue_produce(&cq->q);
 		cq->color = ionic_color_wrap(cq->q.prod, cq->color);
+	}
+
+	/* poll out-of-order rcq completions for recv queue */
+	list_for_each_safe(&cq->poll_rq, qp, qp_next, cq_poll_rq) {
+		if (npolled == nwc)
+			goto out;
+
+		ionic_rq_spin_lock(qp);
+		rc = ionic_poll_rcq_recv_many(ctx, cq, qp,
+					      wc + npolled, nwc - npolled);
+		ionic_rq_spin_unlock(qp);
+
+		if (rc == 0)
+			list_del_init(&qp->cq_poll_rq);
+		else if (rc == -EAGAIN)
+			rc = 0;
+		else if (rc < 0)
+			goto out;
+
+		npolled += rc;
 	}
 
 	/* lastly, flush send and recv queues */
@@ -3269,6 +3409,7 @@ static int ionic_v1_prep_recv(struct ionic_qp *qp,
 
 	wqe->base.wqe_idx = htole64(qp->rq.queue.prod);
 	wqe->base.num_sge_key = wr->num_sge;
+	memset(&meta->rcqe, 0, sizeof(meta->rcqe));
 
 	qp->rq.meta_idx[qp->rq.queue.prod] = meta - qp->rq.meta;
 

--- a/providers/ionic/libionic.map
+++ b/providers/ionic/libionic.map
@@ -10,3 +10,8 @@ IONIC_1.0 {
 		ionic_dv_pd_set_rqcmb;
 	local: *;
 };
+
+IONIC_1.1 {
+	global:
+		ionic_dv_create_qp_ex;
+} IONIC_1.0;

--- a/providers/ionic/man/CMakeLists.txt
+++ b/providers/ionic/man/CMakeLists.txt
@@ -1,5 +1,6 @@
 rdma_man_pages(
   ionicdv.7.md
+  ionic_dv_create_qp_ex.3.md
   ionic_dv_ctx_get_udma_count.3.md
   ionic_dv_ctx_get_udma_mask.3.md
   ionic_dv_pd_get_udma_mask.3.md

--- a/providers/ionic/man/ionic_dv_create_qp_ex.3.md
+++ b/providers/ionic/man/ionic_dv_create_qp_ex.3.md
@@ -1,0 +1,138 @@
+---
+layout: page
+title: IONIC_DV_CREATE_QP_EX
+section: 3
+tagline: Verbs
+date: 2025-06-23
+header: "Ionic Programmer's Manual"
+footer: ionic
+---
+
+# NAME
+
+ionic_dv_create_qp_ex - Create a queue pair with ionic-specific attributes
+
+# SYNOPSIS
+
+```c
+#include <infiniband/ionic_dv.h>
+
+struct ibv_qp *ionic_dv_create_qp_ex(struct ibv_context *ibctx,
+                                     struct ibv_qp_init_attr_ex *ex,
+                                     struct ionic_dv_qp_init_attr_ex *ionic_ex);
+```
+
+# DESCRIPTION
+
+**ionic_dv_create_qp_ex()** creates a queue pair (QP) with ionic-specific
+driver properties. It extends the standard **ibv_create_qp_ex**(3) interface
+with ionic-specific attributes for configuring RCCL (RC Collective)
+operations and Reorder Completion Queue (RCQ) behavior.
+
+The caller specifies **IBV_QPT_RC** as the QP type in the standard *ex*
+attributes. The returned QP always has *qp_type* == **IBV_QPT_RC**.
+
+# ARGUMENTS
+
+Please see *ibv_create_qp_ex(3)* man page for *ibctx* and *ex*.
+
+## ionic_ex
+
+```c
+enum ionic_dv_qp_init_attr_mask {
+	IONIC_DV_QP_INIT_ATTR_MASK_FLAGS = (1 << 0),
+};
+
+enum ionic_dv_qp_init_attr_flags {
+	IONIC_DV_CREATE_QP_TYPE_RCCL       = 1 << 16,
+	IONIC_DV_CREATE_QP_RCCL_DATA       = 1 << 17,
+	IONIC_DV_CREATE_QP_RCCL_RDFENCE    = 1 << 18,
+	IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD = 1 << 19,
+	IONIC_DV_CREATE_QP_RCCL_RCQ        = 1 << 24,
+};
+
+struct ionic_dv_qp_init_attr_ex {
+	uint64_t comp_mask;
+	uint32_t ionic_flags;
+};
+```
+
+*comp_mask*
+:	Bitmask specifying what fields in the structure are valid.
+	Composed of **ionic_dv_qp_init_attr_mask** values:
+
+	**IONIC_DV_QP_INIT_ATTR_MASK_FLAGS**:
+		Valid values in *ionic_flags*.
+
+*ionic_flags*
+:	A bitwise OR of the various values described below. Valid when
+	*comp_mask* includes **IONIC_DV_QP_INIT_ATTR_MASK_FLAGS**.
+
+	**IONIC_DV_CREATE_QP_TYPE_RCCL**:
+		Create an RCCL (RC Collective) QP type.
+
+	**IONIC_DV_CREATE_QP_RCCL_DATA**:
+		Enable RCCL data operations on this QP.
+
+	**IONIC_DV_CREATE_QP_RCCL_RDFENCE**:
+		Enable RCCL read fence operations on this QP.
+
+	**IONIC_DV_CREATE_QP_RCCL_RX_OFFLOAD**:
+		Enable RCCL receive offload operations on this QP.
+
+	**IONIC_DV_CREATE_QP_RCCL_RCQ**:
+		Enable Reorder Completion Queue (RCQ) for this QP. When
+		enabled, out-of-order receive completions are reordered
+		so that completions are delivered to the application in
+		order.
+
+# RETURN VALUE
+
+**ionic_dv_create_qp_ex()** returns a pointer to the created QP, or NULL
+if the request fails (in which case *errno* is set to indicate the error).
+
+# NOTES
+
+The *ex->qp_type* field must be **IBV_QPT_RC**. The returned QP always
+exposes *qp_type* == **IBV_QPT_RC** to the application.
+
+Compatibility is handled through the *comp_mask* field. Applications
+should only set bits for fields they intend to use. Unknown bits in
+*comp_mask* are reserved for future extensions.
+
+# EXAMPLES
+
+```c
+struct ibv_qp_init_attr_ex qp_attr = {
+	.send_cq = cq,
+	.recv_cq = cq,
+	.cap = {
+		.max_send_wr = 64,
+		.max_recv_wr = 64,
+		.max_send_sge = 4,
+		.max_recv_sge = 4,
+	},
+	.qp_type = IBV_QPT_RC,
+	.comp_mask = IBV_QP_INIT_ATTR_PD,
+	.pd = pd,
+};
+
+struct ionic_dv_qp_init_attr_ex ionic_attr = {
+	.comp_mask = IONIC_DV_QP_INIT_ATTR_MASK_FLAGS,
+	.ionic_flags = IONIC_DV_CREATE_QP_RCCL_RCQ,
+};
+
+struct ibv_qp *qp = ionic_dv_create_qp_ex(ctx, &qp_attr, &ionic_attr);
+```
+
+# SEE ALSO
+
+**ionicdv**(7),
+**ibv_create_qp_ex**(3),
+**ionic_dv_pd_set_udma_mask**(3),
+**ionic_dv_pd_set_sqcmb**(3),
+**ionic_dv_pd_set_rqcmb**(3)
+
+# AUTHORS
+
+Advanced Micro Devices, Inc.

--- a/providers/ionic/man/ionicdv.7.md
+++ b/providers/ionic/man/ionicdv.7.md
@@ -45,8 +45,19 @@ may also be enabled. Use **ionic_dv_pd_set_sqcmb**(3) and
 **ionic_dv_pd_set_rqcmb**(3) to configure CMB preferences on a protection
 domain before creating queues.
 
+## RCCL and RCQ
+
+Ionic devices support passing RCCL (RC Collective) flags and Reorder
+Completion Queue (RCQ) selection from userspace to firmware at QP creation
+time. RCCL flags control data, read fence, and receive offload capabilities
+on RC queue pairs. RCQ reorders out-of-order receive completions so that
+they are delivered to the application in order. Use
+**ionic_dv_create_qp_ex**(3) to create a QP with these ionic-specific
+attributes.
+
 # SEE ALSO
 
+**ionic_dv_create_qp_ex**(3),
 **ionic_dv_ctx_get_udma_count**(3),
 **ionic_dv_ctx_get_udma_mask**(3),
 **ionic_dv_pd_get_udma_mask**(3),


### PR DESCRIPTION
Add RCQ support to the ionic provider for out-of-order receive completion handling.
Patch 1: Update kernel headers for RCQ fields.
Patch 2: Fetch RCQ capabilities on context create.
Patch 3: Add ionic_dv_create_qp_ex DV API.
Patch 4: Process RECV_RCQE completions from poll_cq, delivering them in order.