### PR TITLE
tests: Add DevX traffic over dmabuf UMEMs

### DIFF
--- a/pyverbs/providers/mlx5/mlx5dv.pyx
+++ b/pyverbs/providers/mlx5/mlx5dv.pyx
@@ -1998,6 +1998,12 @@ cdef class Mlx5UMEM(PyverbsCM):
         if self.addr:
             return <uintptr_t><void*>self.addr
 
+    @umem_addr.setter
+    def umem_addr(self, addr):
+        if not self.is_user_addr and self.addr != NULL:
+            raise PyverbsUserError('Cannot override the address of an internally allocated UMEM')
+        self.addr = <void*><uintptr_t>addr
+        self.is_user_addr = True
 
 cdef class Mlx5Cqe64(PyverbsObject):
     def __init__(self, addr):

--- a/tests/test_mlx5_devx.py
+++ b/tests/test_mlx5_devx.py
@@ -8,8 +8,11 @@ Test module for mlx5 DevX.
 import resource
 import unittest
 import errno
+import os
 
 from tests.mlx5_base import Mlx5DevxRcResources, Mlx5DevxTrafficBase
+from tests.test_buf import alloc_buf, device_has_cc_dma_bounce, \
+    make_cc_pd, register_buf_mr
 from pyverbs.providers.mlx5.mlx5dv import Mlx5Context, Mlx5DVContextAttr, \
     Mlx5DevxCmdComp, Mlx5DevxObj, Mlx5UMEM
 from pyverbs.providers.mlx5.mlx5_enums import mlx5dv_context_attr_flags
@@ -18,6 +21,72 @@ import pyverbs.mem_alloc as mem
 from pyverbs.mr import MR
 from pyverbs.libibverbs_enums import ibv_access_flags, ibv_odp_transport_cap_bits
 import tests.utils as u
+
+
+class BufDevxRcResources(Mlx5DevxRcResources):
+    """
+    DevX RC resources for a Confidential Computing (CoCo) guest: every DevX
+    UMEM and the data MR live in shared/unprotected memory allocated with
+    Buf on a CC parent domain. Each UMEM is registered through the
+    DevX dmabuf path using an FD exported from its Buf, so all NIC-DMA'd memory
+    is shared as a DMA-bounce device requires.
+    """
+    def __init__(self, dev_name, ib_port, gid_index, msg_size=1024,
+                 activate_port_state=False, send_dbr_mode=0):
+        self.bufs = []
+        self.dmabuf_fds = []
+        self.base_pd = None
+        super().__init__(dev_name, ib_port, gid_index, msg_size,
+                         activate_port_state, send_dbr_mode)
+
+    def create_pd(self):
+        """Build a CC parent domain and derive the DevX pdn from it."""
+        from pyverbs.providers.mlx5.mlx5dv_objects import Mlx5DvObj
+        from pyverbs.providers.mlx5.mlx5_enums import mlx5dv_obj_type
+        if not device_has_cc_dma_bounce(self.ctx):
+            raise unittest.SkipTest('Device is not a CC DMA-bounce device')
+        self.base_pd, self.pd = make_cc_pd(self.ctx)
+        self.dv_pd = Mlx5DvObj(mlx5dv_obj_type.MLX5DV_OBJ_PD, pd=self.pd).dvpd
+
+    def create_mr(self):
+        """Register the data buffer as a shared Buf MR on the CC PD."""
+        access = ibv_access_flags.IBV_ACCESS_REMOTE_WRITE | \
+                 ibv_access_flags.IBV_ACCESS_LOCAL_WRITE | \
+                 ibv_access_flags.IBV_ACCESS_REMOTE_READ
+        buf = alloc_buf(self.pd, self.msg_size)
+        self.mr = register_buf_mr(self.pd, buf, self.msg_size, access)
+
+    def create_umem(self, size, access=ibv_access_flags.IBV_ACCESS_LOCAL_WRITE,
+                    alignment=resource.getpagesize()):
+        """Return a DevX UMEM backed by a Buf exported as a dmabuf FD."""
+        from pyverbs.providers.mlx5.mlx5_enums import MLX5DV_UMEM_MASK_DMABUF
+        page_size = resource.getpagesize()
+        alloc_size = max(size, page_size)
+        buf = alloc_buf(self.pd, alloc_size)
+        mem.write(buf.addr, bytes(alloc_size), alloc_size)  # Zero-fill the buffer
+        fd = self.export_buf_dmabuf_fd(buf)
+        umem = Mlx5UMEM(self.ctx, alloc_size, addr=0, alignment=alignment, access=access,
+                        pgsz_bitmap=page_size, comp_mask=MLX5DV_UMEM_MASK_DMABUF, dmabuf_fd=fd)
+        umem.umem_addr = buf.addr
+        self.bufs.append(buf)
+        self.dmabuf_fds.append(fd)
+        return umem
+
+    def export_buf_dmabuf_fd(self, buf):
+        """Export the Buf's dmabuf FD, skipping when it is not dmabuf-backed."""
+        try:
+            return buf.export_dmabuf_fd()
+        except PyverbsRDMAError as ex:
+            if ex.error_code == errno.ENODATA:
+                raise unittest.SkipTest('Buf is not dmabuf-backed')
+            raise
+
+    def close_resources(self):
+        """Close the exported dmabuf FDs"""
+        super().close_resources()
+        for fd in self.dmabuf_fds:
+            os.close(fd)
+        self.dmabuf_fds = []
 
 
 class Mlx5DevxRcOdpRes(Mlx5DevxRcResources):
@@ -43,6 +112,15 @@ class Mlx5DevxRcTrafficTest(Mlx5DevxTrafficBase):
         """
         self.create_players(Mlx5DevxRcResources)
         # Send traffic
+        self.send_imm_traffic()
+
+    def test_devx_rc_qp_send_imm_buf_umem_traffic(self):
+        """
+        Run DevX RC SEND_IMM traffic where all NIC memory (QP, CQ, doorbell
+        UMEMs and the data MR) is shared CoCo memory: buffers on a CC parent
+        domain, registered as UMEMs via their dmabuf FD.
+        """
+        self.create_players(BufDevxRcResources)
         self.send_imm_traffic()
 
     def test_devx_rc_qp_send_imm_doorbell_less_traffic(self):


### PR DESCRIPTION
Add an Mlx5UMEM.umem_addr setter so DevX UMEMs registered from a dmabuf FD can expose the CPU address of the backing buffer.
Also add a test that runs DevX RC SEND_IMM traffic on CoCo DMA-bounce devices using shared memory exported as dmabuf fds for the QP, CQ, doorbells, and data buffer, and skips elsewhere.