### PR TITLE
verbs: Document that pointer-returning verbs set errno on failure

### DIFF
--- a/libibverbs/driver.h
+++ b/libibverbs/driver.h
@@ -784,6 +784,10 @@ int ibv_cmd_read_counters(struct verbs_counters *vcounters,
 			  uint32_t ncounters,
 			  uint32_t flags,
 			  struct ibv_command_buffer *link);
+/*
+ * Adjust fork protection for the given range. Return 0 on success, or a
+ * non-zero value on failure with errno set to indicate the reason.
+ */
 int ibv_dontfork_range(void *base, size_t size);
 int ibv_dofork_range(void *base, size_t size);
 int ibv_cmd_alloc_dm(struct ibv_context *ctx,

--- a/libibverbs/man/ibv_alloc_dm.3
+++ b/libibverbs/man/ibv_alloc_dm.3
@@ -91,14 +91,14 @@ flag.
 
 .SH "RETURN VALUE"
 .B ibv_alloc_dm()
-returns a pointer to an ibv_dm struct or NULL if the request fails.
+returns a pointer to an ibv_dm struct or NULL if the request fails, and errno is set to indicate the reason.
 The output dm contains the handle which could be used by user to import this device memory.
 .PP
 .B ibv_free_dm()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).
 .PP
 .B ibv_reg_dm_mr()
-returns a pointer to an ibv_mr struct on success or NULL if request fails.
+returns a pointer to an ibv_mr struct on success or NULL if request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_memcpy_to_dm()/ibv_memcpy_from_dm()
 returns 0 on success or the failure reason value on failure.

--- a/libibverbs/man/ibv_alloc_null_mr.3.md
+++ b/libibverbs/man/ibv_alloc_null_mr.3.md
@@ -46,7 +46,7 @@ with this MR is invalid.
 
 # RETURN VALUE
 
-**ibv_alloc_null_mr()** returns a pointer to the allocated MR, or NULL if the request fails.
+**ibv_alloc_null_mr()** returns a pointer to the allocated MR, or NULL if the request fails, and errno is set to indicate the reason.
 
 # SEE ALSO
 

--- a/libibverbs/man/ibv_alloc_pd.3
+++ b/libibverbs/man/ibv_alloc_pd.3
@@ -22,7 +22,7 @@ deallocates the PD
 .I pd\fR.
 .SH "RETURN VALUE"
 .B ibv_alloc_pd()
-returns a pointer to the allocated PD, or NULL if the request fails.
+returns a pointer to the allocated PD, or NULL if the request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_dealloc_pd()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).

--- a/libibverbs/man/ibv_create_ah.3
+++ b/libibverbs/man/ibv_create_ah.3
@@ -52,7 +52,7 @@ destroys the AH
 .I ah\fR.
 .SH "RETURN VALUE"
 .B ibv_create_ah()
-returns a pointer to the created AH, or NULL if the request fails.
+returns a pointer to the created AH, or NULL if the request fails, and errno is set to indicate the reason.
 .SH "NOTES"
 If port flag IBV_QPF_GRH_REQUIRED is set then
 .B ibv_create_ah()

--- a/libibverbs/man/ibv_create_ah_from_wc.3
+++ b/libibverbs/man/ibv_create_ah_from_wc.3
@@ -45,7 +45,7 @@ and the Global Routing Header (GRH) structure
 returns 0 on success, and \-1 on error.
 .PP
 .B ibv_create_ah_from_wc()
-returns a pointer to the created AH, or NULL if the request fails.
+returns a pointer to the created AH, or NULL if the request fails, and errno is set to indicate the reason.
 .SH "NOTES"
 The filled structure
 .I ah_attr

--- a/libibverbs/man/ibv_create_comp_channel.3
+++ b/libibverbs/man/ibv_create_comp_channel.3
@@ -24,7 +24,7 @@ destroys the completion event channel
 .I channel\fR.
 .SH "RETURN VALUE"
 .B ibv_create_comp_channel()
-returns a pointer to the created completion event channel, or NULL if the request fails.
+returns a pointer to the created completion event channel, or NULL if the request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_destroy_comp_channel()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).

--- a/libibverbs/man/ibv_create_cq.3
+++ b/libibverbs/man/ibv_create_cq.3
@@ -38,7 +38,7 @@ destroys the CQ
 .I cq\fR.
 .SH "RETURN VALUE"
 .B ibv_create_cq()
-returns a pointer to the CQ, or NULL if the request fails.
+returns a pointer to the CQ, or NULL if the request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_destroy_cq()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).

--- a/libibverbs/man/ibv_create_cq_ex.3
+++ b/libibverbs/man/ibv_create_cq_ex.3
@@ -168,7 +168,7 @@ uint32_t priv; /* opaque user data from TMH */
 
 .SH "RETURN VALUE"
 .B ibv_create_cq_ex()
-returns a pointer to the CQ, or NULL if the request fails.
+returns a pointer to the CQ, or NULL if the request fails, and errno is set to indicate the reason.
 .SH "NOTES"
 .B ibv_create_cq_ex()
 may create a CQ with size greater than or equal to the requested

