### PR TITLE
tests: Fix WR leak, CUDA 13, and scatter-to-CQE

### DIFF
--- a/pyverbs/wr.pyx
+++ b/pyverbs/wr.pyx
@@ -35,11 +35,13 @@ cdef class SGE(PyverbsCM):
         self.sge.length = length
         self.sge.lkey = lkey
 
-    def __dealloc(self):
+    def __dealloc__(self):
         self.close()
 
     cpdef close(self):
-        free(self.sge)
+        if self.sge != NULL:
+            free(self.sge)
+            self.sge = NULL
 
     cpdef read(self, length, offset):
         """
@@ -105,11 +107,13 @@ cdef class RecvWR(PyverbsCM):
         if next_wr is not None:
             self.recv_wr.next = &next_wr.recv_wr
 
-    def __dealloc(self):
+    def __dealloc__(self):
         self.close()
 
     cpdef close(self):
-        free(self.recv_wr.sg_list)
+        if self.recv_wr.sg_list != NULL:
+            free(self.recv_wr.sg_list)
+            self.recv_wr.sg_list = NULL
 
     def __str__(self):
         print_format = '{:22}: {:<20}\n'
@@ -180,11 +184,13 @@ cdef class SendWR(PyverbsCM):
         self.send_wr.imm_data = imm_data
         self.ah = None
 
-    def __dealloc(self):
+    def __dealloc__(self):
         self.close()
 
     cpdef close(self):
-        free(self.send_wr.sg_list)
+        if self.send_wr.sg_list != NULL:
+            free(self.send_wr.sg_list)
+            self.send_wr.sg_list = NULL
 
     def __str__(self):
         print_format = '{:22}: {:<20}\n'

--- a/tests/cuda_utils.py
+++ b/tests/cuda_utils.py
@@ -8,8 +8,28 @@ including the initialization/tear down needed and some error handlers.
 
 import unittest
 
+
+def import_cuda():
+    """
+    Import the cuda-python bindings for both the cuda-python 13 and 12 layouts.
+
+    :return: A tuple of the (cuda, cudart, nvrtc) cuda-python modules.
+    """
+    try:
+        from cuda.bindings import driver as cuda, runtime as cudart, nvrtc
+    except ImportError:
+        from cuda import cuda, cudart, nvrtc
+
+    return cuda, cudart, nvrtc
+
+
 try:
-    from cuda import cuda, cudart, nvrtc
+    cuda, cudart, nvrtc = import_cuda()
+    try:
+        from cuda.bindings import __version__ as _cuda_version
+    except ImportError:
+        from cuda import __version__ as _cuda_version
+    CUDA_PYTHON_MAJOR = int(_cuda_version.split('.', 1)[0])
     CUDA_FOUND = True
 except ImportError:
     CUDA_FOUND = False
@@ -87,9 +107,24 @@ def init_cuda(obj):
         raise unittest.SkipTest('GPU device ID must be passed')
     check_cuda_errors(cuda.cuInit(0))
     cuda_device = check_cuda_errors(cuda.cuDeviceGet(cuda_dev_id))
-    obj.cuda_ctx = check_cuda_errors(
-        cuda.cuCtxCreate(cuda.CUctx_flags.CU_CTX_MAP_HOST, cuda_device))
+    obj.cuda_ctx = create_cuda_ctx(cuda.CUctx_flags.CU_CTX_MAP_HOST, cuda_device)
     check_cuda_errors(cuda.cuCtxSetCurrent(obj.cuda_ctx))
+
+
+def create_cuda_ctx(flags, cuda_device):
+    """
+    Create a CUDA context using the calling convention for the installed
+    cuda-python version.
+    The cuCtxCreate signature is version-dependent:
+      - cuda-python 12: cuCtxCreate(flags, dev)
+      - cuda-python 13: cuCtxCreate(ctxCreateParams, flags, dev)
+    :param flags: CUDA context creation flags.
+    :param cuda_device: Target CUDA device.
+    :return: The created CUDA context.
+    """
+    if CUDA_PYTHON_MAJOR >= 13:
+        return check_cuda_errors(cuda.cuCtxCreate(None, flags, cuda_device))
+    return check_cuda_errors(cuda.cuCtxCreate(flags, cuda_device))
 
 
 def set_init_cuda_methods(cls):

--- a/tests/test_cuda_dmabuf.py
+++ b/tests/test_cuda_dmabuf.py
@@ -13,7 +13,7 @@ from pyverbs.libibverbs_enums import ibv_access_flags, ibv_wr_opcode, ibv_mr_ini
 import tests.utils as u
 
 try:
-    from cuda import cuda, cudart, nvrtc
+    cuda, cudart, nvrtc = cu.import_cuda()
     cu.CUDA_FOUND = True
 except ImportError:
     cu.CUDA_FOUND = False

--- a/tests/test_mlx5_cq.py
+++ b/tests/test_mlx5_cq.py
@@ -10,7 +10,8 @@ from tests.mlx5_base import Mlx5RDMATestCase
 from tests.mlx5_base import Mlx5DcResources
 from pyverbs.cq import CqInitAttrEx
 from tests.base import RCResources
-from pyverbs.libibverbs_enums import ibv_qp_create_send_ops_flags, ibv_wr_opcode
+from pyverbs.libibverbs_enums import ibv_qp_create_send_ops_flags, ibv_wr_opcode, \
+    ibv_qp_type, ibv_access_flags
 import tests.utils as u
 
 
@@ -81,6 +82,16 @@ class Mlx5CQRes(RCResources):
 
     def create_cq(self):
         create_dv_cq(self)
+
+
+class Mlx5CqRdmaReadRes(Mlx5CQRes):
+    def create_mr(self):
+        self.mr = u.create_custom_mr(self, ibv_access_flags.IBV_ACCESS_REMOTE_READ)
+
+    def create_qps(self):
+        u.create_qp_ex(self, ibv_qp_type.IBV_QPT_RC,
+                       ibv_qp_create_send_ops_flags.IBV_QP_EX_WITH_RDMA_READ,
+                       sq_sig_all=1)
 
 
 class Mlx5DvCqDcRes(Mlx5DcResources):
@@ -187,6 +198,18 @@ class DvCqTest(Mlx5RDMATestCase):
         for size in msg_sizes:
             self.create_players(Mlx5CQRes, cqe_size=128, msg_size=size)
             u.traffic(**self.traffic_args, is_cq_ex=True)
+
+    def test_dv_cq_rdma_read_small_msg_128_cqe(self):
+        """
+        RDMA_READ with mlx5dv 128B CQE and payload < 64B on the requestor side.
+        Exercises scatter-to-CQE inline copy from the CQE (ibv_cq_ex poll path).
+        """
+        msg_sizes = [16, 40, 60]
+        for size in msg_sizes:
+            self.create_players(Mlx5CqRdmaReadRes, cqe_size=128, msg_size=size)
+            u.rdma_traffic(**self.traffic_args, new_send=True,
+                           send_op=ibv_wr_opcode.IBV_WR_RDMA_READ,
+                           is_cq_ex=True)
 
     def test_dv_cq_cqe_size_64(self):
         """

