### PR TITLE
libhns: Fix UD 0 msg length err using new post send

### DIFF
--- a/providers/hns/hns_roce_u_hw_v2.c
+++ b/providers/hns/hns_roce_u_hw_v2.c
@@ -2517,9 +2517,12 @@ static void wr_set_sge_ud(struct ibv_qp_ex *ibv_qp, uint32_t lkey,
 		return;
 
 	wqe->msg_len = htole32(length);
-	hr_reg_write(wqe, UDWQE_SGE_NUM, 1);
+	hr_reg_write(wqe, UDWQE_SGE_NUM, !!length);
 	sge_idx = qp->sge_info.start_idx & (qp->ex_sge.sge_cnt - 1);
 	hr_reg_write(wqe, UDWQE_MSG_START_SGE_IDX, sge_idx);
+
+	if (!length)
+		goto out;
 
 	dseg = get_send_sge_ex(qp, sge_idx);
 
@@ -2529,6 +2532,7 @@ static void wr_set_sge_ud(struct ibv_qp_ex *ibv_qp, uint32_t lkey,
 
 	qp->sge_info.start_idx++;
 
+out:
 	rdma_tracepoint(rdma_core_hns, post_send,
 			ibv_qp->qp_base.context->device->name, ibv_qp->wr_id,
 			1, ibv_qp->qp_base.qp_num,


### PR DESCRIPTION
When msg length is 0, the sge num should also be 0, otherwise there will be a cqe error.

Fixes: 36446a56eea5 ("libhns: Extended QP supports the new post send mechanism")