### PR TITLE
Optimize IP version detection during address handle creation

### DIFF
--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -1009,7 +1009,10 @@ int ibv_init_ah_from_wc(struct ibv_context *context, uint8_t port_num,
 
 	if (wc->wc_flags & IBV_WC_GRH) {
 		ah_attr->is_global = 1;
-		version = get_grh_header_version(grh);
+		if (wc->wc_flags & IBV_WC_WITH_NETWORK_HDR_TYPE)
+			version = (wc->wc_flags & IBV_WC_NETWORK_HDR_IPV6) ? 6 : 4;
+		else
+			version = get_grh_header_version(grh);
 
 		if (version == 4)
 			ret = set_ah_attr_by_ipv4(context, ah_attr,

--- a/libibverbs/verbs.h
+++ b/libibverbs/verbs.h
@@ -587,6 +587,8 @@ enum ibv_wc_flags {
 	IBV_WC_TM_SYNC_REQ	= 1 << 4,
 	IBV_WC_TM_MATCH		= 1 << 5,
 	IBV_WC_TM_DATA_VALID	= 1 << 6,
+	IBV_WC_WITH_NETWORK_HDR_TYPE = 1 << 7,
+	IBV_WC_NETWORK_HDR_IPV6 = 1 << 8,
 };
 
 struct ibv_wc {

--- a/providers/irdma/uverbs.c
+++ b/providers/irdma/uverbs.c
@@ -923,7 +923,9 @@ static void irdma_process_cqe(struct ibv_wc *entry, struct irdma_cq_poll_info *c
 
 	if (ib_qp->qp_type == IBV_QPT_UD) {
 		entry->src_qp = cur_cqe->ud_src_qpn;
-		entry->wc_flags |= IBV_WC_GRH;
+		entry->wc_flags |= (IBV_WC_GRH | IBV_WC_WITH_NETWORK_HDR_TYPE);
+		if (!cur_cqe->ipv4)
+			entry->wc_flags |= IBV_WC_NETWORK_HDR_IPV6;
 	} else {
 		entry->src_qp = cur_cqe->qp_id;
 	}


### PR DESCRIPTION
### Overview
Currently in user space, `ibv_init_ah_from_wc()` relies on parsing the Global Routing Header (GRH) payload to determine whether an incoming Unreliable Datagram (UD) packet is IPv4 or IPv6. This mechanism relies on `get_grh_header_version()`, which introduces two major issues:

1. **Correctness:** Since some hardware zeroes out the IPv4 header checksum in the receive buffer, the software recalculated checksum fails the comparison against the buffer's zeroed field. This causes valid IPv4 packets to be indeterministically misclassified as IPv6.
2. **Performance:** It involves an extra 20-byte stack `memcpy` and a checksum calculation (`ipv4_calc_hdr_csum()`) on the fast path.

Many modern hardware providers already parse the IP version directly in the hardware Completion Queue Entry (CQE). This PR introduces a mechanism to pass this hardware-extracted network header type up to the core library, bypassing the software fallback.

### Changes Introduced

* **`libibverbs`:**
  * Introduces `IBV_WC_WITH_NETWORK_HDR_TYPE` and `IBV_WC_NETWORK_HDR_IPV6` flags to `enum ibv_wc_flags`.
  * Updates `ibv_init_ah_from_wc()` to evaluate this bitmask first, immediately determining the IP version without touching payload memory or executing the software checksum fallback.

* **`irdma` (Provider):**
  * Implements the new flags in `irdma_process_cqe()` for UD queue pairs.
  * Translates the natively hardware-reported `cur_cqe->ipv4` state directly into the generic `wc_flags` bitmask, ensuring accurate IP version reporting regardless of buffer checksum state.

### Impact
* **Correctness:** Fixes a bug where hardware-zeroed checksums cause IPv4 packets to be misclassified as IPv6. Non-supporting providers safely fall back to the existing GRH parsing logic.
* **Performance:** Accelerates address handle creation for incoming UD packets on supporting hardware by eliminating redundant checksum calculation.