### PR TITLE
mlx5: Fix infinite loop caused by signed integer overflow in CQ clean

### DIFF
--- a/providers/mlx5/cq.c
+++ b/providers/mlx5/cq.c
@@ -1842,7 +1842,7 @@ void __mlx5_cq_clean(struct mlx5_cq *cq, uint32_t rsn, struct mlx5_srq *srq)
 	 * that match our QP by copying older entries on top of them.
 	 */
 	cqe_version = (to_mctx(cq->verbs_cq.cq.context))->cqe_version;
-	while ((int) --prod_index - (int) cq->cons_index >= 0) {
+	while (prod_index-- != cq->cons_index) {
 		cqe = get_cqe(cq, prod_index & cq->verbs_cq.cq.cqe);
 		cqe64 = (cq->cqe_sz == 64) ? cqe : cqe + 64;
 		if (free_res_cqe(cqe64, rsn, srq, cqe_version)) {


### PR DESCRIPTION
Fix a potential infinite loop in `mlx5` caused by signed integer overflow during CQ clean.

Note:
A similar issue was previously addressed in `hns` (commit 886b17cd973b).
While checking the codebase, I noticed that `mlx4` and `mthca` also use the same `(int)--prod_index - (int)cq->cons_index >= 0` pattern. Since I don't have the hardware to test those, I'm currently limiting this pull request to `mlx5`. 

If desired, I can prepare separate commits for those providers in this pull request as well.