### PR TITLE
infiniband-diags: add --pkey-idx option for SA/GMP MADs

### DIFF
--- a/infiniband-diags/ibdiag_common.c
+++ b/infiniband-diags/ibdiag_common.c
@@ -52,6 +52,7 @@
 #include <config.h>
 #include <getopt.h>
 #include <limits.h>
+#include <stdint.h>
 #include <sys/stat.h>
 #include <stdarg.h>
 
@@ -74,6 +75,7 @@ uint64_t ibd_mkey;
 uint64_t ibd_sakey = 0;
 int show_keys = 0;
 char *ibd_nd_format = NULL;
+int ibd_pkey_idx;
 
 static const char *prog_name;
 static const char *prog_args;
@@ -287,6 +289,16 @@ static int process_opt(int ch)
 			}
                 }
                 break;
+	case 'Y':
+		errno = 0;
+		val = strtol(optarg, &endp, 0);
+		if (errno || endp == optarg || *endp != '\0' || val < 0 ||
+		    val > UINT16_MAX)
+			IBEXIT("Invalid P_Key index \"%s\".  Requires an integer"
+				" in the range [0, %u].", optarg,
+				(unsigned int)UINT16_MAX);
+		ibd_pkey_idx = (int)val;
+		break;
 	default:
 		return -1;
 	}
@@ -305,6 +317,8 @@ static const struct ibdiag_opt common_opts[] = {
 	{"sm_port", 's', 1, "<lid>", "SM port lid"},
 	{"show_keys", 'K', 0, NULL, "display security keys in output"},
 	{"m_key", 'y', 1, "<key>", "M_Key to use in request"},
+	{"pkey-idx", 'Y', 1, "<idx>",
+	 "P_Key table index for outgoing SA/GMP MADs (default 0)"},
 	{"errors", 'e', 0, NULL, "show send and receive errors"},
 	{"verbose", 'v', 0, NULL, "increase verbosity level"},
 	{"debug", 'd', 0, NULL, "raise debug level"},
@@ -408,6 +422,15 @@ int ibdiag_process_opts(int argc, char *const argv[], void *cxt,
 		} else if (process_opt(ch))
 			ibdiag_show_usage();
 	}
+
+	/*
+	 * Apply the P_Key index to an SM port id resolved during parsing, so
+	 * the result does not depend on whether --pkey-idx was given before or
+	 * after --sm_port.  Other destinations are resolved after this returns
+	 * and pick up ibd_pkey_idx through resolve_portid_str().
+	 */
+	if (ibd_sm_id)
+		ibd_sm_id->pkey_idx = ibd_pkey_idx;
 
 	return 0;
 }
@@ -589,6 +612,7 @@ int resolve_sm_portid(char *ca_name, uint8_t portnum, ib_portid_t *sm_id)
 	memset(sm_id, 0, sizeof(*sm_id));
 	sm_id->lid = port.sm_lid;
 	sm_id->sl = port.sm_sl;
+	sm_id->pkey_idx = ibd_pkey_idx;
 
 	umad_release_port(&port);
 
@@ -616,6 +640,7 @@ int resolve_self(char *ca_name, uint8_t ca_port, ib_portid_t *portid,
 		memset(portid, 0, sizeof(*portid));
 		portid->lid = port.base_lid;
 		portid->sl = port.sm_sl;
+		portid->pkey_idx = ibd_pkey_idx;
 	}
 	if (portnum)
 		*portnum = port.portnum;
