### PR TITLE
[mlx4, mthca]: Fix signed-overflow as part of cq cleanup

### DIFF
--- a/providers/mlx4/cq.c
+++ b/providers/mlx4/cq.c
@@ -700,7 +700,8 @@ void __mlx4_cq_clean(struct mlx4_cq *cq, uint32_t qpn, struct mlx4_srq *srq)
 	 * Now sweep backwards through the CQ, removing CQ entries
 	 * that match our QP by copying older entries on top of them.
 	 */
-	while ((int) --prod_index - (int) cq->cons_index >= 0) {
+	while (prod_index != cq->cons_index) {
+		--prod_index;
 		cqe = get_cqe(cq, prod_index & cq->verbs_cq.cq.cqe);
 		cqe += cqe_inc;
 		if (srq && srq->ext_srq &&

--- a/providers/mthca/cq.c
+++ b/providers/mthca/cq.c
@@ -563,7 +563,8 @@ void __mthca_cq_clean(struct mthca_cq *cq, uint32_t qpn, struct mthca_srq *srq)
 	 * Now sweep backwards through the CQ, removing CQ entries
 	 * that match our QP by copying older entries on top of them.
 	 */
-	while ((int) --prod_index - (int) cq->cons_index >= 0) {
+	while (prod_index != cq->cons_index) {
+		--prod_index;
 		cqe = get_cqe(cq, prod_index & cq->ibv_cq.cqe);
 		if (cqe->my_qpn == htobe32(qpn)) {
 			if (srq && is_recv_cqe(cqe))


### PR DESCRIPTION
This series fixes mlx4 and mthca providers to prevent an overflow upon cq cleanup.

Extra details exist as part of the commit logs.

It follows the same pattern that was done for mlx5 [1].

[1] https://github.com/linux-rdma/rdma-core/pull/1791/changes/2dc29c114f5765758cf3695ab3c428e05bb133c7

