### PR TITLE
providers/rxe: Fix missing length accumulation in wr_set_inline_data_list

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -1102,6 +1102,7 @@ static void wr_set_inline_data_list(struct ibv_qp_ex *ibqp, size_t num_buf,
 
 		memcpy(data, buf_list->addr, length);
 
+		tot_length += length;
 		buf_list++;
 		data += length;
 	}


### PR DESCRIPTION
`wr_set_inline_data_list()` copies each inline buffer into the WQE's
`inline_data` area while advancing the destination pointer, but it never
accumulated the running total into `tot_length`. As a result the bound
check `tot_length + length > qp->sq.max_inline` degenerated into a
per-buffer `length > max_inline` check and the cumulative size was never
verified.

When several buffers are passed whose individual lengths are each within
`max_inline` but whose sum exceeds it, the loop keeps `memcpy()`ing past
the end of `wqe->dma.inline_data`, corrupting adjacent work queue entries
in the shared send queue mapping. In addition `wqe->dma.length` and
`resid` were always left at 0, so a correctly-sized scatter list would
transmit zero bytes.

Accumulate `tot_length` inside the loop so the overflow check works and
the WQE length/resid are set correctly, matching the single-buffer
`wr_set_inline_data()` and the `validate_send_wr()` path used by
post_send.

Fixes: 1a894ca10105 ("Providers/rxe: Implement ibv_create_qp_ex verb")