### PR TITLE
providers/efa: Fix build failure when LTTNG is enabled

### DIFF
--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -2923,7 +2923,7 @@ static void efa_send_wr_set_addr(struct ibv_qp_ex *ibvqpx,
 	rdma_tracepoint(rdma_core_efa, post_send, qp->dev->name, ibvqpx->wr_id,
 			EFA_GET(&md->ctrl1, EFA_IO_TX_META_DESC_OP_TYPE),
 			ibvqpx->qp_base.qp_num, remote_qpn, ah->efa_ah,
-			efa_wqe_get_data_length(qp->sq));
+			efa_wqe_get_data_length(&qp->sq));
 }
 
 static void efa_send_wr_set_processing_hints(struct efadv_qp *efadv_qp, uint32_t hints)


### PR DESCRIPTION
When LTTNG tracing is enabled, compiling providers/efa/verbs.c fails with an incompatible type error. The post_send rdma_tracepoint macro attempts to pass qp->sq by value to efa_wqe_get_data_length(), which strictly expects a pointer (struct efa_sq *).

Fix the error by passing the address of the struct instead.

Fixes: 2166b90e284d ("efa: Add support for 128-byte WQE") (@YonatanNachum)