### PR TITLE
libibumad: Increase UMAD_MAX_DEVICES for VRU system support

### DIFF
--- a/libibumad/umad.h
+++ b/libibumad/umad.h
@@ -62,7 +62,7 @@ union umad_gid {
 	} global;
 } __attribute__((aligned(4))) __attribute__((packed));
 
-#define UMAD_MAX_DEVICES 128
+#define UMAD_MAX_DEVICES 256
 #define UMAD_ANY_PORT	0
 typedef struct ib_mad_addr {
 	__be32 qpn;


### PR DESCRIPTION
VRU systems may require up to 144 UMAD devices,
which exceeds the current UMAD_MAX_DEVICES limit of 128.

Increase UMAD_MAX_DEVICES from 128 to 256 to provide sufficient capacity for VRU configurations
while leaving room for future platform growth.