@@ -700,6 +725,7 @@ int resolve_portid_str(char *ca_name, uint8_t ca_port, ib_portid_t * portid,
 	int selfport = 0;
 
 	memset(portid, 0, sizeof *portid);
+	portid->pkey_idx = ibd_pkey_idx;
 
 	switch (dest_type) {
 	case IB_DEST_LID:

--- a/infiniband-diags/ibdiag_common.h
+++ b/infiniband-diags/ibdiag_common.h
@@ -58,6 +58,7 @@ extern uint64_t ibd_mkey;
 extern uint64_t ibd_sakey;
 extern int show_keys;
 extern char *ibd_nd_format;
+extern int ibd_pkey_idx;
 
 /*========================================================*/
 /*                External interface                      */

--- a/infiniband-diags/ibqueryerrors.c
+++ b/infiniband-diags/ibqueryerrors.c
@@ -774,7 +774,7 @@ static void print_node(ibnd_node_t *node, void *user_data)
 	int startport = 1;
 	int type = 0;
 	int all_port_sup = 0;
-	ib_portid_t portid = { 0 };
+	ib_portid_t portid = { .pkey_idx = ibd_pkey_idx };
 	__be16 cap_mask = 0;
 	uint32_t cap_mask2 = 0;
 	char *node_name = NULL;
@@ -969,7 +969,7 @@ int main(int argc, char **argv)
 {
 	struct ibnd_config config = { 0 };
 	int resolved = -1;
-	ib_portid_t portid = { 0 };
+	ib_portid_t portid = { .pkey_idx = ibd_pkey_idx };
 	ib_portid_t self_portid = { 0 };
 	int rc = 0;
 	ibnd_fabric_t *fabric = NULL;

--- a/infiniband-diags/ibsysstat.c
+++ b/infiniband-diags/ibsysstat.c
@@ -78,6 +78,12 @@ static int server_respond(void *umad, int size)
 	rport.qp = ntohl(mad_addr->qpn);
 	rport.qkey = ntohl(mad_addr->qkey);
 	rport.sl = mad_addr->sl;
+	/*
+	 * The received pkey_index is resolved against our local P_Key table,
+	 * so echoing it sends the reply on the same partition the request
+	 * arrived on.
+	 */
+	rport.pkey_idx = umad_get_pkey(umad);
 	if (!rport.qkey && rport.qp == 1)
 		rport.qkey = IB_DEFAULT_QP1_QKEY;
 

--- a/infiniband-diags/man/CMakeLists.txt
+++ b/infiniband-diags/man/CMakeLists.txt
@@ -32,6 +32,7 @@ rdma_rst_common(
   opt_o-outstanding_smps.rst
   opt_ports-file.rst
   opt_P.rst
+  opt_pkey_idx.rst
   opt_s.rst
   opt_t.rst
   opt_verbose.rst

--- a/infiniband-diags/man/common/opt_pkey_idx.rst
+++ b/infiniband-diags/man/common/opt_pkey_idx.rst
@@ -1,0 +1,5 @@
+.. Define the common option -Y
+
+**-Y, --pkey-idx <idx>**
+  P_Key table index (0-65535, default 0) used for the outgoing SA/GMP MADs.
+  SMP (SMI directed-route/LID-routed) MADs always use P_Key index 0.

--- a/infiniband-diags/man/dump_fts.8.in.rst
+++ b/infiniband-diags/man/dump_fts.8.in.rst
@@ -46,6 +46,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Debugging flags

--- a/infiniband-diags/man/ibaddr.8.in.rst
+++ b/infiniband-diags/man/ibaddr.8.in.rst
@@ -62,6 +62,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/ibccconfig.8.in.rst
+++ b/infiniband-diags/man/ibccconfig.8.in.rst
@@ -62,6 +62,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/ibccquery.8.in.rst
+++ b/infiniband-diags/man/ibccquery.8.in.rst
@@ -61,6 +61,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/iblinkinfo.8.in.rst
+++ b/infiniband-diags/man/iblinkinfo.8.in.rst
@@ -99,6 +99,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/ibnetdiscover.8.in.rst
+++ b/infiniband-diags/man/ibnetdiscover.8.in.rst
@@ -77,6 +77,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/ibping.8.in.rst
+++ b/infiniband-diags/man/ibping.8.in.rst
@@ -54,6 +54,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/ibportstate.8.in.rst
+++ b/infiniband-diags/man/ibportstate.8.in.rst
@@ -87,6 +87,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/ibqueryerrors.8.in.rst
+++ b/infiniband-diags/man/ibqueryerrors.8.in.rst
@@ -96,6 +96,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Configuration flags

--- a/infiniband-diags/man/ibroute.8.in.rst
+++ b/infiniband-diags/man/ibroute.8.in.rst
@@ -50,6 +50,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 Debugging flags

--- a/infiniband-diags/man/ibsysstat.8.in.rst
+++ b/infiniband-diags/man/ibsysstat.8.in.rst
@@ -53,6 +53,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/ibtracert.8.in.rst
+++ b/infiniband-diags/man/ibtracert.8.in.rst
@@ -52,6 +52,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/infiniband-diags.8.in.rst
+++ b/infiniband-diags/man/infiniband-diags.8.in.rst
@@ -61,6 +61,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/perfquery.8.in.rst
+++ b/infiniband-diags/man/perfquery.8.in.rst
@@ -131,6 +131,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/saquery.8.in.rst
+++ b/infiniband-diags/man/saquery.8.in.rst
@@ -107,7 +107,9 @@ OPTIONS
 **--numb_path** Number of paths (PathRecord)
 
 **--pkey** P_Key (PathRecord, MCMemberRecord). If non-numeric value (like 'x')
-        is specified then saquery will prompt for a value
+        is specified then saquery will prompt for a value. Note this is the
+        P_Key *value* queried for, not the P_Key table index of the request
+        MAD itself (see **--pkey-idx**).
 
 **--qos_class** QoS Class (PathRecord)
 
@@ -164,6 +166,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/sminfo.8.in.rst
+++ b/infiniband-diags/man/sminfo.8.in.rst
@@ -54,6 +54,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/smpdump.8.in.rst
+++ b/infiniband-diags/man/smpdump.8.in.rst
@@ -49,6 +49,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/smpquery.8.in.rst
+++ b/infiniband-diags/man/smpquery.8.in.rst
@@ -75,6 +75,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/infiniband-diags/man/vendstat.8.in.rst
+++ b/infiniband-diags/man/vendstat.8.in.rst
@@ -77,6 +77,7 @@ Port Selection flags
 
 .. include:: common/opt_C.rst
 .. include:: common/opt_P.rst
+.. include:: common/opt_pkey_idx.rst
 .. include:: common/sec_portselection.rst
 
 

--- a/libibmad/serv.c
+++ b/libibmad/serv.c
@@ -105,6 +105,12 @@ int mad_respond_via(void *umad, ib_portid_t * portid, uint32_t rstatus,
 		rport.qp = ntohl(mad_addr->qpn);
 		rport.qkey = ntohl(mad_addr->qkey);
 		rport.sl = mad_addr->sl;
+		/*
+		 * The received pkey_index is resolved against our local P_Key
+		 * table, so echoing it sends the reply on the same partition
+		 * the request arrived on.
+		 */
+		rport.pkey_idx = umad_get_pkey(umad);
 
 		portid = &rport;
 	}


### PR DESCRIPTION
  The infiniband-diags tools always sent their SA and GMP MADs with P_Key
  index 0, because the pkey_idx field of the destination ib_portid_t was
  never populated. On fabrics that place management traffic on a non-default
  partition, this prevents the tools from reaching the SA/PM.

  This series adds a `--pkey-idx` option and fixes the server-side reply path.

  **1. infiniband-diags: add common --pkey-idx option**
  - Adds `--pkey-idx` to the shared ibdiag option parser, so every tool that
    issues MADs (saquery, perfquery, ibqueryerrors, smpquery, ibccquery,
    ibccconfig, ibsysstat, vendstat, ibping, ...) can select the P_Key table
    index of its requests.
  - The value is validated as a uint16_t (0..65535, default 0); negative,
    non-numeric and out-of-range values are rejected.
  - It is excluded from ibstat and ibcacheedit, which transmit no MADs.
  - The index is applied to the destination ib_portid_t, where
    mad_build_pkt() passes it to umad_set_pkey() for non-SMP classes (SMPs
    always use index 0). Option order is irrelevant: the value is applied
    to a destination resolved during parsing (the SM port id) once after the
    option loop, and to destinations resolved afterwards via
    resolve_portid_str().
  - Documented in the per-tool and common man pages.

  **2. libibmad: echo the request P_Key index on MAD responses**
  - mad_respond_via() and the ibsysstat server responder rebuilt the
    destination ib_portid_t from the incoming UMAD address but left pkey_idx
    at 0, so responses always went out on index 0 regardless of the partition
    the request arrived on. They now echo the request's locally-resolved index
    (umad_get_pkey()), so a reply follows the same partition as the request.

  **Testing**
  - Builds cleanly (no warnings).
  - Verified on real InfiniBand hardware with management traffic on a
    non-default partition:
    - requests egress on the selected P_Key index;
    - `--sm_port` / `--pkey-idx` ordering (either order) produces the same
      result;
    - server replies (ibping) echo the request's P_Key index, so a reply
      follows the same partition as the request.
  - checkpatch is clean apart from a SPLIT_STRING on a wrapped error-message
    string and a missing-SPDX-tag note on the new man-page snippet (which
    matches the existing common/opt_*.rst fragments that carry no header).