### PR TITLE
providers/rxe: Avoid 32-bit overflow when validating inline send length

### DIFF
--- a/providers/rxe/rxe.c
+++ b/providers/rxe/rxe.c
@@ -1454,7 +1454,7 @@ static int rxe_destroy_qp(struct ibv_qp *ibqp)
 
 /* basic sanity checks for send work request */
 static int validate_send_wr(struct rxe_qp *qp, struct ibv_send_wr *ibwr,
-			    unsigned int length)
+			    uint64_t length)
 {
 	struct rxe_wq *sq = &qp->sq;
 	enum ibv_wr_opcode opcode = ibwr->opcode;
@@ -1593,7 +1593,7 @@ static int post_one_send(struct rxe_qp *qp, struct rxe_wq *sq,
 {
 	int err;
 	struct rxe_send_wqe *wqe;
-	unsigned int length = 0;
+	uint64_t length = 0;
 	int i;
 
 	for (i = 0; i < ibwr->num_sge; i++)


### PR DESCRIPTION
`post_one_send()` accumulates the total length of all SGEs of a send work
request into an `unsigned int` before passing it to `validate_send_wr()`,
which rejects inline work requests whose length exceeds `sq->max_inline`.

Because each `ibv_sge.length` is a 32-bit value and the number of SGEs is
only bounded by `sq->max_sge`, the sum can wrap around 2^32. A caller
posting an `IBV_SEND_INLINE` work request with several SGEs whose real
total exceeds 4 GiB but whose truncated 32-bit sum is `<= max_inline`
passes the check. `init_send_wqe()` then copies each SGE into
`wqe->dma.inline_data` using its real length, writing past the inline
area of the WQE in the mapped send queue and corrupting adjacent WQEs.

Accumulate the length in a 64-bit variable and validate the untruncated
value. Once `validate_send_wr()` accepts an inline request its length is
`<= max_inline`, so the subsequent narrowing to the 32-bit `dma.length`
field is safe.

Fixes: 311e6f0b4 ("Initial version librxe-1.0.0")