--- a/tests/test_mlx5_cuda_umem.py
+++ b/tests/test_mlx5_cuda_umem.py
@@ -10,7 +10,7 @@ import tests.cuda_utils as cu
 from pyverbs.libibverbs_enums import ibv_access_flags
 
 try:
-    from cuda import cuda, cudart, nvrtc
+    cuda, cudart, nvrtc = cu.import_cuda()
     cu.CUDA_FOUND = True
 except ImportError:
     cu.CUDA_FOUND = False

--- a/tests/test_mlx5_dmabuf.py
+++ b/tests/test_mlx5_dmabuf.py
@@ -17,7 +17,7 @@ from pyverbs.libibverbs_enums import ibv_access_flags, ibv_wr_opcode
 import tests.utils as u
 
 try:
-    from cuda import cuda
+    cuda, _, _ = cu.import_cuda()
     cu.CUDA_FOUND = True
 except ImportError:
     cu.CUDA_FOUND = False

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -382,7 +382,7 @@ def get_qp_init_attr(cq, attr):
     return QPInitAttr(scq=cq, rcq=cq, cap=qp_cap, sq_sig_all=sig)
 
 
-def create_qp_ex(agr_obj, qp_type, send_flags):
+def create_qp_ex(agr_obj, qp_type, send_flags, sq_sig_all=0):
     if qp_type == ibv_qp_type.IBV_QPT_XRC_SEND:
         cap = QPCap(max_send_wr=agr_obj.num_msgs, max_recv_wr=0, max_recv_sge=0,
                     max_send_sge=1)
@@ -390,7 +390,8 @@ def create_qp_ex(agr_obj, qp_type, send_flags):
         cap = QPCap(max_send_wr=agr_obj.num_msgs, max_recv_wr=agr_obj.num_msgs,
                     max_recv_sge=1, max_send_sge=1)
     qia = QPInitAttrEx(cap=cap, qp_type=qp_type, scq=agr_obj.cq,
-                       rcq=agr_obj.cq, pd=agr_obj.pd, send_ops_flags=send_flags,
+                       rcq=agr_obj.cq, pd=agr_obj.pd, sq_sig_all=sq_sig_all,
+                       send_ops_flags=send_flags,
                        comp_mask=ibv_qp_init_attr_mask.IBV_QP_INIT_ATTR_PD |
                                  ibv_qp_init_attr_mask.IBV_QP_INIT_ATTR_SEND_OPS_FLAGS)
     qp_attr = QPAttr(port_num=agr_obj.ib_port)


### PR DESCRIPTION
- Fix a misspelled Cython WR destructor so SGE buffers are freed instead of leaked on GC.
- Add cuda-python 13 compatibility (new import layout and cuCtxCreate signature) while keeping cuda-python 12 working.
- Add RDMA_READ scatter-to-CQE test for small payloads on 128B CQEs.