### PR TITLE
providers/mana: skip SQ rollback region when pow2 SQ is supported

### DIFF
--- a/kernel-headers/rdma/mana-abi.h
+++ b/kernel-headers/rdma/mana-abi.h
@@ -48,13 +48,23 @@ struct mana_ib_create_qp_resp {
 	__u32 reserved;
 };
 
+enum mana_ib_create_rc_qp_flags {
+	MANA_IB_RC_QP_FIXED_WQE = 1 << 0,
+	MANA_IB_RC_MMQ_CREATE = 1 << 1,
+};
+
 struct mana_ib_create_rc_qp {
 	__aligned_u64 queue_buf[4];
 	__u32 queue_size[4];
+	__aligned_u64 mmq_buf;
+	__u32 mmq_size;
+	__u32 comp_mask;
 };
 
 struct mana_ib_create_rc_qp_resp {
 	__u32 queue_id[4];
+	__u32 mmq_id;
+	__u32 reserved;
 };
 
 struct mana_ib_create_uc_qp {
@@ -100,6 +110,8 @@ struct mana_ib_create_qp_rss_resp {
 
 enum mana_ib_ucontext_support {
 	MANA_IB_UCNTX_ALLOC_PDN_SUPPORT = 1 << 0,
+	MANA_IB_UCNTX_RC_EXT_SUPPORT = 1 << 1,
+	MANA_IB_UCNTX_RC_SQ_POW2_SUPPORT = 1 << 2,
 };
 
 struct mana_ib_alloc_ucontext_resp {

--- a/providers/mana/mana.h
+++ b/providers/mana/mana.h
@@ -138,6 +138,8 @@ struct mana_qp {
 
 	enum ibv_mtu mtu;
 	int sq_sig_all;
+	/* Requester SQ carries a software rollback region */
+	bool rollback_sq;
 
 	struct shadow_queue shadow_rq;
 	struct shadow_queue shadow_sq;

--- a/providers/mana/qp.c
+++ b/providers/mana/qp.c
@@ -214,7 +214,8 @@ struct mana_qp *mana_get_qp(struct mana_context *ctx, uint32_t qid, bool is_sq)
 	return qp_table[tbl_idx].table[tbl_off];
 }
 
-static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_types type)
+static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_types type,
+			       bool rollback_sq)
 {
 	uint32_t size = 0;
 	uint32_t sges = 0;
@@ -247,7 +248,7 @@ static uint32_t get_queue_size(struct ibv_qp_init_attr *attr, enum user_queue_ty
 		return 0;
 	}
 
-	if (attr->qp_type == IBV_QPT_RC && type == USER_RNIC_SEND_QUEUE_REQUESTER)
+	if (rollback_sq && type == USER_RNIC_SEND_QUEUE_REQUESTER)
 		size += sizeof(struct mana_ib_rollback_shared_mem);
 
 	return size;
@@ -366,6 +367,11 @@ static struct ibv_qp *mana_create_qp_rnic(struct ibv_pd *ibpd,
 	pthread_spin_init(&qp->rq_lock, PTHREAD_PROCESS_PRIVATE);
 	qp->sq_sig_all = attr->sq_sig_all;
 
+	/* The software rollback region is only needed when fixed-size-WQE is unavailable */
+	qp->rollback_sq = attr->qp_type == IBV_QPT_RC &&
+			  !((ctx->comp_mask & MANA_IB_UCNTX_RC_SQ_POW2_SUPPORT) &&
+			    (ctx->comp_mask & MANA_IB_UCNTX_RC_EXT_SUPPORT));
+
 	if (create_shadow_queue(&qp->shadow_sq, attr->cap.max_send_wr,
 				sizeof(struct rnic_sq_shadow_wqe))) {
 		verbs_err(verbs_get_ctx(ibpd->context), "Failed to alloc sq shadow queue\n");
@@ -382,7 +388,7 @@ static struct ibv_qp *mana_create_qp_rnic(struct ibv_pd *ibpd,
 
 	for (i = 0; i < USER_RNIC_QUEUE_TYPE_MAX; ++i) {
 		qp->rnic_qp.queues[i].db_page = ctx->db_page;
-		qp->rnic_qp.queues[i].size = get_queue_size(attr, i);
+		qp->rnic_qp.queues[i].size = get_queue_size(attr, i, qp->rollback_sq);
 		qp->rnic_qp.queues[i].buffer = mana_alloc_mem(qp->rnic_qp.queues[i].size);
 
 		if (qp->rnic_qp.queues[i].size != 0 && !qp->rnic_qp.queues[i].buffer) {

--- a/providers/mana/rollback.h
+++ b/providers/mana/rollback.h
@@ -39,7 +39,7 @@ static inline struct mana_ib_rollback_shared_mem
 
 static inline void mana_ib_init_rb_shmem(struct mana_qp *qp)
 {
-	if (qp->ibqp.qp.qp_type != IBV_QPT_RC)
+	if (!qp->rollback_sq)
 		return;
 	// take some bytes for rollback memory
 	struct mana_gdma_queue *req_sq =
@@ -56,7 +56,7 @@ static inline void mana_ib_init_rb_shmem(struct mana_qp *qp)
 
 static inline void mana_ib_deinit_rb_shmem(struct mana_qp *qp)
 {
-	if (qp->ibqp.qp.qp_type != IBV_QPT_RC)
+	if (!qp->rollback_sq)
 		return;
 	// return back bytes for rollback memory
 	struct mana_gdma_queue *req_sq =
@@ -66,7 +66,7 @@ static inline void mana_ib_deinit_rb_shmem(struct mana_qp *qp)
 
 static inline void mana_ib_reset_rb_shmem(struct mana_qp *qp)
 {
-	if (qp->ibqp.qp.qp_type != IBV_QPT_RC)
+	if (!qp->rollback_sq)
 		return;
 
 	struct mana_ib_rollback_shared_mem *rb_shmem =
@@ -78,7 +78,7 @@ static inline void mana_ib_reset_rb_shmem(struct mana_qp *qp)
 
 static inline void mana_ib_update_shared_mem_right_offset(struct mana_qp *qp, uint32_t offset_in_bu)
 {
-	if (qp->ibqp.qp.qp_type != IBV_QPT_RC)
+	if (!qp->rollback_sq)
 		return;
 
 	struct mana_ib_rollback_shared_mem *rb_shmem =
@@ -89,6 +89,9 @@ static inline void mana_ib_update_shared_mem_right_offset(struct mana_qp *qp, ui
 
 static inline void mana_ib_update_shared_mem_left_offset(struct mana_qp *qp, uint32_t offset_in_bu)
 {
+	if (!qp->rollback_sq)
+		return;
+
 	struct mana_ib_rollback_shared_mem *rb_shmem =
 			mana_ib_get_rollback_sh_mem(qp);
 


### PR DESCRIPTION
The requester SQ of an RC QP carries a trailing rollback shared-memory block so
that the rollback point can be recovered from software. When the adapter accepts
a power-of-two send queue, the rollback point is derived from the WQE size alone
and the block is not needed.

The kernel advertises this with MANA_IB_UCNTX_RC_SQ_POW2_SUPPORT. Skip the extra
allocation and the per-post and per-completion offset updates when it is set
together with MANA_IB_UCNTX_RC_EXT_SUPPORT. Gate the behaviour on a new per-QP
rollback_sq flag so that QPs running on older kernels keep the legacy layout.

Notes:
- Builds on #1795, which adds the user-space fixed-WQE support. Rebases onto #1795 
  with a one-line conflict in the mana-abi.h enum.