### PR TITLE
util: Fix duplicate node name map entries

### DIFF
--- a/util/node_name_map.c
+++ b/util/node_name_map.c
@@ -64,6 +64,7 @@ static int map_name(void *cxt, uint64_t guid, char *p)
 {
 	cl_qmap_t *map = cxt;
 	name_map_item_t *item;
+	cl_map_item_t *inserted;
 
 	p = strtok(p, "\"#");
 	if (!p)
@@ -74,7 +75,16 @@ static int map_name(void *cxt, uint64_t guid, char *p)
 		return -1;
 	item->guid = guid;
 	item->name = strdup(p);
-	cl_qmap_insert(map, item->guid, (cl_map_item_t *) item);
+	if (!item->name) {
+		free(item);
+		return -1;
+	}
+
+	inserted = cl_qmap_insert(map, item->guid, (cl_map_item_t *)item);
+	if (inserted != (cl_map_item_t *)item) {
+		free(item->name);
+		free(item);
+	}
 	return 0;
 }
 


### PR DESCRIPTION
cl_qmap_insert() returns the existing item when a GUID is already present. 
Free the newly allocated node-name-map entry in that case and handle strdup() failure before insertion.

Add a small test for duplicate GUID handling.