### PR TITLE
mlx5: Misc. fixes

### DIFF
--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1842,7 +1842,8 @@ void __mlx5_cq_clean(struct mlx5_cq *cq, uint32_t rsn, struct mlx5_srq *srq)
 	 * that match our QP by copying older entries on top of them.
 	 */
 	cqe_version = (to_mctx(cq->verbs_cq.cq.context))->cqe_version;
-	while ((int) --prod_index - (int) cq->cons_index >= 0) {
+	while (prod_index != cq->cons_index) {
+		--prod_index;
 		cqe = get_cqe(cq, prod_index & cq->verbs_cq.cq.cqe);
 		cqe64 = (cq->cqe_sz == 64) ? cqe : cqe + 64;
 		if (free_res_cqe(cqe64, rsn, srq, cqe_version)) {

--- a/providers/mlx5/dbrec.c
+++ b/providers/mlx5/dbrec.c
@@ -105,8 +105,10 @@ __be32 *mlx5_alloc_dbrec(struct mlx5_context *context, struct ibv_pd *pd,
 				   mparent_domain->pd_context, 8, 8,
 				   MLX5DV_RES_TYPE_DBR);
 
-		if (db == IBV_ALLOCATOR_USE_DEFAULT)
+		if (db == IBV_ALLOCATOR_USE_DEFAULT) {
+			db = NULL;
 			goto default_alloc;
+		}
 
 		if (!db)
 			return NULL;


### PR DESCRIPTION
This series includes two fixes in mlx5 provider as of below.
- Fix error flow upon dbrec allocation.
- Fix signed-overflow in __mlx5_cq_clean().

Extra details exist as part of the commit logs.