--- a/libibverbs/man/ibv_create_qp.3
+++ b/libibverbs/man/ibv_create_qp.3
@@ -58,7 +58,7 @@ destroys the QP
 .I qp\fR.
 .SH "RETURN VALUE"
 .B ibv_create_qp()
-returns a pointer to the created QP, or NULL if the request fails.
+returns a pointer to the created QP, or NULL if the request fails, and errno is set to indicate the reason.
 Check the QP number (\fBqp_num\fR) in the returned QP.
 .PP
 .B ibv_destroy_qp()

--- a/libibverbs/man/ibv_create_srq.3
+++ b/libibverbs/man/ibv_create_srq.3
@@ -52,7 +52,7 @@ destroys the SRQ
 .I srq\fR.
 .SH "RETURN VALUE"
 .B ibv_create_srq()
-returns a pointer to the created SRQ, or NULL if the request fails.
+returns a pointer to the created SRQ, or NULL if the request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_destroy_srq()
 returns 0 on success, or the value of errno on failure (which indicates the failure reason).

--- a/libibverbs/man/ibv_import_device.3.md
+++ b/libibverbs/man/ibv_import_device.3.md
@@ -35,7 +35,7 @@ This call may cleanup whatever is needed/opposite of the import including closin
 
 # RETURN VALUE
 
-**ibv_import_device()** returns a pointer to the allocated RDMA context, or NULL if the request fails.
+**ibv_import_device()** returns a pointer to the allocated RDMA context, or NULL if the request fails, and errno is set to indicate the reason.
 
 # SEE ALSO
 

--- a/libibverbs/man/ibv_import_mr.3.md
+++ b/libibverbs/man/ibv_import_mr.3.md
@@ -44,7 +44,7 @@ collaborate to ensure this.
 
 # RETURN VALUE
 
-**ibv_import_mr()** returns a pointer to the allocated MR, or NULL if the request fails.
+**ibv_import_mr()** returns a pointer to the allocated MR, or NULL if the request fails, and errno is set to indicate the reason.
 
 # NOTES
 

--- a/libibverbs/man/ibv_import_pd.3.md
+++ b/libibverbs/man/ibv_import_pd.3.md
@@ -46,7 +46,7 @@ collaborate to ensure this.
 
 # RETURN VALUE
 
-**ibv_import_pd()** returns a pointer to the allocated PD, or NULL if the request fails.
+**ibv_import_pd()** returns a pointer to the allocated PD, or NULL if the request fails, and errno is set to indicate the reason.
 
 # SEE ALSO
 

--- a/libibverbs/man/ibv_open_device.3
+++ b/libibverbs/man/ibv_open_device.3
@@ -23,7 +23,7 @@ closes the device context
 .I context\fR.
 .SH "RETURN VALUE"
 .B ibv_open_device()
-returns a pointer to the allocated device context, or NULL if the request fails.
+returns a pointer to the allocated device context, or NULL if the request fails, and errno is set to indicate the reason.
 .PP
 .B ibv_close_device()
 returns 0 on success, \-1 on failure.

--- a/libibverbs/man/ibv_reg_mr.3
+++ b/libibverbs/man/ibv_reg_mr.3
@@ -153,6 +153,11 @@ deregisters the MR
 .SH "RETURN VALUE"
 .B ibv_reg_mr() / ibv_reg_mr_iova() / ibv_reg_dmabuf_mr() / ibv_reg_mr_ex()
 returns a pointer to the registered MR, or NULL if the request fails.
+On failure
+.B errno
+is set to indicate the reason (for example
+.B EINVAL
+for an invalid combination of arguments).
 The local key (\fBL_Key\fR) field
 .B lkey
 is used as the lkey field of struct ibv_sge when posting buffers with

--- a/libibverbs/memory.c
+++ b/libibverbs/memory.c
@@ -621,6 +621,7 @@ static int do_madvise(void *addr, size_t length, int advice,
 	return 0;
 }
 
+/* Return 0 on success, or -1 on failure with errno set to indicate the reason. */
 static int ibv_madvise_range(void *base, size_t size, int advice)
 {
 	uintptr_t start, end;

--- a/libibverbs/verbs.c
+++ b/libibverbs/verbs.c
@@ -476,6 +476,7 @@ void ibv_free_buf(struct ibv_buf *buf)
  * The IBV_REG_MR_MASK_BUF bit is consumed here and replaced by the masks the
  * lower layers understand.
  */
+/* Return 0 on success, or -1 on an invalid attr combination with errno set to EINVAL. */
 static int fill_mr_init_attr_from_buf(struct ibv_pd *pd,
 				      struct ibv_mr_init_attr *mr_init_attr)
 {


### PR DESCRIPTION
The RETURN VALUE sections of libibverbs' pointer-returning verbs only stated
that NULL is returned on failure, without documenting that errno is set. Where
errno *was* mentioned in these pages it described the paired int-returning
sibling (e.g. ibv_dealloc_pd, ibv_free_dm), not the pointer verb itself — so
only ibv_import_dm actually documented the errno contract for its NULL return.

Documentation only; no functional or ABI change. I audited the NULL-return
paths of the affected verbs and found no missing errno assignment — every
failure path sets errno directly or via a call that does — so no code fix is
included.