### PR TITLE
efa: Add support for the query port speed verb

### DIFF
--- a/providers/efa/efa.c
+++ b/providers/efa/efa.c
@@ -49,6 +49,7 @@ static const struct verbs_context_ops efa_ctx_ops = {
 	.post_send = efa_post_send,
 	.query_device_ex = efa_query_device_ex,
 	.query_port = efa_query_port,
+	.query_port_speed = efa_query_port_speed,
 	.query_qp = efa_query_qp,
 	.query_qp_data_in_order = efa_query_qp_data_in_order,
 	.reg_dmabuf_mr = efa_reg_dmabuf_mr,

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -63,6 +63,12 @@ struct efa_wq_init_attr {
 	uint16_t gen;
 };
 
+int efa_query_port_speed(struct ibv_context *context, uint32_t port,
+			 uint64_t *speed)
+{
+	return ibv_cmd_query_port_speed(context, port, speed);
+}
+
 int efa_query_port(struct ibv_context *ibvctx, uint8_t port,
 		   struct ibv_port_attr *port_attr)
 {

--- a/providers/efa/verbs.h
+++ b/providers/efa/verbs.h
@@ -1,6 +1,6 @@
 /* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
 /*
- * Copyright 2019-2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright 2019-2026 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef __EFA_VERBS_H__
@@ -12,6 +12,8 @@
 int efa_query_device_ctx(struct efa_context *ctx);
 int efa_query_port(struct ibv_context *uctx, uint8_t port,
 		   struct ibv_port_attr *attr);
+int efa_query_port_speed(struct ibv_context *context, uint32_t port,
+			 uint64_t *speed);
 int efa_query_device_ex(struct ibv_context *context,
 			const struct ibv_query_device_ex_input *input,
 			struct ibv_device_attr_ex *attr, size_t attr_size);


### PR DESCRIPTION
Add support for the query speed verb to get the effective port bandwidth.

Reviewed-by: Michael Margolin <mrgolin@amazon.com>
Reviewed-by: Yonatan Nachum <ynachum@amazon.com>