### PR TITLE
COPYING.GPL2: update FSF address

### DIFF
--- a/COPYING.GPL2
+++ b/COPYING.GPL2
@@ -2,7 +2,7 @@
                        Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
- 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -304,8 +304,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License along
-    with this program; if not, write to the Free Software Foundation, Inc.,
-    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+    with this program; if not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -329,8 +328,8 @@ necessary.  Here is a sample; alter the names:
   Yoyodyne, Inc., hereby disclaims all copyright interest in the program
   `Gnomovision' (which makes passes at compilers) written by James Hacker.
 
-  <signature of Ty Coon>, 1 April 1989
-  Ty Coon, President of Vice
+  <signature of Moe Ghoul>, 1 April 1989
+  Moe Ghoul, President of Vice
 
 This General Public License does not permit incorporating your program into
 proprietary programs.  If your program is a subroutine library, you may


### PR DESCRIPTION
The Free Software Foundation closed its physical office on Franklin Street, Boston, in 2024. The current recommended text of the GPLv2 replaces the physical address with a URL.

Replace COPYING.GPL2 with the latest revision, downloaded from https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt

It also replaces the fictional company president name "Ty Coon" with "Moe Ghoul".

This silences a rpmlint message:
E: incorrect-fsf-address /usr/share/licenses/rdma-core-common/COPYING.GPL2