### PR TITLE
libibverbs: Avoid NULL return from ibv_wr_opcode_str() for unused opcodes

### DIFF
--- a/libibverbs/enum_strs.c
+++ b/libibverbs/enum_strs.c
@@ -153,7 +153,8 @@ const char *ibv_wr_opcode_str(enum ibv_wr_opcode opcode)
 		[IBV_WR_ATOMIC_WRITE]		= "atomic-write"
 	};
 
-	if (opcode < IBV_WR_RDMA_WRITE || opcode > IBV_WR_ATOMIC_WRITE)
+	if (opcode < IBV_WR_RDMA_WRITE || opcode > IBV_WR_ATOMIC_WRITE ||
+	    !wr_opcode_str[opcode])
 		return "unknown";
 
 	return wr_opcode_str[opcode];


### PR DESCRIPTION
The `ibv_wr_opcode` enum is not contiguous: `IBV_WR_DRIVER1` is 11 while `IBV_WR_FLUSH` and `IBV_WR_ATOMIC_WRITE` were later assigned 14 and 15, leaving 12 and 13 unused. The `wr_opcode_str[]` table is built with designated initializers, so those two slots are implicitly NULL.

The bounds check only rejects opcodes outside `[IBV_WR_RDMA_WRITE, IBV_WR_ATOMIC_WRITE]`, so `ibv_wr_opcode_str(12)` or `(13)` passes the check and returns a NULL pointer instead of the expected `"unknown"` string. A caller passing the result to `printf("%s", ...)` may then crash.

This patch also rejects opcodes whose table entry is NULL so that gaps in the enum map to `"unknown"` like any other unrecognized value.

Fixes: 26d999bda ("libibverbs: Introduce ibv_wr_opcode_str")