### PR TITLE
efa: Add support for 64-bit request IDs on post-send

### DIFF
--- a/kernel-headers/rdma/efa-abi.h
+++ b/kernel-headers/rdma/efa-abi.h
@@ -56,7 +56,8 @@ struct efa_ibv_alloc_pd_resp {
 
 enum {
 	EFA_CREATE_CQ_WITH_COMPLETION_CHANNEL = 1 << 0,
-	EFA_CREATE_CQ_WITH_SGID               = 1 << 1,
+	EFA_CREATE_CQ_WITH_SGID = 1 << 1,
+	EFA_CREATE_CQ_WITH_SQ_COMP_64_BIT_REQ_ID = 1 << 2,
 };
 
 struct efa_ibv_create_cq {
@@ -88,6 +89,7 @@ enum {
 
 enum {
 	EFA_CREATE_QP_WITH_UNSOLICITED_WRITE_RECV = 1 << 0,
+	EFA_CREATE_QP_WITH_SQ_64_BIT_REQ_ID = 1 << 1,
 };
 
 struct efa_ibv_create_qp {
@@ -134,6 +136,7 @@ enum {
 	EFA_QUERY_DEVICE_CAPS_UNSOLICITED_WRITE_RECV = 1 << 6,
 	EFA_QUERY_DEVICE_CAPS_CQ_WITH_EXT_MEM = 1 << 7,
 	EFA_QUERY_DEVICE_CAPS_COMP_CNTR = 1 << 8,
+	EFA_QUERY_DEVICE_CAPS_SQ_64_BIT_REQ_ID = 1 << 9,
 };
 
 struct efa_ibv_ex_query_device_resp {

--- a/providers/efa/efa.h
+++ b/providers/efa/efa.h
@@ -134,6 +134,7 @@ struct efa_wq {
 	int phase;
 	pthread_spinlock_t wqlock;
 	bool need_lock;
+	bool req_id_64_bit;
 
 	uint32_t *db;
 	uint16_t sub_cq_idx;

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -70,6 +70,10 @@ enum efa_io_processing_hint {
 	EFA_IO_PROCESSING_HINT_BURST_PPS_SENSITIVE  = 1 << 0,
 };
 
+struct efa_io_req_id_ex {
+	uint16_t w[3];
+};
+
 struct efa_io_tx_meta_desc {
 	/* Verbs-generated Request ID */
 	uint16_t req_id;
@@ -287,8 +291,10 @@ struct efa_io_tx_cdesc {
 	/* Common completion info */
 	struct efa_io_cdesc_common common;
 
+	struct efa_io_req_id_ex req_id_ex;
+
 	/* MBZ */
-	uint16_t reserved16;
+	uint8_t reserved[4];
 };
 
 /* Rx Completion Descriptor */

--- a/providers/efa/efa_io_defs.h
+++ b/providers/efa/efa_io_defs.h
@@ -136,7 +136,9 @@ struct efa_io_tx_meta_desc {
 	/* Queue key */
 	uint32_t qkey;
 
-	uint8_t reserved2[12];
+	uint8_t reserved2[6];
+
+	struct efa_io_req_id_ex req_id_ex;
 };
 
 /*

--- a/providers/efa/efadv.h
+++ b/providers/efa/efadv.h
@@ -106,6 +106,10 @@ struct ibv_qp *efadv_create_qp_ex(struct ibv_context *ibvctx,
 				  struct efadv_qp_init_attr *efa_attr,
 				  uint32_t inlen);
 
+enum {
+	EFADV_WQ_CAPS_64_BIT_REQ_ID = 1 << 0,
+};
+
 struct efadv_wq_attr {
 	uint64_t comp_mask;
 	uint8_t *buffer;
@@ -113,7 +117,8 @@ struct efadv_wq_attr {
 	uint32_t num_entries;
 	uint32_t *doorbell;
 	uint32_t max_batch;
-	uint8_t reserved[4];
+	uint16_t caps;
+	uint8_t reserved[2];
 };
 
 int efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,

--- a/providers/efa/man/efadv_query_qp_wqs.3.md
+++ b/providers/efa/man/efadv_query_qp_wqs.3.md
@@ -35,7 +35,8 @@ struct efadv_wq_attr {
 	uint32_t num_entries;
 	uint32_t *doorbell;
 	uint32_t max_batch;
-	uint8_t reserved[4];
+	uint16_t caps;
+	uint8_t reserved[2];
 };
 ```
 
@@ -59,6 +60,14 @@ struct efadv_wq_attr {
 
 *max_batch*
 :	Maximum batch size for queue submissions.
+
+*caps*
+:	Work queue capabilities:
+
+	EFADV_WQ_CAPS_64_BIT_REQ_ID
+		Work queue supports posting requests with 64-bit IDs.
+		When set, the associated completion queue is guaranteed
+		to return 64-bit request IDs as well.
 
 # RETURN VALUE
 

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -2426,6 +2426,12 @@ int efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
 	sq_attr->num_entries = qp->sq.wq.wqe_cnt;
 	sq_attr->doorbell = qp->sq.wq.db;
 	sq_attr->max_batch = qp->sq.max_batch_wr;
+	if (vext_field_avail(typeof(*sq_attr), reserved, inlen)) {
+		sq_attr->caps = 0;
+		memset(sq_attr->reserved, 0, sizeof(sq_attr->reserved));
+		if (qp->sq.wq.req_id_64_bit)
+			sq_attr->caps |= EFADV_WQ_CAPS_64_BIT_REQ_ID;
+	}
 
 	rq_attr->comp_mask = 0;
 	rq_attr->buffer = qp->rq.buf;
@@ -2433,6 +2439,10 @@ int efadv_query_qp_wqs(struct ibv_qp *ibvqp, struct efadv_wq_attr *sq_attr,
 	rq_attr->num_entries = qp->rq.wq.desc_mask + 1;
 	rq_attr->doorbell = qp->rq.wq.db;
 	rq_attr->max_batch = rq_attr->num_entries;
+	if (vext_field_avail(typeof(*rq_attr), reserved, inlen)) {
+		memset(rq_attr->reserved, 0, sizeof(rq_attr->reserved));
+		rq_attr->caps = 0;
+	}
 
 	return 0;
 }

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -529,6 +529,21 @@ static inline uint64_t efa_get_sq_comp_wrid(struct efa_wq *wq,
 	return efa_wq_get_wrid_by_dev_req_id(wq, cqe->req_id);
 }
 
+static inline void efa_set_sq_comp_wrid(struct efa_io_tx_meta_desc *md, struct efa_wq *wq,
+					uint64_t wr_id) ALWAYS_INLINE;
+static inline void efa_set_sq_comp_wrid(struct efa_io_tx_meta_desc *md, struct efa_wq *wq,
+					uint64_t wr_id)
+{
+	if (wq->req_id_64_bit) {
+		md->req_id = (uint16_t)wr_id;
+		md->req_id_ex.w[0] = (uint16_t)(wr_id >> 16);
+		md->req_id_ex.w[1] = (uint16_t)(wr_id >> 32);
+		md->req_id_ex.w[2] = (uint16_t)(wr_id >> 48);
+	} else {
+		md->req_id = efa_wq_get_dev_req_id_locked(wq, wr_id);
+	}
+}
+
 static uint32_t efa_sub_cq_get_current_index(struct efa_sub_cq *sub_cq)
 {
 	return sub_cq->consumed_cnt & sub_cq->qmask;
@@ -1632,8 +1647,11 @@ static void efa_wq_terminate(struct efa_wq *wq, int pgsz)
 	db_aligned = (void *)((uintptr_t)wq->db & ~(pgsz - 1));
 	munmap(db_aligned, pgsz);
 
-	free(wq->wrid_idx_pool);
-	free(wq->wrid);
+	if (wq->wrid_idx_pool)
+		free(wq->wrid_idx_pool);
+
+	if (wq->wrid)
+		free(wq->wrid);
 }
 
 static int efa_wq_initialize(struct efa_wq *wq, struct efa_wq_init_attr *attr)
@@ -1643,14 +1661,20 @@ static int efa_wq_initialize(struct efa_wq *wq, struct efa_wq_init_attr *attr)
 	int err;
 	int i;
 
-	wq->wrid = malloc(wq->wqe_cnt * sizeof(*wq->wrid));
-	if (!wq->wrid)
-		return ENOMEM;
+	if (!wq->req_id_64_bit) {
+		wq->wrid = malloc(wq->wqe_cnt * sizeof(*wq->wrid));
+		if (!wq->wrid)
+			return ENOMEM;
 
-	wq->wrid_idx_pool = malloc(wq->wqe_cnt * sizeof(uint32_t));
-	if (!wq->wrid_idx_pool) {
-		err = ENOMEM;
-		goto err_free_wrid;
+		wq->wrid_idx_pool = malloc(wq->wqe_cnt * sizeof(uint32_t));
+		if (!wq->wrid_idx_pool) {
+			err = ENOMEM;
+			goto err_free_wrid;
+		}
+
+		/* Initialize the wrid free indexes pool. */
+		for (i = 0; i < wq->wqe_cnt; i++)
+			wq->wrid_idx_pool[i] = i;
 	}
 
 	wrid_idx_mask = roundup_pow_of_two(wq->wqe_cnt) - 1;
@@ -1666,10 +1690,6 @@ static int efa_wq_initialize(struct efa_wq *wq, struct efa_wq_init_attr *attr)
 
 	wq->db = (uint32_t *)(db_base + attr->db_off);
 
-	/* Initialize the wrid free indexes pool. */
-	for (i = 0; i < wq->wqe_cnt; i++)
-		wq->wrid_idx_pool[i] = i;
-
 	wq->need_lock = attr->need_lock;
 	if (wq->need_lock)
 		pthread_spin_init(&wq->wqlock, PTHREAD_PROCESS_PRIVATE);
@@ -1679,9 +1699,11 @@ static int efa_wq_initialize(struct efa_wq *wq, struct efa_wq_init_attr *attr)
 	return 0;
 
 err_free_wrid_idx_pool:
-	free(wq->wrid_idx_pool);
+	if (wq->wrid_idx_pool)
+		free(wq->wrid_idx_pool);
 err_free_wrid:
-	free(wq->wrid);
+	if (wq->wrid)
+		free(wq->wrid);
 	return err;
 }
 
@@ -1965,12 +1987,14 @@ static void efa_setup_qp(struct efa_context *ctx,
 						     ctx->min_sq_wr));
 	qp->sq.wq.max_sge = cap->max_send_sge;
 	qp->sq.wq.desc_mask = qp->sq.wq.wqe_cnt - 1;
+	qp->sq.wq.req_id_64_bit = !!(EFA_DEV_CAP(ctx, SQ_64_BIT_REQ_ID));
 	qp->sq.inline_write_enabled = inline_write_enabled;
 
 	qp->rq.wq.max_sge = cap->max_recv_sge;
 	rq_desc_cnt = roundup_pow_of_two(cap->max_recv_sge * cap->max_recv_wr);
 	qp->rq.wq.desc_mask = rq_desc_cnt - 1;
 	qp->rq.wq.wqe_cnt = rq_desc_cnt / qp->rq.wq.max_sge;
+	qp->rq.wq.req_id_64_bit = false;
 
 	qp->page_size = page_size;
 }
@@ -2185,6 +2209,9 @@ static struct ibv_qp *create_qp(struct ibv_context *ibvctx,
 		req.flags |= EFA_CREATE_QP_WITH_UNSOLICITED_WRITE_RECV;
 
 	req.sl = efa_attr->sl;
+
+	if (qp->sq.wq.req_id_64_bit)
+		req.flags |= EFA_CREATE_QP_WITH_SQ_64_BIT_REQ_ID;
 
 	err = ibv_cmd_create_qp_ex(ibvctx, &qp->verbs_qp,
 				   attr, &req.ibv_cmd, sizeof(req),
@@ -2734,7 +2761,8 @@ int efa_post_send(struct ibv_qp *ibvqp, struct ibv_send_wr *wr,
 
 		/* Set rest of the descriptor fields */
 		efa_set_common_ctrl_flags(md, sq, EFA_IO_SEND);
-		md->req_id = efa_wq_get_dev_req_id_locked(wq, wr->wr_id);
+		efa_set_sq_comp_wrid(md, wq, wr->wr_id);
+
 		md->dest_qp_num = wr->wr.ud.remote_qpn;
 		md->ah = ah->efa_ah;
 		md->qkey = wr->wr.ud.remote_qkey;
@@ -2807,7 +2835,7 @@ static void efa_send_wr_init(struct efa_qp *qp, struct ibv_qp_ex *ibvqpx,
 
 	sq->curr_tx_wqe.md = md;
 	efa_set_common_ctrl_flags(sq->curr_tx_wqe.md, sq, op_type);
-	sq->curr_tx_wqe.md->req_id = efa_wq_get_dev_req_id_locked(&sq->wq, ibvqpx->wr_id);
+	efa_set_sq_comp_wrid(sq->curr_tx_wqe.md, &sq->wq, ibvqpx->wr_id);
 
 	/* advance index and change phase */
 	efa_sq_advance_post_idx(sq);

--- a/providers/efa/verbs.c
+++ b/providers/efa/verbs.c
@@ -470,17 +470,10 @@ static uint32_t efa_wq_get_next_wrid_idx_locked(struct efa_wq *wq,
 	return wrid_idx;
 }
 
-static void efa_wq_put_wrid_idx_unlocked(struct efa_wq *wq, uint32_t wrid_idx)
+static void efa_wq_put_wrid_idx_locked(struct efa_wq *wq, uint32_t wrid_idx)
 {
-	if (wq->need_lock)
-		pthread_spin_lock(&wq->wqlock);
-
 	wq->wrid_idx_pool_next--;
 	wq->wrid_idx_pool[wq->wrid_idx_pool_next] = wrid_idx;
-	wq->wqe_completed++;
-
-	if (wq->need_lock)
-		pthread_spin_unlock(&wq->wqlock);
 }
 
 static uint32_t efa_wq_get_dev_req_id_locked(struct efa_wq *wq, uint64_t wr_id)
@@ -488,14 +481,52 @@ static uint32_t efa_wq_get_dev_req_id_locked(struct efa_wq *wq, uint64_t wr_id)
 	return efa_wq_get_next_wrid_idx_locked(wq, wr_id) | wq->shifted_gen;
 }
 
-static void efa_wq_put_dev_req_id_unlocked(struct efa_wq *wq, uint32_t dev_req_id)
+static void efa_wq_cqe_finalize(struct efa_wq *wq, struct efa_io_cdesc_common *cqe)
 {
-	efa_wq_put_wrid_idx_unlocked(wq, dev_req_id & ~wq->gen_mask);
+	if (wq->need_lock)
+		pthread_spin_lock(&wq->wqlock);
+
+	wq->wqe_completed++;
+	if (!wq->req_id_64_bit)
+		efa_wq_put_wrid_idx_locked(wq, cqe->req_id & ~wq->gen_mask);
+
+	if (wq->need_lock)
+		pthread_spin_unlock(&wq->wqlock);
 }
 
 static uint64_t efa_wq_get_wrid_by_dev_req_id(struct efa_wq *wq, uint16_t dev_req_id)
 {
 	return wq->wrid[dev_req_id & ~wq->gen_mask];
+}
+
+static inline uint64_t efa_cqe_get_dev_req_id_64(struct efa_io_tx_cdesc *tcqe) ALWAYS_INLINE;
+static inline uint64_t efa_cqe_get_dev_req_id_64(struct efa_io_tx_cdesc *tcqe)
+{
+	struct efa_io_req_id_ex *req_id_ex = &tcqe->req_id_ex;
+
+	return (uint64_t)tcqe->common.req_id |
+	       (uint64_t)req_id_ex->w[0] << 16 |
+	       (uint64_t)req_id_ex->w[1] << 32 |
+	       (uint64_t)req_id_ex->w[2] << 48;
+}
+
+static inline uint64_t efa_get_sq_comp_wrid(struct efa_wq *wq,
+					    struct efa_io_cdesc_common *cqe) ALWAYS_INLINE;
+static inline uint64_t efa_get_sq_comp_wrid(struct efa_wq *wq,
+					    struct efa_io_cdesc_common *cqe)
+{
+	if (wq->req_id_64_bit) {
+		struct efa_io_tx_cdesc *tcqe =
+			container_of(cqe, struct efa_io_tx_cdesc, common);
+
+		return efa_cqe_get_dev_req_id_64(tcqe);
+	}
+
+	/* We do not have to take the WQ lock here,
+	 * because this wrid index has not been freed yet,
+	 * so there is no contention on this index.
+	 */
+	return efa_wq_get_wrid_by_dev_req_id(wq, cqe->req_id);
 }
 
 static uint32_t efa_sub_cq_get_current_index(struct efa_sub_cq *sub_cq)
@@ -751,17 +782,13 @@ static void efa_process_cqe(struct efa_cq *cq, struct ibv_wc *wc,
 
 	op_type = EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_OP_TYPE);
 	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) == EFA_IO_SEND_QUEUE) {
-		cq->cur_wq = &qp->sq.wq;
 		if (op_type == EFA_IO_RDMA_WRITE)
 			wc->opcode = IBV_WC_RDMA_WRITE;
 		else
 			wc->opcode = IBV_WC_SEND;
 
-		/* We do not have to take the WQ lock here,
-		 * because this wrid index has not been freed yet,
-		 * so there is no contention on this index.
-		 */
-		wc->wr_id = efa_wq_get_wrid_by_dev_req_id(cq->cur_wq, cqe->req_id);
+		cq->cur_wq = &qp->sq.wq;
+		wc->wr_id = efa_get_sq_comp_wrid(cq->cur_wq, cqe);
 
 		rdma_tracepoint(rdma_core_efa, process_completion, cq->dev->name, wc->wr_id,
 				wc->status, wc->opcode, wc->qp_num, UINT32_MAX, UINT16_MAX,
@@ -809,7 +836,7 @@ static void efa_process_ex_cqe(struct efa_cq *cq, struct efa_qp *qp)
 
 	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) == EFA_IO_SEND_QUEUE) {
 		cq->cur_wq = &qp->sq.wq;
-		ibvcqx->wr_id = efa_wq_get_wrid_by_dev_req_id(cq->cur_wq, cqe->req_id);
+		ibvcqx->wr_id = efa_get_sq_comp_wrid(cq->cur_wq, cqe);
 		ibvcqx->status = to_ibv_status(cqe->status);
 
 		rdma_tracepoint(rdma_core_efa, process_completion, cq->dev->name, ibvcqx->wr_id,
@@ -843,6 +870,13 @@ static bool efa_cqe_is_valid_req_id_qp_gen(struct efa_io_cdesc_common *cqe, stru
 	return (cqe->req_id & wq->gen_mask) == wq->shifted_gen;
 }
 
+static bool efa_cqe_is_64_bit_comp(struct efa_io_cdesc_common *cqe, struct efa_qp *qp)
+{
+	bool sq_cqe = EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) == EFA_IO_SEND_QUEUE;
+
+	return (sq_cqe && qp->sq.wq.req_id_64_bit);
+}
+
 static inline int efa_poll_sub_cq(struct efa_cq *cq, struct efa_sub_cq *sub_cq,
 				  struct ibv_wc *wc,
 				  bool extended) ALWAYS_INLINE;
@@ -865,6 +899,7 @@ static inline int efa_poll_sub_cq(struct efa_cq *cq, struct efa_sub_cq *sub_cq,
 	qp = ctx->qp_table[qpn & ctx->qp_table_sz_m1];
 	if (!qp || qpn != qp->verbs_qp.qp.qp_num ||
 	    (!efa_cqe_is_unsolicited(cq->cur_cqe) &&
+	     !efa_cqe_is_64_bit_comp(cq->cur_cqe, qp) &&
 	     !efa_cqe_is_valid_req_id_qp_gen(cq->cur_cqe, qp))) {
 		cq->cur_wq = NULL;
 		verbs_err(&ctx->ibvctx, "Invalid QP[%u]\n", qpn);
@@ -876,7 +911,7 @@ static inline int efa_poll_sub_cq(struct efa_cq *cq, struct efa_sub_cq *sub_cq,
 	} else {
 		efa_process_cqe(cq, wc, qp);
 		if (cq->cur_wq)
-			efa_wq_put_dev_req_id_unlocked(cq->cur_wq, cq->cur_cqe->req_id);
+			efa_wq_cqe_finalize(cq->cur_wq, cq->cur_cqe);
 	}
 
 	return 0;
@@ -949,7 +984,7 @@ static inline void efa_end_poll_common(struct efa_cq *cq)
 {
 	if (cq->cur_cqe) {
 		if (cq->cur_wq)
-			efa_wq_put_dev_req_id_unlocked(cq->cur_wq, cq->cur_cqe->req_id);
+			efa_wq_cqe_finalize(cq->cur_wq, cq->cur_cqe);
 		if (cq->db)
 			efa_update_cq_doorbell(cq, false);
 	}
@@ -979,7 +1014,7 @@ static int efa_next_poll(struct ibv_cq_ex *ibvcqx)
 	int ret;
 
 	if (cq->cur_wq)
-		efa_wq_put_dev_req_id_unlocked(cq->cur_wq, cq->cur_cqe->req_id);
+		efa_wq_cqe_finalize(cq->cur_wq, cq->cur_cqe);
 	ret = efa_poll_sub_cqs(cq, NULL, true);
 
 	return ret;
@@ -1019,7 +1054,7 @@ static int efa_next_poll_single_sub_cq(struct ibv_cq_ex *ibvcqx)
 	int ret;
 
 	if (cq->cur_wq)
-		efa_wq_put_dev_req_id_unlocked(cq->cur_wq, cq->cur_cqe->req_id);
+		efa_wq_cqe_finalize(cq->cur_wq, cq->cur_cqe);
 
 	ret = efa_poll_sub_cq(cq, cq->sub_cq_arr, NULL, true);
 	if (ret != ENOENT)
@@ -1220,6 +1255,9 @@ static struct ibv_cq_ex *create_cq(struct ibv_context *ibvctx,
 
 	if (attr->channel)
 		cmd.flags |= EFA_CREATE_CQ_WITH_COMPLETION_CHANNEL;
+
+	if (EFA_DEV_CAP(ctx, SQ_64_BIT_REQ_ID))
+		cmd.flags |= EFA_CREATE_CQ_WITH_SQ_COMP_64_BIT_REQ_ID;
 
 	attr->cqe = roundup_pow_of_two(attr->cqe);
 	err = ibv_cmd_create_cq_ex(ibvctx, attr, &prov_attr, &cq->verbs_cq,


### PR DESCRIPTION
Add support for posting send WRs with 64-bit request IDs directly to the
device, bypassing the 16-bit translation pool. When the device advertises the
capability, EFA places the full 64-bit work request ID in the TX descriptor and
reconstructs it from the CQE on the CQ poll path.
Expose this capability in EFA query QP DV for external datapath implementations
to use when supported.