### PR TITLE
mlx5: Misc. items

### DIFF
--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -74,6 +74,11 @@ easily extensible in the future. This function either returns 0 on success or an
 otherwise. When no completions are available on the CQ, ENOENT is returned, but the CQ remains
 in a valid state. On success, querying the completion's attribute could be done using the query
 functions described below. If an error code is given, end_poll shouldn't be called.
+When
+.B IBV_WC_EX_WITH_COMPLETION_TIMESTAMP_WALLCLOCK
+is requested, EBUSY may be returned transiently if the device clock information
+cannot be read due to a concurrent kernel update; the CQ remains in a valid state
+and the application should retry.
 
 .BI "int ibv_next_poll(struct ibv_cq_ex " "*cq")
 .br

--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1136,6 +1136,17 @@ static inline int mlx5_start_poll(struct ibv_cq_ex *ibcq, struct ibv_poll_cq_att
 		return ENOENT;
 	}
 
+	if (clock_update) {
+		err = mlx5dv_get_clock_info(ibcq->context, &cq->last_clock_info);
+		if (err) {
+			if (err == EBUSY)
+				--cq->cons_index;
+			if (lock)
+				mlx5_spin_unlock(&cq->lock);
+			return err;
+		}
+	}
+
 	if (stall)
 		cq->flags |= MLX5_CQ_FLAGS_FOUND_CQES;
 
@@ -1151,17 +1162,8 @@ static inline int mlx5_start_poll(struct ibv_cq_ex *ibcq, struct ibv_poll_cq_att
 		}
 
 		cq->flags &= ~(MLX5_CQ_FLAGS_FOUND_CQES);
-
-		goto out;
 	}
 
-	if (clock_update && !err) {
-		err = mlx5dv_get_clock_info(ibcq->context, &cq->last_clock_info);
-		if (lock && err)
-			mlx5_spin_unlock(&cq->lock);
-	}
-
-out:
 	return err;
 }
 

--- a/providers/mlx5/mlx5.c
+++ b/providers/mlx5/mlx5.c
@@ -84,6 +84,8 @@ const struct verbs_match_ent mlx5_hca_table[] = {
 	HCA(MELLANOX, 0x1021),  /* ConnectX-7 */
 	HCA(MELLANOX, 0x1023),  /* ConnectX-8 */
 	HCA(MELLANOX, 0x1025),  /* ConnectX-9 */
+	HCA(MELLANOX, 0x1027),  /* ConnectX-10 */
+	HCA(MELLANOX, 0x2101),  /* ConnectX-10 NVLink-C2C */
 	HCA(MELLANOX, 0xa2d2),	/* BlueField integrated ConnectX-5 network controller */
 	HCA(MELLANOX, 0xa2d3),	/* BlueField integrated ConnectX-5 network controller VF */
 	HCA(MELLANOX, 0xa2d6),  /* BlueField-2 integrated ConnectX-6 Dx network controller */


### PR DESCRIPTION
This series includes the below:
- Fixing clock update EBUSY error flow.
- Adding the CX10 Family PCI IDs.

Further details exist as part of the commit messages.