### PR TITLE
bnxt_re/lib: Initialize the request structures in bnxt_re ABI

### DIFF
--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -331,7 +331,7 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 				 struct ibv_comp_channel *channel, int vec)
 {
 	struct bnxt_re_cq *cq;
-	struct ubnxt_re_cq cmd;
+	struct ubnxt_re_cq cmd = {};
 	struct ubnxt_re_cq_resp resp;
 	struct bnxt_re_mmap_info minfo = {};
 	int ret;
@@ -2053,7 +2053,7 @@ static struct ibv_qp *__bnxt_re_create_qp(struct ibv_context *ibvctx,
 	struct ubnxt_re_qp_resp resp = {};
 	struct bnxt_re_qattr qattr[2];
 	struct bnxt_re_qpcap *cap;
-	struct ubnxt_re_qp req;
+	struct ubnxt_re_qp req = {};
 	struct bnxt_re_qp *qp;
 	void *mem;
 

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -2786,7 +2786,7 @@ struct ibv_srq *bnxt_re_create_srq(struct ibv_pd *ibvpd,
 	struct bnxt_re_mmap_info minfo = {};
 	struct ubnxt_re_srq_resp resp = {};
 	struct bnxt_re_qattr qattr = {};
-	struct ubnxt_re_srq req;
+	struct ubnxt_re_srq req = {};
 	struct bnxt_re_srq *srq;
 	void *mem;
 	int ret;


### PR DESCRIPTION
Adding the missing request structure initialization in create_qp/cq/srq so that newer kernel which has stricter comp mask checking will identify the correct capabilities and allow resource creation. 