### PR TITLE
rc_pingpong: Prefer IPv6 wildcard when binding control channel

### DIFF
--- a/libibverbs/examples/rc_pingpong.c
+++ b/libibverbs/examples/rc_pingpong.c
@@ -261,17 +261,29 @@ static struct pingpong_dest *pp_server_exch_dest(struct pingpong_context *ctx,
 		return NULL;
 	}
 
-	for (t = res; t; t = t->ai_next) {
-		sockfd = socket(t->ai_family, t->ai_socktype, t->ai_protocol);
-		if (sockfd >= 0) {
-			n = 1;
+	/*
+	 * Prefer binding an IPv6 wildcard ([::]) so IPv6 clients can reach
+	 * the control channel; with the Linux-default dual-stack [::]
+	 * socket, IPv4 clients are accepted as well.  Fall back to the IPv4
+	 * wildcard (0.0.0.0) when IPv6 is not available on this host.
+	 */
+	for (int i = 0; i < 2 && sockfd < 0; i++) {
+		int family = i ? AF_INET : AF_INET6;
 
-			setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &n, sizeof n);
+		for (t = res; t; t = t->ai_next) {
+			if (t->ai_family != family)
+				continue;
 
-			if (!bind(sockfd, t->ai_addr, t->ai_addrlen))
-				break;
-			close(sockfd);
-			sockfd = -1;
+			sockfd = socket(t->ai_family, t->ai_socktype, t->ai_protocol);
+			if (sockfd >= 0) {
+				n = 1;
+				setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &n, sizeof(n));
+
+				if (!bind(sockfd, t->ai_addr, t->ai_addrlen))
+					break;
+				close(sockfd);
+				sockfd = -1;
+			}
 		}
 	}
 


### PR DESCRIPTION
Bind the server's control channel to the IPv6 wildcard ([::]) so IPv6 clients can reach it; 
with the Linux-default dual-stack [::] socket, IPv4 clients are accepted as well.  
Fall back to the IPv4 wildcard (0.0.0.0) when IPv6 is not available on the host.

Signed-off-by: Shuang Li <shuali2026@gmail.com>

---

**Without the patch:**

[root@localhost ~]# ibv_rc_pingpong -d rxe_server -g 2 -n 3 &
[1] 2584
  local address:  LID 0x0000, QPN 0x000013, PSN 0xf49ff2, GID 2001:db8:1::1

[root@localhost ~]# ss -tunl
Netid      State       Recv-Q      Send-Q            Local Address:Port              Peer Address:Port      
...
udp        UNCONN      0           0                       0.0.0.0:4791                   0.0.0.0:*         
...
udp        UNCONN      0           0                          [::]:4791                      [::]:*         
...
tcp        LISTEN      0           1                       0.0.0.0:18515                  0.0.0.0:*         
...

[root@localhost ~]# ibv_rc_pingpong -d rxe_client -g 2 -n 3 2001:db8:1::1
  local address:  LID 0x0000, QPN 0x000013, PSN 0x6fe117, GID 2001:db8:1::2
Couldn't connect to 2001:db8:1::1:18515

**With the patch:**

[root@localhost bin]# ./ibv_rc_pingpong -d rxe_server -g 2 -n 3 &
[1] 5804
  local address:  LID 0x0000, QPN 0x000013, PSN 0xdc57b0, GID 2001:db8:1::1

[root@localhost bin]# ss -tunl
Netid      State       Recv-Q      Send-Q            Local Address:Port              Peer Address:Port      
...         
udp        UNCONN      0           0                       0.0.0.0:4791                   0.0.0.0:*         
...        
udp        UNCONN      0           0                          [::]:4791                      [::]:*         
...      
tcp        LISTEN      0           1                             *:18515                        *:*         
...       

[root@localhost ~]# ibv_rc_pingpong -d rxe_client -g 2 -n 3 2001:db8:1::1
  local address:  LID 0x0000, QPN 0x000014, PSN 0xc68c38, GID 2001:db8:1::2
  remote address: LID 0x0000, QPN 0x000013, PSN 0xdc57b0, GID 2001:db8:1::1
24576 bytes in 0.00 seconds = 62.45 Mbit/sec
3 iters in 0.00 seconds = 1049.33 usec/iter