### PR TITLE
ionic: Fix have_movdir64b() cpuid max-leaf query

### DIFF
--- a/providers/ionic/ionic_verbs.c
+++ b/providers/ionic/ionic_verbs.c
@@ -42,7 +42,7 @@ static inline bool have_movdir64b(void)
 	/* Return highest supported cpuid input value.  */
 	__asm__ volatile ("cpuid\n\t"
 			  : "=a" (ax), "=b" (bx), "=c" (cx), "=d" (dx)
-			  : "0" (leaf));
+			  : "0" (0));
 
 	if (ax == 0 || ax < leaf)
 		return 0;


### PR DESCRIPTION
use eax=0 to query the max supported leaf, not eax=7 which executes leaf 7 directly and returns an unrelated value for the support check.

Fixes: 6d82ac7ba ("ionic: Add ionic provider")